### PR TITLE
Add MSC-2 model soil consortium entry

### DIFF
--- a/docs/communities/MSC2_Model_Soil_Consortium.html
+++ b/docs/communities/MSC2_Model_Soil_Consortium.html
@@ -1,0 +1,1213 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Model Soil Consortium-2 (MSC-2) - CommunityMech</title>
+    <style>
+        :root {
+            --primary: #2563eb;
+            --secondary: #64748b;
+            --background: #f8fafc;
+            --card: #ffffff;
+            --border: #e2e8f0;
+            --text: #1e293b;
+            --text-muted: #64748b;
+            --success: #10b981;
+            --warning: #f59e0b;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background: var(--background);
+            color: var(--text);
+            line-height: 1.6;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 2rem;
+        }
+
+        header {
+            background: var(--card);
+            border-bottom: 2px solid var(--primary);
+            padding: 1.5rem 0;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            color: var(--primary);
+            font-size: 2rem;
+            margin-bottom: 0.5rem;
+        }
+
+        h2 {
+            color: var(--text);
+            font-size: 1.5rem;
+            margin: 2rem 0 1rem;
+            border-bottom: 1px solid var(--border);
+            padding-bottom: 0.5rem;
+        }
+
+        h3 {
+            color: var(--text);
+            font-size: 1.25rem;
+            margin: 1.5rem 0 0.75rem;
+        }
+
+        .metadata {
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .metadata-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 1rem;
+            margin-top: 1rem;
+        }
+
+        .metadata-item {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .metadata-label {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin-bottom: 0.25rem;
+        }
+
+        .metadata-value {
+            color: var(--text);
+            font-size: 1rem;
+        }
+
+        .badge {
+            display: inline-block;
+            padding: 0.25rem 0.75rem;
+            border-radius: 12px;
+            font-size: 0.875rem;
+            font-weight: 500;
+        }
+
+        .badge-engineered { background: #dbeafe; color: #1e40af; }
+        .badge-natural { background: #d1fae5; color: #065f46; }
+
+        .description {
+            background: var(--card);
+            border-left: 4px solid var(--primary);
+            padding: 1rem 1.5rem;
+            margin: 1rem 0;
+            border-radius: 4px;
+        }
+
+        table {
+            width: 100%;
+            background: var(--card);
+            border-radius: 8px;
+            overflow: hidden;
+            border: 1px solid var(--border);
+            margin: 1rem 0;
+        }
+
+        th, td {
+            padding: 0.75rem 1rem;
+            text-align: left;
+        }
+
+        th {
+            background: #f1f5f9;
+            font-weight: 600;
+            color: var(--text);
+            border-bottom: 2px solid var(--border);
+        }
+
+        tr:not(:last-child) td {
+            border-bottom: 1px solid var(--border);
+        }
+
+        .term-link {
+            color: var(--primary);
+            text-decoration: none;
+            font-family: 'Courier New', monospace;
+            font-size: 0.875rem;
+        }
+
+        .term-link:hover {
+            text-decoration: underline;
+        }
+
+        .interaction-card {
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 1.5rem;
+            margin: 1rem 0;
+        }
+
+        .interaction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 1rem;
+        }
+
+        .interaction-type {
+            padding: 0.25rem 0.75rem;
+            background: #f0fdf4;
+            color: #166534;
+            border-radius: 4px;
+            font-size: 0.875rem;
+            font-weight: 500;
+        }
+
+        .interaction-flow {
+            background: #fafafa;
+            border-left: 3px solid var(--primary);
+            padding: 1rem;
+            margin: 1rem 0;
+            border-radius: 4px;
+        }
+
+        .flow-item {
+            margin: 0.5rem 0;
+        }
+
+        .flow-arrow {
+            color: var(--primary);
+            margin: 0 0.5rem;
+        }
+
+        .evidence-list {
+            list-style: none;
+            margin: 0.5rem 0;
+        }
+
+        .evidence-item {
+            background: #fefce8;
+            border-left: 3px solid #ca8a04;
+            padding: 0.75rem;
+            margin: 0.5rem 0;
+            border-radius: 4px;
+        }
+
+        .empty-state {
+            background: #f8fafc;
+            border: 1px dashed #cbd5e1;
+            border-radius: 8px;
+            padding: 2rem;
+            text-align: center;
+            color: #64748b;
+        }
+
+        .empty-state p {
+            margin: 0.5rem 0;
+        }
+
+        .empty-state-note {
+            font-size: 0.875rem;
+            color: #94a3b8;
+        }
+
+        .pmid-link {
+            color: var(--primary);
+            text-decoration: none;
+            font-weight: 500;
+        }
+
+        .pmid-link:hover {
+            text-decoration: underline;
+        }
+
+        .snippet {
+            color: var(--text-muted);
+            font-style: italic;
+            font-size: 0.875rem;
+            margin-top: 0.5rem;
+        }
+
+        .roles-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }
+
+        .role-badge {
+            padding: 0.25rem 0.5rem;
+            background: #ede9fe;
+            color: #5b21b6;
+            border-radius: 4px;
+            font-size: 0.75rem;
+            font-weight: 500;
+        }
+
+        .dataset-description {
+            color: var(--text-muted);
+            font-size: 0.875rem;
+        }
+
+        footer {
+            margin-top: 3rem;
+            padding-top: 2rem;
+            border-top: 1px solid var(--border);
+            text-align: center;
+            color: var(--text-muted);
+            font-size: 0.875rem;
+        }
+
+        .back-link {
+            display: inline-block;
+            color: var(--primary);
+            text-decoration: none;
+            margin-bottom: 1rem;
+        }
+
+        .back-link:hover {
+            text-decoration: underline;
+        }
+
+        /* Network diagram */
+        .network-container {
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 1rem;
+            margin: 1rem 0 2rem;
+            position: relative;
+        }
+
+        .network-container svg {
+            width: 100%;
+            display: block;
+        }
+
+        .network-legend {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+            padding: 0.75rem 0 0;
+            border-top: 1px solid var(--border);
+            margin-top: 0.5rem;
+            font-size: 0.8rem;
+            color: var(--text-muted);
+        }
+
+        .legend-item {
+            display: flex;
+            align-items: center;
+            gap: 0.35rem;
+        }
+
+        .legend-swatch {
+            width: 14px;
+            height: 14px;
+            border-radius: 3px;
+            display: inline-block;
+        }
+
+        .legend-circle {
+            border-radius: 50%;
+        }
+
+        .network-tooltip {
+            position: absolute;
+            background: rgba(30, 41, 59, 0.95);
+            color: #f8fafc;
+            padding: 0.5rem 0.75rem;
+            border-radius: 6px;
+            font-size: 0.8rem;
+            line-height: 1.4;
+            pointer-events: none;
+            opacity: 0;
+            transition: opacity 0.15s;
+            max-width: 280px;
+            z-index: 10;
+        }
+
+        .network-tooltip strong {
+            color: #93c5fd;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <h1>Model Soil Consortium-2 (MSC-2)</h1>
+        </div>
+    </header>
+
+    <main class="container">
+        <!-- Metadata Overview -->
+        <section class="metadata">
+            <div class="metadata-grid">
+                <div class="metadata-item">
+                    <span class="metadata-label">Ecological State</span>
+                    <span class="metadata-value">
+                        <span class="badge badge-engineered">
+                            ENGINEERED
+                        </span>
+                    </span>
+                </div>
+
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Environment</span>
+                    <span class="metadata-value">
+                        grassland soil
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_00001998"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:00001998
+                        </a>
+                    </span>
+                </div>
+                
+
+                <div class="metadata-item">
+                    <span class="metadata-label">Source File</span>
+                    <span class="metadata-value">MSC2_Model_Soil_Consortium.yaml</span>
+                </div>
+            </div>
+        </section>
+
+        <!-- Description -->
+        
+        <section class="description">
+            <p>Reduced-complexity model soil consortium assembled from MSC-1 isolates to study community-level chitin decomposition, interspecies interactions, and emergent phenotypes in soil. MSC-2 contains eight bacterial members spanning diverse phyla and was used for isolate genome sequencing, 16S profiling, metatranscriptomics, metabolomics, and KBase-enabled metabolic modeling in the Hofmockel Soil Microbiome SFA context.</p>
+        </section>
+        
+
+        <!-- Taxonomy -->
+        
+        <section>
+            <h2>Taxonomy</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Taxon</th>
+                        <th>Ontology ID</th>
+                        <th>Functional Roles</th>
+                        <th>Abundance</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    
+                    <tr>
+                        <td>
+                            <strong>Streptomyces sp. MSC1_001</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1931"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:1931
+                            </a>
+                        </td>
+                        <td>
+                            
+                            <div class="roles-list">
+                                
+                                <span class="role-badge">CROSS_FEEDER</span>
+                                
+                            </div>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>
+                            <strong>Neorhizobium tomejilense MSC1_005</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=2093828"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:2093828
+                            </a>
+                        </td>
+                        <td>
+                            
+                            <div class="roles-list">
+                                
+                                <span class="role-badge">CROSS_FEEDER</span>
+                                
+                            </div>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>
+                            <strong>Dyadobacter sp. MSC1_007</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1914288"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:1914288
+                            </a>
+                        </td>
+                        <td>
+                            
+                            <div class="roles-list">
+                                
+                                <span class="role-badge">PRIMARY_DEGRADER</span>
+                                
+                            </div>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>
+                            <strong>Sphingopyxis sp. MSC1_008</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1908224"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:1908224
+                            </a>
+                        </td>
+                        <td>
+                            
+                            <div class="roles-list">
+                                
+                                <span class="role-badge">CROSS_FEEDER</span>
+                                
+                            </div>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>
+                            <strong>Ensifer adhaerens MSC1_011</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=106592"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:106592
+                            </a>
+                        </td>
+                        <td>
+                            
+                            <div class="roles-list">
+                                
+                                <span class="role-badge">PRIMARY_DEGRADER</span>
+                                
+                            </div>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>
+                            <strong>Variovorax beijingensis MSC1_012</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=2496117"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:2496117
+                            </a>
+                        </td>
+                        <td>
+                            
+                            <div class="roles-list">
+                                
+                                <span class="role-badge">PRIMARY_DEGRADER</span>
+                                
+                                <span class="role-badge">CROSS_FEEDER</span>
+                                
+                            </div>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>
+                            <strong>Sinorhizobium meliloti MSC1_014</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=382"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:382
+                            </a>
+                        </td>
+                        <td>
+                            
+                            <div class="roles-list">
+                                
+                                <span class="role-badge">PRIMARY_DEGRADER</span>
+                                
+                            </div>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>
+                            <strong>Rhodococcus sp. MSC1_016</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1827"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:1827
+                            </a>
+                        </td>
+                        <td>
+                            
+                            <div class="roles-list">
+                                
+                                <span class="role-badge">PRIMARY_DEGRADER</span>
+                                
+                            </div>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                </tbody>
+            </table>
+        </section>
+        
+
+        <!-- Ecological Interactions -->
+        <section>
+            <h2>Ecological Interactions</h2>
+        
+
+            <!-- Network Diagram -->
+            <div class="network-container" id="network-container">
+                <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
+                <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
+                    <title id="network-svg-title">Ecological interaction network for Model Soil Consortium-2 (MSC-2)</title>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, syntrophy, competition, commensalism).</desc>
+                </svg>
+                <div class="network-legend">
+                    <div class="legend-item">
+                        <span class="legend-swatch legend-circle" style="background: #3b82f6;"></span> Taxon
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #22c55e;"></span> Cross-feeding
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #3b82f6;"></span> Mutualism
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #a855f7;"></span> Syntrophy
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #ef4444;"></span> Competition
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #f97316;"></span> Commensalism
+                    </div>
+                </div>
+            </div>
+
+            
+            <div class="interaction-card">
+                <div class="interaction-header">
+                    <h3>Chitin Breakdown Product Sharing</h3>
+                    <span class="interaction-type">CROSS_FEEDING</span>
+                </div>
+
+                
+
+                
+
+                
+                <p><strong>Metabolites:</strong>
+                    
+                    chitin
+                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=18246"
+                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:18246</a>)
+                    
+                </p>
+                
+
+                
+
+                
+                <div class="interaction-flow">
+                    <strong>Downstream Effects:</strong>
+                    
+                    <div class="flow-item">
+                        <span class="flow-arrow">→</span> Community growth on chitin decomposition products
+                    </div>
+                    
+                </div>
+                
+
+                
+                <h4>Evidence</h4>
+                <ul class="evidence-list">
+                    
+                    <li class="evidence-item">
+                        <div>
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/36154140/"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:36154140</a>
+                            
+                            - SUPPORT (IN_VITRO)
+                        </div>
+                        
+                        <div class="snippet">"the most abundant members of MSC-2 were not those that were able to metabolize chitin itself, but rather those that were able to take full advantage of interspecies interactions to grow on chitin decomposition products"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="interaction-card">
+                <div class="interaction-header">
+                    <h3>Community-Responsive Streptomyces Chitin Phenotype</h3>
+                    <span class="interaction-type">NICHE_PARTITIONING</span>
+                </div>
+
+                
+                <p><strong>Source Taxon:</strong> Streptomyces sp. MSC1_001</p>
+                
+
+                
+
+                
+
+                
+
+                
+                <div class="interaction-flow">
+                    <strong>Downstream Effects:</strong>
+                    
+                    <div class="flow-item">
+                        <span class="flow-arrow">→</span> Distinct functional roles during chitin degradation
+                    </div>
+                    
+                </div>
+                
+
+                
+                <h4>Evidence</h4>
+                <ul class="evidence-list">
+                    
+                    <li class="evidence-item">
+                        <div>
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/36154140/"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:36154140</a>
+                            
+                            - SUPPORT (IN_VITRO)
+                        </div>
+                        
+                        <div class="snippet">"Emergent properties of both species and the community were found, including changes in the chitin degradation potential of Streptomyces species and organization of all species into distinct roles in the chitin degradation process."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+        
+        </section>
+
+        <!-- Associated Datasets -->
+        
+        <section>
+            <h2>Associated Datasets</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Dataset</th>
+                        <th>Type</th>
+                        <th>Repository</th>
+                        <th>Accession</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    
+                    <tr>
+                        <td>
+                            <strong>MSC-2 isolate genomes</strong>
+                            
+                            <br><span class="dataset-description">BioProject containing the eight isolate genome assemblies used for MSC-2.</span>
+                            
+                        </td>
+                        <td><span class="role-badge">GENOME</span></td>
+                        <td>NCBI_BIOPROJECT</td>
+                        <td>
+                            
+                            <a href="https://www.ncbi.nlm.nih.gov/bioproject/PRJNA788902" class="term-link" target="_blank" rel="noopener noreferrer">PRJNA788902</a>
+                            
+                        </td>
+                    </tr>
+                    
+                    <tr>
+                        <td>
+                            <strong>MSC-2 bacterial isolate genomes (PNNL DataHub)</strong>
+                            
+                            <br><span class="dataset-description">PNNL DataHub record linking the MSC-2 isolate genome assemblies and accessions.</span>
+                            
+                        </td>
+                        <td><span class="role-badge">GENOME</span></td>
+                        <td>OTHER</td>
+                        <td>
+                            
+                            <a href="https://data.pnnl.gov/group/nodes/dataset/33234" class="term-link" target="_blank" rel="noopener noreferrer">10.25584/PNNLDH/1986536</a>
+                            
+                        </td>
+                    </tr>
+                    
+                    <tr>
+                        <td>
+                            <strong>MSC-2 16S growth dataset</strong>
+                            
+                            <br><span class="dataset-description">16S rRNA gene data from MSC-2 growth experiments.</span>
+                            
+                        </td>
+                        <td><span class="role-badge">AMPLICON_16S</span></td>
+                        <td>OTHER</td>
+                        <td>
+                            
+                            <a href="https://data.pnnl.gov/group/nodes/dataset/33231" class="term-link" target="_blank" rel="noopener noreferrer">PNNLDH:33231</a>
+                            
+                        </td>
+                    </tr>
+                    
+                    <tr>
+                        <td>
+                            <strong>MSC-2 metatranscriptomic dataset</strong>
+                            
+                            <br><span class="dataset-description">Metatranscriptomic data from MSC-2 chitin growth assays.</span>
+                            
+                        </td>
+                        <td><span class="role-badge">METATRANSCRIPTOME</span></td>
+                        <td>OTHER</td>
+                        <td>
+                            
+                            <a href="https://data.pnnl.gov/group/nodes/dataset/33232" class="term-link" target="_blank" rel="noopener noreferrer">PNNLDH:33232</a>
+                            
+                        </td>
+                    </tr>
+                    
+                    <tr>
+                        <td>
+                            <strong>MSC-2 primary publication</strong>
+                            
+                            <br><span class="dataset-description">Primary publication describing MSC-2 assembly, multiomics, and community interaction results.</span>
+                            
+                        </td>
+                        <td><span class="role-badge">OTHER</span></td>
+                        <td>OTHER</td>
+                        <td>
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/36154140/" class="term-link" target="_blank" rel="noopener noreferrer">PMID:36154140</a>
+                            
+                        </td>
+                    </tr>
+                    
+                </tbody>
+            </table>
+        </section>
+        
+
+        <!-- Environmental Factors -->
+        
+
+        <!-- Growth Media -->
+        
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>Generated by CommunityMech | <a href="https://github.com/CultureBotAI/CommunityMech">View on GitHub</a></p>
+        </div>
+    </footer>
+
+    
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script>
+    (function() {
+        var interactionColors = {
+            CROSS_FEEDING: "#22c55e",
+            MUTUALISM: "#3b82f6",
+            SYNTROPHY: "#a855f7",
+            COMPETITION: "#ef4444",
+            COMMENSALISM: "#f97316"
+        };
+
+        // Build taxon lookup keyed by preferred_term
+        var taxonData = {};
+        
+        taxonData["Streptomyces sp. MSC1_001"] = {
+            id: "NCBITaxon:1931",
+            label: "Streptomyces sp. MSC1_001",
+            abundance: "UNKNOWN",
+            roles: ["CROSS_FEEDER"]
+        };
+        
+        taxonData["Neorhizobium tomejilense MSC1_005"] = {
+            id: "NCBITaxon:2093828",
+            label: "Neorhizobium tomejilense MSC1_005",
+            abundance: "UNKNOWN",
+            roles: ["CROSS_FEEDER"]
+        };
+        
+        taxonData["Dyadobacter sp. MSC1_007"] = {
+            id: "NCBITaxon:1914288",
+            label: "Dyadobacter sp. MSC1_007",
+            abundance: "UNKNOWN",
+            roles: ["PRIMARY_DEGRADER"]
+        };
+        
+        taxonData["Sphingopyxis sp. MSC1_008"] = {
+            id: "NCBITaxon:1908224",
+            label: "Sphingopyxis sp. MSC1_008",
+            abundance: "UNKNOWN",
+            roles: ["CROSS_FEEDER"]
+        };
+        
+        taxonData["Ensifer adhaerens MSC1_011"] = {
+            id: "NCBITaxon:106592",
+            label: "Ensifer adhaerens MSC1_011",
+            abundance: "UNKNOWN",
+            roles: ["PRIMARY_DEGRADER"]
+        };
+        
+        taxonData["Variovorax beijingensis MSC1_012"] = {
+            id: "NCBITaxon:2496117",
+            label: "Variovorax beijingensis MSC1_012",
+            abundance: "UNKNOWN",
+            roles: ["PRIMARY_DEGRADER", "CROSS_FEEDER"]
+        };
+        
+        taxonData["Sinorhizobium meliloti MSC1_014"] = {
+            id: "NCBITaxon:382",
+            label: "Sinorhizobium meliloti MSC1_014",
+            abundance: "UNKNOWN",
+            roles: ["PRIMARY_DEGRADER"]
+        };
+        
+        taxonData["Rhodococcus sp. MSC1_016"] = {
+            id: "NCBITaxon:1827",
+            label: "Rhodococcus sp. MSC1_016",
+            abundance: "UNKNOWN",
+            roles: ["PRIMARY_DEGRADER"]
+        };
+        
+
+        // Build nodes and links
+        var nodes = [];
+        var links = [];
+        var taxonNodeIds = {};
+
+        // Add taxon nodes
+        Object.keys(taxonData).forEach(function(key) {
+            var t = taxonData[key];
+            var nodeId = "taxon:" + key;
+            taxonNodeIds[key] = nodeId;
+            nodes.push({
+                id: nodeId,
+                label: t.label,
+                type: "taxon",
+                abundance: t.abundance,
+                roles: t.roles,
+                ontologyId: t.id
+            });
+        });
+
+        // Add interaction nodes and edges
+        
+        (function() {
+            var intId = "interaction:0";
+            var intType = "CROSS_FEEDING";
+            var metabolites = [];
+            
+            
+            metabolites.push("chitin");
+            
+            
+            var processes = [];
+            
+            var evidenceCount = 1;
+
+            nodes.push({
+                id: intId,
+                label: "Chitin Breakdown Product Sharing",
+                type: "interaction",
+                interactionType: intType,
+                metabolites: metabolites,
+                processes: processes,
+                evidenceCount: evidenceCount
+            });
+
+            
+
+            
+        })();
+        
+        (function() {
+            var intId = "interaction:1";
+            var intType = "NICHE_PARTITIONING";
+            var metabolites = [];
+            
+            var processes = [];
+            
+            var evidenceCount = 1;
+
+            nodes.push({
+                id: intId,
+                label: "Community-Responsive Streptomyces Chitin Phenotype",
+                type: "interaction",
+                interactionType: intType,
+                metabolites: metabolites,
+                processes: processes,
+                evidenceCount: evidenceCount
+            });
+
+            
+            var srcKey = "Streptomyces sp. MSC1_001";
+            if (taxonNodeIds[srcKey]) {
+                links.push({ source: taxonNodeIds[srcKey], target: intId });
+            }
+            
+
+            
+        })();
+        
+
+        // Remove taxon nodes with no connections
+        var connectedIds = new Set();
+        links.forEach(function(l) {
+            connectedIds.add(typeof l.source === "object" ? l.source.id : l.source);
+            connectedIds.add(typeof l.target === "object" ? l.target.id : l.target);
+        });
+        nodes = nodes.filter(function(n) {
+            return n.type === "interaction" || connectedIds.has(n.id);
+        });
+
+        // D3 setup
+        var container = document.getElementById("network-container");
+        var svg = d3.select("#network-svg");
+        var width = container.clientWidth - 32;
+        // Dynamic height based on node count: minimum 500px, add 40px per node
+        var nodeCount = 10;
+        var height = Math.max(500, 400 + nodeCount * 20);
+        svg.attr("width", width).attr("height", height);
+
+        // Arrow marker
+        svg.append("defs").append("marker")
+            .attr("id", "arrowhead")
+            .attr("viewBox", "0 -5 10 10")
+            .attr("refX", 20)
+            .attr("refY", 0)
+            .attr("markerWidth", 6)
+            .attr("markerHeight", 6)
+            .attr("orient", "auto")
+            .append("path")
+            .attr("d", "M0,-5L10,0L0,5")
+            .attr("fill", "#94a3b8");
+
+        var simulation = d3.forceSimulation(nodes)
+            .force("link", d3.forceLink(links).id(function(d) { return d.id; }).distance(100))
+            .force("charge", d3.forceManyBody().strength(-400))
+            .force("center", d3.forceCenter(width / 2, height / 2))
+            .force("collision", d3.forceCollide().radius(40))
+            .force("x", d3.forceX(width / 2).strength(0.05))
+            .force("y", d3.forceY(height / 2).strength(0.05));
+
+        var link = svg.append("g")
+            .selectAll("line")
+            .data(links)
+            .join("line")
+            .attr("stroke", "#94a3b8")
+            .attr("stroke-width", 1.5)
+            .attr("marker-end", "url(#arrowhead)");
+
+        var node = svg.append("g")
+            .selectAll("g")
+            .data(nodes)
+            .join("g")
+            .style("cursor", "pointer");
+
+        // Taxon nodes: circles
+        node.filter(function(d) { return d.type === "taxon"; })
+            .append("circle")
+            .attr("r", function(d) { return d.abundance === "DOMINANT" ? 18 : 12; })
+            .attr("fill", "#3b82f6")
+            .attr("stroke", "#1e40af")
+            .attr("stroke-width", 1.5);
+
+        // Interaction nodes: rounded rects
+        node.filter(function(d) { return d.type === "interaction"; })
+            .append("rect")
+            .attr("width", 28)
+            .attr("height", 18)
+            .attr("x", -14)
+            .attr("y", -9)
+            .attr("rx", 5)
+            .attr("fill", function(d) { return interactionColors[d.interactionType] || "#6b7280"; })
+            .attr("stroke", function(d) {
+                var c = d3.color(interactionColors[d.interactionType] || "#6b7280");
+                return c ? c.darker(0.5) : "#4b5563";
+            })
+            .attr("stroke-width", 1.5);
+
+        // Labels for taxa (positioned below circle)
+        node.filter(function(d) { return d.type === "taxon"; })
+            .append("text")
+            .text(function(d) {
+                var parts = d.label.split(" ");
+                return parts.length >= 2 ? parts[0][0] + ". " + parts.slice(1).join(" ") : d.label;
+            })
+            .attr("text-anchor", "middle")
+            .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
+            .attr("font-size", "10px")
+            .attr("fill", "#475569");
+
+        // Labels for interactions (multi-line, centered in rectangle)
+        node.filter(function(d) { return d.type === "interaction"; })
+            .each(function(d) {
+                var textElem = d3.select(this).append("text")
+                    .attr("text-anchor", "middle")
+                    .attr("font-size", "9px")
+                    .attr("fill", "#475569")
+                    .style("pointer-events", "none");
+
+                // Word-wrap text to fit in rectangle (max ~24 chars per line)
+                var words = d.label.split(/\s+/);
+                var line = "";
+                var lines = [];
+                var maxWidth = 24;
+
+                for (var i = 0; i < words.length; i++) {
+                    var testLine = line + (line ? " " : "") + words[i];
+                    if (testLine.length > maxWidth && line.length > 0) {
+                        lines.push(line);
+                        line = words[i];
+                    } else {
+                        line = testLine;
+                    }
+                }
+                if (line) lines.push(line);
+
+                // Limit to 3 lines maximum
+                if (lines.length > 3) {
+                    lines = lines.slice(0, 3);
+                    lines[2] = lines[2].substring(0, 21) + "...";
+                }
+
+                // Add tspan for each line
+                var lineHeight = 11;
+                var startY = -(lines.length - 1) * lineHeight / 2;
+                lines.forEach(function(lineText, i) {
+                    textElem.append("tspan")
+                        .attr("x", 0)
+                        .attr("dy", i === 0 ? startY : lineHeight)
+                        .text(lineText);
+                });
+            });
+
+        // Tooltip
+        var tooltip = d3.select("#network-tooltip");
+
+        node.on("mouseenter", function(event, d) {
+            tooltip.selectAll("*").remove();
+            if (d.type === "taxon") {
+                tooltip.append("strong").text(d.label);
+                tooltip.append("br");
+                tooltip.append("span").text(d.ontologyId);
+                tooltip.append("br");
+                tooltip.append("span").text("Abundance: " + d.abundance);
+                if (d.roles.length) {
+                    tooltip.append("br");
+                    tooltip.append("span").text("Roles: " + d.roles.join(", "));
+                }
+            } else {
+                tooltip.append("strong").text(d.label);
+                tooltip.append("br");
+                tooltip.append("span").text(d.interactionType);
+                if (d.metabolites.length) {
+                    tooltip.append("br");
+                    tooltip.append("span").text("Metabolites: " + d.metabolites.join(", "));
+                }
+                if (d.processes.length) {
+                    tooltip.append("br");
+                    tooltip.append("span").text("Processes: " + d.processes.join(", "));
+                }
+                tooltip.append("br");
+                tooltip.append("span").text("Evidence items: " + d.evidenceCount);
+            }
+            tooltip.style("opacity", 1)
+                .style("left", (event.offsetX + 12) + "px")
+                .style("top", (event.offsetY - 12) + "px");
+        })
+        .on("mousemove", function(event) {
+            tooltip.style("left", (event.offsetX + 12) + "px")
+                .style("top", (event.offsetY - 12) + "px");
+        })
+        .on("mouseleave", function() {
+            tooltip.style("opacity", 0);
+        });
+
+        // Tick
+        simulation.on("tick", function() {
+            link.attr("x1", function(d) { return d.source.x; })
+                .attr("y1", function(d) { return d.source.y; })
+                .attr("x2", function(d) { return d.target.x; })
+                .attr("y2", function(d) { return d.target.y; });
+
+            node.attr("transform", function(d) {
+                // Constrain nodes within safe boundaries
+                // Account for: node size, label text, and extra padding
+                var nodeRadius = (d.type === "taxon" && d.abundance === "DOMINANT") ? 18 :
+                                (d.type === "taxon") ? 12 : 14; // interaction nodes
+                var labelOffset = d.type === "taxon" ? 35 : 0; // taxon labels below node
+
+                var marginTop = 40;
+                var marginBottom = 60; // extra space for labels
+                var marginSide = 80; // space for long names
+
+                d.x = Math.max(marginSide, Math.min(width - marginSide, d.x));
+                d.y = Math.max(marginTop, Math.min(height - marginBottom, d.y));
+                return "translate(" + d.x + "," + d.y + ")";
+            });
+        });
+
+        // Stabilize after 300 ticks then stop
+        simulation.alpha(1).alphaDecay(0.02);
+        for (var i = 0; i < 300; i++) simulation.tick();
+        simulation.stop();
+
+        // Apply final positions
+        link.attr("x1", function(d) { return d.source.x; })
+            .attr("y1", function(d) { return d.source.y; })
+            .attr("x2", function(d) { return d.target.x; })
+            .attr("y2", function(d) { return d.target.y; });
+
+        node.attr("transform", function(d) { return "translate(" + d.x + "," + d.y + ")"; });
+    })();
+    </script>
+    
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -422,7 +422,7 @@
                     <button id="search-clear" class="clear-btn" title="Clear search">✕</button>
                 </div>
                 <div class="search-results-count">
-                    Showing <span id="results-count">78</span> of 78 communities
+                    Showing <span id="results-count">79</span> of 79 communities
                 </div>
 
                 <!-- Active filters summary -->
@@ -1785,6 +1785,35 @@
                                 <span class="badge badge-STABLE">STABLE</span>
                             </div>
                             <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/MSC2_Model_Soil_Consortium.html"
+                       class="community-card"
+                       data-id="MSC2_Model_Soil_Consortium"
+                       data-name="model soil consortium-2 (msc-2)"
+                       data-description="reduced-complexity model soil consortium assembled from msc-1 isolates to study community-level chitin decomposition, interspecies interactions, and emergent phenotypes in soil. msc-2 contains eight bacterial members spanning diverse phyla and was used for isolate genome sequencing, 16s profiling, metatranscriptomics, metabolomics, and kbase-enabled metabolic modeling in the hofmockel soil microbiome sfa context."
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="8">
+                        <h2>Model Soil Consortium-2 (MSC-2)</h2>
+                        <p class="description">Reduced-complexity model soil consortium assembled from MSC-1 isolates to study community-level chitin decomposition, interspecies interactions, and emergent phenotypes in soil. MSC-2 contains eight bacterial members spanning diverse phyla and was used for isolate genome sequencing, 16S profiling, metatranscriptomics, metabolomics, and KBase-enabled metabolic modeling in the Hofmockel Soil Microbiome SFA context.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    8
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
                         </div>
                     </a>
                     

--- a/kb/communities/MSC2_Model_Soil_Consortium.yaml
+++ b/kb/communities/MSC2_Model_Soil_Consortium.yaml
@@ -1,0 +1,207 @@
+name: Model Soil Consortium-2 (MSC-2)
+description: >-
+  Reduced-complexity model soil consortium assembled from MSC-1 isolates to study
+  community-level chitin decomposition, interspecies interactions, and emergent
+  phenotypes in soil. MSC-2 contains eight bacterial members spanning diverse phyla
+  and was used for isolate genome sequencing, 16S profiling, metatranscriptomics,
+  metabolomics, and KBase-enabled metabolic modeling in the Hofmockel Soil Microbiome
+  SFA context.
+ecological_state: ENGINEERED
+community_origin: SYNTHETIC
+community_category: OTHER
+engineering_design:
+  objective: >-
+    Build a reduced, tractable soil consortium for studying how community context
+    shapes chitin degradation and member success during decomposition.
+  assembly_strategy: >-
+    Eight isolates were selected from MSC-1 to include both chitin degraders and
+    nondegraders while maximizing taxonomic diversity.
+  inoculation_strategy: Eight individually isolated strains assembled into a defined mixed community.
+  passaging_regimen: >-
+    Developed as a reduced-complexity follow-on to the naturally evolved MSC-1 soil
+    consortium for monoculture and coculture chitin assays.
+  measurement_endpoints:
+  - isolate growth on chitin and alternative carbon sources
+  - 16S rRNA community composition profiling
+  - metatranscriptomics during community growth on chitin
+  - community metabolomics during chitin decomposition
+  notes: >-
+    The KBase Soil Microbiome SFA page describes MSC-2 as one of the model consortia
+    used for OMEGGA and ModelSEED2 workflows.
+  evidence:
+  - reference: PMID:36154140
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: 'Chitin was applied to a model soil consortium that we developed, "model soil consortium-2" (MSC-2), consisting of eight members of diverse phyla and including both chitin degraders and nondegraders.'
+    explanation: Supports the reduced eight-member MSC-2 design and mixed degrader/nondegrader composition.
+environment_term:
+  preferred_term: grassland soil
+  term:
+    id: ENVO:00001998
+    label: soil
+  notes: Isolates were derived from IAREC grassland soil in Prosser, Washington.
+taxonomy:
+- taxon_term:
+    preferred_term: Streptomyces sp. MSC1_001
+    term:
+      id: NCBITaxon:1931
+      label: Streptomyces sp.
+  strain_designation:
+    strain_name: MSC1_001
+    genome_accession: GCA_023667545.1
+    genome_url: https://www.ncbi.nlm.nih.gov/assembly/GCA_023667545.1
+  functional_role:
+  - CROSS_FEEDER
+- taxon_term:
+    preferred_term: Neorhizobium tomejilense MSC1_005
+    term:
+      id: NCBITaxon:2093828
+      label: Neorhizobium tomejilense
+  strain_designation:
+    strain_name: MSC1_005
+    genome_accession: GCA_023667605.1
+    genome_url: https://www.ncbi.nlm.nih.gov/assembly/GCA_023667605.1
+  functional_role:
+  - CROSS_FEEDER
+- taxon_term:
+    preferred_term: Dyadobacter sp. MSC1_007
+    term:
+      id: NCBITaxon:1914288
+      label: Dyadobacter sp.
+  strain_designation:
+    strain_name: MSC1_007
+    genome_accession: GCA_023667495.1
+    genome_url: https://www.ncbi.nlm.nih.gov/assembly/GCA_023667495.1
+  functional_role:
+  - PRIMARY_DEGRADER
+- taxon_term:
+    preferred_term: Sphingopyxis sp. MSC1_008
+    term:
+      id: NCBITaxon:1908224
+      label: Sphingopyxis sp.
+  strain_designation:
+    strain_name: MSC1_008
+    genome_accession: GCA_023197165.1
+    genome_url: https://www.ncbi.nlm.nih.gov/assembly/GCA_023197165.1
+  functional_role:
+  - CROSS_FEEDER
+- taxon_term:
+    preferred_term: Ensifer adhaerens MSC1_011
+    term:
+      id: NCBITaxon:106592
+      label: Ensifer adhaerens
+  strain_designation:
+    strain_name: MSC1_011
+    genome_accession: GCA_023667555.1
+    genome_url: https://www.ncbi.nlm.nih.gov/assembly/GCA_023667555.1
+  functional_role:
+  - PRIMARY_DEGRADER
+- taxon_term:
+    preferred_term: Variovorax beijingensis MSC1_012
+    term:
+      id: NCBITaxon:2496117
+      label: Variovorax beijingensis
+  strain_designation:
+    strain_name: MSC1_012
+    genome_accession: GCA_023667525.1
+    genome_url: https://www.ncbi.nlm.nih.gov/assembly/GCA_023667525.1
+  functional_role:
+  - PRIMARY_DEGRADER
+  - CROSS_FEEDER
+- taxon_term:
+    preferred_term: Sinorhizobium meliloti MSC1_014
+    term:
+      id: NCBITaxon:382
+      label: Sinorhizobium meliloti
+  strain_designation:
+    strain_name: MSC1_014
+    genome_accession: GCA_023197145.1
+    genome_url: https://www.ncbi.nlm.nih.gov/assembly/GCA_023197145.1
+  functional_role:
+  - PRIMARY_DEGRADER
+- taxon_term:
+    preferred_term: Rhodococcus sp. MSC1_016
+    term:
+      id: NCBITaxon:1827
+      label: Rhodococcus
+  strain_designation:
+    strain_name: MSC1_016
+    genome_accession: GCA_023667485.1
+    genome_url: https://www.ncbi.nlm.nih.gov/assembly/GCA_023667485.1
+  functional_role:
+  - PRIMARY_DEGRADER
+associated_datasets:
+- name: MSC-2 isolate genomes
+  dataset_type: GENOME
+  repository: NCBI_BIOPROJECT
+  accession: PRJNA788902
+  url: https://www.ncbi.nlm.nih.gov/bioproject/PRJNA788902
+  description: BioProject containing the eight isolate genome assemblies used for MSC-2.
+- name: MSC-2 bacterial isolate genomes (PNNL DataHub)
+  dataset_type: GENOME
+  repository: OTHER
+  accession: 10.25584/PNNLDH/1986536
+  url: https://data.pnnl.gov/group/nodes/dataset/33234
+  description: PNNL DataHub record linking the MSC-2 isolate genome assemblies and accessions.
+- name: MSC-2 16S growth dataset
+  dataset_type: AMPLICON_16S
+  repository: OTHER
+  accession: PNNLDH:33231
+  url: https://data.pnnl.gov/group/nodes/dataset/33231
+  description: 16S rRNA gene data from MSC-2 growth experiments.
+- name: MSC-2 metatranscriptomic dataset
+  dataset_type: METATRANSCRIPTOME
+  repository: OTHER
+  accession: PNNLDH:33232
+  url: https://data.pnnl.gov/group/nodes/dataset/33232
+  description: Metatranscriptomic data from MSC-2 chitin growth assays.
+- name: MSC-2 primary publication
+  dataset_type: OTHER
+  repository: OTHER
+  accession: PMID:36154140
+  url: https://pubmed.ncbi.nlm.nih.gov/36154140/
+  description: Primary publication describing MSC-2 assembly, multiomics, and community interaction results.
+ecological_interactions:
+- name: Chitin Breakdown Product Sharing
+  description: >-
+    Community growth on chitin is supported by interspecies sharing of decomposition
+    products, so the most abundant members are not necessarily the taxa that directly
+    metabolize chitin in monoculture.
+  interaction_type: CROSS_FEEDING
+  metabolites:
+  - preferred_term: chitin
+    term:
+      id: CHEBI:18246
+      label: chitin
+  downstream:
+  - target: Community growth on chitin decomposition products
+  evidence:
+  - reference: PMID:36154140
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the most abundant members of MSC-2 were not those that were able to metabolize chitin itself, but rather those that were able to take full advantage of interspecies interactions to grow on chitin decomposition products
+    explanation: Supports cross-feeding and shared access to products released during community chitin degradation.
+- name: Community-Responsive Streptomyces Chitin Phenotype
+  description: >-
+    Streptomyces exhibits a community-responsive chitin phenotype, and MSC-2 organizes
+    members into distinct functional roles during decomposition.
+  interaction_type: NICHE_PARTITIONING
+  source_taxon:
+    preferred_term: Streptomyces sp. MSC1_001
+    term:
+      id: NCBITaxon:1931
+      label: Streptomyces sp.
+  downstream:
+  - target: Distinct functional roles during chitin degradation
+  evidence:
+  - reference: PMID:36154140
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Emergent properties of both species and the community were found, including changes in the chitin degradation potential of Streptomyces species and organization of all species into distinct roles in the chitin degradation process.
+    explanation: Supports that Streptomyces behavior and community roles depend on the surrounding MSC-2 membership.
+external_resources:
+- name: KBase Soil Microbiome SFA collaboration page
+  repository: KBASE
+  resource_id: hofmockel-sfa
+  url: https://www.kbase.us/research/hofmockel-sfa/
+  description: KBase Soil Microbiome SFA page describing OMEGGA and MSC-2 use in ModelSEED2 workflows.

--- a/kb/communities/MSC2_Model_Soil_Consortium.yaml
+++ b/kb/communities/MSC2_Model_Soil_Consortium.yaml
@@ -1,3 +1,4 @@
+id: CommunityMech:000086
 name: Model Soil Consortium-2 (MSC-2)
 description: >-
   Reduced-complexity model soil consortium assembled from MSC-1 isolates to study

--- a/references_cache/PMID_36154140.md
+++ b/references_cache/PMID_36154140.md
@@ -1,0 +1,96 @@
+---
+reference_id: PMID:36154140
+title: Interaction Networks Are Driven by Community-Responsive Phenotypes in a Chitin-Degrading Consortium of Soil Microbes.
+authors:
+- McClure R
+- Farris Y
+- Danczak R
+- Nelson W
+- Song HS
+- Kessell A
+- Lee JY
+- Couvillion S
+- Henry C
+- Jansson JK
+- Hofmockel KS
+journal: mSystems
+year: '2022'
+doi: 10.1128/msystems.00372-22
+keywords:
+- Chitin/metabolism
+- Soil/chemistry
+- Microbiota/genetics
+- Carbon
+- Nitrogen/metabolism
+content_type: abstract_only
+---
+
+# Interaction Networks Are Driven by Community-Responsive Phenotypes in a Chitin-Degrading Consortium of Soil Microbes.
+**Authors:** McClure R, Farris Y, Danczak R, Nelson W, Song HS, Kessell A, Lee JY, Couvillion S, Henry C, Jansson JK, Hofmockel KS
+**Journal:** mSystems (2022)
+**DOI:** [10.1128/msystems.00372-22](https://doi.org/10.1128/msystems.00372-22)
+
+## Content
+
+1. mSystems. 2022 Oct 26;7(5):e0037222. doi: 10.1128/msystems.00372-22. Epub 2022
+ Sep 26.
+
+Interaction Networks Are Driven by Community-Responsive Phenotypes in a 
+Chitin-Degrading Consortium of Soil Microbes.
+
+McClure R(1), Farris Y(1), Danczak R(1), Nelson W(1), Song HS(2)(3), Kessell 
+A(2), Lee JY(1), Couvillion S(1), Henry C(4), Jansson JK(1), Hofmockel KS(1)(5).
+
+Author information:
+(1)Biological Sciences Division, Pacific Northwest National 
+Laboratorygrid.451303.0, Richland, Washington, USA.
+(2)Department of Biological Systems Engineering, University of Nebraska-Lincoln, 
+Lincoln, Nebraska, USA.
+(3)Department of Food Science and Technology, Nebraska Food for Health Center, 
+University of Nebraska-Lincoln, Lincoln, Nebraska, USA.
+(4)Data Science and Learning Division, Argonne National Laboratory, Lemont, 
+Illinois, USA.
+(5)Department of Agronomy, Iowa State University, Ames, Iowa, USA.
+
+Soil microorganisms provide key ecological functions that often rely on 
+metabolic interactions between individual populations of the soil microbiome. To 
+better understand these interactions and community processes, we used chitin, a 
+major carbon and nitrogen source in soil, as a test substrate to investigate 
+microbial interactions during its decomposition. Chitin was applied to a model 
+soil consortium that we developed, "model soil consortium-2" (MSC-2), consisting 
+of eight members of diverse phyla and including both chitin degraders and 
+nondegraders. A multiomics approach revealed how MSC-2 community-level processes 
+during chitin decomposition differ from monocultures of the constituent species. 
+Emergent properties of both species and the community were found, including 
+changes in the chitin degradation potential of Streptomyces species and 
+organization of all species into distinct roles in the chitin degradation 
+process. The members of MSC-2 were further evaluated via metatranscriptomics and 
+community metabolomics. Intriguingly, the most abundant members of MSC-2 were 
+not those that were able to metabolize chitin itself, but rather those that were 
+able to take full advantage of interspecies interactions to grow on chitin 
+decomposition products. Using a model soil consortium greatly increased our 
+knowledge of how carbon is decomposed and metabolized in a community setting, 
+showing that niche size, rather than species metabolic capacity, can drive 
+success and that certain species become active carbon degraders only in the 
+context of their surrounding community. These conclusions fill important 
+knowledge gaps that are key to our understanding of community interactions that 
+support carbon and nitrogen cycling in soil. IMPORTANCE The soil microbiome 
+performs many functions that are key to ecology, agriculture, and nutrient 
+cycling. However, because of the complexity of this ecosystem we do not know the 
+molecular details of the interactions between microbial species that lead to 
+these important functions. Here, we use a representative but simplified model 
+community of bacteria to understand the details of these interactions. We show 
+that certain species act as primary degraders of carbon sources and that the 
+most successful species are likely those that can take the most advantage of 
+breakdown products, not necessarily the primary degraders. We also show that a 
+species phenotype, including whether it is a primary degrader or not, is driven 
+in large part by the membership of the community it resides in. These 
+conclusions are critical to a better understanding of the soil microbial 
+interaction network and how these interactions drive central soil microbiome 
+functions.
+
+DOI: 10.1128/msystems.00372-22
+PMCID: PMC9599572
+PMID: 36154140 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no conflict of interest.


### PR DESCRIPTION
## Summary
- add a new `MSC-2` CommunityMech entry with member strains, datasets, and a KBase resource
- render the new community HTML page and update the docs index
- add the PubMed cache entry for `PMID:36154140`

## Validation
- `just validate kb/communities/MSC2_Model_Soil_Consortium.yaml`
- `just validate-terms kb/communities/MSC2_Model_Soil_Consortium.yaml`
- `just validate-references kb/communities/MSC2_Model_Soil_Consortium.yaml`
- `just gen-html`
- `just gen-browser`

## Notes
- `just gen-umap` currently fails in this repo because `data/embeddings/DeepWalkSkipGramEnsmallen_degreenorm_embedding_512_2026-02-01_05_54_01.tsv.gz` is missing.