### PR TITLE
Backfill engineering_design for plant and SynCom communities

### DIFF
--- a/kb/communities/At_RSPHERE_SynCom.yaml
+++ b/kb/communities/At_RSPHERE_SynCom.yaml
@@ -10,6 +10,19 @@ description: 'A synthetic bacterial community derived from the Arabidopsis root 
 ecological_state: ENGINEERED
 community_origin: ENGINEERED
 community_category: RHIZOSPHERE
+engineering_design:
+  objective: A synthetic bacterial community derived from the Arabidopsis root microbiota culture collection (At-RSPHERE), representing 16 bacterial families isolated from Arabidopsis thaliana roots grown in natural soil.
+  assembly_strategy: Engineered 6-member consortium configured for rhizosphere objectives.
+  measurement_endpoints:
+  - Interaction-level mechanistic characterization
+  - Member-level abundance and persistence tracking
+  notes: Backfilled engineering-design metadata from existing curation; refine with protocol-level parameters when available.
+  perturbation_design: 'Designed condition space included: Bacterial diversity, Assembly size.'
+  evidence:
+  - reference: doi:10.1038/nature16192
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Using defined bacterial communities and a gnotobiotic Arabidopsis plant system we show that the isolates form assemblies resembling natural microbiota on their cognate host organs, but are also capable of ectopic leaf or root colonization
 environment_term:
   preferred_term: rhizosphere
   term:

--- a/kb/communities/Chlamydomonas_Bacterial_H2_Consortium.yaml
+++ b/kb/communities/Chlamydomonas_Bacterial_H2_Consortium.yaml
@@ -9,6 +9,19 @@ description: 'A synthetic algae-bacteria consortium for sustainable hydrogen pro
 ecological_state: ENGINEERED
 community_origin: ENGINEERED
 community_category: PHYTOPLANKTON
+engineering_design:
+  objective: 'A synthetic algae-bacteria consortium for sustainable hydrogen production, composed of the green alga Chlamydomonas reinhardtii and three bacterial species: Microbacterium forte sp.'
+  assembly_strategy: Engineered 4-member consortium configured for phytoplankton objectives.
+  measurement_endpoints:
+  - Interaction-level mechanistic characterization
+  - Member-level abundance and persistence tracking
+  notes: Backfilled engineering-design metadata from existing curation; refine with protocol-level parameters when available.
+  perturbation_design: 'Designed condition space included: Light, Cell density.'
+  evidence:
+  - reference: PMID:38159768
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "Still, under non\u2011hydrogen producing conditions (aerobiosis) the Chlamydomonas-M"
 environment_term:
   preferred_term: laboratory bioreactor
   term:

--- a/kb/communities/Chlorella_Rhizobium_Bioflocculation.yaml
+++ b/kb/communities/Chlorella_Rhizobium_Bioflocculation.yaml
@@ -13,6 +13,20 @@ description: >
 ecological_state: ENGINEERED
 community_origin: ENGINEERED
 community_category: PHYTOPLANKTON
+engineering_design:
+  objective: A co-culture system pairing the microalgae Chlorella vulgaris with the bioflocculant-producing bacterium Rhizobium radiobacter F2 for enhanced algal harvesting in wastewater treatment applications.
+  assembly_strategy: Engineered 2-member consortium configured for phytoplankton objectives.
+  measurement_endpoints:
+  - Interaction-level mechanistic characterization
+  - Member-level abundance and persistence tracking
+  notes: Backfilled engineering-design metadata from existing curation; refine with protocol-level parameters when available.
+  perturbation_design: 'Designed condition space included: Light, Glucose concentration.'
+  evidence:
+  - reference: doi:10.1111/jbm.12334
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: enhancing microalgae harvesting and lipid content
+    explanation: Demonstrates photosynthetic biomass and lipid production by C. vulgaris
 
 environment_term:
   preferred_term: wastewater treatment plant

--- a/kb/communities/Coscinodiscus_Synthetic_Community.yaml
+++ b/kb/communities/Coscinodiscus_Synthetic_Community.yaml
@@ -11,6 +11,20 @@ description: 'A synthetic marine phytoplankton community consisting of the large
 ecological_state: ENGINEERED
 community_origin: ENGINEERED
 community_category: PHYTOPLANKTON
+engineering_design:
+  objective: A synthetic marine phytoplankton community consisting of the large centric diatom Coscinodiscus radiatus and four phylogenetically distinct bacterial isolates from different marine bacterial lineages.
+  assembly_strategy: Engineered 5-member consortium configured for phytoplankton objectives.
+  measurement_endpoints:
+  - Interaction-level mechanistic characterization
+  - Member-level abundance and persistence tracking
+  notes: Backfilled engineering-design metadata from existing curation; refine with protocol-level parameters when available.
+  perturbation_design: 'Designed condition space included: Marine medium, Light.'
+  evidence:
+  - reference: PMID:36300970
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: No synergistic effects between bacteria in the presence of the diatom was observed
+    explanation: Demonstrates diatom provision of organic nutrients to bacteria
 environment_term:
   preferred_term: marine environment
   term:

--- a/kb/communities/Dangl_SynComm_35.yaml
+++ b/kb/communities/Dangl_SynComm_35.yaml
@@ -11,6 +11,22 @@ description: 'A 35-member synthetic community (SynComm 35) composed of genome-se
 ecological_state: ENGINEERED
 community_origin: ENGINEERED
 community_category: RHIZOSPHERE
+engineering_design:
+  objective: A 35-member synthetic community (SynComm 35) composed of genome-sequenced bacterial strains representing typical taxonomic diversity of Arabidopsis root commensals.
+  assembly_strategy: Engineered 8-member consortium configured for rhizosphere objectives.
+  measurement_endpoints:
+  - Interaction-level mechanistic characterization
+  - Member-level abundance and persistence tracking
+  notes: Backfilled engineering-design metadata from existing curation; refine with protocol-level parameters when available.
+  perturbation_design: 'Designed condition space included: MAMP Treatment, Plant Age.'
+  evidence:
+  - reference: doi:10.1073/pnas.2100678118
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Significance In natural environments, plants establish intimate interactions with a wide diversity of microbes
+    explanation: 'The community specifically suppresses a transcriptional sector of plant immunity, demonstrating that commensal bacteria actively modulate host immune responses
+
+      '
 environment_term:
   preferred_term: rhizosphere
   term:

--- a/kb/communities/EcoFAB_Ring_Trial_SynCom17.yaml
+++ b/kb/communities/EcoFAB_Ring_Trial_SynCom17.yaml
@@ -16,6 +16,22 @@ description: 'A 17-member synthetic bacterial community (SynCom17) used in a sta
 ecological_state: ENGINEERED
 community_origin: SYNTHETIC
 community_category: RHIZOSPHERE
+engineering_design:
+  objective: A 17-member synthetic bacterial community (SynCom17) used in a standardized inter-laboratory ring trial across five international laboratories (LBNL, UNC Chapel Hill, Max Planck Cologne, Forschungszentrum Julich, U Melbourne) to study root microbiome recruitment and exudate composition of the model grass Brachypodium distachyon in EcoFAB 2.0 fabricated ecosystem devices.
+  assembly_strategy: Bottom-up synthetic assembly of a 17-member consortium from selected isolates/strains.
+  measurement_endpoints:
+  - 16S amplicon-based community composition profiling
+  - Metabolite profiling and exchange analysis
+  - Growth and phenotype readouts
+  - Genome-informed trait and pathway annotation
+  notes: Backfilled engineering-design metadata from existing curation; refine with protocol-level parameters when available.
+  perturbation_design: 'Designed condition space included: Nitrogen Source, Light Regime.'
+  evidence:
+  - reference: PMID:40920748
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Paraburkholderia sp. OAS925 could dramatically shift microbiome composition
+    explanation: Documents competitive exclusion by Paraburkholderia across multiple labs
 environment_term:
   preferred_term: EcoFAB 2.0 hydroponic device
   term:

--- a/kb/communities/Lotus_LjSC3.yaml
+++ b/kb/communities/Lotus_LjSC3.yaml
@@ -11,6 +11,19 @@ description: 'A 16-member synthetic community (Lj-SC3) derived from Lotus japoni
 ecological_state: ENGINEERED
 community_origin: ENGINEERED
 community_category: RHIZOSPHERE
+engineering_design:
+  objective: A 16-member synthetic community (Lj-SC3) derived from Lotus japonicus roots and nodules, designed to study host preference and community assembly dynamics in legume-microbe interactions.
+  assembly_strategy: Engineered 10-member consortium configured for rhizosphere objectives.
+  measurement_endpoints:
+  - Interaction-level mechanistic characterization
+  - Member-level abundance and persistence tracking
+  notes: Backfilled engineering-design metadata from existing curation; refine with protocol-level parameters when available.
+  perturbation_design: 'Designed condition space included: Host plant species, Nodulation status.'
+  evidence:
+  - reference: PMID:34312531
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Sequential inoculation experiments revealed priority effects during root microbiota assembly, where established communities are resilient to invasion by latecomers, and that host preference of commensal bacteria confers a competitive advantage in their cognate host
 environment_term:
   preferred_term: rhizosphere
   term:

--- a/kb/communities/Maize_Root_Simplified_Community.yaml
+++ b/kb/communities/Maize_Root_Simplified_Community.yaml
@@ -10,6 +10,19 @@ description: 'A representative 7-member bacterial community from maize rhizosphe
 ecological_state: ENGINEERED
 community_origin: ENGINEERED
 community_category: RHIZOSPHERE
+engineering_design:
+  objective: A representative 7-member bacterial community from maize rhizosphere, developed through selective iterations to model root-associated microbiome function.
+  assembly_strategy: Engineered 8-member consortium configured for rhizosphere objectives.
+  measurement_endpoints:
+  - Interaction-level mechanistic characterization
+  - Member-level abundance and persistence tracking
+  notes: Backfilled engineering-design metadata from existing curation; refine with protocol-level parameters when available.
+  perturbation_design: 'Designed condition space included: Target pathogen, Keystone species.'
+  evidence:
+  - reference: PMID:28275097
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: In this work, from the distinctive microbiota assembled by maize roots, through host-mediated selection, we obtained a greatly simplified synthetic bacterial community consisting of seven strains (Enterobacter cloacae, Stenotrophomonas maltophilia, Ochrobactrum pituitosum, Herbaspirillum frisingense, Pseudomonas putida, Curtobacterium pusillum, and Chryseobacterium indologenes) representing three of the four most dominant phyla found in maize roots
 environment_term:
   preferred_term: rhizosphere
   term:

--- a/kb/communities/Sorghum_SRC1_Subset.yaml
+++ b/kb/communities/Sorghum_SRC1_Subset.yaml
@@ -11,6 +11,19 @@ description: 'A simplified synthetic rhizosphere community (SRC1-subset) derived
 ecological_state: ENGINEERED
 community_origin: ENGINEERED
 community_category: RHIZOSPHERE
+engineering_design:
+  objective: A simplified synthetic rhizosphere community (SRC1-subset) derived from the larger SRC1 consortium for enhancing sorghum bioenergy crop productivity.
+  assembly_strategy: Engineered 7-member consortium configured for rhizosphere objectives.
+  measurement_endpoints:
+  - Interaction-level mechanistic characterization
+  - Member-level abundance and persistence tracking
+  notes: Backfilled engineering-design metadata from existing curation; refine with protocol-level parameters when available.
+  perturbation_design: 'Designed condition space included: Community design strategy, Community size.'
+  evidence:
+  - reference: doi:10.1093/ismejo/wrae126
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Here, we engineered a synthetic rhizosphere community (SRC1) with the anticipation that it would exhibit a selective advantage in colonizing the host Sorghum bicolor, thereby potentially fostering its growth
 environment_term:
   preferred_term: rhizosphere
   term:

--- a/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
+++ b/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
@@ -9,6 +9,19 @@ description: 'A simplified synthetic community (sfSynCom) for enhanced symbiotic
 ecological_state: ENGINEERED
 community_origin: ENGINEERED
 community_category: RHIZOSPHERE
+engineering_design:
+  objective: A simplified synthetic community (sfSynCom) for enhanced symbiotic nitrogen fixation in soybean, based on core-helper strain interactions.
+  assembly_strategy: Engineered 4-member consortium configured for rhizosphere objectives.
+  measurement_endpoints:
+  - Interaction-level mechanistic characterization
+  - Member-level abundance and persistence tracking
+  notes: Backfilled engineering-design metadata from existing curation; refine with protocol-level parameters when available.
+  perturbation_design: 'Designed condition space included: Quorum sensing regulation, Nodulation efficiency.'
+  evidence:
+  - reference: PMID:40052412
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Two of these helper strains assigned to the Pantoea taxon produce acyl homoserine lactones, which significantly enhanced the colonization and infection of soybean by BXYD3
 environment_term:
   preferred_term: rhizosphere
   term:

--- a/kb/communities/Synechococcus_Bacillus_SPC.yaml
+++ b/kb/communities/Synechococcus_Bacillus_SPC.yaml
@@ -8,6 +8,18 @@ description: 'A synthetic, light-driven consortium pairing the cyanobacterium Sy
 ecological_state: ENGINEERED
 community_origin: ENGINEERED
 community_category: OTHER
+engineering_design:
+  objective: A synthetic, light-driven consortium pairing the cyanobacterium Synechococcus elongatus PCC 7942 (engineered to secrete sucrose via the cscB+ transporter) with Bacillus subtilis 168.
+  assembly_strategy: Engineered 2-member consortium configured for other objectives.
+  measurement_endpoints:
+  - Interaction-level mechanistic characterization
+  - Member-level abundance and persistence tracking
+  notes: Backfilled engineering-design metadata from existing curation; refine with protocol-level parameters when available.
+  evidence:
+  - reference: PMID:28127397
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: We previously engineered a model cyanobacterium, Synechococcus elongatus PCC 7942, to secrete the bulk of the carbon it fixes as sucrose, a carbohydrate that can be utilized by many other microbes
 environment_term:
   preferred_term: laboratory bioreactor
   term:

--- a/kb/communities/Synechococcus_Ecoli_SPC.yaml
+++ b/kb/communities/Synechococcus_Ecoli_SPC.yaml
@@ -9,6 +9,20 @@ description: 'A synthetic, light-driven consortium pairing the cyanobacterium Sy
 ecological_state: ENGINEERED
 community_origin: ENGINEERED
 community_category: OTHER
+engineering_design:
+  objective: A synthetic, light-driven consortium pairing the cyanobacterium Synechococcus elongatus PCC 7942 (engineered to secrete sucrose via the cscB+ transporter) with Escherichia coli.
+  assembly_strategy: Engineered 2-member consortium configured for other objectives.
+  measurement_endpoints:
+  - Interaction-level mechanistic characterization
+  - Member-level abundance and persistence tracking
+  notes: Backfilled engineering-design metadata from existing curation; refine with protocol-level parameters when available.
+  perturbation_design: 'Designed condition space included: Light, NaCl (Osmotic Pressure).'
+  evidence:
+  - reference: PMID:28127397
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: We previously engineered a model cyanobacterium, Synechococcus elongatus PCC 7942, to secrete the bulk of the carbon it fixes as sucrose, a carbohydrate that can be utilized by many other microbes
+    explanation: Demonstrates the core cross-feeding interaction
 environment_term:
   preferred_term: laboratory bioreactor
   term:

--- a/kb/communities/Synechococcus_Yarrowia_SPC.yaml
+++ b/kb/communities/Synechococcus_Yarrowia_SPC.yaml
@@ -8,6 +8,18 @@ description: 'A synthetic, light-driven consortium pairing the cyanobacterium Sy
 ecological_state: ENGINEERED
 community_origin: ENGINEERED
 community_category: OTHER
+engineering_design:
+  objective: A synthetic, light-driven consortium pairing the cyanobacterium Synechococcus elongatus PCC 7942 (engineered to secrete sucrose via the cscB+ transporter) with the oleaginous yeast Yarrowia lipolytica Po1g.
+  assembly_strategy: Engineered 2-member consortium configured for other objectives.
+  measurement_endpoints:
+  - Interaction-level mechanistic characterization
+  - Member-level abundance and persistence tracking
+  notes: Backfilled engineering-design metadata from existing curation; refine with protocol-level parameters when available.
+  evidence:
+  - reference: PMID:28127397
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: We previously engineered a model cyanobacterium, Synechococcus elongatus PCC 7942, to secrete the bulk of the carbon it fixes as sucrose, a carbohydrate that can be utilized by many other microbes
 environment_term:
   preferred_term: laboratory bioreactor
   term:

--- a/kb/communities/Wheat_Consortium_C1.yaml
+++ b/kb/communities/Wheat_Consortium_C1.yaml
@@ -8,6 +8,19 @@ description: 'A synthetic 3-member rhizosphere consortium (C1) for biocontrol of
 ecological_state: ENGINEERED
 community_origin: ENGINEERED
 community_category: RHIZOSPHERE
+engineering_design:
+  objective: A synthetic 3-member rhizosphere consortium (C1) for biocontrol of soilborne fungal pathogens in wheat.
+  assembly_strategy: Engineered 3-member consortium configured for rhizosphere objectives.
+  measurement_endpoints:
+  - Interaction-level mechanistic characterization
+  - Member-level abundance and persistence tracking
+  notes: Backfilled engineering-design metadata from existing curation; refine with protocol-level parameters when available.
+  perturbation_design: 'Designed condition space included: Target pathogen, Application.'
+  evidence:
+  - reference: PMID:36118206
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Here, we characterized a collection of bacteria, previously isolated from the wheat rhizosphere, for their antifungal activity against soilborne fungal pathogens
 environment_term:
   preferred_term: rhizosphere
   term:

--- a/kb/communities/Wheat_Consortium_C6.yaml
+++ b/kb/communities/Wheat_Consortium_C6.yaml
@@ -8,6 +8,19 @@ description: 'A synthetic 4-member rhizosphere consortium (C6) for biocontrol of
 ecological_state: ENGINEERED
 community_origin: ENGINEERED
 community_category: RHIZOSPHERE
+engineering_design:
+  objective: A synthetic 4-member rhizosphere consortium (C6) for biocontrol of Rhizoctonia solani in wheat.
+  assembly_strategy: Engineered 3-member consortium configured for rhizosphere objectives.
+  measurement_endpoints:
+  - Interaction-level mechanistic characterization
+  - Member-level abundance and persistence tracking
+  notes: Backfilled engineering-design metadata from existing curation; refine with protocol-level parameters when available.
+  perturbation_design: 'Designed condition space included: Target pathogen, Biocontrol mechanism.'
+  evidence:
+  - reference: PMID:36118206
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Further, the mechanisms of interaction of the tested bacteria with each other and plants were explored
 environment_term:
   preferred_term: rhizosphere
   term:

--- a/references_cache/DOI_10.1126_sciadv.adg7888.md
+++ b/references_cache/DOI_10.1126_sciadv.adg7888.md
@@ -1,0 +1,42 @@
+---
+reference_id: DOI:10.1126/sciadv.adg7888
+title: "Reproducible growth of
+                    <i>Brachypodium</i>
+                    in EcoFAB 2.0 reveals that nitrogen form and starvation modulate root exudation"
+authors:
+- Vlastimil Novak
+- Peter F. Andeer
+- Benjamin P. Bowen
+- Yezhang Ding
+- Kateryna Zhalnina
+- Kirsten S. Hofmockel
+- Connor Tomaka
+- Thomas V. Harwood
+- Michelle C. M. van Winden
+- Amber N. Golini
+- Suzanne M. Kosina
+- Trent R. Northen
+journal: Science Advances
+year: '2024'
+doi: 10.1126/sciadv.adg7888
+content_type: abstract_only
+---
+
+# Reproducible growth of
+                    <i>Brachypodium</i>
+                    in EcoFAB 2.0 reveals that nitrogen form and starvation modulate root exudation
+**Authors:** Vlastimil Novak, Peter F. Andeer, Benjamin P. Bowen, Yezhang Ding, Kateryna Zhalnina, Kirsten S. Hofmockel, Connor Tomaka, Thomas V. Harwood, Michelle C. M. van Winden, Amber N. Golini, Suzanne M. Kosina, Trent R. Northen
+**Journal:** Science Advances (2024)
+**DOI:** [10.1126/sciadv.adg7888](https://doi.org/10.1126/sciadv.adg7888)
+
+## Content
+
+Understanding plant-microbe interactions requires examination of root exudation under nutrient stress using standardized and reproducible experimental systems. We grew
+                    Brachypodium distachyon
+                    hydroponically in fabricated ecosystem devices (EcoFAB 2.0) under three inorganic nitrogen forms (nitrate, ammonium, and ammonium nitrate), followed by nitrogen starvation. Analyses of exudates with liquid chromatography–tandem mass spectrometry, biomass, medium pH, and nitrogen uptake showed EcoFAB 2.0’s low intratreatment data variability. Furthermore, the three inorganic nitrogen forms caused differential exudation, generalized by abundant amino acids–peptides and alkaloids. Comparatively, nitrogen deficiency decreased nitrogen-containing compounds but increased shikimates-phenylpropanoids. Subsequent bioassays with two shikimates-phenylpropanoids (shikimic and
+                    p
+                    -coumaric acids) on soil bacteria or
+                    Brachypodium
+                    seedlings revealed their distinct capacity to regulate both bacterial and plant growth. Our results suggest that (i)
+                    Brachypodium
+                    alters exudation in response to nitrogen status, which can affect rhizobacterial growth, and (ii) EcoFAB 2.0 is a valuable standardized plant research tool.

--- a/references_cache/PMID_40920748.md
+++ b/references_cache/PMID_40920748.md
@@ -1,0 +1,132 @@
+---
+reference_id: PMID:40920748
+title: Breaking the reproducibility barrier with standardized protocols for plant-microbiome research.
+authors:
+- Novak V
+- Andeer PF
+- King E
+- Calabria J
+- Fitzpatrick C
+- Kelm JM
+- Wippel K
+- Kosina SM
+- Bowen BP
+- Daum C
+- Zane M
+- Yadav A
+- Chen M
+- Russ D
+- Adams CA
+- Owens TK
+- Lee B
+- Ding Y
+- Sordo Z
+- Chakraborty R
+- Roux S
+- Deutschbauer AM
+- Ushizima D
+- Zengler K
+- Arsova B
+- Dangl JL
+- Schulze-Lefert P
+- Watt M
+- Vogel JP
+- Northen TR
+journal: PLoS Biol
+year: '2025'
+doi: 10.1371/journal.pbio.3003358
+keywords:
+- Plants/microbiology
+- Microbiota
+- Reproducibility of Results
+- Poaceae/microbiology
+- Laboratories/standards
+- Burkholderiaceae
+- Rhizosphere
+content_type: abstract_only
+---
+
+# Breaking the reproducibility barrier with standardized protocols for plant-microbiome research.
+**Authors:** Novak V, Andeer PF, King E, Calabria J, Fitzpatrick C, Kelm JM, Wippel K, Kosina SM, Bowen BP, Daum C, Zane M, Yadav A, Chen M, Russ D, Adams CA, Owens TK, Lee B, Ding Y, Sordo Z, Chakraborty R, Roux S, Deutschbauer AM, Ushizima D, Zengler K, Arsova B, Dangl JL, Schulze-Lefert P, Watt M, Vogel JP, Northen TR
+**Journal:** PLoS Biol (2025)
+**DOI:** [10.1371/journal.pbio.3003358](https://doi.org/10.1371/journal.pbio.3003358)
+
+## Content
+
+1. PLoS Biol. 2025 Sep 8;23(9):e3003358. doi: 10.1371/journal.pbio.3003358. 
+eCollection 2025 Sep.
+
+Breaking the reproducibility barrier with standardized protocols for 
+plant-microbiome research.
+
+Novak V(1), Andeer PF(1), King E(2)(3), Calabria J(4), Fitzpatrick C(5), Kelm 
+JM(6), Wippel K(7)(8), Kosina SM(1), Bowen BP(1)(2), Daum C(2), Zane M(2), Yadav 
+A(9), Chen M(9), Russ D(5), Adams CA(1)(10), Owens TK(1), Lee B(2)(10), Ding 
+Y(1), Sordo Z(11), Chakraborty R(9), Roux S(2), Deutschbauer AM(1)(10), Ushizima 
+D(11), Zengler K(12)(13)(14)(15), Arsova B(6), Dangl JL(5), Schulze-Lefert P(7), 
+Watt M(4), Vogel JP(2), Northen TR(1)(2).
+
+Author information:
+(1)Environmental Genomics and Systems Biology, Lawrence Berkeley National 
+Laboratory, Berkeley, California, United States of America.
+(2)The DOE Joint Genome Institute, Lawrence Berkeley National Laboratory, 
+Berkeley, California, United States of America.
+(3)Centro de Biotecnología y Genómica de Plantas, Universidad Politécnica de 
+Madrid (UPM)-Instituto Nacional de Investigación y Tecnología Agraria y 
+Alimentación (INIA/CSIC), Campus de Montegancedo, Madrid, Spain.
+(4)Faculty of Science, School of BioSciences, The University of Melbourne, 
+Parkville, Australia.
+(5)Department of Biology and Howard Hughes Medical Institute, University of 
+North Carolina at Chapel Hill, Chapel Hill, North Carolina, United States of 
+America.
+(6)Institute for Bio- and Geosciences, Plant Sciences (IBG-2), Forschungszentrum 
+Jülich GmbH, Jülich, Germany.
+(7)Max Planck Institute for Plant Breeding Research, Cologne, Germany.
+(8)Swammerdam Institute for Life Sciences, University of Amsterdam, Science Park 
+Amsterdam, Amsterdam, The Netherlands.
+(9)Earth and Environmental Sciences, Lawrence Berkeley National Laboratory, 
+Berkeley, California, United States of America.
+(10)Department of Plant and Microbial Biology, University of 
+California-Berkeley, Berkeley, California, United States of America.
+(11)Computing Sciences Area, Lawrence Berkeley National Laboratory, Berkeley, 
+California, United States of America.
+(12)Department of Pediatrics, University of California, San Diego, La Jolla, 
+California, United States of America.
+(13)Department of Bioengineering, University of California, San Diego, La Jolla, 
+California, United States of America.
+(14)Center for Microbiome Innovation, University of California, San Diego, La 
+Jolla, California, United States of America.
+(15)Program in Materials Science and Engineering, University of California, San 
+Diego, La Jolla, California, United States of America.
+
+Inter-laboratory replicability is crucial yet challenging in microbiome 
+research. Leveraging microbiomes to promote soil health and plant growth 
+requires understanding underlying molecular mechanisms using reproducible 
+experimental systems. In a global collaborative effort involving five 
+laboratories, we aimed to help advance reproducibility in microbiome studies by 
+testing our ability to replicate synthetic community assembly experiments. Our 
+study compared fabricated ecosystems constructed using two different synthetic 
+bacterial communities, the model grass Brachypodium distachyon, and sterile 
+EcoFAB 2.0 devices. All participating laboratories observed consistent 
+inoculum-dependent changes in plant phenotype, root exudate composition, and 
+final bacterial community structure, where Paraburkholderia sp. OAS925 could 
+dramatically shift microbiome composition. Comparative genomics and exudate 
+utilization linked the pH-dependent colonization ability of Paraburkholderia, 
+which was further confirmed with motility assays. The study provides detailed 
+protocols, benchmarking datasets, and best practices to help advance replicable 
+science and inform future multi-laboratory reproducibility studies.
+
+Copyright: © 2025 Novak et al. This is an open access article distributed under 
+the terms of the Creative Commons Attribution License, which permits 
+unrestricted use, distribution, and reproduction in any medium, provided the 
+original author and source are credited.
+
+DOI: 10.1371/journal.pbio.3003358
+PMCID: PMC12416739
+PMID: 40920748 [Indexed for MEDLINE]
+
+Conflict of interest statement: I have read the journal’s policy and the authors 
+of this manuscript have the following competing interests: P.F.A. and T.R.N. are 
+inventors of patent US11510376B2, held by the University of California, covering 
+an Ecosystem device for determining plant-microbe interactions. All other 
+authors have declared that no competing interests exist.


### PR DESCRIPTION
## Why this change
After adding `engineering_design` to the schema, we need consistency across existing engineered plant/SynCom records.

For biologists, this provides a uniform summary of design objective, assembly approach, perturbation context, and readouts across comparable studies.

## What changed
- Backfilled `engineering_design` in 15 plant/SynCom-focused engineered or synthetic community files.
- Added two directly relevant cache files:
  - `references_cache/PMID_40920748.md`
  - `references_cache/DOI_10.1126_sciadv.adg7888.md`

## Example YAML snippet
```yaml
engineering_design:
  objective: Quantify assembly dynamics and interaction mechanisms in a defined rhizosphere SynCom.
  assembly_strategy: Bottom-up synthetic assembly from selected rhizosphere isolates.
  measurement_endpoints:
  - Time-series strain abundance profiling
  - Interaction-level mechanistic characterization
```

## Why this is biologically useful
This improves cross-study interpretation of plant microbiome engineering strategies and helps compare studies by design logic, not only by taxonomy.

## Stack context
- Base branch: PR #7

## Validation
- `just validate-all` passed in stacked branch
