### PR TITLE
Add oral caries and dysbiosis community models

### DIFF
--- a/kb/communities/Defined_Multispecies_Enamel_Caries_Model.yaml
+++ b/kb/communities/Defined_Multispecies_Enamel_Caries_Model.yaml
@@ -1,0 +1,144 @@
+id: CommunityMech:000082
+name: Defined Multispecies Enamel Caries Model
+description: >-
+  A defined four-member oral biofilm model for in vitro enamel caries
+  development, composed of Lactobacillus casei, Streptococcus mutans,
+  Streptococcus salivarius, and Streptococcus sanguinis on
+  salivary-pellicle-coated enamel slabs. The system was used to quantify how
+  sucrose, fluoride, and calcium shift biofilm growth and enamel
+  demineralization.
+ecological_state: ENGINEERED
+community_origin: SYNTHETIC
+community_category: ORAL
+engineering_design:
+  objective: >-
+    Build a defined multispecies enamel caries model that reports dose-dependent
+    effects of sucrose, fluoride, and calcium on biofilm growth and enamel
+    demineralization.
+  assembly_strategy: >-
+    Bottom-up assembly of four oral species on salivary-pellicle-coated enamel
+    slabs with daily medium replacement over a four-day biofilm growth period.
+  perturbation_design: >-
+    Medium sucrose concentration was varied between 0.5 and 1.0%, fluoride
+    between 0.4 and 1.0 ppm, and calcium between 1.0 and 2.0 mM.
+  measurement_endpoints:
+  - Viable cell counts
+  - Surface microhardness change
+  - Lesion depth
+  - Integrated mineral loss
+  evidence:
+  - reference: PMID:23446436
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      Defined-multispecies biofilms, formed by Lactobacillus casei,
+      Streptococcus mutans, S. salivarius and S. sanguinis, were grown on the
+      surface of salivary-pellicle-coated enamel slabs
+    explanation: Supports the member composition and cultivation platform of the model.
+environment_term:
+  preferred_term: cariogenic enamel biofilm on tooth surface
+  term:
+    id: ENVO:01001034
+    label: environment determined by a biofilm on an animal surface
+  notes: >-
+    In vitro enamel caries system using salivary-pellicle-coated enamel slabs
+    as the colonization surface.
+taxonomy:
+- taxon_term:
+    preferred_term: Lactobacillus casei
+    term:
+      id: NCBITaxon:1582
+      label: Lacticaseibacillus casei
+    notes: Study uses the historical name Lactobacillus casei.
+  evidence:
+  - reference: PMID:23446436
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      Defined-multispecies biofilms, formed by Lactobacillus casei,
+      Streptococcus mutans, S. salivarius and S. sanguinis, were grown on the
+      surface of salivary-pellicle-coated enamel slabs
+    explanation: Documents Lactobacillus casei as a member of the enamel caries consortium.
+- taxon_term:
+    preferred_term: Streptococcus mutans
+    term:
+      id: NCBITaxon:1309
+      label: Streptococcus mutans
+  evidence:
+  - reference: PMID:23446436
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      Defined-multispecies biofilms, formed by Lactobacillus casei,
+      Streptococcus mutans, S. salivarius and S. sanguinis, were grown on the
+      surface of salivary-pellicle-coated enamel slabs
+    explanation: Documents Streptococcus mutans as a member of the enamel caries consortium.
+- taxon_term:
+    preferred_term: Streptococcus salivarius
+    term:
+      id: NCBITaxon:1304
+      label: Streptococcus salivarius
+  evidence:
+  - reference: PMID:23446436
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      Defined-multispecies biofilms, formed by Lactobacillus casei,
+      Streptococcus mutans, S. salivarius and S. sanguinis, were grown on the
+      surface of salivary-pellicle-coated enamel slabs
+    explanation: Documents Streptococcus salivarius as a member of the enamel caries consortium.
+- taxon_term:
+    preferred_term: Streptococcus sanguinis
+    term:
+      id: NCBITaxon:1305
+      label: Streptococcus sanguinis
+  evidence:
+  - reference: PMID:23446436
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      Defined-multispecies biofilms, formed by Lactobacillus casei,
+      Streptococcus mutans, S. salivarius and S. sanguinis, were grown on the
+      surface of salivary-pellicle-coated enamel slabs
+    explanation: Documents Streptococcus sanguinis as a member of the enamel caries consortium.
+environmental_factors:
+- name: Sucrose concentration
+  value: 0.5-1.0
+  unit: '%'
+  description: >-
+    Sucrose was titrated to test how carbohydrate supply alters multispecies
+    growth and enamel demineralization.
+  evidence:
+  - reference: PMID:23446436
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      The aims of this study were to describe and validate an in vitro
+      multispecies microbial biofilm model for caries development by evaluating
+      the effects of varying medium concentration of sucrose (0.5 and 1.0%)
+    explanation: Documents the sucrose range used in the enamel caries model.
+- name: Fluoride concentration
+  value: 0.4-1.0
+  unit: ppm
+  description: Fluoride was varied to quantify inhibition of biofilm-driven enamel caries.
+  evidence:
+  - reference: PMID:23446436
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      There was a decrease in %SMC in response to increased fluoride and
+      calcium concentrations (p < 0.001). Lower IML (p < 0.001) and LD (p <
+      0.05) were found in the presence of 0.8 and 1.0 ppm F.
+    explanation: Supports fluoride-dependent attenuation of enamel demineralization.
+- name: Calcium concentration
+  value: 1.0-2.0
+  unit: mM
+  description: Calcium supplementation was varied to test its effect on caries inhibition.
+  evidence:
+  - reference: PMID:23446436
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      There was a decrease in %SMC in response to increased fluoride and
+      calcium concentrations (p < 0.001).
+    explanation: Supports calcium as a controlled environmental factor in the model.

--- a/kb/communities/Early_Dental_Biofilm_FiveSpecies.yaml
+++ b/kb/communities/Early_Dental_Biofilm_FiveSpecies.yaml
@@ -1,0 +1,142 @@
+id: CommunityMech:000081
+name: Early Dental Biofilm Five-Species Model
+description: >-
+  A defined five-member oral biofilm model representing early acidogenic stages
+  of the caries process. The community combines Streptococcus oralis,
+  Streptococcus sanguinis, Streptococcus mitis, Streptococcus downei, and
+  Actinomyces naeslundii in flow-channel biofilms to reproduce the composition,
+  architecture, and microscale pH heterogeneity of early dental plaque.
+ecological_state: ENGINEERED
+community_origin: SYNTHETIC
+community_category: ORAL
+engineering_design:
+  objective: >-
+    Model early acidogenic dental plaque and resolve extracellular pH
+    microenvironments during glucose challenge.
+  assembly_strategy: >-
+    Bottom-up assembly of five oral isolates selected to mimic the bacterial
+    community present during early acidogenic stages of caries.
+  perturbation_design: >-
+    Biofilms were grown in flow channels and challenged with salivary
+    solutions containing glucose for time-resolved pH imaging at the
+    biofilm-substrate interface.
+  measurement_endpoints:
+  - Fluorescence in situ hybridization
+  - Confocal laser scanning microscopy
+  - Real-time extracellular pH imaging
+  evidence:
+  - reference: PMID:21966490
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      In this study, we designed a laboratory biofilm model that mimics the
+      bacterial community present during early acidogenic stages of the caries
+      process.
+    explanation: Supports the purpose and composition rationale of the model.
+environment_term:
+  preferred_term: dental plaque biofilm on tooth surface
+  term:
+    id: ENVO:01001034
+    label: environment determined by a biofilm on an animal surface
+  notes: >-
+    Flow-channel dental biofilm model built to emulate early supragingival
+    plaque under salivary glucose challenge.
+taxonomy:
+- taxon_term:
+    preferred_term: Streptococcus oralis
+    term:
+      id: NCBITaxon:1303
+      label: Streptococcus oralis
+  evidence:
+  - reference: PMID:21966490
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      Strains of Streptococcus oralis, Streptococcus sanguinis, Streptococcus
+      mitis, Streptococcus downei and Actinomyces naeslundii were employed in
+      the model.
+    explanation: Documents Streptococcus oralis as a member of the five-species model.
+- taxon_term:
+    preferred_term: Streptococcus sanguinis
+    term:
+      id: NCBITaxon:1305
+      label: Streptococcus sanguinis
+  evidence:
+  - reference: PMID:21966490
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      Strains of Streptococcus oralis, Streptococcus sanguinis, Streptococcus
+      mitis, Streptococcus downei and Actinomyces naeslundii were employed in
+      the model.
+    explanation: Documents Streptococcus sanguinis as a member of the five-species model.
+- taxon_term:
+    preferred_term: Streptococcus mitis
+    term:
+      id: NCBITaxon:28037
+      label: Streptococcus mitis
+  evidence:
+  - reference: PMID:21966490
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      Strains of Streptococcus oralis, Streptococcus sanguinis, Streptococcus
+      mitis, Streptococcus downei and Actinomyces naeslundii were employed in
+      the model.
+    explanation: Documents Streptococcus mitis as a member of the five-species model.
+- taxon_term:
+    preferred_term: Streptococcus downei
+    term:
+      id: NCBITaxon:1317
+      label: Streptococcus downei
+  evidence:
+  - reference: PMID:21966490
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      Strains of Streptococcus oralis, Streptococcus sanguinis, Streptococcus
+      mitis, Streptococcus downei and Actinomyces naeslundii were employed in
+      the model.
+    explanation: Documents Streptococcus downei as a member of the five-species model.
+- taxon_term:
+    preferred_term: Actinomyces naeslundii
+    term:
+      id: NCBITaxon:1655
+      label: Actinomyces naeslundii
+  evidence:
+  - reference: PMID:21966490
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      Strains of Streptococcus oralis, Streptococcus sanguinis, Streptococcus
+      mitis, Streptococcus downei and Actinomyces naeslundii were employed in
+      the model.
+    explanation: Documents Actinomyces naeslundii as a member of the five-species model.
+environmental_factors:
+- name: Glucose challenge
+  description: >-
+    Salivary solutions containing glucose were used to trigger anaerobic
+    glycolysis and map extracellular pH at the biofilm-substrate interface.
+  evidence:
+  - reference: PMID:21966490
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      We employed the pH-sensitive ratiometric probe C-SNARF-4 to perform
+      real-time microscopic analyses of the biofilm pH in response to salivary
+      solutions containing glucose.
+    explanation: Documents the carbohydrate perturbation used to probe pH dynamics.
+- name: Persistent acidic microenvironments
+  description: >-
+    Anaerobic glycolysis generated conserved extracellular acidic microniches
+    across the developing biofilm.
+  evidence:
+  - reference: PMID:21966490
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      Anaerobic glycolysis in the model biofilms created a mildly acidic
+      environment. Decrease in pH in different areas of the biofilms varied,
+      and distinct extracellular pH-microenvironments were conserved over
+      several hours.
+    explanation: Supports the dysbiosis-relevant pH heterogeneity captured by the model.

--- a/kb/communities/SMutans_CAlbicans_ECC_Biofilm.yaml
+++ b/kb/communities/SMutans_CAlbicans_ECC_Biofilm.yaml
@@ -1,0 +1,153 @@
+id: CommunityMech:000083
+name: Streptococcus mutans - Candida albicans ECC Biofilm Model
+description: >-
+  A defined cross-kingdom dual-species plaque biofilm model capturing the
+  synergistic virulence of Streptococcus mutans and Candida albicans in early
+  childhood caries. Coinfection produces an EPS-rich biofilm with higher
+  biomass, larger microcolonies, and more severe carious lesions than either
+  species alone.
+ecological_state: ENGINEERED
+community_origin: SYNTHETIC
+community_category: ORAL
+engineering_design:
+  objective: >-
+    Test whether a dual-species bacterium-fungus consortium amplifies plaque
+    biofilm virulence and caries severity beyond single-species infections.
+  assembly_strategy: >-
+    Bottom-up assembly of Streptococcus mutans and Candida albicans in
+    cospecies plaque biofilms, followed by validation in a rodent caries model.
+  perturbation_design: >-
+    Cospecies biofilms were compared with single-species controls in vitro and
+    in vivo to measure EPS production, biofilm architecture, virulence gene
+    expression, and caries severity.
+  measurement_endpoints:
+  - Biofilm biomass
+  - EPS accumulation
+  - Virulence gene expression
+  - Three-dimensional biofilm imaging
+  - Rodent caries scoring
+  evidence:
+  - reference: PMID:24566629
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: >-
+      We showed that the ability of these organisms together to form biofilms
+      is enhanced in vitro and in vivo.
+    explanation: Supports the defined dual-species design and its enhanced biofilm phenotype.
+environment_term:
+  preferred_term: cariogenic plaque biofilm on tooth surface
+  term:
+    id: ENVO:01001034
+    label: environment determined by a biofilm on an animal surface
+  notes: >-
+    Cross-kingdom plaque biofilm model relevant to early childhood caries and
+    validated on rodent tooth surfaces in vivo.
+taxonomy:
+- taxon_term:
+    preferred_term: Streptococcus mutans
+    term:
+      id: NCBITaxon:1309
+      label: Streptococcus mutans
+  evidence:
+  - reference: PMID:24566629
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: >-
+      Streptococcus mutans is often cited as the main bacterial pathogen in
+      dental caries, particularly in early-childhood caries (ECC).
+    explanation: Establishes Streptococcus mutans as the bacterial member of the model.
+- taxon_term:
+    preferred_term: Candida albicans
+    term:
+      id: NCBITaxon:5476
+      label: Candida albicans
+  evidence:
+  - reference: PMID:24566629
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: >-
+      Candida albicans cells are frequently detected along with heavy
+      infection by S. mutans in plaque biofilms from ECC-affected children.
+    explanation: Establishes Candida albicans as the fungal member of the model.
+ecological_interactions:
+- name: Cross-Kingdom Biofilm Enhancement
+  description: >-
+    Coinoculation of Streptococcus mutans and Candida albicans enhances biofilm
+    formation relative to either species alone in both in vitro and in vivo
+    settings.
+  interaction_type: MUTUALISM
+  source_taxon:
+    preferred_term: Streptococcus mutans
+    term:
+      id: NCBITaxon:1309
+      label: Streptococcus mutans
+  target_taxon:
+    preferred_term: Candida albicans
+    term:
+      id: NCBITaxon:5476
+      label: Candida albicans
+  evidence:
+  - reference: PMID:24566629
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: >-
+      We showed that the ability of these organisms together to form biofilms
+      is enhanced in vitro and in vivo.
+    explanation: Supports a mutually reinforcing cross-kingdom biofilm interaction.
+- name: Candida-Driven EPS Amplification of Streptococcus mutans
+  description: >-
+    Candida albicans promotes an EPS-rich matrix and higher viable Streptococcus
+    mutans abundance within cospecies plaque biofilms.
+  interaction_type: COLONIZATION_FACILITATION
+  source_taxon:
+    preferred_term: Candida albicans
+    term:
+      id: NCBITaxon:5476
+      label: Candida albicans
+  target_taxon:
+    preferred_term: Streptococcus mutans
+    term:
+      id: NCBITaxon:1309
+      label: Streptococcus mutans
+  evidence:
+  - reference: PMID:24566629
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: >-
+      The presence of C. albicans augments the production of
+      exopolysaccharides (EPS), such that cospecies biofilms accrue more
+      biomass and harbor more viable S. mutans cells than single-species
+      biofilms.
+    explanation: Supports Candida-mediated enhancement of S. mutans colonization and matrix formation.
+- name: Synergistic Caries Virulence
+  description: >-
+    Coinfection with Streptococcus mutans and Candida albicans increases plaque
+    infection burden and produces more aggressive carious lesions than either
+    species alone.
+  interaction_type: COLONIZATION_FACILITATION
+  source_taxon:
+    preferred_term: Candida albicans
+    term:
+      id: NCBITaxon:5476
+      label: Candida albicans
+  target_taxon:
+    preferred_term: Streptococcus mutans
+    term:
+      id: NCBITaxon:1309
+      label: Streptococcus mutans
+  evidence:
+  - reference: PMID:24566629
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: >-
+      Coinfected animals displayed higher levels of infection and microbial
+      carriage within plaque biofilms than animals infected with either species
+      alone.
+    explanation: Documents increased pathogenic load during dual-species coinfection.
+  - reference: PMID:24566629
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: >-
+      Furthermore, coinfection synergistically enhanced biofilm virulence,
+      leading to aggressive onset of the disease with rampant carious lesions.
+    explanation: Documents amplified caries severity caused by the dual-species consortium.

--- a/kb/communities/SMutans_SSputigena_ECC_Pathobiont.yaml
+++ b/kb/communities/SMutans_SSputigena_ECC_Pathobiont.yaml
@@ -1,0 +1,127 @@
+id: CommunityMech:000084
+name: Streptococcus mutans - Selenomonas sputigena ECC Pathobiont Model
+description: >-
+  A defined dual-species oral biofilm model derived from early childhood caries
+  discovery-validation work. Selenomonas sputigena becomes trapped within
+  Streptococcus mutans exoglucans, builds a honeycomb-like multicellular
+  superstructure, enhances acidogenesis, and increases enamel lesion severity
+  in vivo.
+ecological_state: ENGINEERED
+community_origin: SYNTHETIC
+community_category: ORAL
+engineering_design:
+  objective: >-
+    Identify disease-relevant inter-species interactions in early childhood
+    caries and validate whether Selenomonas sputigena acts as a pathobiont with
+    Streptococcus mutans.
+  assembly_strategy: >-
+    Discovery-validation pipeline starting from supragingival biofilm
+    metagenomics and metatranscriptomics, followed by dual-species imaging,
+    virulence assays, and rodent coinfection experiments.
+  perturbation_design: >-
+    Selenomonas sputigena was tested individually and with Streptococcus
+    mutans to compare spatial arrangement, acidogenesis, tooth-surface
+    colonization, and in vivo cariogenicity.
+  measurement_endpoints:
+  - Metagenomics
+  - Metatranscriptomics
+  - Multiscale imaging
+  - Virulence assays
+  - Rodent caries scoring
+  evidence:
+  - reference: PMID:37217495
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: >-
+      Here, we integrate multi-omics of supragingival biofilm (dental plaque)
+      from 416 preschool-age children (208 males and 208 females) in a
+      discovery-validation pipeline to identify disease-relevant inter-species
+      interactions.
+    explanation: Supports the study design used to derive and validate this pathobiont model.
+environment_term:
+  preferred_term: supragingival cariogenic plaque biofilm
+  term:
+    id: ENVO:01001034
+    label: environment determined by a biofilm on an animal surface
+  notes: >-
+    Model is grounded in supragingival plaque from preschool children with
+    early childhood caries and validated on tooth surfaces in vivo.
+taxonomy:
+- taxon_term:
+    preferred_term: Streptococcus mutans
+    term:
+      id: NCBITaxon:1309
+      label: Streptococcus mutans
+  evidence:
+  - reference: PMID:37217495
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: >-
+      Streptococcus mutans has been implicated as the primary pathogen in
+      childhood caries (tooth decay).
+    explanation: Establishes Streptococcus mutans as the reference pathogen in the model.
+- taxon_term:
+    preferred_term: Selenomonas sputigena
+    term:
+      id: NCBITaxon:69823
+      label: Selenomonas sputigena
+  evidence:
+  - reference: PMID:37217495
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: >-
+      We show that S. sputigena, a flagellated anaerobe with previously unknown
+      role in supragingival biofilm, becomes trapped in streptococcal
+      exoglucans
+    explanation: Establishes Selenomonas sputigena as the pathobiont evaluated in the model.
+ecological_interactions:
+- name: Streptococcal Exoglucan Entrapment of Selenomonas sputigena
+  description: >-
+    Streptococcus mutans exoglucans trap Selenomonas sputigena, suppress its
+    motility, and create a structured mixed-species biofilm.
+  interaction_type: COLONIZATION_FACILITATION
+  source_taxon:
+    preferred_term: Streptococcus mutans
+    term:
+      id: NCBITaxon:1309
+      label: Streptococcus mutans
+  target_taxon:
+    preferred_term: Selenomonas sputigena
+    term:
+      id: NCBITaxon:69823
+      label: Selenomonas sputigena
+  evidence:
+  - reference: PMID:37217495
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: >-
+      We show that S. sputigena, a flagellated anaerobe with previously unknown
+      role in supragingival biofilm, becomes trapped in streptococcal
+      exoglucans, loses motility but actively proliferates to build a
+      honeycomb-like multicellular-superstructure encapsulating S. mutans,
+      enhancing acidogenesis.
+    explanation: Documents matrix-mediated trapping and structured coassembly with S. mutans.
+- name: Pathobiont-Enhanced Cariogenicity
+  description: >-
+    Selenomonas sputigena is non-cariogenic alone but markedly worsens enamel
+    lesion formation when coinfected with Streptococcus mutans.
+  interaction_type: COLONIZATION_FACILITATION
+  source_taxon:
+    preferred_term: Selenomonas sputigena
+    term:
+      id: NCBITaxon:69823
+      label: Selenomonas sputigena
+  target_taxon:
+    preferred_term: Streptococcus mutans
+    term:
+      id: NCBITaxon:1309
+      label: Streptococcus mutans
+  evidence:
+  - reference: PMID:37217495
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: >-
+      While incapable of causing caries on its own, when co-infected with S.
+      mutans, S. sputigena causes extensive tooth enamel lesions and
+      exacerbates disease severity in vivo.
+    explanation: Supports S. sputigena as a pathobiont that heightens S. mutans virulence.

--- a/kb/communities/SMutans_VParvula_ASC_Biofilm.yaml
+++ b/kb/communities/SMutans_VParvula_ASC_Biofilm.yaml
@@ -1,0 +1,129 @@
+id: CommunityMech:000085
+name: Streptococcus mutans - Veillonella parvula Adult Severe Caries Model
+description: >-
+  A defined dual-species oral biofilm model for adult severe caries pairing
+  Streptococcus mutans with the ASC-associated pathobiont Veillonella parvula.
+  The coculture increases mature biofilm formation, acid resistance, oxidative
+  stress tolerance, and rodent caries severity relative to Streptococcus
+  mutans alone.
+ecological_state: ENGINEERED
+community_origin: SYNTHETIC
+community_category: ORAL
+engineering_design:
+  objective: >-
+    Identify adult severe caries-associated taxa and test whether Veillonella
+    parvula enhances Streptococcus mutans biofilm virulence.
+  assembly_strategy: >-
+    Metagenomic identification of adult severe caries-associated taxa followed
+    by defined dual-species coculture and rodent caries experiments with
+    Streptococcus mutans and Veillonella parvula.
+  perturbation_design: >-
+    Dual-species biofilms were evaluated for acidification, aciduricity,
+    oxidative stress tolerance, gtf expression, EPS synthesis, and in vivo
+    cariogenicity relative to single-species controls.
+  measurement_endpoints:
+  - Metagenomic profiling
+  - Acidification assays
+  - Aciduricity assays
+  - Oxidative stress tolerance assays
+  - EPS imaging
+  - Rodent caries scoring
+  evidence:
+  - reference: PMID:39345197
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: >-
+      Samples of dental plaque were collected for metagenomic analysis. The
+      acidification, aciduricity, oxidative stress tolerance, and gtf
+      (glucosyltransferase) gene expression of S. mutans cocultured with V.
+      parvula
+    explanation: Supports the design of the dual-species adult severe caries model.
+environment_term:
+  preferred_term: adult severe caries plaque biofilm
+  term:
+    id: ENVO:01001034
+    label: environment determined by a biofilm on an animal surface
+  notes: >-
+    Defined plaque biofilm model motivated by metagenomic analysis of adult
+    severe caries and validated with rodent infection experiments.
+taxonomy:
+- taxon_term:
+    preferred_term: Streptococcus mutans
+    term:
+      id: NCBITaxon:1309
+      label: Streptococcus mutans
+  evidence:
+  - reference: PMID:39345197
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: >-
+      This study is focused on the composition of dental plaque microbiome
+      profiles in order to identify disease-relevant species and to investigate
+      into their interactions with the S. mutans.
+    explanation: Establishes Streptococcus mutans as the reference pathogen in the model.
+- taxon_term:
+    preferred_term: Veillonella parvula
+    term:
+      id: NCBITaxon:29466
+      label: Veillonella parvula
+  abundance_level: DOMINANT
+  evidence:
+  - reference: PMID:39345197
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: >-
+      The most significantly abundant taxon found associated with ASC was V.
+      parvula.
+    explanation: Establishes Veillonella parvula as the adult severe caries-associated pathobiont.
+ecological_interactions:
+- name: Veillonella parvula Promotion of Streptococcus mutans Biofilm Virulence
+  description: >-
+    Veillonella parvula promotes mature Streptococcus mutans biofilm formation
+    and increases stress tolerance and virulence traits in the dual-species
+    consortium.
+  interaction_type: COLONIZATION_FACILITATION
+  source_taxon:
+    preferred_term: Veillonella parvula
+    term:
+      id: NCBITaxon:29466
+      label: Veillonella parvula
+  target_taxon:
+    preferred_term: Streptococcus mutans
+    term:
+      id: NCBITaxon:1309
+      label: Streptococcus mutans
+  evidence:
+  - reference: PMID:39345197
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: >-
+      In vitro experiments found that V. parvula can effectively promote S.
+      mutans mature biofilm formation with enhanced acid resistance, hydrogen
+      peroxide detoxicity, and biofilm virulence.
+    explanation: Supports Veillonella-driven enhancement of S. mutans virulence traits.
+- name: Pathobiont-Driven Adult Severe Caries Exacerbation
+  description: >-
+    Veillonella parvula is not independently cariogenic in the model but
+    significantly worsens disease progression when coinfected with
+    Streptococcus mutans.
+  interaction_type: COLONIZATION_FACILITATION
+  source_taxon:
+    preferred_term: Veillonella parvula
+    term:
+      id: NCBITaxon:29466
+      label: Veillonella parvula
+  target_taxon:
+    preferred_term: Streptococcus mutans
+    term:
+      id: NCBITaxon:1309
+      label: Streptococcus mutans
+  evidence:
+  - reference: PMID:39345197
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: >-
+      Rodent model experiments revealed that V. parvula was incapable of
+      causing disease on its own, but it significantly heightened the biofilm
+      virulence of S. mutans when being co-infected and augmented the
+      progression, quantity, and severity of dental caries.
+    explanation: Supports Veillonella parvula as a synergistic pathobiont in adult severe caries.

--- a/references_cache/pmid_21966490.txt
+++ b/references_cache/pmid_21966490.txt
@@ -1,0 +1,50 @@
+1. PLoS One. 2011;6(9):e25299. doi: 10.1371/journal.pone.0025299. Epub 2011 Sep
+23.
+
+pH landscapes in a novel five-species model of early dental biofilm.
+
+Schlafer S(1), Raarup MK, Meyer RL, Sutherland DS, Dige I, Nyengaard JR, Nyvad 
+B.
+
+Author information:
+(1)iNANO The Interdisciplinary Nanoscience Center, Faculty of Science, Aarhus 
+University, Aarhus, Denmark. sebastian.schlafer@hotmail.de
+
+BACKGROUND: Despite continued preventive efforts, dental caries remains the most 
+common disease of man. Organic acids produced by microorganisms in dental plaque 
+play a crucial role for the development of carious lesions. During early stages 
+of the pathogenetic process, repeated pH drops induce changes in microbial 
+composition and favour the establishment of an increasingly acidogenic and 
+aciduric microflora. The complex structure of dental biofilms, allowing for a 
+multitude of different ecological environments in close proximity, remains 
+largely unexplored. In this study, we designed a laboratory biofilm model that 
+mimics the bacterial community present during early acidogenic stages of the 
+caries process. We then performed a time-resolved microscopic analysis of the 
+extracellular pH landscape at the interface between bacterial biofilm and 
+underlying substrate.
+METHODOLOGY/PRINCIPAL FINDINGS: Strains of Streptococcus oralis, Streptococcus 
+sanguinis, Streptococcus mitis, Streptococcus downei and Actinomyces naeslundii 
+were employed in the model. Biofilms were grown in flow channels that allowed 
+for direct microscopic analysis of the biofilms in situ. The architecture and 
+composition of the biofilms were analysed using fluorescence in situ 
+hybridization and confocal laser scanning microscopy. Both biofilm structure and 
+composition were highly reproducible and showed similarity to in-vivo-grown 
+dental plaque. We employed the pH-sensitive ratiometric probe C-SNARF-4 to 
+perform real-time microscopic analyses of the biofilm pH in response to salivary 
+solutions containing glucose. Anaerobic glycolysis in the model biofilms created 
+a mildly acidic environment. Decrease in pH in different areas of the biofilms 
+varied, and distinct extracellular pH-microenvironments were conserved over 
+several hours.
+CONCLUSIONS/SIGNIFICANCE: The designed biofilm model represents a promising tool 
+to determine the effect of potential therapeutic agents on biofilm growth, 
+composition and extracellular pH. Ratiometric pH analysis using C-SNARF-4 gives 
+detailed insight into the pH landscape of living biofilms and contributes to our 
+general understanding of metabolic processes in in-vivo-grown bacterial 
+biofilms.
+
+DOI: 10.1371/journal.pone.0025299
+PMCID: PMC3179500
+PMID: 21966490 [Indexed for MEDLINE]
+
+Conflict of interest statement: Competing Interests: The authors have declared 
+that no competing interests exist.

--- a/references_cache/pmid_23446436.txt
+++ b/references_cache/pmid_23446436.txt
@@ -1,0 +1,36 @@
+1. Caries Res. 2013;47(4):318-24. doi: 10.1159/000347050. Epub 2013 Feb 27.
+
+A defined-multispecies microbial model for studying enamel caries development.
+
+Arthur RA(1), Waeiss RA, Hara AT, Lippert F, Eckert GJ, Zero DT.
+
+Author information:
+(1)Oral Health Research Institute, Department of Preventive and Community 
+Dentistry, Indiana University School of Dentistry, Indianapolis, Ind., USA.
+
+The aims of this study were to describe and validate an in vitro multispecies 
+microbial biofilm model for caries development by evaluating the effects of 
+varying medium concentration of sucrose (0.5 and 1.0%) and fluoride (0.4, 0.8 
+and 1.0 ppm F) in study 1, and calcium (1.0 and 2.0 mM Ca) in study 2. 
+Defined-multispecies biofilms, formed by Lactobacillus casei, Streptococcus 
+mutans, S. salivarius and S. sanguinis, were grown on the surface of 
+salivary-pellicle-coated enamel slabs, with known baseline surface hardness; 
+growth medium was changed daily. Counts of viable cells on biofilms and the 
+percentage of surface microhardness change (%SMC), lesion depth (LD) and 
+integrated mineral loss (IML) on enamel slabs were assessed after 4 days of 
+biofilm formation under the tested conditions. Counts of viable cells on 
+biofilms were significantly affected by sucrose, fluoride and calcium 
+concentrations (p < 0.05). There was a decrease in %SMC in response to increased 
+fluoride and calcium concentrations (p < 0.001). Lower IML (p < 0.001) and LD (p 
+< 0.05) were found in the presence of 0.8 and 1.0 ppm F. A negative correlation 
+was found between the response variables (%SMC, LD and IML) and fluoride and 
+calcium concentrations. The results suggest that the microbial caries model 
+developed was able to show distinct levels of caries inhibition in response to 
+fluoride and calcium concentrations, corroborating clinical observations. An 
+effect of sucrose concentration on caries development was found only in the 
+presence of the lowest fluoride concentration.
+
+Copyright © 2013 S. Karger AG, Basel.
+
+DOI: 10.1159/000347050
+PMID: 23446436 [Indexed for MEDLINE]

--- a/references_cache/pmid_24566629.txt
+++ b/references_cache/pmid_24566629.txt
@@ -1,0 +1,42 @@
+1. Infect Immun. 2014 May;82(5):1968-81. doi: 10.1128/IAI.00087-14. Epub 2014 Feb
+ 24.
+
+Symbiotic relationship between Streptococcus mutans and Candida albicans 
+synergizes virulence of plaque biofilms in vivo.
+
+Falsetta ML(1), Klein MI, Colonne PM, Scott-Anne K, Gregoire S, Pai CH, 
+Gonzalez-Begne M, Watson G, Krysan DJ, Bowen WH, Koo H.
+
+Author information:
+(1)Center for Oral Biology, University of Rochester Medical Center, Rochester, 
+New York, USA.
+
+Streptococcus mutans is often cited as the main bacterial pathogen in dental 
+caries, particularly in early-childhood caries (ECC). S. mutans may not act 
+alone; Candida albicans cells are frequently detected along with heavy infection 
+by S. mutans in plaque biofilms from ECC-affected children. It remains to be 
+elucidated whether this association is involved in the enhancement of biofilm 
+virulence. We showed that the ability of these organisms together to form 
+biofilms is enhanced in vitro and in vivo. The presence of C. albicans augments 
+the production of exopolysaccharides (EPS), such that cospecies biofilms accrue 
+more biomass and harbor more viable S. mutans cells than single-species 
+biofilms. The resulting 3-dimensional biofilm architecture displays sizeable S. 
+mutans microcolonies surrounded by fungal cells, which are enmeshed in a dense 
+EPS-rich matrix. Using a rodent model, we explored the implications of this 
+cross-kingdom interaction for the pathogenesis of dental caries. Coinfected 
+animals displayed higher levels of infection and microbial carriage within 
+plaque biofilms than animals infected with either species alone. Furthermore, 
+coinfection synergistically enhanced biofilm virulence, leading to aggressive 
+onset of the disease with rampant carious lesions. Our in vitro data also 
+revealed that glucosyltransferase-derived EPS is a key mediator of cospecies 
+biofilm development and that coexistence with C. albicans induces the expression 
+of virulence genes in S. mutans (e.g., gtfB, fabM). We also found that 
+Candida-derived β1,3-glucans contribute to the EPS matrix structure, while 
+fungal mannan and β-glucan provide sites for GtfB binding and activity. 
+Altogether, we demonstrate a novel mutualistic bacterium-fungus relationship 
+that occurs at a clinically relevant site to amplify the severity of a 
+ubiquitous infectious disease.
+
+DOI: 10.1128/IAI.00087-14
+PMCID: PMC3993459
+PMID: 24566629 [Indexed for MEDLINE]

--- a/references_cache/pmid_37217495.txt
+++ b/references_cache/pmid_37217495.txt
@@ -1,0 +1,78 @@
+1. Nat Commun. 2023 May 22;14(1):2919. doi: 10.1038/s41467-023-38346-3.
+
+Selenomonas sputigena acts as a pathobiont mediating spatial structure and 
+biofilm virulence in early childhood caries.
+
+Cho H(#)(1), Ren Z(#)(2), Divaris K(3)(4), Roach J(5)(6), Lin BM(1), Liu C(1), 
+Azcarate-Peril MA(6)(7), Simancas-Pallares MA(8), Shrestha P(8)(9), Orlenko 
+A(10), Ginnis J(8), North KE(9), Zandona AGF(11), Ribeiro AA(12), Wu D(13)(14), 
+Koo H(15)(16).
+
+Author information:
+(1)Department of Biostatistics, Gillings School of Global Public Health, 
+University of North Carolina at Chapel Hill, Chapel Hill, NC, USA.
+(2)Biofilm Research Laboratories, Center for Innovation & Precision Dentistry, 
+School of Dental Medicine, University of Pennsylvania, Philadelphia, PA, USA.
+(3)Division of Pediatric and Public Health, Adams School of Dentistry, 
+University of North Carolina at Chapel Hill, Chapel Hill, NC, USA. 
+Kimon_Divaris@unc.edu.
+(4)Department of Epidemiology, Gillings School of Public Health, University of 
+North Carolina at Chapel Hill, Chapel Hill, NC, USA. Kimon_Divaris@unc.edu.
+(5)UNC Information Technology Services and Research Computing, University of 
+North Carolina at Chapel Hill, Chapel Hill, NC, USA.
+(6)UNC Microbiome Core, Center for Gastrointestinal Biology and Disease, School 
+of Medicine, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA.
+(7)Department of Medicine, Division of Gastroenterology and Hepatology, School 
+of Medicine, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA.
+(8)Division of Pediatric and Public Health, Adams School of Dentistry, 
+University of North Carolina at Chapel Hill, Chapel Hill, NC, USA.
+(9)Department of Epidemiology, Gillings School of Public Health, University of 
+North Carolina at Chapel Hill, Chapel Hill, NC, USA.
+(10)Artificial Intelligence Innovation Lab, Cedars-Sinai Medical Center, Los 
+Angeles, CA, USA.
+(11)Department of Comprehensive Care, School of Dental Medicine, Tufts 
+University, Boston, MA, USA.
+(12)Division of Diagnostic Sciences, Adams School of Dentistry, University of 
+North Carolina at Chapel Hill, Chapel Hill, NC, USA.
+(13)Department of Biostatistics, Gillings School of Global Public Health, 
+University of North Carolina at Chapel Hill, Chapel Hill, NC, USA. 
+did@email.unc.edu.
+(14)Division of Oral and Craniofacial Health Sciences, Adams School of 
+Dentistry, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA. 
+did@email.unc.edu.
+(15)Biofilm Research Laboratories, Center for Innovation & Precision Dentistry, 
+School of Dental Medicine, University of Pennsylvania, Philadelphia, PA, USA. 
+koohy@upenn.edu.
+(16)Department of Orthodontics, School of Dental Medicine, University of 
+Pennsylvania, Philadelphia, PA, USA. koohy@upenn.edu.
+(#)Contributed equally
+
+Streptococcus mutans has been implicated as the primary pathogen in childhood 
+caries (tooth decay). While the role of polymicrobial communities is 
+appreciated, it remains unclear whether other microorganisms are active 
+contributors or interact with pathogens. Here, we integrate multi-omics of 
+supragingival biofilm (dental plaque) from 416 preschool-age children (208 males 
+and 208 females) in a discovery-validation pipeline to identify disease-relevant 
+inter-species interactions. Sixteen taxa associate with childhood caries in 
+metagenomics-metatranscriptomics analyses. Using multiscale/computational 
+imaging and virulence assays, we examine biofilm formation dynamics, spatial 
+arrangement, and metabolic activity of Selenomonas sputigena, Prevotella salivae 
+and Leptotrichia wadei, either individually or with S. mutans. We show that S. 
+sputigena, a flagellated anaerobe with previously unknown role in supragingival 
+biofilm, becomes trapped in streptococcal exoglucans, loses motility but 
+actively proliferates to build a honeycomb-like multicellular-superstructure 
+encapsulating S. mutans, enhancing acidogenesis. Rodent model experiments reveal 
+an unrecognized ability of S. sputigena to colonize supragingival tooth 
+surfaces. While incapable of causing caries on its own, when co-infected with S. 
+mutans, S. sputigena causes extensive tooth enamel lesions and exacerbates 
+disease severity in vivo. In summary, we discover a pathobiont cooperating with 
+a known pathogen to build a unique spatial structure and heighten biofilm 
+virulence in a prevalent human disease.
+
+© 2023. The Author(s).
+
+DOI: 10.1038/s41467-023-38346-3
+PMCID: PMC10202936
+PMID: 37217495 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no competing interests.

--- a/references_cache/pmid_39345197.txt
+++ b/references_cache/pmid_39345197.txt
@@ -1,0 +1,58 @@
+1. Microbiol Spectr. 2024 Nov 5;12(11):e0431823. doi: 10.1128/spectrum.04318-23. 
+Epub 2024 Sep 30.
+
+Veillonella parvula acts as a pathobiont promoting the biofilm virulence and 
+cariogenicity of Streptococcus mutans in adult severe caries.
+
+Wei Y(#)(1), Zhang Y(#)(1), Zhuang Y(1), Tang Y(1), Nie H(1), Haung Y(2), Liu 
+T(2), Yang W(3), Yan F(1), Zhu Y(1).
+
+Author information:
+(1)Nanjing Stomatological Hospital, Affiliated Hospital of Medical School, 
+Institute of Stomatology, Nanjing University, Nanjing, China.
+(2)Department of Endodontics, Nanjing Stomatological Hospital, Affiliated 
+Hospital of Medical School, Institute of Stomatology, Nanjing University, 
+Nanjing, China.
+(3)Department of General Dentistry, Nanjing Stomatological Hospital, Affiliated 
+Hospital of Medical School, Institute of Stomatology, Nanjing University, 
+Nanjing, China.
+(#)Contributed equally
+
+Adult severe caries (ASC) brings severe oral dysfunction and treatment 
+difficulties to patients, and yet no clear pathogenic mechanism for it has been 
+found. This study is focused on the composition of dental plaque microbiome 
+profiles in order to identify disease-relevant species and to investigate into 
+their interactions with the S. mutans. Samples of dental plaque were collected 
+for metagenomic analysis. The acidification, aciduricity, oxidative stress 
+tolerance, and gtf (glucosyltransferase) gene expression of S. mutans cocultured 
+with V. parvula which was identified as ASC-related dominant bacterium. The 
+bioﬁlm formation and extracellular exopolysaccharide (EPS) synthesis of 
+dual-strain were analyzed with scanning electron microscopy (SEM), crystal 
+violet (CV) staining, live/dead bacterial staining, and confocal laser scanning 
+microscopy (CLSM). Furthermore, rodent model experiments were performed to 
+validate the in vivo cariogenicity of the dual-species biofilm. The most 
+significantly abundant taxon found associated with ASC was V. parvula. In vitro 
+experiments found that V. parvula can effectively promote S. mutans mature 
+biofilm formation with enhanced acid resistance, hydrogen peroxide detoxicity, 
+and biofilm virulence. Rodent model experiments revealed that V. parvula was 
+incapable of causing disease on its own, but it significantly heightened the 
+biofilm virulence of S. mutans when being co-infected and augmented the 
+progression, quantity, and severity of dental caries. Our findings demonstrated 
+that V. parvula may act as a synergistic pathobiont to modulate the metabolic 
+activity, spatial structure, and pathogenicity of biofilms of S. mutans in the 
+context of ASC.IMPORTANCEAdult severe caries (ASC), as a special type of acute 
+caries, is rarely reported and its worthiness of further study is still in 
+dispute. Yet studies on the etiology of severe caries in adults have not found a 
+clear pathogenic mechanism for it. Knowledge of the oral microbiota is important 
+for the treatment of dental caries. We discovered that the interaction between 
+V. parvula and S. mutans augments the severity of dental caries in vivo, 
+suggesting V. parvula may act as a synergistic pathobiont exacerbating biofilm 
+virulence of S. mutans in ASC. Our findings may improve the understanding of ASC 
+pathogenesis and are likely to provide a basis for planning appropriate 
+therapeutic strategies.
+
+DOI: 10.1128/spectrum.04318-23
+PMCID: PMC11537095
+PMID: 39345197 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no conflict of interest.

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-03-22T20:07:04
+# Generation date: 2026-04-14T18:15:13
 # Schema: communitymech
 #
 # id: https://w3id.org/culturebot-ai/communitymech
@@ -1247,6 +1247,9 @@ class CommunityCategoryEnum(EnumDefinitionImpl):
     RHIZOSPHERE = PermissibleValue(
         text="RHIZOSPHERE",
         description="Plant root-associated communities")
+    ORAL = PermissibleValue(
+        text="ORAL",
+        description="Oral microbiome and dental biofilm communities")
     LIGNOCELLULOSE = PermissibleValue(
         text="LIGNOCELLULOSE",
         description="Lignocellulose degradation systems")
@@ -2179,4 +2182,3 @@ slots.microbialCommunity__metal_relevance = Slot(uri=COMMUNITYMECH.metal_relevan
 
 slots.microbialCommunity__metal_notes = Slot(uri=COMMUNITYMECH.metal_notes, name="microbialCommunity__metal_notes", curie=COMMUNITYMECH.curie('metal_notes'),
                    model_uri=COMMUNITYMECH.microbialCommunity__metal_notes, domain=None, range=Optional[str])
-

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -109,6 +109,8 @@ enums:
         description: Algae-bacteria associations
       RHIZOSPHERE:
         description: Plant root-associated communities
+      ORAL:
+        description: Oral microbiome and dental biofilm communities
       LIGNOCELLULOSE:
         description: Lignocellulose degradation systems
       METHANOGENESIS:


### PR DESCRIPTION
## Summary
This PR adds oral microbiome exemplars focused on dysbiosis and caries, plus a small schema extension to classify them cleanly.

Included communities:
- Early Dental Biofilm Five-Species Model
- Defined Multispecies Enamel Caries Model
- Streptococcus mutans - Candida albicans ECC Biofilm Model
- Streptococcus mutans - Selenomonas sputigena ECC Pathobiont Model
- Streptococcus mutans - Veillonella parvula Adult Severe Caries Model

Schema/datamodel changes:
- Add `ORAL` to `CommunityCategoryEnum`
- Regenerate the LinkML Python datamodel

Evidence support:
- Added cached PubMed abstracts for PMIDs 21966490, 23446436, 24566629, 37217495, and 39345197 used by reference validation

## Validation
Passed:
- `just validate` for all 5 new community YAMLs
- `just validate-terms` for all 5 new community YAMLs
- `just validate-references` for all 5 new community YAMLs

## Tests
`just test` is not clean on this branch, but the failures appear pre-existing and unrelated to this change set:
- 61 passed
- 9 failed in `tests/test_llm_client.py`
- failure mode: missing `anthropic` package / tests attempting to patch `anthropic.Anthropic`
