### PR TITLE
Add InteractionScopeEnum: PAIRWISE vs COMMUNITY_LEVEL

### DIFF
--- a/kb/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.yaml
+++ b/kb/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.yaml
@@ -175,6 +175,7 @@ ecological_interactions:
   description: In situ water electrolysis supplies H2 to support autotrophic coculture operation,
     with hydrogen limitation identified as a process constraint.
   interaction_type: COMMENSALISM
+  scope: COMMUNITY_LEVEL
   target_taxon:
     preferred_term: Acetobacterium woodii
     term:

--- a/kb/communities/Aerobic_Denitrification_Disturbance_SynCom.yaml
+++ b/kb/communities/Aerobic_Denitrification_Disturbance_SynCom.yaml
@@ -63,6 +63,7 @@ ecological_interactions:
 - name: Disturbance-Stable Division of Labor
   description: Members redistribute functional dominance and metabolic pathways to maintain denitrification.
   interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Aerobic_Denitrification_QQ_SynCom.yaml
+++ b/kb/communities/Aerobic_Denitrification_QQ_SynCom.yaml
@@ -62,6 +62,7 @@ ecological_interactions:
 - name: AHL-Mediated Aerobic Denitrification
   description: AHL signaling and quorum quenching coordinate electron transfer and nitrate reduction.
   interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.yaml
+++ b/kb/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.yaml
@@ -109,6 +109,7 @@ ecological_interactions:
   description: The ASF members are mouse-derived, culturable bacteria that can be stably maintained across
     generations in gnotobiotic mice.
   interaction_type: COLONIZATION_FACILITATION
+  scope: COMMUNITY_LEVEL
   evidence:
   - reference: PMID:26323627
     supports: SUPPORT
@@ -119,6 +120,7 @@ ecological_interactions:
   description: ASF provides a reduced-complexity model for studying mutualistic host-GI microbiota
     relationships while preserving a known consortium rather than a single isolate.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - reference: PMID:26323627
     supports: SUPPORT
@@ -129,6 +131,7 @@ ecological_interactions:
   description: Draft genomes for all eight ASF members enable community-level study of member functions
     and interactions in a controlled murine gut setting.
   interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
   evidence:
   - reference: PMID:24723722
     supports: SUPPORT

--- a/kb/communities/Arabidopsis_Coumarin_Root_SynCom.yaml
+++ b/kb/communities/Arabidopsis_Coumarin_Root_SynCom.yaml
@@ -43,6 +43,7 @@ ecological_interactions:
 - name: Coumarin-Dependent Recruitment
   description: Plant exuded specialized metabolites structure which bacteria persist in the rhizosphere.
   interaction_type: COLONIZATION_FACILITATION
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Arabidopsis_Phyllosphere_SynCom7.yaml
+++ b/kb/communities/Arabidopsis_Phyllosphere_SynCom7.yaml
@@ -45,6 +45,7 @@ ecological_interactions:
 - name: Host-Genotype-Structured Assembly
   description: Arabidopsis host genotype shifts the abundance and composition of the phyllosphere SynCom.
   interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/At_RSPHERE_SynCom.yaml
+++ b/kb/communities/At_RSPHERE_SynCom.yaml
@@ -305,53 +305,53 @@ growth_media:
   - name: Yeast extract
     concentration: '0.5'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000025
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000025
   - name: Proteose peptone no. 3
     concentration: '0.5'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
   - name: Casamino acids
     concentration: '0.5'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000173
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000173
   - name: Glucose
     concentration: '0.5'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000138
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000138
   - name: Starch
     concentration: '0.5'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000169
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000169
   - name: Sodium pyruvate
     concentration: '0.3'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000185
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000185
   - name: K2HPO4
     concentration: '0.3'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000122
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000122
   - name: MgSO4 x 7 H2O
     concentration: '0.05'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000118
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000118
   - name: Agar
     concentration: '15'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000119
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000119
 - name: Half-strength Murashige-Skoog medium for Arabidopsis growth

--- a/kb/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.yaml
+++ b/kb/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.yaml
@@ -54,6 +54,7 @@ ecological_interactions:
 - name: Straw Humification Cross-Feeding
   description: Bacillus and Bradyrhizobium cross-feed to promote straw-degrading enzymes and humification.
   interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.yaml
+++ b/kb/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.yaml
@@ -172,6 +172,7 @@ ecological_interactions:
   description: Cocolonization changes cecal short-chain fatty acid pools, including lower acetate relative
     to B. thetaiotaomicron monoassociation while maintaining butyrate output associated with E. rectale.
   interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
   metabolites:
   - preferred_term: acetate
     term:

--- a/kb/communities/Banana_Fusarium_Biocontrol_SynCom12.yaml
+++ b/kb/communities/Banana_Fusarium_Biocontrol_SynCom12.yaml
@@ -62,6 +62,7 @@ ecological_interactions:
 - name: Coordinated Pathogen Suppression
   description: Bacterial and fungal antagonists suppress Fusarium wilt while avoiding detrimental cross-inhibition.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/BioModels_MODEL2407300002_Sponge_Holobiont_Network.yaml
+++ b/kb/communities/BioModels_MODEL2407300002_Sponge_Holobiont_Network.yaml
@@ -102,6 +102,7 @@ ecological_interactions:
     and demonstrates metabolic interdependence between archaeal and bacterial partners. The partnership
     enables complete nitrification and contributes to nutrient cycling within the holobiont.
   interaction_type: SYNTROPHY
+  scope: COMMUNITY_LEVEL
   metabolites:
   - preferred_term: ammonia
     term:
@@ -139,6 +140,7 @@ ecological_interactions:
     net heterotrophy or autotrophy, demonstrating nutrient-dependent metabolic flexibility coordinated
     through cross-feeding interactions.
   interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
   evidence:
   - reference: PMID:39738126
     supports: SUPPORT
@@ -157,6 +159,7 @@ ecological_interactions:
     nutrient flow represents a fundamental mutualistic relationship where the host supplies resources
     that structure the eight-species microbial community and drive their metabolic interactions.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - reference: PMID:39738126
     supports: SUPPORT

--- a/kb/communities/CRC_Fusobacterium_Control_SynCom.yaml
+++ b/kb/communities/CRC_Fusobacterium_Control_SynCom.yaml
@@ -47,6 +47,7 @@ ecological_interactions:
   description: The designed SynCom inhibits F. nucleatum growth and promotes decolonization through ecological
     and metabolic control.
   interaction_type: COMPETITION
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
+++ b/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
@@ -74,6 +74,7 @@ ecological_interactions:
   description: Cellulose fermentation products are exchanged with methanogens and sulfate reducers, producing
     methane and modulating competition.
   interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Cheese_Rind_InSitu_InVitro_Model_Community.yaml
+++ b/kb/communities/Cheese_Rind_InSitu_InVitro_Model_Community.yaml
@@ -97,6 +97,7 @@ ecological_interactions:
   description: Moisture and rind-style manipulations selected different bacterial and fungal assemblages,
     with drier natural-rind conditions enriching Debaryomyces, Staphylococcus, and Penicillium.
   interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
   biological_processes:
   - preferred_term: biofilm formation
     term:
@@ -117,6 +118,7 @@ ecological_interactions:
   description: Yeasts and filamentous fungi increased cheese-curd-medium pH, and the study linked this
     deacidification to positive growth responses of multiple bacterial genera in fungal coculture.
   interaction_type: COLONIZATION_FACILITATION
+  scope: COMMUNITY_LEVEL
   biological_processes:
   - preferred_term: biological process involved in interspecies interaction between organisms
     term:
@@ -138,6 +140,7 @@ ecological_interactions:
     curd agar, with early Staphylococcus and Candida followed by later Brevibacterium, Brachybacterium,
     Penicillium, and Scopulariopsis.
   interaction_type: COLONIZATION_FACILITATION
+  scope: COMMUNITY_LEVEL
   biological_processes:
   - preferred_term: biofilm formation
     term:

--- a/kb/communities/Chlamydomonas_Bacterial_H2_Consortium.yaml
+++ b/kb/communities/Chlamydomonas_Bacterial_H2_Consortium.yaml
@@ -260,7 +260,7 @@ growth_media:
       term:
         id: CHEBI:9754
         label: tris(hydroxymethyl)aminomethane
-    from: community_curated
+    from_source: community_curated
   - name: Acetate (carbon source)
     concentration: '17'
     unit: mM
@@ -269,7 +269,7 @@ growth_media:
       term:
         id: CHEBI:30089
         label: acetate
-    from: community_curated
+    from_source: community_curated
   - name: Mannitol
     concentration: '20'
     unit: mM
@@ -278,7 +278,7 @@ growth_media:
       term:
         id: CHEBI:16899
         label: mannitol
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000308
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000308
   - name: Yeast extract
@@ -289,7 +289,7 @@ growth_media:
       term:
         id: CHEBI:89981
         label: yeast extract
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000025
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000025
   - name: Ammonium chloride (nitrogen source)
@@ -300,7 +300,7 @@ growth_media:
       term:
         id: CHEBI:31206
         label: ammonium chloride
-    from: community_curated
+    from_source: community_curated
   - name: Potassium phosphate
     concentration: '1.0'
     unit: mM
@@ -309,7 +309,7 @@ growth_media:
       term:
         id: CHEBI:131527
         label: dipotassium hydrogen phosphate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000630
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000630
   - name: Magnesium sulfate
@@ -320,7 +320,7 @@ growth_media:
       term:
         id: CHEBI:32599
         label: magnesium sulfate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000174
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000174
   - name: Calcium chloride
@@ -331,13 +331,13 @@ growth_media:
       term:
         id: CHEBI:3312
         label: calcium dichloride
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000484
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000484
   - name: See source for composition
     concentration: variable
     unit: VARIABLE
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000002
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000002
   evidence:

--- a/kb/communities/Chlamydomonas_Methylobacterium_Mutualism.yaml
+++ b/kb/communities/Chlamydomonas_Methylobacterium_Mutualism.yaml
@@ -257,7 +257,7 @@ growth_media:
       term:
         id: CHEBI:9754
         label: tris(hydroxymethyl)aminomethane
-    from: community_curated
+    from_source: community_curated
   - name: Acetate (carbon source)
     concentration: '17'
     unit: mM
@@ -266,7 +266,7 @@ growth_media:
       term:
         id: CHEBI:30089
         label: acetate
-    from: community_curated
+    from_source: community_curated
   - name: Ammonium chloride (nitrogen source)
     concentration: '7.5'
     unit: mM
@@ -275,7 +275,7 @@ growth_media:
       term:
         id: CHEBI:31206
         label: ammonium chloride
-    from: community_curated
+    from_source: community_curated
   - name: Potassium phosphate
     concentration: '1.0'
     unit: mM
@@ -284,7 +284,7 @@ growth_media:
       term:
         id: CHEBI:131527
         label: dipotassium hydrogen phosphate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000630
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000630
   - name: Magnesium sulfate
@@ -295,7 +295,7 @@ growth_media:
       term:
         id: CHEBI:32599
         label: magnesium sulfate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000174
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000174
   - name: Calcium chloride
@@ -306,13 +306,13 @@ growth_media:
       term:
         id: CHEBI:3312
         label: calcium dichloride
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000484
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000484
   - name: See source for composition
     concentration: variable
     unit: VARIABLE
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000002
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000002
   evidence:

--- a/kb/communities/Copper_Biomining_Heap_Leach.yaml
+++ b/kb/communities/Copper_Biomining_Heap_Leach.yaml
@@ -584,7 +584,7 @@ growth_media:
       term:
         id: CHEBI:62946
         label: ammonium sulfate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000258
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000258
   - name: Dipotassium hydrogen phosphate
@@ -595,7 +595,7 @@ growth_media:
       term:
         id: CHEBI:131527
         label: dipotassium hydrogen phosphate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000639
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000639
   - name: Magnesium sulfate heptahydrate
@@ -606,7 +606,7 @@ growth_media:
       term:
         id: CHEBI:32599
         label: magnesium sulfate heptahydrate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000614
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000614
   - name: Potassium chloride
@@ -617,7 +617,7 @@ growth_media:
       term:
         id: CHEBI:32588
         label: potassium chloride
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000230
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000230
   - name: Calcium nitrate
@@ -628,7 +628,7 @@ growth_media:
       term:
         id: CHEBI:64205
         label: calcium nitrate
-    from: community_curated
+    from_source: community_curated
   - name: Iron(II) sulfate heptahydrate
     concentration: 44.22
     unit: g/L
@@ -637,7 +637,7 @@ growth_media:
       term:
         id: CHEBI:31437
         label: iron(II) sulfate (anhydrous)
-    from: community_curated
+    from_source: community_curated
   - name: Elemental sulfur
     concentration: 10
     unit: g/L
@@ -646,49 +646,49 @@ growth_media:
       term:
         id: CHEBI:27568
         label: sulfur atom
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000727
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000727
   - name: K2HPO4
     concentration: '0.499501'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000122
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000122
   - name: (NH4)2SO4
     concentration: '2.997'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000145
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000145
   - name: KCl
     concentration: '0.0999001'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000123
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000123
   - name: MgSO4 x 7 H2O
     concentration: '0.499501'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000118
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000118
   - name: FeSO4 x 7 H2O
     concentration: '49.9501'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000130
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000130
   - name: Ca(NO3)2
     concentration: '0.00999001'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000470
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000470
   - name: H2SO4
     concentration: '1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000181
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000181
   ph: 2.0

--- a/kb/communities/Coscinodiscus_Synthetic_Community.yaml
+++ b/kb/communities/Coscinodiscus_Synthetic_Community.yaml
@@ -399,7 +399,7 @@ growth_media:
       term:
         id: CHEBI:78870
         label: sodium nitrate
-    from: community_curated
+    from_source: community_curated
   - name: Sodium phosphate monobasic (phosphorus source)
     concentration: '5'
     unit: mg/L
@@ -408,7 +408,7 @@ growth_media:
       term:
         id: CHEBI:37585
         label: sodium dihydrogen phosphate
-    from: community_curated
+    from_source: community_curated
   - name: Sodium metasilicate (silicate for diatom frustules)
     concentration: '30'
     unit: mg/L
@@ -417,7 +417,7 @@ growth_media:
       term:
         id: CHEBI:86154
         label: sodium metasilicate
-    from: community_curated
+    from_source: community_curated
   - name: Iron (as FeCl3 in EDTA)
     concentration: '3.15'
     unit: mg/L
@@ -426,7 +426,7 @@ growth_media:
       term:
         id: CHEBI:30808
         label: iron trichloride
-    from: community_curated
+    from_source: community_curated
   - name: EDTA (chelating agent)
     concentration: '4.36'
     unit: mg/L
@@ -435,7 +435,7 @@ growth_media:
       term:
         id: CHEBI:42191
         label: EDTA(4-)
-    from: community_curated
+    from_source: community_curated
   - name: Manganese chloride
     concentration: '0.18'
     unit: mg/L
@@ -444,7 +444,7 @@ growth_media:
       term:
         id: CHEBI:132177
         label: manganese dichloride
-    from: community_curated
+    from_source: community_curated
   - name: Zinc sulfate
     concentration: '0.022'
     unit: mg/L
@@ -453,7 +453,7 @@ growth_media:
       term:
         id: CHEBI:10106
         label: zinc sulfate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000204
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000204
   - name: Cobalt chloride
@@ -464,7 +464,7 @@ growth_media:
       term:
         id: CHEBI:35696
         label: cobalt dichloride
-    from: community_curated
+    from_source: community_curated
   - name: Copper sulfate
     concentration: '0.01'
     unit: mg/L
@@ -473,7 +473,7 @@ growth_media:
       term:
         id: CHEBI:23414
         label: copper(II) sulfate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000578
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000578
   - name: Sodium molybdate
@@ -484,7 +484,7 @@ growth_media:
       term:
         id: CHEBI:75213
         label: sodium molybdate (anhydrous)
-    from: community_curated
+    from_source: community_curated
   - name: Vitamin B12 (cyanocobalamin)
     concentration: '0.0005'
     unit: mg/L
@@ -493,7 +493,7 @@ growth_media:
       term:
         id: CHEBI:28115
         label: cob(I)alamin
-    from: community_curated
+    from_source: community_curated
   - name: Biotin (Vitamin B7)
     concentration: '0.0005'
     unit: mg/L
@@ -502,7 +502,7 @@ growth_media:
       term:
         id: CHEBI:57586
         label: biotin
-    from: community_curated
+    from_source: community_curated
   - name: Thiamine HCl (Vitamin B1)
     concentration: '0.1'
     unit: mg/L
@@ -511,11 +511,11 @@ growth_media:
       term:
         id: CHEBI:18385
         label: thiamine(1+)
-    from: community_curated
+    from_source: community_curated
   - name: See source for composition
     concentration: variable
     unit: VARIABLE
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000002
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000002
   evidence:

--- a/kb/communities/Dangl_SynComm_35.yaml
+++ b/kb/communities/Dangl_SynComm_35.yaml
@@ -421,13 +421,13 @@ growth_media:
   - name: Distilled water
     concentration: '1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000114
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000114
   - name: Bacto Tryptic Soy Broth (Difco)
     concentration: '30'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
 - name: Half-strength Murashige-Skoog medium for Arabidopsis growth
   ph: '5.8'
   temperature: '22'

--- a/kb/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.yaml
+++ b/kb/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.yaml
@@ -164,6 +164,7 @@ ecological_interactions:
     alkane and polycyclic aromatic hydrocarbons, so community-level degradation exceeded single-member
     capabilities.
   interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
   metabolites:
   - preferred_term: hydrocarbon
     term:

--- a/kb/communities/Desert_Tomato_Salt_Stress_SynCom5.yaml
+++ b/kb/communities/Desert_Tomato_Salt_Stress_SynCom5.yaml
@@ -46,6 +46,7 @@ ecological_interactions:
   description: Desert root isolates improve tomato salt-stress tolerance in a natural soil microbiome
     context.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Desulfovibrio_Methanococcus_Syntrophy.yaml
+++ b/kb/communities/Desulfovibrio_Methanococcus_Syntrophy.yaml
@@ -267,7 +267,7 @@ growth_media:
       term:
         id: CHEBI:78320
         label: sodium L-lactate
-    from: community_curated
+    from_source: community_curated
   - name: Sodium bicarbonate
     concentration: '30'
     unit: mM
@@ -276,7 +276,7 @@ growth_media:
       term:
         id: CHEBI:32139
         label: sodium hydrogencarbonate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000255
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000255
   - name: Ammonium chloride
@@ -287,7 +287,7 @@ growth_media:
       term:
         id: CHEBI:31206
         label: ammonium chloride
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000178
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000178
   - name: Sodium phosphate buffer
@@ -298,7 +298,7 @@ growth_media:
       term:
         id: CHEBI:37585
         label: sodium dihydrogen phosphate
-    from: community_curated
+    from_source: community_curated
   - name: Potassium phosphate buffer
     concentration: '3.5'
     unit: mM
@@ -307,7 +307,7 @@ growth_media:
       term:
         id: CHEBI:131527
         label: dipotassium hydrogen phosphate
-    from: community_curated
+    from_source: community_curated
   - name: Magnesium chloride
     concentration: '1'
     unit: mM
@@ -316,7 +316,7 @@ growth_media:
       term:
         id: CHEBI:6636
         label: magnesium dichloride
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000234
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000234
   - name: Calcium chloride
@@ -327,7 +327,7 @@ growth_media:
       term:
         id: CHEBI:3312
         label: calcium dichloride
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000484
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000484
   - name: Sodium sulfide
@@ -338,7 +338,7 @@ growth_media:
       term:
         id: CHEBI:87157
         label: sodium sulfide
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000988
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000988
   - name: L-Cysteine hydrochloride
@@ -349,7 +349,7 @@ growth_media:
       term:
         id: CHEBI:32447
         label: L-cysteine hydrochloride
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000459
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000459
   - name: Resazurin
@@ -360,93 +360,93 @@ growth_media:
       term:
         id: CHEBI:48953
         label: resazurin
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000143
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000143
   - name: Trace element solution SL-10
     concentration: '1'
     unit: mL/L
-    from: community_curated
+    from_source: community_curated
   - name: Vitamin solution
     concentration: '1'
     unit: mL/L
-    from: community_curated
+    from_source: community_curated
   - name: Yeast extract
     concentration: '0.5'
     unit: g/L
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000025
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000025
   - name: KNO3
     concentration: '0.25'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000170
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000170
   - name: KH2PO4
     concentration: '0.1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000116
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000116
   - name: MgSO4 x 7 H2O
     concentration: '0.05'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000118
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000118
   - name: CaCl2 x 2 H2O
     concentration: '0.01'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000115
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000115
   - name: EDTA
     concentration: '5'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000165
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000165
   - name: CuCl2 x 5 H2O
     concentration: '0.1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000357
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000357
   - name: FeSO4 x 7 H2O
     concentration: '2'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000130
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000130
   - name: ZnSO4 x 7 H2O
     concentration: '0.1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000135
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000135
   - name: NiCl2 x 6 H2O
     concentration: '0.02'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000124
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000124
   - name: CoCl2 x 6 H2O
     concentration: '0.2'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000126
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000126
   - name: Na2MoO4
     concentration: '0.03'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000330
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000330
   - name: MnCl2 x 4 H2O
     concentration: '0.03'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000127
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000127
   evidence:

--- a/kb/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.yaml
+++ b/kb/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.yaml
@@ -103,6 +103,7 @@ ecological_interactions:
     acid, creating reciprocal nutritional dependencies that supported growth without external addition
     of the cross-fed amino acids.
   interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
   metabolites:
   - preferred_term: amino acid
     term:
@@ -134,6 +135,7 @@ ecological_interactions:
   description: Engineered amino acid exchange alleviated antagonistic interactions and added beneficial
     interactions to the four-species consortium.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   biological_processes:
   - preferred_term: interspecies interaction between organisms
     term:
@@ -149,6 +151,7 @@ ecological_interactions:
   description: Engineered cross-feeding increased population evenness in anaerobic batch culture and in
     the gnotobiotic mouse gut, especially under low amino acid or low-protein conditions.
   interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
   metabolites:
   - preferred_term: amino acid
     term:

--- a/kb/communities/Ferroplasma_Leptospirillum_Syntrophy.yaml
+++ b/kb/communities/Ferroplasma_Leptospirillum_Syntrophy.yaml
@@ -487,7 +487,7 @@ growth_media:
       term:
         id: CHEBI:62946
         label: ammonium sulfate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000258
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000258
   - name: Magnesium sulfate heptahydrate
@@ -498,7 +498,7 @@ growth_media:
       term:
         id: CHEBI:32599
         label: magnesium sulfate heptahydrate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000614
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000614
   - name: Dipotassium hydrogen phosphate
@@ -509,7 +509,7 @@ growth_media:
       term:
         id: CHEBI:131527
         label: dipotassium hydrogen phosphate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000639
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000639
   - name: Potassium chloride
@@ -520,7 +520,7 @@ growth_media:
       term:
         id: CHEBI:32588
         label: potassium chloride
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000230
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000230
   - name: Calcium nitrate
@@ -531,7 +531,7 @@ growth_media:
       term:
         id: CHEBI:64205
         label: calcium nitrate
-    from: community_curated
+    from_source: community_curated
   - name: Iron(II) sulfate heptahydrate
     concentration: 44.2
     unit: g/L
@@ -540,53 +540,53 @@ growth_media:
       term:
         id: CHEBI:31437
         label: iron(II) sulfate (anhydrous)
-    from: community_curated
+    from_source: community_curated
   - name: Yeast extract
     concentration: 0.04
     unit: '% wt/vol'
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000025
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000025
   - name: K2HPO4
     concentration: '0.499501'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000122
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000122
   - name: (NH4)2SO4
     concentration: '2.997'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000145
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000145
   - name: KCl
     concentration: '0.0999001'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000123
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000123
   - name: MgSO4 x 7 H2O
     concentration: '0.499501'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000118
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000118
   - name: FeSO4 x 7 H2O
     concentration: '49.9501'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000130
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000130
   - name: Ca(NO3)2
     concentration: '0.00999001'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000470
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000470
   - name: H2SO4
     concentration: '1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000181
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000181
   ph: 1.7

--- a/kb/communities/GLBRC_Exometabolite_Transwell_SynCom.yaml
+++ b/kb/communities/GLBRC_Exometabolite_Transwell_SynCom.yaml
@@ -44,6 +44,7 @@ ecological_interactions:
   description: Community members interact chemically through small molecules, extracellular enzymes, and
     antibiotics in shared medium.
   interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/GLBRC_Populus_Variovorax_SynCom28.yaml
+++ b/kb/communities/GLBRC_Populus_Variovorax_SynCom28.yaml
@@ -662,6 +662,7 @@ ecological_interactions:
     are enriched in genes for nutrient metabolism, redox balance, and transcriptional regulation, while
     rhizosphere strains exhibit different trait profiles.
   interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
   evidence:
   - reference: PMID:41543249
     supports: SUPPORT
@@ -686,6 +687,7 @@ ecological_interactions:
     The endosphere exhibits a distinct and reduced set of functional traits compared to the rhizosphere,
     reflecting intense selective pressure.
   interaction_type: STRAIN_COMPETITION
+  scope: COMMUNITY_LEVEL
   evidence:
   - reference: PMID:41543249
     supports: SUPPORT
@@ -709,6 +711,7 @@ ecological_interactions:
     colonization and may influence the establishment of other community members through priority effects
     or niche modification.
   interaction_type: COLONIZATION_FACILITATION
+  scope: COMMUNITY_LEVEL
   metabolites:
   - preferred_term: L-fucose
     term:

--- a/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
+++ b/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
@@ -310,6 +310,7 @@ ecological_interactions:
 
     '
   interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
   metabolites:
   - preferred_term: lactose
     term:
@@ -348,6 +349,7 @@ ecological_interactions:
 
     '
   interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
   metabolites:
   - preferred_term: lactic acid
     term:

--- a/kb/communities/Garlic_Pseudomonas_SynCom6.yaml
+++ b/kb/communities/Garlic_Pseudomonas_SynCom6.yaml
@@ -43,6 +43,7 @@ ecological_interactions:
 - name: Pseudomonas-Mediated Growth Promotion
   description: Pseudomonas strains selected from garlic rhizosphere promote host plant growth.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Honeybee_Core20_Defined_Microbiota.yaml
+++ b/kb/communities/Honeybee_Core20_Defined_Microbiota.yaml
@@ -46,6 +46,7 @@ ecological_interactions:
   description: The defined Core-20 community primes host immune gene expression and reduces Hafnia alvei
     prevalence.
   interaction_type: COLONIZATION_FACILITATION
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.yaml
+++ b/kb/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.yaml
@@ -108,6 +108,7 @@ ecological_interactions:
   description: Species-subset biofilms and growth modeling revealed a dynamic network of positive and
     negative interspecies effects that determined final biofilm composition.
   interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
   biological_processes:
   - preferred_term: biofilm formation
     term:
@@ -161,6 +162,7 @@ ecological_interactions:
   description: The model biofilm reproducibly returned to a stable equilibrium composition after transient
     inoculum perturbations, but continuous perturbations reduced robustness.
   interaction_type: COLONIZATION_FACILITATION
+  scope: COMMUNITY_LEVEL
   biological_processes:
   - preferred_term: biofilm formation
     term:

--- a/kb/communities/Jala_Maize_PGPB_SynCom.yaml
+++ b/kb/communities/Jala_Maize_PGPB_SynCom.yaml
@@ -70,6 +70,7 @@ ecological_interactions:
 - name: Maize Growth Promotion
   description: PGPB members contribute growth-promotion, biocontrol, and induced systemic resistance traits.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/KBase_Models_for_Zahmeeth_Original_PLOS.yaml
+++ b/kb/communities/KBase_Models_for_Zahmeeth_Original_PLOS.yaml
@@ -122,6 +122,7 @@ ecological_interactions:
     inaccessible to individual species. The finding justifies community formation as a strategy to expand
     collective metabolic capabilities beyond the sum of individual organism capacities.
   interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
   metabolites:
   - preferred_term: dextrin
     term:

--- a/kb/communities/KBase_ORT_Workflow_Community_Model.yaml
+++ b/kb/communities/KBase_ORT_Workflow_Community_Model.yaml
@@ -111,6 +111,7 @@ ecological_interactions:
     between archaeal and bacterial partners. The partnership enables complete nitrification from ammonium
     to nitrate, feeding nitrate to downstream denitrifiers.
   interaction_type: SYNTROPHY
+  scope: COMMUNITY_LEVEL
   metabolites:
   - preferred_term: ammonium
     term:
@@ -147,6 +148,7 @@ ecological_interactions:
     models revealed that denitrifiers utilize 15 to 23 unique carbon sources including betaine, leucine,
     and choline, enabling precise identification of biogeochemical limiting factors.
   interaction_type: SYNTROPHY
+  scope: COMMUNITY_LEVEL
   metabolites:
   - preferred_term: nitrate
     term:

--- a/kb/communities/Kombucha_KMC_IMBG1_Fermentation_Community.yaml
+++ b/kb/communities/Kombucha_KMC_IMBG1_Fermentation_Community.yaml
@@ -84,6 +84,7 @@ ecological_interactions:
   description: The kombucha microbial community is described as a bacteria-yeast mutualistic metabolic
     system, with yeasts and cellulose-forming acetobacteria maintained together in a surface pellicle.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   biological_processes:
   - preferred_term: fermentation
     term:
@@ -124,6 +125,7 @@ ecological_interactions:
     composition across sterile sweetened tea, nonsterile sweetened tea, honey-supplemented tea, and
     cabbage-brine hybrid microenvironments.
   interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
   biological_processes:
   - preferred_term: biological process involved in interspecies interaction between organisms
     term:

--- a/kb/communities/LBNL_Brachypodium_Drought_SynCom15.yaml
+++ b/kb/communities/LBNL_Brachypodium_Drought_SynCom15.yaml
@@ -44,6 +44,7 @@ ecological_interactions:
 - name: Drought Resilience Promotion
   description: SynCom members encode and express plant growth-promoting traits linked to drought recovery.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/LBNL_Human_Gut_Interaction_SynCom.yaml
+++ b/kb/communities/LBNL_Human_Gut_Interaction_SynCom.yaml
@@ -45,6 +45,7 @@ ecological_interactions:
 - name: Pairwise Gut Community Interactions
   description: Pairwise positive and negative interactions structure multi-species community dynamics.
   interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/LBNL_Switchgrass_Soil_SynCom16.yaml
+++ b/kb/communities/LBNL_Switchgrass_Soil_SynCom16.yaml
@@ -46,6 +46,7 @@ ecological_interactions:
 - name: Reproducible Rhizosphere Assembly
   description: Defined members reproducibly assemble under low-nutrient and EcoFAB conditions.
   interaction_type: COLONIZATION_FACILITATION
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Lotus_LjSC3.yaml
+++ b/kb/communities/Lotus_LjSC3.yaml
@@ -494,13 +494,13 @@ growth_media:
   - name: Distilled water
     concentration: '1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000114
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000114
   - name: Bacto Tryptic Soy Agar (Difco)
     concentration: '40'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
 - name: Nitrogen-free B&D medium for Lotus japonicus growth
   ph: '6.5'
   temperature: '21'

--- a/kb/communities/MAMC_M48_Lignocellulose.yaml
+++ b/kb/communities/MAMC_M48_Lignocellulose.yaml
@@ -253,81 +253,81 @@ growth_media:
       term:
         id: CHEBI:18246
         label: cellulose
-    from: community_curated
+    from_source: community_curated
   - name: Mineral salts medium base
     concentration: standard MSM formulation
     unit: unspecified
-    from: community_curated
+    from_source: community_curated
   - name: KNO3
     concentration: '0.25'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000170
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000170
   - name: KH2PO4
     concentration: '0.1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000116
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000116
   - name: MgSO4 x 7 H2O
     concentration: '0.05'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000118
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000118
   - name: CaCl2 x 2 H2O
     concentration: '0.01'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000115
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000115
   - name: EDTA
     concentration: '5'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000165
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000165
   - name: CuCl2 x 5 H2O
     concentration: '0.1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000357
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000357
   - name: FeSO4 x 7 H2O
     concentration: '2'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000130
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000130
   - name: ZnSO4 x 7 H2O
     concentration: '0.1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000135
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000135
   - name: NiCl2 x 6 H2O
     concentration: '0.02'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000124
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000124
   - name: CoCl2 x 6 H2O
     concentration: '0.2'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000126
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000126
   - name: Na2MoO4
     concentration: '0.03'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000330
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000330
   - name: MnCl2 x 4 H2O
     concentration: '0.03'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000127
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000127
   evidence:

--- a/kb/communities/MSC2_Model_Soil_Consortium.yaml
+++ b/kb/communities/MSC2_Model_Soil_Consortium.yaml
@@ -169,6 +169,7 @@ ecological_interactions:
     products, so the most abundant members are not necessarily the taxa that directly
     metabolize chitin in monoculture.
   interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
   metabolites:
   - preferred_term: chitin
     term:

--- a/kb/communities/Maize_Benzoxazinoid_Metabolizing_SynComs.yaml
+++ b/kb/communities/Maize_Benzoxazinoid_Metabolizing_SynComs.yaml
@@ -43,6 +43,7 @@ ecological_interactions:
   description: Community members differ in benzoxazinoid tolerance and metabolism, redirecting metabolite
     fate.
   interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Maize_Drought_Response_SynCom.yaml
+++ b/kb/communities/Maize_Drought_Response_SynCom.yaml
@@ -46,6 +46,7 @@ ecological_interactions:
 - name: Maize Drought Physiology Modulation
   description: SynCom inoculation modulates maize water-use physiology and drought recovery.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Medicago_Nodule_Biofertilizer_SynCom.yaml
+++ b/kb/communities/Medicago_Nodule_Biofertilizer_SynCom.yaml
@@ -55,6 +55,7 @@ ecological_interactions:
 - name: Legume Nodule Biofertilization
   description: Nodule endophytes support growth and nodulation under abiotic stress.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
+++ b/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
@@ -231,6 +231,7 @@ ecological_interactions:
 
     '
   interaction_type: COMMENSALISM
+  scope: COMMUNITY_LEVEL
   metabolites:
   - preferred_term: methylmercury
     term:
@@ -267,6 +268,7 @@ ecological_interactions:
 
     '
   interaction_type: COMMENSALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - reference: PMID:33927032
     supports: SUPPORT
@@ -281,6 +283,7 @@ ecological_interactions:
 
     '
   interaction_type: COMMENSALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - reference: PMID:33927032
     supports: SUPPORT

--- a/kb/communities/Methane_Oxidation_CrVI_Reduction_SynCom.yaml
+++ b/kb/communities/Methane_Oxidation_CrVI_Reduction_SynCom.yaml
@@ -62,6 +62,7 @@ ecological_interactions:
   description: Methanotrophs and partner genera couple methane oxidation with Cr(VI) reduction through
     extracellular electron transfer.
   interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.yaml
+++ b/kb/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.yaml
@@ -82,6 +82,7 @@ ecological_interactions:
   description: Root-derived bacteria couple nitrification, denitrification, and plant growth promotion
     to remove ammonia nitrogen.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Multiomics_Corn_Straw_Degradation_SynCom.yaml
+++ b/kb/communities/Multiomics_Corn_Straw_Degradation_SynCom.yaml
@@ -44,6 +44,7 @@ ecological_interactions:
   description: A multi-strain community partitions enzymatic roles for cellulose, hemicellulose, and lignin
     conversion.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/NCycle_Bioflocculation_Model_Consortium.yaml
+++ b/kb/communities/NCycle_Bioflocculation_Model_Consortium.yaml
@@ -45,6 +45,7 @@ ecological_interactions:
   description: Nitrifier microcolonies and denitrifier flocs formed larger aggregate structures under
     reactor cycling.
   interaction_type: COLONIZATION_FACILITATION
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/OMM12_Gnotobiotic_Mouse_Gut_Community.yaml
+++ b/kb/communities/OMM12_Gnotobiotic_Mouse_Gut_Community.yaml
@@ -68,6 +68,7 @@ ecological_interactions:
     enterica serovar Typhimurium in gnotobiotic mice, making it useful for dissecting microbe-microbe and
     host-microbe mechanisms that prevent pathogen expansion.
   interaction_type: COMPETITION
+  scope: COMMUNITY_LEVEL
   biological_processes:
   - preferred_term: interspecies interaction between organisms
     term:
@@ -84,6 +85,7 @@ ecological_interactions:
     individual strain abundances can be resolved by strain-specific qPCR. This makes the consortium a
     standardized model for comparing mouse microbiome experiments.
   interaction_type: COLONIZATION_FACILITATION
+  scope: COMMUNITY_LEVEL
   biological_processes:
   - preferred_term: multi-organism process
     term:

--- a/kb/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.yaml
+++ b/kb/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.yaml
@@ -138,6 +138,7 @@ ecological_interactions:
   description: The contaminated well FW113-47 selected for bacteria associated with uranium, nitrate, and
     iron reduction, indicating bioremediation-relevant redox capacity in the natural groundwater community.
   interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
   metabolites:
   - preferred_term: uranium(VI)
     term:

--- a/kb/communities/Okeke_Lu_Cellulolytic_Consortium.yaml
+++ b/kb/communities/Okeke_Lu_Cellulolytic_Consortium.yaml
@@ -232,7 +232,7 @@ growth_media:
       term:
         id: CHEBI:31357
         label: carboxymethylcellulose
-    from: community_curated
+    from_source: community_curated
   - name: Xylan (hemicellulose substrate)
     concentration: '5'
     unit: g/L
@@ -241,81 +241,81 @@ growth_media:
       term:
         id: CHEBI:37686
         label: xylan
-    from: community_curated
+    from_source: community_curated
   - name: Mineral salts base
     concentration: standard formulation
     unit: unspecified
-    from: community_curated
+    from_source: community_curated
   - name: KNO3
     concentration: '0.25'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000170
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000170
   - name: KH2PO4
     concentration: '0.1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000116
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000116
   - name: MgSO4 x 7 H2O
     concentration: '0.05'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000118
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000118
   - name: CaCl2 x 2 H2O
     concentration: '0.01'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000115
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000115
   - name: EDTA
     concentration: '5'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000165
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000165
   - name: CuCl2 x 5 H2O
     concentration: '0.1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000357
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000357
   - name: FeSO4 x 7 H2O
     concentration: '2'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000130
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000130
   - name: ZnSO4 x 7 H2O
     concentration: '0.1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000135
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000135
   - name: NiCl2 x 6 H2O
     concentration: '0.02'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000124
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000124
   - name: CoCl2 x 6 H2O
     concentration: '0.2'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000126
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000126
   - name: Na2MoO4
     concentration: '0.03'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000330
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000330
   - name: MnCl2 x 4 H2O
     concentration: '0.03'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000127
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000127
   evidence:

--- a/kb/communities/Peanut_Seed_Bacterial_CS_SynCom.yaml
+++ b/kb/communities/Peanut_Seed_Bacterial_CS_SynCom.yaml
@@ -46,6 +46,7 @@ ecological_interactions:
 - name: Seed-Borne Fungal Suppression
   description: Seed-borne bacterial consortia suppress fungal invasion and stimulate host defense.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Pelotomaculum_Methanothermobacter_Syntrophy.yaml
+++ b/kb/communities/Pelotomaculum_Methanothermobacter_Syntrophy.yaml
@@ -286,7 +286,7 @@ growth_media:
       term:
         id: CHEBI:82898
         label: sodium propanoate
-    from: community_curated
+    from_source: community_curated
   - name: Sodium bicarbonate
     concentration: '30'
     unit: mM
@@ -295,7 +295,7 @@ growth_media:
       term:
         id: CHEBI:32139
         label: sodium hydrogencarbonate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000255
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000255
   - name: Ammonium chloride
@@ -306,7 +306,7 @@ growth_media:
       term:
         id: CHEBI:31206
         label: ammonium chloride
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000178
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000178
   - name: Sodium phosphate buffer
@@ -317,7 +317,7 @@ growth_media:
       term:
         id: CHEBI:37585
         label: sodium dihydrogen phosphate
-    from: community_curated
+    from_source: community_curated
   - name: Potassium phosphate buffer
     concentration: '3.5'
     unit: mM
@@ -326,7 +326,7 @@ growth_media:
       term:
         id: CHEBI:131527
         label: dipotassium hydrogen phosphate
-    from: community_curated
+    from_source: community_curated
   - name: Magnesium chloride
     concentration: '2'
     unit: mM
@@ -335,7 +335,7 @@ growth_media:
       term:
         id: CHEBI:6636
         label: magnesium dichloride
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000234
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000234
   - name: Calcium chloride
@@ -346,7 +346,7 @@ growth_media:
       term:
         id: CHEBI:3312
         label: calcium dichloride
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000484
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000484
   - name: Sodium sulfide
@@ -357,7 +357,7 @@ growth_media:
       term:
         id: CHEBI:87157
         label: sodium sulfide
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000988
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000988
   - name: L-Cysteine hydrochloride
@@ -368,13 +368,13 @@ growth_media:
       term:
         id: CHEBI:32447
         label: L-cysteine hydrochloride
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000459
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000459
   - name: Titanium(III) citrate
     concentration: '0.2'
     unit: mM
-    from: community_curated
+    from_source: community_curated
   - name: Resazurin
     concentration: '0.5'
     unit: mg/L
@@ -383,93 +383,93 @@ growth_media:
       term:
         id: CHEBI:48953
         label: resazurin
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000143
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000143
   - name: Trace element solution SL-10
     concentration: '1'
     unit: mL/L
-    from: community_curated
+    from_source: community_curated
   - name: Vitamin solution (thermophilic formulation)
     concentration: '1'
     unit: mL/L
-    from: community_curated
+    from_source: community_curated
   - name: Yeast extract
     concentration: '0.2'
     unit: g/L
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000025
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000025
   - name: KNO3
     concentration: '0.25'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000170
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000170
   - name: KH2PO4
     concentration: '0.1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000116
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000116
   - name: MgSO4 x 7 H2O
     concentration: '0.05'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000118
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000118
   - name: CaCl2 x 2 H2O
     concentration: '0.01'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000115
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000115
   - name: EDTA
     concentration: '5'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000165
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000165
   - name: CuCl2 x 5 H2O
     concentration: '0.1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000357
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000357
   - name: FeSO4 x 7 H2O
     concentration: '2'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000130
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000130
   - name: ZnSO4 x 7 H2O
     concentration: '0.1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000135
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000135
   - name: NiCl2 x 6 H2O
     concentration: '0.02'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000124
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000124
   - name: CoCl2 x 6 H2O
     concentration: '0.2'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000126
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000126
   - name: Na2MoO4
     concentration: '0.03'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000330
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000330
   - name: MnCl2 x 4 H2O
     concentration: '0.03'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000127
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000127
   evidence:

--- a/kb/communities/Pepper_Growth_Rhizosphere_SynCom.yaml
+++ b/kb/communities/Pepper_Growth_Rhizosphere_SynCom.yaml
@@ -45,6 +45,7 @@ ecological_interactions:
   description: SynCom inoculation enriches growth-associated rhizosphere taxa and improves pepper root
     traits.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Pepper_Phytophthora_SynCom5.yaml
+++ b/kb/communities/Pepper_Phytophthora_SynCom5.yaml
@@ -73,6 +73,7 @@ ecological_interactions:
   description: Rhizosphere isolates combine antagonism and plant growth-promoting traits to suppress pathogen
     damage.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Phylogenetically_Diverse_Denitrifying_SynCom.yaml
+++ b/kb/communities/Phylogenetically_Diverse_Denitrifying_SynCom.yaml
@@ -54,6 +54,7 @@ ecological_interactions:
   description: Distantly related denitrifiers improve function and stability through complementarity and
     asynchronous fluctuations.
   interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Populus_Salt_Tolerant_SynComs.yaml
+++ b/kb/communities/Populus_Salt_Tolerant_SynComs.yaml
@@ -46,6 +46,7 @@ ecological_interactions:
   description: Selected rhizosphere bacteria improve plant salt tolerance through oxidative stress, osmolyte,
     and ion-balance mechanisms.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Pseudonitzschia_Sulfitobacter_Association.yaml
+++ b/kb/communities/Pseudonitzschia_Sulfitobacter_Association.yaml
@@ -166,7 +166,7 @@ growth_media:
       term:
         id: CHEBI:78870
         label: sodium nitrate
-    from: community_curated
+    from_source: community_curated
   - name: Sodium phosphate monobasic (phosphorus source)
     concentration: '5'
     unit: mg/L
@@ -175,7 +175,7 @@ growth_media:
       term:
         id: CHEBI:37585
         label: sodium dihydrogen phosphate
-    from: community_curated
+    from_source: community_curated
   - name: Sodium metasilicate (silicate for diatom frustules)
     concentration: '30'
     unit: mg/L
@@ -184,7 +184,7 @@ growth_media:
       term:
         id: CHEBI:86154
         label: sodium metasilicate
-    from: community_curated
+    from_source: community_curated
   - name: Iron (as FeCl3 in EDTA)
     concentration: '3.15'
     unit: mg/L
@@ -193,7 +193,7 @@ growth_media:
       term:
         id: CHEBI:30808
         label: iron trichloride
-    from: community_curated
+    from_source: community_curated
   - name: EDTA (chelating agent)
     concentration: '4.36'
     unit: mg/L
@@ -202,7 +202,7 @@ growth_media:
       term:
         id: CHEBI:42191
         label: EDTA(4-)
-    from: community_curated
+    from_source: community_curated
   - name: Manganese chloride
     concentration: '0.18'
     unit: mg/L
@@ -211,7 +211,7 @@ growth_media:
       term:
         id: CHEBI:132177
         label: manganese dichloride
-    from: community_curated
+    from_source: community_curated
   - name: Zinc sulfate
     concentration: '0.022'
     unit: mg/L
@@ -220,7 +220,7 @@ growth_media:
       term:
         id: CHEBI:10106
         label: zinc sulfate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000204
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000204
   - name: Cobalt chloride
@@ -231,7 +231,7 @@ growth_media:
       term:
         id: CHEBI:35696
         label: cobalt dichloride
-    from: community_curated
+    from_source: community_curated
   - name: Copper sulfate
     concentration: '0.01'
     unit: mg/L
@@ -240,7 +240,7 @@ growth_media:
       term:
         id: CHEBI:23414
         label: copper(II) sulfate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000578
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000578
   - name: Sodium molybdate
@@ -251,7 +251,7 @@ growth_media:
       term:
         id: CHEBI:75213
         label: sodium molybdate (anhydrous)
-    from: community_curated
+    from_source: community_curated
   - name: Vitamin B12 (cyanocobalamin)
     concentration: '0.0005'
     unit: mg/L
@@ -260,7 +260,7 @@ growth_media:
       term:
         id: CHEBI:28115
         label: cob(I)alamin
-    from: community_curated
+    from_source: community_curated
   - name: Biotin (Vitamin B7)
     concentration: '0.0005'
     unit: mg/L
@@ -269,7 +269,7 @@ growth_media:
       term:
         id: CHEBI:57586
         label: biotin
-    from: community_curated
+    from_source: community_curated
   - name: Thiamine HCl (Vitamin B1)
     concentration: '0.1'
     unit: mg/L
@@ -278,11 +278,11 @@ growth_media:
       term:
         id: CHEBI:18385
         label: thiamine(1+)
-    from: community_curated
+    from_source: community_curated
   - name: See source for composition
     concentration: variable
     unit: VARIABLE
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000002
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000002
   evidence:

--- a/kb/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.yaml
+++ b/kb/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.yaml
@@ -53,6 +53,7 @@ ecological_interactions:
 - name: Reciprocal Carbon-Nitrogen Cross-Feeding
   description: R. palustris supplies ammonium while E. coli supplies fermentation products.
   interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Rice_Acid_Soil_Bioinoculant_SynCom.yaml
+++ b/kb/communities/Rice_Acid_Soil_Bioinoculant_SynCom.yaml
@@ -44,6 +44,7 @@ ecological_interactions:
 - name: Rice Acid-Soil Stress Mitigation
   description: Rhizosphere competent bacteria improve rice growth and yield under acid soil stress.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Rice_Duckweed_Bacillus_SynCom.yaml
+++ b/kb/communities/Rice_Duckweed_Bacillus_SynCom.yaml
@@ -111,6 +111,7 @@ ecological_interactions:
     iron mobilization, complementing each other for rice growth promotion. These complementary yet partially
     redundant contributions render community performance resilient to single-member loss.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   metabolites:
   - preferred_term: indole-3-acetic acid
     term:

--- a/kb/communities/Rice_P_Uptake_Intercropping_SynCom4.yaml
+++ b/kb/communities/Rice_P_Uptake_Intercropping_SynCom4.yaml
@@ -73,6 +73,7 @@ ecological_interactions:
   description: SynCom members increase soil available phosphorus and support root-to-shoot phosphorus
     transport.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
+++ b/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
@@ -701,11 +701,11 @@ growth_media:
       term:
         id: CHEBI:29033
         label: iron(2+)
-    from: community_curated
+    from_source: community_curated
   - name: Yeast extract
     concentration: 0.1
     unit: '% wt/vol'
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000025
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000025
   - name: Ammonium sulfate
@@ -716,7 +716,7 @@ growth_media:
       term:
         id: CHEBI:62946
         label: ammonium sulfate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000258
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000258
   - name: Magnesium sulfate heptahydrate
@@ -727,7 +727,7 @@ growth_media:
       term:
         id: CHEBI:32599
         label: magnesium sulfate heptahydrate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000614
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000614
   - name: Monopotassium phosphate
@@ -738,79 +738,79 @@ growth_media:
       term:
         id: CHEBI:63036
         label: potassium dihydrogenphosphate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000485
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000485
   - name: KNO3
     concentration: '0.25'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000170
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000170
   - name: KH2PO4
     concentration: '0.1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000116
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000116
   - name: MgSO4 x 7 H2O
     concentration: '0.05'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000118
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000118
   - name: CaCl2 x 2 H2O
     concentration: '0.01'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000115
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000115
   - name: EDTA
     concentration: '5'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000165
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000165
   - name: CuCl2 x 5 H2O
     concentration: '0.1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000357
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000357
   - name: FeSO4 x 7 H2O
     concentration: '2'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000130
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000130
   - name: ZnSO4 x 7 H2O
     concentration: '0.1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000135
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000135
   - name: NiCl2 x 6 H2O
     concentration: '0.02'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000124
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000124
   - name: CoCl2 x 6 H2O
     concentration: '0.2'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000126
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000126
   - name: Na2MoO4
     concentration: '0.03'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000330
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000330
   - name: MnCl2 x 4 H2O
     concentration: '0.03'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000127
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000127
   ph: 1.5

--- a/kb/communities/SIHUMIx_Human_Intestinal_Model_Community.yaml
+++ b/kb/communities/SIHUMIx_Human_Intestinal_Model_Community.yaml
@@ -199,6 +199,7 @@ ecological_interactions:
     degraders and secondary fermenters that together support acetate, propionate, and butyrate output
     under controlled bioreactor conditions.
   interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
   metabolites:
   - preferred_term: acetate
     term:
@@ -234,6 +235,7 @@ ecological_interactions:
     indicate that community context changes functional gene-product expression relative to single-strain
     growth.
   interaction_type: COLONIZATION_FACILITATION
+  scope: COMMUNITY_LEVEL
   biological_processes:
   - preferred_term: gene expression
     term:

--- a/kb/communities/SPRUCE_Peatland_Methane_Cycling_Community.yaml
+++ b/kb/communities/SPRUCE_Peatland_Methane_Cycling_Community.yaml
@@ -119,6 +119,7 @@ ecological_interactions:
   description: SPRUCE peat microbial composition and functional potential vary with depth, structuring
     terminal anaerobic carbon turnover across surface and deep peat zones.
   interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
   evidence:
   - reference: PMID:40715043
     supports: SUPPORT

--- a/kb/communities/Shewanella_Denitrifying_Richness_SynComs.yaml
+++ b/kb/communities/Shewanella_Denitrifying_Richness_SynComs.yaml
@@ -44,6 +44,7 @@ ecological_interactions:
   description: Shewanella richness gradients produce dynamic biodiversity-function relationships during
     evolution.
   interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/SkinCom_Synthetic_Skin_Community.yaml
+++ b/kb/communities/SkinCom_Synthetic_Skin_Community.yaml
@@ -44,6 +44,7 @@ ecological_interactions:
   description: The standardized SkinCom enables reproducible assays of microbial responses to skin-relevant
     chemicals.
   interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.yaml
+++ b/kb/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.yaml
@@ -55,6 +55,7 @@ ecological_interactions:
   description: Recurrent host-mediated selection favored nodulating Bradyrhizobium and associated beneficial
     rhizosphere taxa.
   interaction_type: COLONIZATION_FACILITATION
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
+++ b/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
@@ -239,13 +239,13 @@ growth_media:
       term:
         id: CHEBI:16899
         label: mannitol
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000308
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000308
   - name: Yeast extract
     concentration: '0.5'
     unit: g/L
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000025
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000025
   - name: Dipotassium phosphate
@@ -256,7 +256,7 @@ growth_media:
       term:
         id: CHEBI:131527
         label: dipotassium hydrogen phosphate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000600
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000600
   - name: Magnesium sulfate
@@ -267,7 +267,7 @@ growth_media:
       term:
         id: CHEBI:32599
         label: magnesium sulfate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000174
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000174
   - name: Sodium chloride
@@ -278,23 +278,23 @@ growth_media:
       term:
         id: CHEBI:26710
         label: sodium chloride
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000187
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000187
   - name: Agar
     concentration: '15'
     unit: g/L
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000119
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000119
   - name: Peptone
     concentration: '3'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
   - name: CaCO3
     concentration: '10'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000188
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000188
   evidence:
@@ -326,13 +326,13 @@ growth_media:
   - name: Tryptone
     concentration: '10'
     unit: g/L
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000022
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000022
   - name: Yeast extract
     concentration: '5'
     unit: g/L
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000025
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000025
   - name: Sodium chloride
@@ -343,19 +343,19 @@ growth_media:
       term:
         id: CHEBI:26710
         label: sodium chloride
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000187
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000187
   - name: Distilled water
     concentration: '1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000114
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000114
   - name: NaCl
     concentration: '10'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000113
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000113
   evidence:

--- a/kb/communities/SynComBac10_Chicken_Intestinal_SynCom.yaml
+++ b/kb/communities/SynComBac10_Chicken_Intestinal_SynCom.yaml
@@ -47,6 +47,7 @@ ecological_interactions:
   description: SynComBac10-derived metabolites likely facilitate early establishment of segmented filamentous
     bacteria.
   interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Synthetic_Periphyton_Freshwater_Biofilm.yaml
+++ b/kb/communities/Synthetic_Periphyton_Freshwater_Biofilm.yaml
@@ -64,6 +64,7 @@ ecological_interactions:
   description: Phototrophic species assemble into a diverse, stable, reproducible biofilm with trackable
     species dynamics.
   interaction_type: COLONIZATION_FACILITATION
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Syntrophobacter_Methanospirillum_Syntrophy.yaml
+++ b/kb/communities/Syntrophobacter_Methanospirillum_Syntrophy.yaml
@@ -258,7 +258,7 @@ growth_media:
       term:
         id: CHEBI:82898
         label: sodium propanoate
-    from: community_curated
+    from_source: community_curated
   - name: Sodium bicarbonate
     concentration: '30'
     unit: mM
@@ -267,7 +267,7 @@ growth_media:
       term:
         id: CHEBI:32139
         label: sodium hydrogencarbonate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000255
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000255
   - name: Ammonium chloride
@@ -278,7 +278,7 @@ growth_media:
       term:
         id: CHEBI:31206
         label: ammonium chloride
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000178
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000178
   - name: Sodium phosphate buffer
@@ -289,7 +289,7 @@ growth_media:
       term:
         id: CHEBI:37585
         label: sodium dihydrogen phosphate
-    from: community_curated
+    from_source: community_curated
   - name: Potassium phosphate buffer
     concentration: '3.5'
     unit: mM
@@ -298,7 +298,7 @@ growth_media:
       term:
         id: CHEBI:131527
         label: dipotassium hydrogen phosphate
-    from: community_curated
+    from_source: community_curated
   - name: Magnesium chloride
     concentration: '1'
     unit: mM
@@ -307,7 +307,7 @@ growth_media:
       term:
         id: CHEBI:6636
         label: magnesium dichloride
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000234
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000234
   - name: Calcium chloride
@@ -318,7 +318,7 @@ growth_media:
       term:
         id: CHEBI:3312
         label: calcium dichloride
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000484
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000484
   - name: Sodium sulfide
@@ -329,7 +329,7 @@ growth_media:
       term:
         id: CHEBI:87157
         label: sodium sulfide
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000988
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000988
   - name: L-Cysteine hydrochloride
@@ -340,7 +340,7 @@ growth_media:
       term:
         id: CHEBI:32447
         label: L-cysteine hydrochloride
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000459
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000459
   - name: Resazurin
@@ -351,93 +351,93 @@ growth_media:
       term:
         id: CHEBI:48953
         label: resazurin
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000143
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000143
   - name: Trace element solution SL-10
     concentration: '1'
     unit: mL/L
-    from: community_curated
+    from_source: community_curated
   - name: Vitamin solution
     concentration: '1'
     unit: mL/L
-    from: community_curated
+    from_source: community_curated
   - name: Yeast extract
     concentration: '0.2'
     unit: g/L
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000025
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000025
   - name: KNO3
     concentration: '0.25'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000170
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000170
   - name: KH2PO4
     concentration: '0.1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000116
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000116
   - name: MgSO4 x 7 H2O
     concentration: '0.05'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000118
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000118
   - name: CaCl2 x 2 H2O
     concentration: '0.01'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000115
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000115
   - name: EDTA
     concentration: '5'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000165
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000165
   - name: CuCl2 x 5 H2O
     concentration: '0.1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000357
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000357
   - name: FeSO4 x 7 H2O
     concentration: '2'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000130
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000130
   - name: ZnSO4 x 7 H2O
     concentration: '0.1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000135
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000135
   - name: NiCl2 x 6 H2O
     concentration: '0.02'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000124
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000124
   - name: CoCl2 x 6 H2O
     concentration: '0.2'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000126
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000126
   - name: Na2MoO4
     concentration: '0.03'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000330
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000330
   - name: MnCl2 x 4 H2O
     concentration: '0.03'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000127
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000127
   evidence:

--- a/kb/communities/Syntrophomonas_Methanospirillum_Syntrophy.yaml
+++ b/kb/communities/Syntrophomonas_Methanospirillum_Syntrophy.yaml
@@ -229,7 +229,7 @@ growth_media:
       term:
         id: CHEBI:88613
         label: sodium butyrate
-    from: community_curated
+    from_source: community_curated
   - name: Sodium bicarbonate
     concentration: '30'
     unit: mM
@@ -238,7 +238,7 @@ growth_media:
       term:
         id: CHEBI:32139
         label: sodium hydrogencarbonate
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000255
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000255
   - name: Ammonium chloride
@@ -249,7 +249,7 @@ growth_media:
       term:
         id: CHEBI:31206
         label: ammonium chloride
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000178
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000178
   - name: Sodium phosphate buffer
@@ -260,7 +260,7 @@ growth_media:
       term:
         id: CHEBI:37585
         label: sodium dihydrogen phosphate
-    from: community_curated
+    from_source: community_curated
   - name: Potassium phosphate buffer
     concentration: '3.5'
     unit: mM
@@ -269,7 +269,7 @@ growth_media:
       term:
         id: CHEBI:131527
         label: dipotassium hydrogen phosphate
-    from: community_curated
+    from_source: community_curated
   - name: Magnesium chloride
     concentration: '1'
     unit: mM
@@ -278,7 +278,7 @@ growth_media:
       term:
         id: CHEBI:6636
         label: magnesium dichloride
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000234
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000234
   - name: Calcium chloride
@@ -289,7 +289,7 @@ growth_media:
       term:
         id: CHEBI:3312
         label: calcium dichloride
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000484
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000484
   - name: Sodium sulfide
@@ -300,7 +300,7 @@ growth_media:
       term:
         id: CHEBI:87157
         label: sodium sulfide
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000988
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000988
   - name: L-Cysteine hydrochloride
@@ -311,7 +311,7 @@ growth_media:
       term:
         id: CHEBI:32447
         label: L-cysteine hydrochloride
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000459
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000459
   - name: Resazurin
@@ -322,93 +322,93 @@ growth_media:
       term:
         id: CHEBI:48953
         label: resazurin
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000143
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000143
   - name: Trace element solution SL-10
     concentration: '1'
     unit: mL/L
-    from: community_curated
+    from_source: community_curated
   - name: Vitamin solution
     concentration: '1'
     unit: mL/L
-    from: community_curated
+    from_source: community_curated
   - name: Yeast extract
     concentration: '0.2'
     unit: g/L
-    from: community_curated
+    from_source: community_curated
     media_ingredient_mech_id: MediaIngredientMech:000025
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000025
   - name: KNO3
     concentration: '0.25'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000170
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000170
   - name: KH2PO4
     concentration: '0.1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000116
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000116
   - name: MgSO4 x 7 H2O
     concentration: '0.05'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000118
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000118
   - name: CaCl2 x 2 H2O
     concentration: '0.01'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000115
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000115
   - name: EDTA
     concentration: '5'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000165
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000165
   - name: CuCl2 x 5 H2O
     concentration: '0.1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000357
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000357
   - name: FeSO4 x 7 H2O
     concentration: '2'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000130
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000130
   - name: ZnSO4 x 7 H2O
     concentration: '0.1'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000135
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000135
   - name: NiCl2 x 6 H2O
     concentration: '0.02'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000124
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000124
   - name: CoCl2 x 6 H2O
     concentration: '0.2'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000126
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000126
   - name: Na2MoO4
     concentration: '0.03'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000330
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000330
   - name: MnCl2 x 4 H2O
     concentration: '0.03'
     unit: G_PER_L
-    from: CultureMech
+    from_source: CultureMech
     media_ingredient_mech_id: MediaIngredientMech:000127
     media_ingredient_mech_url: https://github.com/CultureBotAI/MediaIngredientMech/tree/main/data/ingredients/MediaIngredientMech:000127
   evidence:

--- a/kb/communities/THOR_Rhizosphere_Model_Community.yaml
+++ b/kb/communities/THOR_Rhizosphere_Model_Community.yaml
@@ -175,6 +175,7 @@ ecological_interactions:
     This makes THOR useful for studying how pairwise and higher-order interactions shape aggregate
     community outputs.
   interaction_type: COLONIZATION_FACILITATION
+  scope: COMMUNITY_LEVEL
   metabolites: []
   biological_processes:
   - preferred_term: biofilm formation

--- a/kb/communities/TYQ1_Nematode_Biocontrol_SynCom.yaml
+++ b/kb/communities/TYQ1_Nematode_Biocontrol_SynCom.yaml
@@ -258,6 +258,7 @@ ecological_interactions:
 
     '
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - reference: PMID:41660888
     supports: SUPPORT

--- a/kb/communities/Teosinte_Maize_Biofertilizer_SynCom7.yaml
+++ b/kb/communities/Teosinte_Maize_Biofertilizer_SynCom7.yaml
@@ -73,6 +73,7 @@ ecological_interactions:
   description: Teosinte-associated SynCom members reshape maize-associated microbial communities and enrich
     beneficial taxa.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Tobacco_Chemotactic_Biocontrol_SynCom.yaml
+++ b/kb/communities/Tobacco_Chemotactic_Biocontrol_SynCom.yaml
@@ -53,6 +53,7 @@ ecological_interactions:
 - name: Chemotactic Bacterial Wilt Suppression
   description: Chemotactic SynCom members colonize the rhizosphere and suppress Ralstonia invasion.
   interaction_type: COLONIZATION_FACILITATION
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Tomato_Oxylipin_SynCom3.yaml
+++ b/kb/communities/Tomato_Oxylipin_SynCom3.yaml
@@ -63,6 +63,7 @@ ecological_interactions:
   description: Inducible and stable colonizers synergize to trigger host defense and biofilm-mediated
     protection.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.yaml
+++ b/kb/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.yaml
@@ -65,6 +65,7 @@ ecological_interactions:
 - name: Anaerobic Halophenol Mineralization
   description: Debromination, hydrogen supply, and phenol degradation are partitioned among members.
   interaction_type: SYNTROPHY
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Urine_Nitrification_SynCom.yaml
+++ b/kb/communities/Urine_Nitrification_SynCom.yaml
@@ -80,6 +80,7 @@ ecological_interactions:
 - name: Nitrifier-Heterotroph Urine Conversion
   description: Ureolytic heterotrophs and nitrifiers cooperate to convert urine nitrogen to nitrate.
   interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Watermelon_Rhizosphere_Fusarium_SynCom8.yaml
+++ b/kb/communities/Watermelon_Rhizosphere_Fusarium_SynCom8.yaml
@@ -55,6 +55,7 @@ ecological_interactions:
   description: Pseudomonas and partner bacteria act synergistically to improve plant growth and disease
     resistance.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.yaml
+++ b/kb/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.yaml
@@ -75,6 +75,7 @@ ecological_interactions:
   description: Bacterial and fungal enzyme producers jointly degrade wheat straw polymers before anaerobic
     digestion.
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/hCom2_Complex_Gut_Microbiome.yaml
+++ b/kb/communities/hCom2_Complex_Gut_Microbiome.yaml
@@ -46,6 +46,7 @@ ecological_interactions:
   description: Iterative niche filling improved stability to fecal challenge and resistance to pathogenic
     Escherichia coli.
   interaction_type: COLONIZATION_FACILITATION
+  scope: COMMUNITY_LEVEL
   evidence:
   - *id001
 environmental_factors:

--- a/kb/communities/mCAFEs_Brachypodium_RCC.yaml
+++ b/kb/communities/mCAFEs_Brachypodium_RCC.yaml
@@ -196,6 +196,7 @@ ecological_interactions:
     fast-growing taxa while complex carbon sources like 1/10 R2A enrich slow-growing yet functionally
     important soil taxa.
   interaction_type: COMPETITION
+  scope: COMMUNITY_LEVEL
   evidence:
   - reference: PMID:38846575
     supports: SUPPORT
@@ -208,6 +209,7 @@ ecological_interactions:
     (Pseudomonas, Stenotrophomonas, Methylobacterium) while 7-day transfers enrich slow growers (Acidobacteria,
     Verrucomicrobia, Terriglobus). This creates distinct ecological niches within the enrichment framework.
   interaction_type: COMPETITION
+  scope: COMMUNITY_LEVEL
   evidence:
   - reference: PMID:38846575
     supports: SUPPORT

--- a/scripts/audit_network_integrity.py
+++ b/scripts/audit_network_integrity.py
@@ -72,15 +72,17 @@ class NetworkIntegrityAuditor:
 
         for idx, interaction in enumerate(interactions):
             int_name = interaction.get("name", f"Interaction {idx+1}")
+            scope = interaction.get("scope", "PAIRWISE")
 
-            # Check source_taxon
+            # Check source_taxon (only required for PAIRWISE interactions)
             source = interaction.get("source_taxon")
             if not source:
-                issues.append({
-                    "type": "MISSING_SOURCE",
-                    "interaction": int_name,
-                    "message": "Interaction has no source_taxon"
-                })
+                if scope != "COMMUNITY_LEVEL":
+                    issues.append({
+                        "type": "MISSING_SOURCE",
+                        "interaction": int_name,
+                        "message": "Interaction has no source_taxon"
+                    })
             else:
                 source_term = source.get("preferred_term") or source.get("term", {}).get("label")
                 source_id = source.get("term", {}).get("id")

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-11T22:45:13
+# Generation date: 2026-05-11T23:05:18
 # Schema: communitymech
 #
 # id: https://w3id.org/culturebot-ai/communitymech
@@ -495,7 +495,7 @@ class EcologicalInteraction(YAMLRoot):
             self.interaction_type = InteractionTypeEnum(self.interaction_type)
 
         if self.scope is not None and not isinstance(self.scope, InteractionScopeEnum):
-            self.scope = getattr(InteractionScopeEnum, self.scope)
+            self.scope = InteractionScopeEnum(self.scope)
 
         if self.source_taxon is not None and not isinstance(self.source_taxon, TaxonDescriptor):
             self.source_taxon = TaxonDescriptor(**as_dict(self.source_taxon))
@@ -1908,8 +1908,8 @@ slots.growthMediaComponent__unit = Slot(uri=COMMUNITYMECH.unit, name="growthMedi
 slots.growthMediaComponent__chebi_term = Slot(uri=COMMUNITYMECH.chebi_term, name="growthMediaComponent__chebi_term", curie=COMMUNITYMECH.curie('chebi_term'),
                    model_uri=COMMUNITYMECH.growthMediaComponent__chebi_term, domain=None, range=Optional[Union[dict, MetaboliteDescriptor]])
 
-slots.growthMediaComponent__from = Slot(uri=getattr(COMMUNITYMECH, 'from'), name="growthMediaComponent__from", curie=COMMUNITYMECH.curie('from'),
-                   model_uri=COMMUNITYMECH.growthMediaComponent__from, domain=None, range=Optional[str])
+slots.growthMediaComponent__from_source = Slot(uri=COMMUNITYMECH.from_source, name="growthMediaComponent__from_source", curie=COMMUNITYMECH.curie('from_source'),
+                   model_uri=COMMUNITYMECH.growthMediaComponent__from_source, domain=None, range=Optional[str])
 
 slots.growthMedia__name = Slot(uri=COMMUNITYMECH.name, name="growthMedia__name", curie=COMMUNITYMECH.curie('name'),
                    model_uri=COMMUNITYMECH.growthMedia__name, domain=None, range=str)

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,39 +1,79 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-14T18:15:13
+# Generation date: 2026-05-11T22:45:13
 # Schema: communitymech
 #
 # id: https://w3id.org/culturebot-ai/communitymech
 # description: Schema for modeling microbial community structure, function, and ecological interactions
 # license: BSD-3-Clause
 
+import dataclasses
 import re
 from dataclasses import dataclass
-from typing import Any, ClassVar, Optional, Union
+from datetime import (
+    date,
+    datetime,
+    time
+)
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+    Union
+)
 
-from jsonasobj2 import as_dict
-from linkml_runtime.linkml_model.meta import EnumDefinition, PermissibleValue
+from jsonasobj2 import (
+    JsonObj,
+    as_dict
+)
+from linkml_runtime.linkml_model.meta import (
+    EnumDefinition,
+    PermissibleValue,
+    PvFormulaOptions
+)
 from linkml_runtime.utils.curienamespace import CurieNamespace
 from linkml_runtime.utils.enumerations import EnumDefinitionImpl
-from linkml_runtime.utils.metamodelcore import Bool, empty_list
+from linkml_runtime.utils.formatutils import (
+    camelcase,
+    sfx,
+    underscore
+)
+from linkml_runtime.utils.metamodelcore import (
+    bnode,
+    empty_dict,
+    empty_list
+)
 from linkml_runtime.utils.slot import Slot
-from linkml_runtime.utils.yamlutils import YAMLRoot, extended_str
-from rdflib import URIRef
+from linkml_runtime.utils.yamlutils import (
+    YAMLRoot,
+    extended_float,
+    extended_int,
+    extended_str
+)
+from rdflib import (
+    Namespace,
+    URIRef
+)
+
+from linkml_runtime.linkml_model.types import Boolean, Float, String
+from linkml_runtime.utils.metamodelcore import Bool
 
 metamodel_version = "1.7.0"
 version = None
 
 # Namespaces
-CHEBI = CurieNamespace("CHEBI", "http://purl.obolibrary.org/obo/CHEBI_")
-CL = CurieNamespace("CL", "http://purl.obolibrary.org/obo/CL_")
-ENVO = CurieNamespace("ENVO", "http://purl.obolibrary.org/obo/ENVO_")
-GO = CurieNamespace("GO", "http://purl.obolibrary.org/obo/GO_")
-NCBITAXON = CurieNamespace("NCBITaxon", "http://purl.obolibrary.org/obo/NCBITaxon_")
-PMID = CurieNamespace("PMID", "http://www.ncbi.nlm.nih.gov/pubmed/")
-UBERON = CurieNamespace("UBERON", "http://purl.obolibrary.org/obo/UBERON_")
-COMMUNITYMECH = CurieNamespace("communitymech", "https://w3id.org/culturebot-ai/communitymech/")
-DOI = CurieNamespace("doi", "https://doi.org/")
-LINKML = CurieNamespace("linkml", "https://w3id.org/linkml/")
-XSD = CurieNamespace("xsd", "http://www.w3.org/2001/XMLSchema#")
+CHEBI = CurieNamespace('CHEBI', 'http://purl.obolibrary.org/obo/CHEBI_')
+CL = CurieNamespace('CL', 'http://purl.obolibrary.org/obo/CL_')
+ENVO = CurieNamespace('ENVO', 'http://purl.obolibrary.org/obo/ENVO_')
+GO = CurieNamespace('GO', 'http://purl.obolibrary.org/obo/GO_')
+NCBITAXON = CurieNamespace('NCBITaxon', 'http://purl.obolibrary.org/obo/NCBITaxon_')
+PMID = CurieNamespace('PMID', 'http://www.ncbi.nlm.nih.gov/pubmed/')
+UBERON = CurieNamespace('UBERON', 'http://purl.obolibrary.org/obo/UBERON_')
+COMMUNITYMECH = CurieNamespace('communitymech', 'https://w3id.org/culturebot-ai/communitymech/')
+DOI = CurieNamespace('doi', 'https://doi.org/')
+LINKML = CurieNamespace('linkml', 'https://w3id.org/linkml/')
+XSD = CurieNamespace('xsd', 'http://www.w3.org/2001/XMLSchema#')
 DEFAULT_ = COMMUNITYMECH
 
 
@@ -55,7 +95,6 @@ class Term(YAMLRoot):
     """
     An ontology term with ID and label
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["Term"]
@@ -85,7 +124,6 @@ class EvidenceItem(YAMLRoot):
     """
     An evidence item linking a claim to a publication
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["EvidenceItem"]
@@ -97,8 +135,8 @@ class EvidenceItem(YAMLRoot):
     supports: Union[str, "EvidenceItemSupportEnum"] = None
     evidence_source: Union[str, "EvidenceSourceEnum"] = None
     snippet: str = None
-    explanation: str | None = None
-    confidence_score: float | None = None
+    explanation: Optional[str] = None
+    confidence_score: Optional[float] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.reference):
@@ -135,7 +173,6 @@ class TaxonDescriptor(YAMLRoot):
     """
     Describes an organism with NCBITaxon term
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["TaxonDescriptor"]
@@ -144,8 +181,8 @@ class TaxonDescriptor(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.TaxonDescriptor
 
     preferred_term: str = None
-    term: dict | Term = None
-    notes: str | None = None
+    term: Union[dict, Term] = None
+    notes: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.preferred_term):
@@ -169,7 +206,6 @@ class MetaboliteDescriptor(YAMLRoot):
     """
     Describes a metabolite with CHEBI term
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["MetaboliteDescriptor"]
@@ -178,9 +214,9 @@ class MetaboliteDescriptor(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.MetaboliteDescriptor
 
     preferred_term: str = None
-    term: dict | Term = None
-    concentration: str | None = None
-    notes: str | None = None
+    term: Union[dict, Term] = None
+    concentration: Optional[str] = None
+    notes: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.preferred_term):
@@ -207,7 +243,6 @@ class BiologicalProcessDescriptor(YAMLRoot):
     """
     Describes a biological process with GO term
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["BiologicalProcessDescriptor"]
@@ -216,8 +251,8 @@ class BiologicalProcessDescriptor(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.BiologicalProcessDescriptor
 
     preferred_term: str = None
-    term: dict | Term = None
-    notes: str | None = None
+    term: Union[dict, Term] = None
+    notes: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.preferred_term):
@@ -241,7 +276,6 @@ class EnvironmentDescriptor(YAMLRoot):
     """
     Describes an environment with ENVO term
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["EnvironmentDescriptor"]
@@ -250,8 +284,8 @@ class EnvironmentDescriptor(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.EnvironmentDescriptor
 
     preferred_term: str = None
-    term: dict | Term = None
-    notes: str | None = None
+    term: Union[dict, Term] = None
+    notes: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.preferred_term):
@@ -275,7 +309,6 @@ class CultureCollectionID(YAMLRoot):
     """
     A culture collection identifier with accession number
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["CultureCollectionID"]
@@ -285,8 +318,8 @@ class CultureCollectionID(YAMLRoot):
 
     collection: Union[str, "CultureCollectionEnum"] = None
     accession: str = None
-    url: str | None = None
-    notes: str | None = None
+    url: Optional[str] = None
+    notes: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.collection):
@@ -313,7 +346,6 @@ class StrainDesignation(YAMLRoot):
     """
     Detailed strain-level information for reproducibility
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["StrainDesignation"]
@@ -321,29 +353,20 @@ class StrainDesignation(YAMLRoot):
     class_name: ClassVar[str] = "StrainDesignation"
     class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.StrainDesignation
 
-    strain_name: str | None = None
-    culture_collections: dict | CultureCollectionID | list[dict | CultureCollectionID] | None = (
-        empty_list()
-    )
-    type_strain: bool | Bool | None = None
-    genome_accession: str | None = None
-    genome_url: str | None = None
-    genetic_modification: str | None = None
-    isolation_source: str | None = None
-    notes: str | None = None
+    strain_name: Optional[str] = None
+    culture_collections: Optional[Union[Union[dict, CultureCollectionID], list[Union[dict, CultureCollectionID]]]] = empty_list()
+    type_strain: Optional[Union[bool, Bool]] = None
+    genome_accession: Optional[str] = None
+    genome_url: Optional[str] = None
+    genetic_modification: Optional[str] = None
+    isolation_source: Optional[str] = None
+    notes: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.strain_name is not None and not isinstance(self.strain_name, str):
             self.strain_name = str(self.strain_name)
 
-        if not isinstance(self.culture_collections, list):
-            self.culture_collections = (
-                [self.culture_collections] if self.culture_collections is not None else []
-            )
-        self.culture_collections = [
-            v if isinstance(v, CultureCollectionID) else CultureCollectionID(**as_dict(v))
-            for v in self.culture_collections
-        ]
+        self._normalize_inlined_as_dict(slot_name="culture_collections", slot_type=CultureCollectionID, key_name="collection", keyed=False)
 
         if self.type_strain is not None and not isinstance(self.type_strain, Bool):
             self.type_strain = Bool(self.type_strain)
@@ -371,7 +394,6 @@ class TaxonomicComposition(YAMLRoot):
     """
     A taxon present in the community with abundance and role
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["TaxonomicComposition"]
@@ -379,14 +401,12 @@ class TaxonomicComposition(YAMLRoot):
     class_name: ClassVar[str] = "TaxonomicComposition"
     class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.TaxonomicComposition
 
-    taxon_term: dict | TaxonDescriptor = None
-    strain_designation: dict | StrainDesignation | None = None
-    abundance_level: Union[str, "AbundanceEnum"] | None = None
-    abundance_value: str | None = None
-    functional_role: (
-        Union[str, "FunctionalRoleEnum"] | list[Union[str, "FunctionalRoleEnum"]] | None
-    ) = empty_list()
-    evidence: dict | EvidenceItem | list[dict | EvidenceItem] | None = empty_list()
+    taxon_term: Union[dict, TaxonDescriptor] = None
+    strain_designation: Optional[Union[dict, StrainDesignation]] = None
+    abundance_level: Optional[Union[str, "AbundanceEnum"]] = None
+    abundance_value: Optional[str] = None
+    functional_role: Optional[Union[Union[str, "FunctionalRoleEnum"], list[Union[str, "FunctionalRoleEnum"]]]] = empty_list()
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.taxon_term):
@@ -394,9 +414,7 @@ class TaxonomicComposition(YAMLRoot):
         if not isinstance(self.taxon_term, TaxonDescriptor):
             self.taxon_term = TaxonDescriptor(**as_dict(self.taxon_term))
 
-        if self.strain_designation is not None and not isinstance(
-            self.strain_designation, StrainDesignation
-        ):
+        if self.strain_designation is not None and not isinstance(self.strain_designation, StrainDesignation):
             self.strain_designation = StrainDesignation(**as_dict(self.strain_designation))
 
         if self.abundance_level is not None and not isinstance(self.abundance_level, AbundanceEnum):
@@ -406,19 +424,10 @@ class TaxonomicComposition(YAMLRoot):
             self.abundance_value = str(self.abundance_value)
 
         if not isinstance(self.functional_role, list):
-            self.functional_role = (
-                [self.functional_role] if self.functional_role is not None else []
-            )
-        self.functional_role = [
-            v if isinstance(v, FunctionalRoleEnum) else FunctionalRoleEnum(v)
-            for v in self.functional_role
-        ]
+            self.functional_role = [self.functional_role] if self.functional_role is not None else []
+        self.functional_role = [v if isinstance(v, FunctionalRoleEnum) else FunctionalRoleEnum(v) for v in self.functional_role]
 
-        if not isinstance(self.evidence, list):
-            self.evidence = [self.evidence] if self.evidence is not None else []
-        self.evidence = [
-            v if isinstance(v, EvidenceItem) else EvidenceItem(**as_dict(v)) for v in self.evidence
-        ]
+        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
 
         super().__post_init__(**kwargs)
 
@@ -428,7 +437,6 @@ class InteractionDownstream(YAMLRoot):
     """
     A downstream target in a causal interaction graph
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["InteractionDownstream"]
@@ -437,7 +445,7 @@ class InteractionDownstream(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.InteractionDownstream
 
     target: str = None
-    description: str | None = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.target):
@@ -456,7 +464,6 @@ class EcologicalInteraction(YAMLRoot):
     """
     An interaction between organisms or metabolic processes
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["EcologicalInteraction"]
@@ -465,20 +472,15 @@ class EcologicalInteraction(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.EcologicalInteraction
 
     name: str = None
-    description: str | None = None
-    interaction_type: Union[str, "InteractionTypeEnum"] | None = None
-    source_taxon: dict | TaxonDescriptor | None = None
-    target_taxon: dict | TaxonDescriptor | None = None
-    metabolites: dict | MetaboliteDescriptor | list[dict | MetaboliteDescriptor] | None = (
-        empty_list()
-    )
-    biological_processes: (
-        dict | BiologicalProcessDescriptor | list[dict | BiologicalProcessDescriptor] | None
-    ) = empty_list()
-    downstream: dict | InteractionDownstream | list[dict | InteractionDownstream] | None = (
-        empty_list()
-    )
-    evidence: dict | EvidenceItem | list[dict | EvidenceItem] | None = empty_list()
+    description: Optional[str] = None
+    interaction_type: Optional[Union[str, "InteractionTypeEnum"]] = None
+    scope: Optional[Union[str, "InteractionScopeEnum"]] = 'PAIRWISE'
+    source_taxon: Optional[Union[dict, TaxonDescriptor]] = None
+    target_taxon: Optional[Union[dict, TaxonDescriptor]] = None
+    metabolites: Optional[Union[Union[dict, MetaboliteDescriptor], list[Union[dict, MetaboliteDescriptor]]]] = empty_list()
+    biological_processes: Optional[Union[Union[dict, BiologicalProcessDescriptor], list[Union[dict, BiologicalProcessDescriptor]]]] = empty_list()
+    downstream: Optional[Union[Union[dict, InteractionDownstream], list[Union[dict, InteractionDownstream]]]] = empty_list()
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.name):
@@ -489,10 +491,11 @@ class EcologicalInteraction(YAMLRoot):
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
 
-        if self.interaction_type is not None and not isinstance(
-            self.interaction_type, InteractionTypeEnum
-        ):
+        if self.interaction_type is not None and not isinstance(self.interaction_type, InteractionTypeEnum):
             self.interaction_type = InteractionTypeEnum(self.interaction_type)
+
+        if self.scope is not None and not isinstance(self.scope, InteractionScopeEnum):
+            self.scope = getattr(InteractionScopeEnum, self.scope)
 
         if self.source_taxon is not None and not isinstance(self.source_taxon, TaxonDescriptor):
             self.source_taxon = TaxonDescriptor(**as_dict(self.source_taxon))
@@ -500,38 +503,13 @@ class EcologicalInteraction(YAMLRoot):
         if self.target_taxon is not None and not isinstance(self.target_taxon, TaxonDescriptor):
             self.target_taxon = TaxonDescriptor(**as_dict(self.target_taxon))
 
-        if not isinstance(self.metabolites, list):
-            self.metabolites = [self.metabolites] if self.metabolites is not None else []
-        self.metabolites = [
-            v if isinstance(v, MetaboliteDescriptor) else MetaboliteDescriptor(**as_dict(v))
-            for v in self.metabolites
-        ]
+        self._normalize_inlined_as_dict(slot_name="metabolites", slot_type=MetaboliteDescriptor, key_name="preferred_term", keyed=False)
 
-        if not isinstance(self.biological_processes, list):
-            self.biological_processes = (
-                [self.biological_processes] if self.biological_processes is not None else []
-            )
-        self.biological_processes = [
-            (
-                v
-                if isinstance(v, BiologicalProcessDescriptor)
-                else BiologicalProcessDescriptor(**as_dict(v))
-            )
-            for v in self.biological_processes
-        ]
+        self._normalize_inlined_as_dict(slot_name="biological_processes", slot_type=BiologicalProcessDescriptor, key_name="preferred_term", keyed=False)
 
-        if not isinstance(self.downstream, list):
-            self.downstream = [self.downstream] if self.downstream is not None else []
-        self.downstream = [
-            v if isinstance(v, InteractionDownstream) else InteractionDownstream(**as_dict(v))
-            for v in self.downstream
-        ]
+        self._normalize_inlined_as_dict(slot_name="downstream", slot_type=InteractionDownstream, key_name="target", keyed=False)
 
-        if not isinstance(self.evidence, list):
-            self.evidence = [self.evidence] if self.evidence is not None else []
-        self.evidence = [
-            v if isinstance(v, EvidenceItem) else EvidenceItem(**as_dict(v)) for v in self.evidence
-        ]
+        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
 
         super().__post_init__(**kwargs)
 
@@ -541,7 +519,6 @@ class EnvironmentalFactor(YAMLRoot):
     """
     An environmental condition or parameter
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["EnvironmentalFactor"]
@@ -550,10 +527,10 @@ class EnvironmentalFactor(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.EnvironmentalFactor
 
     name: str = None
-    value: str | None = None
-    unit: str | None = None
-    description: str | None = None
-    evidence: dict | EvidenceItem | list[dict | EvidenceItem] | None = empty_list()
+    value: Optional[str] = None
+    unit: Optional[str] = None
+    description: Optional[str] = None
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.name):
@@ -570,11 +547,7 @@ class EnvironmentalFactor(YAMLRoot):
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
 
-        if not isinstance(self.evidence, list):
-            self.evidence = [self.evidence] if self.evidence is not None else []
-        self.evidence = [
-            v if isinstance(v, EvidenceItem) else EvidenceItem(**as_dict(v)) for v in self.evidence
-        ]
+        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
 
         super().__post_init__(**kwargs)
 
@@ -584,7 +557,6 @@ class GrowthMediaComponent(YAMLRoot):
     """
     A component of growth media (nutrient, salt, buffer, etc.)
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["GrowthMediaComponent"]
@@ -593,12 +565,12 @@ class GrowthMediaComponent(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.GrowthMediaComponent
 
     name: str = None
-    media_ingredient_mech_id: str | None = None
-    media_ingredient_mech_url: str | None = None
-    concentration: str | None = None
-    unit: str | None = None
-    chebi_term: dict | MetaboliteDescriptor | None = None
-    from_source: str | None = None
+    media_ingredient_mech_id: Optional[str] = None
+    media_ingredient_mech_url: Optional[str] = None
+    concentration: Optional[str] = None
+    unit: Optional[str] = None
+    chebi_term: Optional[Union[dict, MetaboliteDescriptor]] = None
+    from_source: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.name):
@@ -606,14 +578,10 @@ class GrowthMediaComponent(YAMLRoot):
         if not isinstance(self.name, str):
             self.name = str(self.name)
 
-        if self.media_ingredient_mech_id is not None and not isinstance(
-            self.media_ingredient_mech_id, str
-        ):
+        if self.media_ingredient_mech_id is not None and not isinstance(self.media_ingredient_mech_id, str):
             self.media_ingredient_mech_id = str(self.media_ingredient_mech_id)
 
-        if self.media_ingredient_mech_url is not None and not isinstance(
-            self.media_ingredient_mech_url, str
-        ):
+        if self.media_ingredient_mech_url is not None and not isinstance(self.media_ingredient_mech_url, str):
             self.media_ingredient_mech_url = str(self.media_ingredient_mech_url)
 
         if self.concentration is not None and not isinstance(self.concentration, str):
@@ -636,7 +604,6 @@ class GrowthMedia(YAMLRoot):
     """
     Growth media used for cultivation of the community or its members
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["GrowthMedia"]
@@ -645,38 +612,36 @@ class GrowthMedia(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.GrowthMedia
 
     name: str = None
-    culturemech_id: str | None = None
-    culturemech_url: str | None = None
-    composition: dict | GrowthMediaComponent | list[dict | GrowthMediaComponent] | None = (
-        empty_list()
-    )
-    ph: str | None = None
-    ph_range: str | None = None
-    temperature: str | None = None
-    temperature_unit: str | None = None
-    temperature_range: str | None = None
-    atmosphere: Union[str, "AtmosphereEnum"] | None = None
-    headspace_gas: str | None = None
-    salinity: str | None = None
-    salinity_unit: str | None = None
-    pressure: str | None = None
-    pressure_unit: str | None = None
-    light_regime: str | None = None
-    light_intensity: str | None = None
-    light_intensity_unit: str | None = None
-    redox_potential: str | None = None
-    redox_potential_unit: str | None = None
-    inoculum_source: str | None = None
-    inoculum_size: str | None = None
-    inoculum_unit: str | None = None
-    incubation_time: str | None = None
-    incubation_time_unit: str | None = None
-    shaking_speed: str | None = None
-    shaking_speed_unit: str | None = None
-    vessel_type: str | None = None
-    preparation_notes: str | None = None
-    protocol_url: str | None = None
-    evidence: dict | EvidenceItem | list[dict | EvidenceItem] | None = empty_list()
+    culturemech_id: Optional[str] = None
+    culturemech_url: Optional[str] = None
+    composition: Optional[Union[Union[dict, GrowthMediaComponent], list[Union[dict, GrowthMediaComponent]]]] = empty_list()
+    ph: Optional[str] = None
+    ph_range: Optional[str] = None
+    temperature: Optional[str] = None
+    temperature_unit: Optional[str] = None
+    temperature_range: Optional[str] = None
+    atmosphere: Optional[Union[str, "AtmosphereEnum"]] = None
+    headspace_gas: Optional[str] = None
+    salinity: Optional[str] = None
+    salinity_unit: Optional[str] = None
+    pressure: Optional[str] = None
+    pressure_unit: Optional[str] = None
+    light_regime: Optional[str] = None
+    light_intensity: Optional[str] = None
+    light_intensity_unit: Optional[str] = None
+    redox_potential: Optional[str] = None
+    redox_potential_unit: Optional[str] = None
+    inoculum_source: Optional[str] = None
+    inoculum_size: Optional[str] = None
+    inoculum_unit: Optional[str] = None
+    incubation_time: Optional[str] = None
+    incubation_time_unit: Optional[str] = None
+    shaking_speed: Optional[str] = None
+    shaking_speed_unit: Optional[str] = None
+    vessel_type: Optional[str] = None
+    preparation_notes: Optional[str] = None
+    protocol_url: Optional[str] = None
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.name):
@@ -690,12 +655,7 @@ class GrowthMedia(YAMLRoot):
         if self.culturemech_url is not None and not isinstance(self.culturemech_url, str):
             self.culturemech_url = str(self.culturemech_url)
 
-        if not isinstance(self.composition, list):
-            self.composition = [self.composition] if self.composition is not None else []
-        self.composition = [
-            v if isinstance(v, GrowthMediaComponent) else GrowthMediaComponent(**as_dict(v))
-            for v in self.composition
-        ]
+        self._normalize_inlined_as_dict(slot_name="composition", slot_type=GrowthMediaComponent, key_name="name", keyed=False)
 
         if self.ph is not None and not isinstance(self.ph, str):
             self.ph = str(self.ph)
@@ -775,11 +735,7 @@ class GrowthMedia(YAMLRoot):
         if self.protocol_url is not None and not isinstance(self.protocol_url, str):
             self.protocol_url = str(self.protocol_url)
 
-        if not isinstance(self.evidence, list):
-            self.evidence = [self.evidence] if self.evidence is not None else []
-        self.evidence = [
-            v if isinstance(v, EvidenceItem) else EvidenceItem(**as_dict(v)) for v in self.evidence
-        ]
+        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
 
         super().__post_init__(**kwargs)
 
@@ -791,7 +747,6 @@ class RelatedMedia(YAMLRoot):
     Complements GrowthMedia (which captures media actually used for cultivation) by enabling environment-based
     discovery of potentially useful media across the CultureMech repository.
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["RelatedMedia"]
@@ -800,11 +755,11 @@ class RelatedMedia(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.RelatedMedia
 
     preferred_term: str = None
-    culturemech_id: str | None = None
-    relationship_type: Union[str, "MediaRelationshipEnum"] | None = None
-    shared_environment_term: dict | Term | None = None
-    relevance_notes: str | None = None
-    evidence: dict | EvidenceItem | list[dict | EvidenceItem] | None = empty_list()
+    culturemech_id: Optional[str] = None
+    relationship_type: Optional[Union[str, "MediaRelationshipEnum"]] = None
+    shared_environment_term: Optional[Union[dict, Term]] = None
+    relevance_notes: Optional[str] = None
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.preferred_term):
@@ -815,24 +770,16 @@ class RelatedMedia(YAMLRoot):
         if self.culturemech_id is not None and not isinstance(self.culturemech_id, str):
             self.culturemech_id = str(self.culturemech_id)
 
-        if self.relationship_type is not None and not isinstance(
-            self.relationship_type, MediaRelationshipEnum
-        ):
+        if self.relationship_type is not None and not isinstance(self.relationship_type, MediaRelationshipEnum):
             self.relationship_type = MediaRelationshipEnum(self.relationship_type)
 
-        if self.shared_environment_term is not None and not isinstance(
-            self.shared_environment_term, Term
-        ):
+        if self.shared_environment_term is not None and not isinstance(self.shared_environment_term, Term):
             self.shared_environment_term = Term(**as_dict(self.shared_environment_term))
 
         if self.relevance_notes is not None and not isinstance(self.relevance_notes, str):
             self.relevance_notes = str(self.relevance_notes)
 
-        if not isinstance(self.evidence, list):
-            self.evidence = [self.evidence] if self.evidence is not None else []
-        self.evidence = [
-            v if isinstance(v, EvidenceItem) else EvidenceItem(**as_dict(v)) for v in self.evidence
-        ]
+        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
 
         super().__post_init__(**kwargs)
 
@@ -844,7 +791,6 @@ class RelatedIngredient(YAMLRoot):
     GrowthMediaComponent (which captures ingredients in actual cultivation media) by linking to environmentally
     significant compounds that may not be in any currently used medium.
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["RelatedIngredient"]
@@ -853,10 +799,10 @@ class RelatedIngredient(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.RelatedIngredient
 
     preferred_term: str = None
-    mediaingredientmech_id: str | None = None
-    chebi_term: dict | Term | None = None
-    relevance: str | None = None
-    evidence: dict | EvidenceItem | list[dict | EvidenceItem] | None = empty_list()
+    mediaingredientmech_id: Optional[str] = None
+    chebi_term: Optional[Union[dict, Term]] = None
+    relevance: Optional[str] = None
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.preferred_term):
@@ -864,9 +810,7 @@ class RelatedIngredient(YAMLRoot):
         if not isinstance(self.preferred_term, str):
             self.preferred_term = str(self.preferred_term)
 
-        if self.mediaingredientmech_id is not None and not isinstance(
-            self.mediaingredientmech_id, str
-        ):
+        if self.mediaingredientmech_id is not None and not isinstance(self.mediaingredientmech_id, str):
             self.mediaingredientmech_id = str(self.mediaingredientmech_id)
 
         if self.chebi_term is not None and not isinstance(self.chebi_term, Term):
@@ -875,11 +819,7 @@ class RelatedIngredient(YAMLRoot):
         if self.relevance is not None and not isinstance(self.relevance, str):
             self.relevance = str(self.relevance)
 
-        if not isinstance(self.evidence, list):
-            self.evidence = [self.evidence] if self.evidence is not None else []
-        self.evidence = [
-            v if isinstance(v, EvidenceItem) else EvidenceItem(**as_dict(v)) for v in self.evidence
-        ]
+        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
 
         super().__post_init__(**kwargs)
 
@@ -889,7 +829,6 @@ class AssociatedDataset(YAMLRoot):
     """
     An omics or other dataset associated with the community
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["AssociatedDataset"]
@@ -900,10 +839,10 @@ class AssociatedDataset(YAMLRoot):
     name: str = None
     dataset_type: Union[str, "DatasetTypeEnum"] = None
     accession: str = None
-    repository: Union[str, "DatasetRepositoryEnum"] | None = None
-    url: str | None = None
-    description: str | None = None
-    evidence: dict | EvidenceItem | list[dict | EvidenceItem] | None = empty_list()
+    repository: Optional[Union[str, "DatasetRepositoryEnum"]] = None
+    url: Optional[str] = None
+    description: Optional[str] = None
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.name):
@@ -930,11 +869,7 @@ class AssociatedDataset(YAMLRoot):
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
 
-        if not isinstance(self.evidence, list):
-            self.evidence = [self.evidence] if self.evidence is not None else []
-        self.evidence = [
-            v if isinstance(v, EvidenceItem) else EvidenceItem(**as_dict(v)) for v in self.evidence
-        ]
+        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
 
         super().__post_init__(**kwargs)
 
@@ -944,7 +879,6 @@ class ExternalResource(YAMLRoot):
     """
     An external model or narrative resource linked to the community
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["ExternalResource"]
@@ -956,8 +890,8 @@ class ExternalResource(YAMLRoot):
     repository: Union[str, "ExternalResourceRepositoryEnum"] = None
     resource_id: str = None
     url: str = None
-    description: str | None = None
-    evidence: dict | EvidenceItem | list[dict | EvidenceItem] | None = empty_list()
+    description: Optional[str] = None
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.name):
@@ -983,11 +917,7 @@ class ExternalResource(YAMLRoot):
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
 
-        if not isinstance(self.evidence, list):
-            self.evidence = [self.evidence] if self.evidence is not None else []
-        self.evidence = [
-            v if isinstance(v, EvidenceItem) else EvidenceItem(**as_dict(v)) for v in self.evidence
-        ]
+        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
 
         super().__post_init__(**kwargs)
 
@@ -997,7 +927,6 @@ class CommunityEngineeringDesign(YAMLRoot):
     """
     Design intent and implementation details for engineered or synthetic communities
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["CommunityEngineeringDesign"]
@@ -1005,15 +934,15 @@ class CommunityEngineeringDesign(YAMLRoot):
     class_name: ClassVar[str] = "CommunityEngineeringDesign"
     class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.CommunityEngineeringDesign
 
-    objective: str | None = None
-    assembly_strategy: str | None = None
-    inoculation_strategy: str | None = None
-    passaging_regimen: str | None = None
-    perturbation_design: str | None = None
-    measurement_endpoints: str | list[str] | None = empty_list()
-    protocol_url: str | None = None
-    notes: str | None = None
-    evidence: dict | EvidenceItem | list[dict | EvidenceItem] | None = empty_list()
+    objective: Optional[str] = None
+    assembly_strategy: Optional[str] = None
+    inoculation_strategy: Optional[str] = None
+    passaging_regimen: Optional[str] = None
+    perturbation_design: Optional[str] = None
+    measurement_endpoints: Optional[Union[str, list[str]]] = empty_list()
+    protocol_url: Optional[str] = None
+    notes: Optional[str] = None
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.objective is not None and not isinstance(self.objective, str):
@@ -1032,12 +961,8 @@ class CommunityEngineeringDesign(YAMLRoot):
             self.perturbation_design = str(self.perturbation_design)
 
         if not isinstance(self.measurement_endpoints, list):
-            self.measurement_endpoints = (
-                [self.measurement_endpoints] if self.measurement_endpoints is not None else []
-            )
-        self.measurement_endpoints = [
-            v if isinstance(v, str) else str(v) for v in self.measurement_endpoints
-        ]
+            self.measurement_endpoints = [self.measurement_endpoints] if self.measurement_endpoints is not None else []
+        self.measurement_endpoints = [v if isinstance(v, str) else str(v) for v in self.measurement_endpoints]
 
         if self.protocol_url is not None and not isinstance(self.protocol_url, str):
             self.protocol_url = str(self.protocol_url)
@@ -1045,11 +970,7 @@ class CommunityEngineeringDesign(YAMLRoot):
         if self.notes is not None and not isinstance(self.notes, str):
             self.notes = str(self.notes)
 
-        if not isinstance(self.evidence, list):
-            self.evidence = [self.evidence] if self.evidence is not None else []
-        self.evidence = [
-            v if isinstance(v, EvidenceItem) else EvidenceItem(**as_dict(v)) for v in self.evidence
-        ]
+        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
 
         super().__post_init__(**kwargs)
 
@@ -1059,7 +980,6 @@ class MicrobialCommunity(YAMLRoot):
     """
     A microbial community with composition and interactions
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["MicrobialCommunity"]
@@ -1067,40 +987,26 @@ class MicrobialCommunity(YAMLRoot):
     class_name: ClassVar[str] = "MicrobialCommunity"
     class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.MicrobialCommunity
 
-    id: str | MicrobialCommunityId = None
+    id: Union[str, MicrobialCommunityId] = None
     name: str = None
-    description: str | None = None
-    ecological_state: Union[str, "EcologicalStateEnum"] | None = None
-    community_origin: Union[str, "CommunityOriginEnum"] | None = None
-    community_category: Union[str, "CommunityCategoryEnum"] | None = None
-    engineering_design: dict | CommunityEngineeringDesign | None = None
-    environment_term: dict | EnvironmentDescriptor | None = None
-    taxonomy: dict | TaxonomicComposition | list[dict | TaxonomicComposition] | None = empty_list()
-    ecological_interactions: (
-        dict | EcologicalInteraction | list[dict | EcologicalInteraction] | None
-    ) = empty_list()
-    environmental_factors: dict | EnvironmentalFactor | list[dict | EnvironmentalFactor] | None = (
-        empty_list()
-    )
-    growth_media: dict | GrowthMedia | list[dict | GrowthMedia] | None = empty_list()
-    related_media: dict | RelatedMedia | list[dict | RelatedMedia] | None = empty_list()
-    related_ingredients: dict | RelatedIngredient | list[dict | RelatedIngredient] | None = (
-        empty_list()
-    )
-    associated_datasets: dict | AssociatedDataset | list[dict | AssociatedDataset] | None = (
-        empty_list()
-    )
-    external_resources: dict | ExternalResource | list[dict | ExternalResource] | None = (
-        empty_list()
-    )
-    metals_present: Union[str, "MetalElementEnum"] | list[Union[str, "MetalElementEnum"]] | None = (
-        empty_list()
-    )
-    rare_earth_elements_present: (
-        Union[str, "RareEarthElementEnum"] | list[Union[str, "RareEarthElementEnum"]] | None
-    ) = empty_list()
-    metal_relevance: Union[str, "MetalRelevanceEnum"] | None = None
-    metal_notes: str | None = None
+    description: Optional[str] = None
+    ecological_state: Optional[Union[str, "EcologicalStateEnum"]] = None
+    community_origin: Optional[Union[str, "CommunityOriginEnum"]] = None
+    community_category: Optional[Union[str, "CommunityCategoryEnum"]] = None
+    engineering_design: Optional[Union[dict, CommunityEngineeringDesign]] = None
+    environment_term: Optional[Union[dict, EnvironmentDescriptor]] = None
+    taxonomy: Optional[Union[Union[dict, TaxonomicComposition], list[Union[dict, TaxonomicComposition]]]] = empty_list()
+    ecological_interactions: Optional[Union[Union[dict, EcologicalInteraction], list[Union[dict, EcologicalInteraction]]]] = empty_list()
+    environmental_factors: Optional[Union[Union[dict, EnvironmentalFactor], list[Union[dict, EnvironmentalFactor]]]] = empty_list()
+    growth_media: Optional[Union[Union[dict, GrowthMedia], list[Union[dict, GrowthMedia]]]] = empty_list()
+    related_media: Optional[Union[Union[dict, RelatedMedia], list[Union[dict, RelatedMedia]]]] = empty_list()
+    related_ingredients: Optional[Union[Union[dict, RelatedIngredient], list[Union[dict, RelatedIngredient]]]] = empty_list()
+    associated_datasets: Optional[Union[Union[dict, AssociatedDataset], list[Union[dict, AssociatedDataset]]]] = empty_list()
+    external_resources: Optional[Union[Union[dict, ExternalResource], list[Union[dict, ExternalResource]]]] = empty_list()
+    metals_present: Optional[Union[Union[str, "MetalElementEnum"], list[Union[str, "MetalElementEnum"]]]] = empty_list()
+    rare_earth_elements_present: Optional[Union[Union[str, "RareEarthElementEnum"], list[Union[str, "RareEarthElementEnum"]]]] = empty_list()
+    metal_relevance: Optional[Union[str, "MetalRelevanceEnum"]] = None
+    metal_notes: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1116,118 +1022,50 @@ class MicrobialCommunity(YAMLRoot):
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
 
-        if self.ecological_state is not None and not isinstance(
-            self.ecological_state, EcologicalStateEnum
-        ):
+        if self.ecological_state is not None and not isinstance(self.ecological_state, EcologicalStateEnum):
             self.ecological_state = EcologicalStateEnum(self.ecological_state)
 
-        if self.community_origin is not None and not isinstance(
-            self.community_origin, CommunityOriginEnum
-        ):
+        if self.community_origin is not None and not isinstance(self.community_origin, CommunityOriginEnum):
             self.community_origin = CommunityOriginEnum(self.community_origin)
 
-        if self.community_category is not None and not isinstance(
-            self.community_category, CommunityCategoryEnum
-        ):
+        if self.community_category is not None and not isinstance(self.community_category, CommunityCategoryEnum):
             self.community_category = CommunityCategoryEnum(self.community_category)
 
-        if self.engineering_design is not None and not isinstance(
-            self.engineering_design, CommunityEngineeringDesign
-        ):
+        if self.engineering_design is not None and not isinstance(self.engineering_design, CommunityEngineeringDesign):
             self.engineering_design = CommunityEngineeringDesign(**as_dict(self.engineering_design))
 
-        if self.environment_term is not None and not isinstance(
-            self.environment_term, EnvironmentDescriptor
-        ):
+        if self.environment_term is not None and not isinstance(self.environment_term, EnvironmentDescriptor):
             self.environment_term = EnvironmentDescriptor(**as_dict(self.environment_term))
 
-        if not isinstance(self.taxonomy, list):
-            self.taxonomy = [self.taxonomy] if self.taxonomy is not None else []
-        self.taxonomy = [
-            v if isinstance(v, TaxonomicComposition) else TaxonomicComposition(**as_dict(v))
-            for v in self.taxonomy
-        ]
+        self._normalize_inlined_as_dict(slot_name="taxonomy", slot_type=TaxonomicComposition, key_name="taxon_term", keyed=False)
 
-        if not isinstance(self.ecological_interactions, list):
-            self.ecological_interactions = (
-                [self.ecological_interactions] if self.ecological_interactions is not None else []
-            )
-        self.ecological_interactions = [
-            v if isinstance(v, EcologicalInteraction) else EcologicalInteraction(**as_dict(v))
-            for v in self.ecological_interactions
-        ]
+        self._normalize_inlined_as_dict(slot_name="ecological_interactions", slot_type=EcologicalInteraction, key_name="name", keyed=False)
 
-        if not isinstance(self.environmental_factors, list):
-            self.environmental_factors = (
-                [self.environmental_factors] if self.environmental_factors is not None else []
-            )
-        self.environmental_factors = [
-            v if isinstance(v, EnvironmentalFactor) else EnvironmentalFactor(**as_dict(v))
-            for v in self.environmental_factors
-        ]
+        self._normalize_inlined_as_dict(slot_name="environmental_factors", slot_type=EnvironmentalFactor, key_name="name", keyed=False)
 
-        if not isinstance(self.growth_media, list):
-            self.growth_media = [self.growth_media] if self.growth_media is not None else []
-        self.growth_media = [
-            v if isinstance(v, GrowthMedia) else GrowthMedia(**as_dict(v))
-            for v in self.growth_media
-        ]
+        self._normalize_inlined_as_dict(slot_name="growth_media", slot_type=GrowthMedia, key_name="name", keyed=False)
 
         if not isinstance(self.related_media, list):
             self.related_media = [self.related_media] if self.related_media is not None else []
-        self.related_media = [
-            v if isinstance(v, RelatedMedia) else RelatedMedia(**as_dict(v))
-            for v in self.related_media
-        ]
+        self.related_media = [v if isinstance(v, RelatedMedia) else RelatedMedia(**as_dict(v)) for v in self.related_media]
 
         if not isinstance(self.related_ingredients, list):
-            self.related_ingredients = (
-                [self.related_ingredients] if self.related_ingredients is not None else []
-            )
-        self.related_ingredients = [
-            v if isinstance(v, RelatedIngredient) else RelatedIngredient(**as_dict(v))
-            for v in self.related_ingredients
-        ]
+            self.related_ingredients = [self.related_ingredients] if self.related_ingredients is not None else []
+        self.related_ingredients = [v if isinstance(v, RelatedIngredient) else RelatedIngredient(**as_dict(v)) for v in self.related_ingredients]
 
-        if not isinstance(self.associated_datasets, list):
-            self.associated_datasets = (
-                [self.associated_datasets] if self.associated_datasets is not None else []
-            )
-        self.associated_datasets = [
-            v if isinstance(v, AssociatedDataset) else AssociatedDataset(**as_dict(v))
-            for v in self.associated_datasets
-        ]
+        self._normalize_inlined_as_dict(slot_name="associated_datasets", slot_type=AssociatedDataset, key_name="name", keyed=False)
 
-        if not isinstance(self.external_resources, list):
-            self.external_resources = (
-                [self.external_resources] if self.external_resources is not None else []
-            )
-        self.external_resources = [
-            v if isinstance(v, ExternalResource) else ExternalResource(**as_dict(v))
-            for v in self.external_resources
-        ]
+        self._normalize_inlined_as_dict(slot_name="external_resources", slot_type=ExternalResource, key_name="name", keyed=False)
 
         if not isinstance(self.metals_present, list):
             self.metals_present = [self.metals_present] if self.metals_present is not None else []
-        self.metals_present = [
-            v if isinstance(v, MetalElementEnum) else MetalElementEnum(v)
-            for v in self.metals_present
-        ]
+        self.metals_present = [v if isinstance(v, MetalElementEnum) else MetalElementEnum(v) for v in self.metals_present]
 
         if not isinstance(self.rare_earth_elements_present, list):
-            self.rare_earth_elements_present = (
-                [self.rare_earth_elements_present]
-                if self.rare_earth_elements_present is not None
-                else []
-            )
-        self.rare_earth_elements_present = [
-            v if isinstance(v, RareEarthElementEnum) else RareEarthElementEnum(v)
-            for v in self.rare_earth_elements_present
-        ]
+            self.rare_earth_elements_present = [self.rare_earth_elements_present] if self.rare_earth_elements_present is not None else []
+        self.rare_earth_elements_present = [v if isinstance(v, RareEarthElementEnum) else RareEarthElementEnum(v) for v in self.rare_earth_elements_present]
 
-        if self.metal_relevance is not None and not isinstance(
-            self.metal_relevance, MetalRelevanceEnum
-        ):
+        if self.metal_relevance is not None and not isinstance(self.metal_relevance, MetalRelevanceEnum):
             self.metal_relevance = MetalRelevanceEnum(self.metal_relevance)
 
         if self.metal_notes is not None and not isinstance(self.metal_notes, str):
@@ -1241,1839 +1079,1090 @@ class EvidenceItemSupportEnum(EnumDefinitionImpl):
     """
     The level of support for an evidence item
     """
-
-    SUPPORT = PermissibleValue(text="SUPPORT", description="Evidence supports the claim")
-    REFUTE = PermissibleValue(text="REFUTE", description="Evidence refutes the claim")
-    PARTIAL = PermissibleValue(text="PARTIAL", description="Evidence partially supports the claim")
-    NO_EVIDENCE = PermissibleValue(text="NO_EVIDENCE", description="No evidence found")
-    WRONG_STATEMENT = PermissibleValue(text="WRONG_STATEMENT", description="Statement is incorrect")
+    SUPPORT = PermissibleValue(
+        text="SUPPORT",
+        description="Evidence supports the claim")
+    REFUTE = PermissibleValue(
+        text="REFUTE",
+        description="Evidence refutes the claim")
+    PARTIAL = PermissibleValue(
+        text="PARTIAL",
+        description="Evidence partially supports the claim")
+    NO_EVIDENCE = PermissibleValue(
+        text="NO_EVIDENCE",
+        description="No evidence found")
+    WRONG_STATEMENT = PermissibleValue(
+        text="WRONG_STATEMENT",
+        description="Statement is incorrect")
 
     _defn = EnumDefinition(
         name="EvidenceItemSupportEnum",
         description="The level of support for an evidence item",
     )
 
-
 class EvidenceSourceEnum(EnumDefinitionImpl):
     """
     The provenance/source of the evidence
     """
-
     IN_VITRO = PermissibleValue(
-        text="IN_VITRO", description="In vitro experiments (batch culture, bioreactor, etc.)"
-    )
+        text="IN_VITRO",
+        description="In vitro experiments (batch culture, bioreactor, etc.)")
     IN_VIVO = PermissibleValue(
-        text="IN_VIVO", description="In vivo experiments (field studies, host-associated, etc.)"
-    )
+        text="IN_VIVO",
+        description="In vivo experiments (field studies, host-associated, etc.)")
     COMPUTATIONAL = PermissibleValue(
-        text="COMPUTATIONAL", description="In silico modeling, simulation, or prediction"
-    )
-    REVIEW = PermissibleValue(text="REVIEW", description="Review article or meta-analysis")
-    OTHER = PermissibleValue(text="OTHER", description="Other evidence type")
+        text="COMPUTATIONAL",
+        description="In silico modeling, simulation, or prediction")
+    REVIEW = PermissibleValue(
+        text="REVIEW",
+        description="Review article or meta-analysis")
+    OTHER = PermissibleValue(
+        text="OTHER",
+        description="Other evidence type")
 
     _defn = EnumDefinition(
         name="EvidenceSourceEnum",
         description="The provenance/source of the evidence",
     )
 
-
 class EcologicalStateEnum(EnumDefinitionImpl):
     """
     The ecological or health state of the community
     """
-
-    STABLE = PermissibleValue(text="STABLE", description="Stable, equilibrium community")
+    STABLE = PermissibleValue(
+        text="STABLE",
+        description="Stable, equilibrium community")
     PERTURBED = PermissibleValue(
-        text="PERTURBED", description="Recently perturbed (e.g., antibiotic treatment)"
-    )
+        text="PERTURBED",
+        description="Recently perturbed (e.g., antibiotic treatment)")
     ENGINEERED = PermissibleValue(
-        text="ENGINEERED", description="Synthetic or engineered community"
-    )
-    TRANSIENT = PermissibleValue(text="TRANSIENT", description="Transient or developing community")
+        text="ENGINEERED",
+        description="Synthetic or engineered community")
+    TRANSIENT = PermissibleValue(
+        text="TRANSIENT",
+        description="Transient or developing community")
 
     _defn = EnumDefinition(
         name="EcologicalStateEnum",
         description="The ecological or health state of the community",
     )
 
-
 class CommunityOriginEnum(EnumDefinitionImpl):
     """
     The origin or source of the community
     """
-
     NATURAL = PermissibleValue(
-        text="NATURAL", description="Naturally occurring community from environment"
-    )
+        text="NATURAL",
+        description="Naturally occurring community from environment")
     ENGINEERED = PermissibleValue(
-        text="ENGINEERED", description="Deliberately engineered or synthetic community"
-    )
+        text="ENGINEERED",
+        description="Deliberately engineered or synthetic community")
     SYNTHETIC = PermissibleValue(
-        text="SYNTHETIC", description="Fully synthetic community designed in laboratory"
-    )
+        text="SYNTHETIC",
+        description="Fully synthetic community designed in laboratory")
 
     _defn = EnumDefinition(
         name="CommunityOriginEnum",
         description="The origin or source of the community",
     )
 
-
 class MediaRelationshipEnum(EnumDefinitionImpl):
     """
     Type of relationship between a microbial community and a growth medium. Distinguishes actual cultivation media
     from environmentally related media.
     """
-
     CULTIVATION_MEDIUM = PermissibleValue(
         text="CULTIVATION_MEDIUM",
-        description="Medium actually used for cultivation of community members",
-    )
+        description="Medium actually used for cultivation of community members")
     ISOLATION_MEDIUM = PermissibleValue(
         text="ISOLATION_MEDIUM",
-        description="Medium used for initial isolation of community members from the environment",
-    )
+        description="Medium used for initial isolation of community members from the environment")
     ENVIRONMENT_ANALOG = PermissibleValue(
         text="ENVIRONMENT_ANALOG",
-        description="Medium designed to mimic the community's natural environment",
-    )
+        description="Medium designed to mimic the community's natural environment")
     REFERENCED_IN_STUDY = PermissibleValue(
         text="REFERENCED_IN_STUDY",
-        description="Medium referenced in a study of this community but not necessarily used for cultivation",
-    )
+        description="Medium referenced in a study of this community but not necessarily used for cultivation")
     SELECTIVE_ENRICHMENT = PermissibleValue(
         text="SELECTIVE_ENRICHMENT",
-        description="Medium used for selective enrichment of specific functional groups within the community",
-    )
+        description="Medium used for selective enrichment of specific functional groups within the community")
 
     _defn = EnumDefinition(
         name="MediaRelationshipEnum",
         description="""Type of relationship between a microbial community and a growth medium. Distinguishes actual cultivation media from environmentally related media.""",
     )
 
-
 class CommunityCategoryEnum(EnumDefinitionImpl):
     """
     Broad functional/ecological category of the community
     """
-
     BIOMINING = PermissibleValue(
-        text="BIOMINING", description="Metal extraction and bioleaching systems"
-    )
-    AMD = PermissibleValue(text="AMD", description="Acid mine drainage communities")
-    SYNTROPHY = PermissibleValue(text="SYNTROPHY", description="Syntrophic metabolic cooperation")
+        text="BIOMINING",
+        description="Metal extraction and bioleaching systems")
+    AMD = PermissibleValue(
+        text="AMD",
+        description="Acid mine drainage communities")
+    SYNTROPHY = PermissibleValue(
+        text="SYNTROPHY",
+        description="Syntrophic metabolic cooperation")
     PHYTOPLANKTON = PermissibleValue(
-        text="PHYTOPLANKTON", description="Algae-bacteria associations"
-    )
+        text="PHYTOPLANKTON",
+        description="Algae-bacteria associations")
     RHIZOSPHERE = PermissibleValue(
-        text="RHIZOSPHERE", description="Plant root-associated communities"
-    )
+        text="RHIZOSPHERE",
+        description="Plant root-associated communities")
     ORAL = PermissibleValue(
-        text="ORAL", description="Oral microbiome and dental biofilm communities"
-    )
+        text="ORAL",
+        description="Oral microbiome and dental biofilm communities")
     LIGNOCELLULOSE = PermissibleValue(
-        text="LIGNOCELLULOSE", description="Lignocellulose degradation systems"
-    )
+        text="LIGNOCELLULOSE",
+        description="Lignocellulose degradation systems")
     METHANOGENESIS = PermissibleValue(
-        text="METHANOGENESIS", description="Methane-producing communities"
-    )
-    DIET = PermissibleValue(text="DIET", description="Direct interspecies electron transfer")
+        text="METHANOGENESIS",
+        description="Methane-producing communities")
+    DIET = PermissibleValue(
+        text="DIET",
+        description="Direct interspecies electron transfer")
     METAL_REDUCTION = PermissibleValue(
-        text="METAL_REDUCTION", description="Metal-reducing communities"
-    )
+        text="METAL_REDUCTION",
+        description="Metal-reducing communities")
     BIOREMEDIATION = PermissibleValue(
-        text="BIOREMEDIATION", description="Pollutant degradation and remediation"
-    )
+        text="BIOREMEDIATION",
+        description="Pollutant degradation and remediation")
     CARBON_SEQUESTRATION = PermissibleValue(
-        text="CARBON_SEQUESTRATION", description="Carbon fixation and storage"
-    )
+        text="CARBON_SEQUESTRATION",
+        description="Carbon fixation and storage")
     EXTREME_ENVIRONMENT = PermissibleValue(
-        text="EXTREME_ENVIRONMENT", description="Communities from extreme conditions"
-    )
+        text="EXTREME_ENVIRONMENT",
+        description="Communities from extreme conditions")
     BIOTECHNOLOGY = PermissibleValue(
-        text="BIOTECHNOLOGY", description="Industrial biotechnology applications"
-    )
-    OTHER = PermissibleValue(text="OTHER", description="Other or uncategorized communities")
+        text="BIOTECHNOLOGY",
+        description="Industrial biotechnology applications")
+    OTHER = PermissibleValue(
+        text="OTHER",
+        description="Other or uncategorized communities")
 
     _defn = EnumDefinition(
         name="CommunityCategoryEnum",
         description="Broad functional/ecological category of the community",
     )
 
-
 class InteractionTypeEnum(EnumDefinitionImpl):
     """
     Type of ecological interaction between organisms
     """
-
-    MUTUALISM = PermissibleValue(text="MUTUALISM", description="Both organisms benefit (+/+)")
+    MUTUALISM = PermissibleValue(
+        text="MUTUALISM",
+        description="Both organisms benefit (+/+)")
     COMMENSALISM = PermissibleValue(
-        text="COMMENSALISM", description="One benefits, other unaffected (+/0)"
-    )
+        text="COMMENSALISM",
+        description="One benefits, other unaffected (+/0)")
     CROSS_FEEDING = PermissibleValue(
-        text="CROSS_FEEDING", description="Metabolite exchange between organisms"
-    )
-    COMPETITION = PermissibleValue(text="COMPETITION", description="Both negatively affected (-/-)")
-    PREDATION = PermissibleValue(text="PREDATION", description="One benefits, other harmed (+/-)")
-    SYNTROPHY = PermissibleValue(text="SYNTROPHY", description="Obligate metabolic cooperation")
+        text="CROSS_FEEDING",
+        description="Metabolite exchange between organisms")
+    COMPETITION = PermissibleValue(
+        text="COMPETITION",
+        description="Both negatively affected (-/-)")
+    PREDATION = PermissibleValue(
+        text="PREDATION",
+        description="One benefits, other harmed (+/-)")
+    SYNTROPHY = PermissibleValue(
+        text="SYNTROPHY",
+        description="Obligate metabolic cooperation")
     NICHE_PARTITIONING = PermissibleValue(
         text="NICHE_PARTITIONING",
-        description="""Strains/species occupy distinct ecological niches, reducing competition through spatial or temporal separation""",
-    )
+        description="""Strains/species occupy distinct ecological niches, reducing competition through spatial or temporal separation""")
     STRAIN_COMPETITION = PermissibleValue(
         text="STRAIN_COMPETITION",
-        description="Intraspecific competition between closely related strains of the same species",
-    )
+        description="Intraspecific competition between closely related strains of the same species")
     COLONIZATION_FACILITATION = PermissibleValue(
         text="COLONIZATION_FACILITATION",
-        description="""One organism facilitates the colonization or establishment of another through priority effects or niche modification""",
-    )
+        description="""One organism facilitates the colonization or establishment of another through priority effects or niche modification""")
 
     _defn = EnumDefinition(
         name="InteractionTypeEnum",
         description="Type of ecological interaction between organisms",
     )
 
+class InteractionScopeEnum(EnumDefinitionImpl):
+    """
+    Whether an interaction is a pairwise organism-to-organism edge or a community-level phenomenon
+    """
+    PAIRWISE = PermissibleValue(
+        text="PAIRWISE",
+        description="""Standard pairwise interaction between a source organism and (usually) a target. Requires source_taxon.""")
+    COMMUNITY_LEVEL = PermissibleValue(
+        text="COMMUNITY_LEVEL",
+        description="""Community-wide or emergent phenomenon (e.g., division of labor, host-microbiota colonization patterns, abiotic-input-driven processes such as electrolysis-supplied H2). source_taxon may be omitted because no single organism is the source.""")
+
+    _defn = EnumDefinition(
+        name="InteractionScopeEnum",
+        description="Whether an interaction is a pairwise organism-to-organism edge or a community-level phenomenon",
+    )
 
 class AbundanceEnum(EnumDefinitionImpl):
     """
     Relative abundance categories
     """
-
-    DOMINANT = PermissibleValue(text="DOMINANT", description="Greater than 1% relative abundance")
-    ABUNDANT = PermissibleValue(text="ABUNDANT", description="0.1-1% relative abundance")
-    COMMON = PermissibleValue(text="COMMON", description="0.01-0.1% relative abundance")
-    RARE = PermissibleValue(text="RARE", description="Less than 0.01% relative abundance")
+    DOMINANT = PermissibleValue(
+        text="DOMINANT",
+        description="Greater than 1% relative abundance")
+    ABUNDANT = PermissibleValue(
+        text="ABUNDANT",
+        description="0.1-1% relative abundance")
+    COMMON = PermissibleValue(
+        text="COMMON",
+        description="0.01-0.1% relative abundance")
+    RARE = PermissibleValue(
+        text="RARE",
+        description="Less than 0.01% relative abundance")
 
     _defn = EnumDefinition(
         name="AbundanceEnum",
         description="Relative abundance categories",
     )
 
-
 class FunctionalRoleEnum(EnumDefinitionImpl):
     """
     Functional role in the community
     """
-
     PRIMARY_PRODUCER = PermissibleValue(
-        text="PRIMARY_PRODUCER", description="Fixes carbon (autotroph)"
-    )
+        text="PRIMARY_PRODUCER",
+        description="Fixes carbon (autotroph)")
     PRIMARY_DEGRADER = PermissibleValue(
-        text="PRIMARY_DEGRADER", description="Degrades complex substrates"
-    )
+        text="PRIMARY_DEGRADER",
+        description="Degrades complex substrates")
     SECONDARY_FERMENTER = PermissibleValue(
-        text="SECONDARY_FERMENTER", description="Ferments products from primary degraders"
-    )
+        text="SECONDARY_FERMENTER",
+        description="Ferments products from primary degraders")
     SYNTROPHIC_PARTNER = PermissibleValue(
-        text="SYNTROPHIC_PARTNER", description="Engages in syntrophic metabolism"
-    )
+        text="SYNTROPHIC_PARTNER",
+        description="Engages in syntrophic metabolism")
     CROSS_FEEDER = PermissibleValue(
-        text="CROSS_FEEDER", description="Utilizes metabolites from other taxa"
-    )
+        text="CROSS_FEEDER",
+        description="Utilizes metabolites from other taxa")
 
     _defn = EnumDefinition(
         name="FunctionalRoleEnum",
         description="Functional role in the community",
     )
 
-
 class AtmosphereEnum(EnumDefinitionImpl):
     """
     Atmospheric/oxygen requirements for growth
     """
-
-    AEROBIC = PermissibleValue(text="AEROBIC", description="Requires oxygen for growth")
+    AEROBIC = PermissibleValue(
+        text="AEROBIC",
+        description="Requires oxygen for growth")
     ANAEROBIC = PermissibleValue(
-        text="ANAEROBIC", description="Growth only in absence of oxygen (strict anaerobe)"
-    )
+        text="ANAEROBIC",
+        description="Growth only in absence of oxygen (strict anaerobe)")
     MICROAEROBIC = PermissibleValue(
-        text="MICROAEROBIC", description="Requires low oxygen levels (typically 2-10%)"
-    )
+        text="MICROAEROBIC",
+        description="Requires low oxygen levels (typically 2-10%)")
     FACULTATIVE_ANAEROBIC = PermissibleValue(
-        text="FACULTATIVE_ANAEROBIC", description="Can grow with or without oxygen"
-    )
+        text="FACULTATIVE_ANAEROBIC",
+        description="Can grow with or without oxygen")
     FACULTATIVE_AEROBIC = PermissibleValue(
-        text="FACULTATIVE_AEROBIC", description="Preferentially aerobic but can grow anaerobically"
-    )
-    CAPNOPHILIC = PermissibleValue(text="CAPNOPHILIC", description="Requires elevated CO2 levels")
+        text="FACULTATIVE_AEROBIC",
+        description="Preferentially aerobic but can grow anaerobically")
+    CAPNOPHILIC = PermissibleValue(
+        text="CAPNOPHILIC",
+        description="Requires elevated CO2 levels")
 
     _defn = EnumDefinition(
         name="AtmosphereEnum",
         description="Atmospheric/oxygen requirements for growth",
     )
 
-
 class DatasetTypeEnum(EnumDefinitionImpl):
     """
     Type of omics or other dataset associated with a community
     """
-
-    METAGENOME = PermissibleValue(text="METAGENOME", description="Shotgun metagenomic sequencing")
-    AMPLICON_16S = PermissibleValue(text="AMPLICON_16S", description="16S rRNA amplicon sequencing")
+    METAGENOME = PermissibleValue(
+        text="METAGENOME",
+        description="Shotgun metagenomic sequencing")
+    AMPLICON_16S = PermissibleValue(
+        text="AMPLICON_16S",
+        description="16S rRNA amplicon sequencing")
     AMPLICON_ITS = PermissibleValue(
-        text="AMPLICON_ITS", description="ITS amplicon sequencing (fungal)"
-    )
+        text="AMPLICON_ITS",
+        description="ITS amplicon sequencing (fungal)")
     METATRANSCRIPTOME = PermissibleValue(
-        text="METATRANSCRIPTOME", description="Metatranscriptomic sequencing"
-    )
-    METAPROTEOME = PermissibleValue(text="METAPROTEOME", description="Metaproteomic analysis")
+        text="METATRANSCRIPTOME",
+        description="Metatranscriptomic sequencing")
+    METAPROTEOME = PermissibleValue(
+        text="METAPROTEOME",
+        description="Metaproteomic analysis")
     METABOLOMICS = PermissibleValue(
-        text="METABOLOMICS", description="Metabolomics (LC-MS, GC-MS, etc.)"
-    )
-    GENOME = PermissibleValue(text="GENOME", description="Isolate whole genome sequencing")
+        text="METABOLOMICS",
+        description="Metabolomics (LC-MS, GC-MS, etc.)")
+    GENOME = PermissibleValue(
+        text="GENOME",
+        description="Isolate whole genome sequencing")
     PHENOTYPE = PermissibleValue(
-        text="PHENOTYPE", description="Phenotypic measurements (growth, imaging, etc.)"
-    )
-    OTHER = PermissibleValue(text="OTHER", description="Other dataset type")
+        text="PHENOTYPE",
+        description="Phenotypic measurements (growth, imaging, etc.)")
+    OTHER = PermissibleValue(
+        text="OTHER",
+        description="Other dataset type")
 
     _defn = EnumDefinition(
         name="DatasetTypeEnum",
         description="Type of omics or other dataset associated with a community",
     )
 
-
 class DatasetRepositoryEnum(EnumDefinitionImpl):
     """
     Data repositories for omics and related datasets
     """
-
-    NCBI_SRA = PermissibleValue(text="NCBI_SRA", description="NCBI Sequence Read Archive")
-    NCBI_BIOPROJECT = PermissibleValue(text="NCBI_BIOPROJECT", description="NCBI BioProject")
-    NMDC = PermissibleValue(text="NMDC", description="National Microbiome Data Collaborative")
-    JGI_GOLD = PermissibleValue(text="JGI_GOLD", description="JGI Genomes OnLine Database")
-    JGI_IMG = PermissibleValue(text="JGI_IMG", description="JGI Integrated Microbial Genomes")
-    MGNIFY = PermissibleValue(text="MGNIFY", description="MGnify (EBI metagenomics)")
+    NCBI_SRA = PermissibleValue(
+        text="NCBI_SRA",
+        description="NCBI Sequence Read Archive")
+    NCBI_BIOPROJECT = PermissibleValue(
+        text="NCBI_BIOPROJECT",
+        description="NCBI BioProject")
+    NMDC = PermissibleValue(
+        text="NMDC",
+        description="National Microbiome Data Collaborative")
+    JGI_GOLD = PermissibleValue(
+        text="JGI_GOLD",
+        description="JGI Genomes OnLine Database")
+    JGI_IMG = PermissibleValue(
+        text="JGI_IMG",
+        description="JGI Integrated Microbial Genomes")
+    MGNIFY = PermissibleValue(
+        text="MGNIFY",
+        description="MGnify (EBI metagenomics)")
     METABOLOMICS_WORKBENCH = PermissibleValue(
-        text="METABOLOMICS_WORKBENCH", description="Metabolomics Workbench"
-    )
-    MASSIVE = PermissibleValue(text="MASSIVE", description="MassIVE mass spectrometry data")
+        text="METABOLOMICS_WORKBENCH",
+        description="Metabolomics Workbench")
+    MASSIVE = PermissibleValue(
+        text="MASSIVE",
+        description="MassIVE mass spectrometry data")
     GNPS = PermissibleValue(
-        text="GNPS", description="Global Natural Products Social Molecular Networking"
-    )
-    FIGSHARE = PermissibleValue(text="FIGSHARE", description="Figshare data repository")
-    ZENODO = PermissibleValue(text="ZENODO", description="Zenodo data repository")
-    OTHER = PermissibleValue(text="OTHER", description="Other data repository")
+        text="GNPS",
+        description="Global Natural Products Social Molecular Networking")
+    FIGSHARE = PermissibleValue(
+        text="FIGSHARE",
+        description="Figshare data repository")
+    ZENODO = PermissibleValue(
+        text="ZENODO",
+        description="Zenodo data repository")
+    OTHER = PermissibleValue(
+        text="OTHER",
+        description="Other data repository")
 
     _defn = EnumDefinition(
         name="DatasetRepositoryEnum",
         description="Data repositories for omics and related datasets",
     )
 
-
 class ExternalResourceRepositoryEnum(EnumDefinitionImpl):
     """
     External repositories and platforms that host community model resources
     """
-
-    BIOMODELS = PermissibleValue(text="BIOMODELS", description="BioModels database")
-    KBASE = PermissibleValue(text="KBASE", description="KBase Narrative platform")
-    BIGG = PermissibleValue(text="BIGG", description="BiGG Models")
-    VMH = PermissibleValue(text="VMH", description="Virtual Metabolic Human")
-    MODELSEED = PermissibleValue(text="MODELSEED", description="ModelSEED resources")
-    GITHUB = PermissibleValue(text="GITHUB", description="GitHub repository")
-    OTHER = PermissibleValue(text="OTHER", description="Other resource repository")
+    BIOMODELS = PermissibleValue(
+        text="BIOMODELS",
+        description="BioModels database")
+    KBASE = PermissibleValue(
+        text="KBASE",
+        description="KBase Narrative platform")
+    BIGG = PermissibleValue(
+        text="BIGG",
+        description="BiGG Models")
+    VMH = PermissibleValue(
+        text="VMH",
+        description="Virtual Metabolic Human")
+    MODELSEED = PermissibleValue(
+        text="MODELSEED",
+        description="ModelSEED resources")
+    GITHUB = PermissibleValue(
+        text="GITHUB",
+        description="GitHub repository")
+    OTHER = PermissibleValue(
+        text="OTHER",
+        description="Other resource repository")
 
     _defn = EnumDefinition(
         name="ExternalResourceRepositoryEnum",
         description="External repositories and platforms that host community model resources",
     )
 
-
 class CultureCollectionEnum(EnumDefinitionImpl):
     """
     Major microbial culture collections worldwide
     """
-
-    ATCC = PermissibleValue(text="ATCC", description="American Type Culture Collection (USA)")
+    ATCC = PermissibleValue(
+        text="ATCC",
+        description="American Type Culture Collection (USA)")
     DSM = PermissibleValue(
-        text="DSM", description="Deutsche Sammlung von Mikroorganismen (DSMZ, Germany)"
-    )
-    JCM = PermissibleValue(text="JCM", description="Japan Collection of Microorganisms (Japan)")
-    NCTC = PermissibleValue(text="NCTC", description="National Collection of Type Cultures (UK)")
+        text="DSM",
+        description="Deutsche Sammlung von Mikroorganismen (DSMZ, Germany)")
+    JCM = PermissibleValue(
+        text="JCM",
+        description="Japan Collection of Microorganisms (Japan)")
+    NCTC = PermissibleValue(
+        text="NCTC",
+        description="National Collection of Type Cultures (UK)")
     CCUG = PermissibleValue(
-        text="CCUG", description="Culture Collection University of Gothenburg (Sweden)"
-    )
+        text="CCUG",
+        description="Culture Collection University of Gothenburg (Sweden)")
     PCC = PermissibleValue(
-        text="PCC", description="Pasteur Culture Collection of Cyanobacteria (France)"
-    )
+        text="PCC",
+        description="Pasteur Culture Collection of Cyanobacteria (France)")
     NCIMB = PermissibleValue(
-        text="NCIMB", description="National Collection of Industrial Marine Bacteria (UK)"
-    )
-    LMG = PermissibleValue(text="LMG", description="BCCM/LMG Bacteria Collection (Belgium)")
-    KCTC = PermissibleValue(text="KCTC", description="Korean Collection for Type Cultures (Korea)")
-    CIP = PermissibleValue(text="CIP", description="Collection de l'Institut Pasteur (France)")
-    NBRC = PermissibleValue(text="NBRC", description="NITE Biological Resource Center (Japan)")
+        text="NCIMB",
+        description="National Collection of Industrial Marine Bacteria (UK)")
+    LMG = PermissibleValue(
+        text="LMG",
+        description="BCCM/LMG Bacteria Collection (Belgium)")
+    KCTC = PermissibleValue(
+        text="KCTC",
+        description="Korean Collection for Type Cultures (Korea)")
+    CIP = PermissibleValue(
+        text="CIP",
+        description="Collection de l'Institut Pasteur (France)")
+    NBRC = PermissibleValue(
+        text="NBRC",
+        description="NITE Biological Resource Center (Japan)")
     VKM = PermissibleValue(
-        text="VKM", description="All-Russian Collection of Microorganisms (Russia)"
-    )
+        text="VKM",
+        description="All-Russian Collection of Microorganisms (Russia)")
     CGMCC = PermissibleValue(
-        text="CGMCC", description="China General Microbiological Culture Collection (China)"
-    )
+        text="CGMCC",
+        description="China General Microbiological Culture Collection (China)")
     BCRC = PermissibleValue(
-        text="BCRC", description="Bioresource Collection and Research Center (Taiwan)"
-    )
+        text="BCRC",
+        description="Bioresource Collection and Research Center (Taiwan)")
     CBS = PermissibleValue(
-        text="CBS", description="Westerdijk Fungal Biodiversity Institute (Netherlands)"
-    )
-    OTHER = PermissibleValue(text="OTHER", description="Other culture collection not listed")
+        text="CBS",
+        description="Westerdijk Fungal Biodiversity Institute (Netherlands)")
+    OTHER = PermissibleValue(
+        text="OTHER",
+        description="Other culture collection not listed")
 
     _defn = EnumDefinition(
         name="CultureCollectionEnum",
         description="Major microbial culture collections worldwide",
     )
 
-
 class MetalElementEnum(EnumDefinitionImpl):
     """
     Metal elements relevant to microbial communities
     """
-
     COPPER = PermissibleValue(
-        text="COPPER", description="Copper(2+) cation", meaning=CHEBI["29036"]
-    )
-    IRON = PermissibleValue(text="IRON", description="Iron(2+) cation", meaning=CHEBI["29033"])
-    ZINC = PermissibleValue(text="ZINC", description="Zinc(2+) cation", meaning=CHEBI["27363"])
+        text="COPPER",
+        description="Copper(2+) cation",
+        meaning=CHEBI["29036"])
+    IRON = PermissibleValue(
+        text="IRON",
+        description="Iron(2+) cation",
+        meaning=CHEBI["29033"])
+    ZINC = PermissibleValue(
+        text="ZINC",
+        description="Zinc(2+) cation",
+        meaning=CHEBI["27363"])
     NICKEL = PermissibleValue(
-        text="NICKEL", description="Nickel(2+) cation", meaning=CHEBI["49786"]
-    )
+        text="NICKEL",
+        description="Nickel(2+) cation",
+        meaning=CHEBI["49786"])
     COBALT = PermissibleValue(
-        text="COBALT", description="Cobalt(2+) cation", meaning=CHEBI["48828"]
-    )
+        text="COBALT",
+        description="Cobalt(2+) cation",
+        meaning=CHEBI["48828"])
     VANADIUM = PermissibleValue(
-        text="VANADIUM", description="Vanadium cation", meaning=CHEBI["27698"]
-    )
-    URANIUM = PermissibleValue(text="URANIUM", description="Uranium atom", meaning=CHEBI["27214"])
+        text="VANADIUM",
+        description="Vanadium cation",
+        meaning=CHEBI["27698"])
+    URANIUM = PermissibleValue(
+        text="URANIUM",
+        description="Uranium atom",
+        meaning=CHEBI["27214"])
     CHROMIUM = PermissibleValue(
-        text="CHROMIUM", description="Chromium atom", meaning=CHEBI["28073"]
-    )
-    LEAD = PermissibleValue(text="LEAD", description="Lead(2+) cation", meaning=CHEBI["25016"])
+        text="CHROMIUM",
+        description="Chromium atom",
+        meaning=CHEBI["28073"])
+    LEAD = PermissibleValue(
+        text="LEAD",
+        description="Lead(2+) cation",
+        meaning=CHEBI["25016"])
     LITHIUM = PermissibleValue(
-        text="LITHIUM", description="Lithium(1+) cation", meaning=CHEBI["49713"]
-    )
-    GOLD = PermissibleValue(text="GOLD", description="Gold atom", meaning=CHEBI["29287"])
+        text="LITHIUM",
+        description="Lithium(1+) cation",
+        meaning=CHEBI["49713"])
+    GOLD = PermissibleValue(
+        text="GOLD",
+        description="Gold atom",
+        meaning=CHEBI["29287"])
     SILVER = PermissibleValue(
-        text="SILVER", description="Silver(1+) cation", meaning=CHEBI["30512"]
-    )
+        text="SILVER",
+        description="Silver(1+) cation",
+        meaning=CHEBI["30512"])
     PALLADIUM = PermissibleValue(
-        text="PALLADIUM", description="Palladium atom", meaning=CHEBI["33373"]
-    )
+        text="PALLADIUM",
+        description="Palladium atom",
+        meaning=CHEBI["33373"])
     GALLIUM = PermissibleValue(
-        text="GALLIUM", description="Gallium(3+) cation", meaning=CHEBI["49631"]
-    )
+        text="GALLIUM",
+        description="Gallium(3+) cation",
+        meaning=CHEBI["49631"])
     INDIUM = PermissibleValue(
-        text="INDIUM", description="Indium(3+) cation", meaning=CHEBI["49464"]
-    )
+        text="INDIUM",
+        description="Indium(3+) cation",
+        meaning=CHEBI["49464"])
     TITANIUM = PermissibleValue(
-        text="TITANIUM", description="Titanium atom", meaning=CHEBI["33341"]
-    )
+        text="TITANIUM",
+        description="Titanium atom",
+        meaning=CHEBI["33341"])
 
     _defn = EnumDefinition(
         name="MetalElementEnum",
         description="Metal elements relevant to microbial communities",
     )
 
-
 class RareEarthElementEnum(EnumDefinitionImpl):
     """
     Rare earth elements (lanthanides + Y, Sc)
     """
-
     LANTHANUM = PermissibleValue(
-        text="LANTHANUM", description="Lanthanum(3+) cation", meaning=CHEBI["32359"]
-    )
+        text="LANTHANUM",
+        description="Lanthanum(3+) cation",
+        meaning=CHEBI["32359"])
     CERIUM = PermissibleValue(
-        text="CERIUM", description="Cerium(3+) cation", meaning=CHEBI["32998"]
-    )
+        text="CERIUM",
+        description="Cerium(3+) cation",
+        meaning=CHEBI["32998"])
     PRASEODYMIUM = PermissibleValue(
-        text="PRASEODYMIUM", description="Praseodymium(3+) cation", meaning=CHEBI["49648"]
-    )
+        text="PRASEODYMIUM",
+        description="Praseodymium(3+) cation",
+        meaning=CHEBI["49648"])
     NEODYMIUM = PermissibleValue(
-        text="NEODYMIUM", description="Neodymium(3+) cation", meaning=CHEBI["33372"]
-    )
+        text="NEODYMIUM",
+        description="Neodymium(3+) cation",
+        meaning=CHEBI["33372"])
     SAMARIUM = PermissibleValue(
-        text="SAMARIUM", description="Samarium(3+) cation", meaning=CHEBI["33376"]
-    )
+        text="SAMARIUM",
+        description="Samarium(3+) cation",
+        meaning=CHEBI["33376"])
     EUROPIUM = PermissibleValue(
-        text="EUROPIUM", description="Europium(3+) cation", meaning=CHEBI["30688"]
-    )
+        text="EUROPIUM",
+        description="Europium(3+) cation",
+        meaning=CHEBI["30688"])
     GADOLINIUM = PermissibleValue(
-        text="GADOLINIUM", description="Gadolinium(3+) cation", meaning=CHEBI["33375"]
-    )
+        text="GADOLINIUM",
+        description="Gadolinium(3+) cation",
+        meaning=CHEBI["33375"])
     TERBIUM = PermissibleValue(
-        text="TERBIUM", description="Terbium(3+) cation", meaning=CHEBI["33374"]
-    )
+        text="TERBIUM",
+        description="Terbium(3+) cation",
+        meaning=CHEBI["33374"])
     DYSPROSIUM = PermissibleValue(
-        text="DYSPROSIUM", description="Dysprosium(3+) cation", meaning=CHEBI["49782"]
-    )
+        text="DYSPROSIUM",
+        description="Dysprosium(3+) cation",
+        meaning=CHEBI["49782"])
     HOLMIUM = PermissibleValue(
-        text="HOLMIUM", description="Holmium(3+) cation", meaning=CHEBI["49649"]
-    )
+        text="HOLMIUM",
+        description="Holmium(3+) cation",
+        meaning=CHEBI["49649"])
     ERBIUM = PermissibleValue(
-        text="ERBIUM", description="Erbium(3+) cation", meaning=CHEBI["49650"]
-    )
+        text="ERBIUM",
+        description="Erbium(3+) cation",
+        meaning=CHEBI["49650"])
     THULIUM = PermissibleValue(
-        text="THULIUM", description="Thulium(3+) cation", meaning=CHEBI["33377"]
-    )
+        text="THULIUM",
+        description="Thulium(3+) cation",
+        meaning=CHEBI["33377"])
     YTTERBIUM = PermissibleValue(
-        text="YTTERBIUM", description="Ytterbium(3+) cation", meaning=CHEBI["33378"]
-    )
+        text="YTTERBIUM",
+        description="Ytterbium(3+) cation",
+        meaning=CHEBI["33378"])
     LUTETIUM = PermissibleValue(
-        text="LUTETIUM", description="Lutetium(3+) cation", meaning=CHEBI["33382"]
-    )
+        text="LUTETIUM",
+        description="Lutetium(3+) cation",
+        meaning=CHEBI["33382"])
     YTTRIUM = PermissibleValue(
-        text="YTTRIUM", description="Yttrium(3+) cation", meaning=CHEBI["49976"]
-    )
+        text="YTTRIUM",
+        description="Yttrium(3+) cation",
+        meaning=CHEBI["49976"])
     SCANDIUM = PermissibleValue(
-        text="SCANDIUM", description="Scandium(3+) cation", meaning=CHEBI["33330"]
-    )
+        text="SCANDIUM",
+        description="Scandium(3+) cation",
+        meaning=CHEBI["33330"])
 
     _defn = EnumDefinition(
         name="RareEarthElementEnum",
         description="Rare earth elements (lanthanides + Y, Sc)",
     )
 
-
 class MetalRelevanceEnum(EnumDefinitionImpl):
     """
     Relevance of metals/REE to community function
     """
-
     PRIMARY = PermissibleValue(
-        text="PRIMARY", description="Primary function involves metal/REE extraction or cycling"
-    )
+        text="PRIMARY",
+        description="Primary function involves metal/REE extraction or cycling")
     SIGNIFICANT = PermissibleValue(
-        text="SIGNIFICANT", description="Significant metal/REE metabolism but not primary function"
-    )
-    INCIDENTAL = PermissibleValue(text="INCIDENTAL", description="Incidental metal/REE interaction")
+        text="SIGNIFICANT",
+        description="Significant metal/REE metabolism but not primary function")
+    INCIDENTAL = PermissibleValue(
+        text="INCIDENTAL",
+        description="Incidental metal/REE interaction")
     NOT_APPLICABLE = PermissibleValue(
-        text="NOT_APPLICABLE", description="No significant metal/REE relevance"
-    )
+        text="NOT_APPLICABLE",
+        description="No significant metal/REE relevance")
 
     _defn = EnumDefinition(
         name="MetalRelevanceEnum",
         description="Relevance of metals/REE to community function",
     )
 
-
 # Slots
 class slots:
     pass
 
+slots.term__id = Slot(uri=COMMUNITYMECH.id, name="term__id", curie=COMMUNITYMECH.curie('id'),
+                   model_uri=COMMUNITYMECH.term__id, domain=None, range=str)
 
-slots.term__id = Slot(
-    uri=COMMUNITYMECH.id,
-    name="term__id",
-    curie=COMMUNITYMECH.curie("id"),
-    model_uri=COMMUNITYMECH.term__id,
-    domain=None,
-    range=str,
-)
-
-slots.term__label = Slot(
-    uri=COMMUNITYMECH.label,
-    name="term__label",
-    curie=COMMUNITYMECH.curie("label"),
-    model_uri=COMMUNITYMECH.term__label,
-    domain=None,
-    range=str,
-)
-
-slots.evidenceItem__reference = Slot(
-    uri=COMMUNITYMECH.reference,
-    name="evidenceItem__reference",
-    curie=COMMUNITYMECH.curie("reference"),
-    model_uri=COMMUNITYMECH.evidenceItem__reference,
-    domain=None,
-    range=str,
-    pattern=re.compile(r"^(PMID:|doi:|bioproject:).*"),
-)
-
-slots.evidenceItem__supports = Slot(
-    uri=COMMUNITYMECH.supports,
-    name="evidenceItem__supports",
-    curie=COMMUNITYMECH.curie("supports"),
-    model_uri=COMMUNITYMECH.evidenceItem__supports,
-    domain=None,
-    range=Union[str, "EvidenceItemSupportEnum"],
-)
-
-slots.evidenceItem__evidence_source = Slot(
-    uri=COMMUNITYMECH.evidence_source,
-    name="evidenceItem__evidence_source",
-    curie=COMMUNITYMECH.curie("evidence_source"),
-    model_uri=COMMUNITYMECH.evidenceItem__evidence_source,
-    domain=None,
-    range=Union[str, "EvidenceSourceEnum"],
-)
-
-slots.evidenceItem__snippet = Slot(
-    uri=COMMUNITYMECH.snippet,
-    name="evidenceItem__snippet",
-    curie=COMMUNITYMECH.curie("snippet"),
-    model_uri=COMMUNITYMECH.evidenceItem__snippet,
-    domain=None,
-    range=str,
-)
-
-slots.evidenceItem__explanation = Slot(
-    uri=COMMUNITYMECH.explanation,
-    name="evidenceItem__explanation",
-    curie=COMMUNITYMECH.curie("explanation"),
-    model_uri=COMMUNITYMECH.evidenceItem__explanation,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.evidenceItem__confidence_score = Slot(
-    uri=COMMUNITYMECH.confidence_score,
-    name="evidenceItem__confidence_score",
-    curie=COMMUNITYMECH.curie("confidence_score"),
-    model_uri=COMMUNITYMECH.evidenceItem__confidence_score,
-    domain=None,
-    range=Optional[float],
-)
-
-slots.taxonDescriptor__preferred_term = Slot(
-    uri=COMMUNITYMECH.preferred_term,
-    name="taxonDescriptor__preferred_term",
-    curie=COMMUNITYMECH.curie("preferred_term"),
-    model_uri=COMMUNITYMECH.taxonDescriptor__preferred_term,
-    domain=None,
-    range=str,
-)
-
-slots.taxonDescriptor__term = Slot(
-    uri=COMMUNITYMECH.term,
-    name="taxonDescriptor__term",
-    curie=COMMUNITYMECH.curie("term"),
-    model_uri=COMMUNITYMECH.taxonDescriptor__term,
-    domain=None,
-    range=Union[dict, Term],
-)
-
-slots.taxonDescriptor__notes = Slot(
-    uri=COMMUNITYMECH.notes,
-    name="taxonDescriptor__notes",
-    curie=COMMUNITYMECH.curie("notes"),
-    model_uri=COMMUNITYMECH.taxonDescriptor__notes,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.metaboliteDescriptor__preferred_term = Slot(
-    uri=COMMUNITYMECH.preferred_term,
-    name="metaboliteDescriptor__preferred_term",
-    curie=COMMUNITYMECH.curie("preferred_term"),
-    model_uri=COMMUNITYMECH.metaboliteDescriptor__preferred_term,
-    domain=None,
-    range=str,
-)
-
-slots.metaboliteDescriptor__term = Slot(
-    uri=COMMUNITYMECH.term,
-    name="metaboliteDescriptor__term",
-    curie=COMMUNITYMECH.curie("term"),
-    model_uri=COMMUNITYMECH.metaboliteDescriptor__term,
-    domain=None,
-    range=Union[dict, Term],
-)
-
-slots.metaboliteDescriptor__concentration = Slot(
-    uri=COMMUNITYMECH.concentration,
-    name="metaboliteDescriptor__concentration",
-    curie=COMMUNITYMECH.curie("concentration"),
-    model_uri=COMMUNITYMECH.metaboliteDescriptor__concentration,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.metaboliteDescriptor__notes = Slot(
-    uri=COMMUNITYMECH.notes,
-    name="metaboliteDescriptor__notes",
-    curie=COMMUNITYMECH.curie("notes"),
-    model_uri=COMMUNITYMECH.metaboliteDescriptor__notes,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.biologicalProcessDescriptor__preferred_term = Slot(
-    uri=COMMUNITYMECH.preferred_term,
-    name="biologicalProcessDescriptor__preferred_term",
-    curie=COMMUNITYMECH.curie("preferred_term"),
-    model_uri=COMMUNITYMECH.biologicalProcessDescriptor__preferred_term,
-    domain=None,
-    range=str,
-)
-
-slots.biologicalProcessDescriptor__term = Slot(
-    uri=COMMUNITYMECH.term,
-    name="biologicalProcessDescriptor__term",
-    curie=COMMUNITYMECH.curie("term"),
-    model_uri=COMMUNITYMECH.biologicalProcessDescriptor__term,
-    domain=None,
-    range=Union[dict, Term],
-)
-
-slots.biologicalProcessDescriptor__notes = Slot(
-    uri=COMMUNITYMECH.notes,
-    name="biologicalProcessDescriptor__notes",
-    curie=COMMUNITYMECH.curie("notes"),
-    model_uri=COMMUNITYMECH.biologicalProcessDescriptor__notes,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.environmentDescriptor__preferred_term = Slot(
-    uri=COMMUNITYMECH.preferred_term,
-    name="environmentDescriptor__preferred_term",
-    curie=COMMUNITYMECH.curie("preferred_term"),
-    model_uri=COMMUNITYMECH.environmentDescriptor__preferred_term,
-    domain=None,
-    range=str,
-)
-
-slots.environmentDescriptor__term = Slot(
-    uri=COMMUNITYMECH.term,
-    name="environmentDescriptor__term",
-    curie=COMMUNITYMECH.curie("term"),
-    model_uri=COMMUNITYMECH.environmentDescriptor__term,
-    domain=None,
-    range=Union[dict, Term],
-)
-
-slots.environmentDescriptor__notes = Slot(
-    uri=COMMUNITYMECH.notes,
-    name="environmentDescriptor__notes",
-    curie=COMMUNITYMECH.curie("notes"),
-    model_uri=COMMUNITYMECH.environmentDescriptor__notes,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.cultureCollectionID__collection = Slot(
-    uri=COMMUNITYMECH.collection,
-    name="cultureCollectionID__collection",
-    curie=COMMUNITYMECH.curie("collection"),
-    model_uri=COMMUNITYMECH.cultureCollectionID__collection,
-    domain=None,
-    range=Union[str, "CultureCollectionEnum"],
-)
-
-slots.cultureCollectionID__accession = Slot(
-    uri=COMMUNITYMECH.accession,
-    name="cultureCollectionID__accession",
-    curie=COMMUNITYMECH.curie("accession"),
-    model_uri=COMMUNITYMECH.cultureCollectionID__accession,
-    domain=None,
-    range=str,
-)
-
-slots.cultureCollectionID__url = Slot(
-    uri=COMMUNITYMECH.url,
-    name="cultureCollectionID__url",
-    curie=COMMUNITYMECH.curie("url"),
-    model_uri=COMMUNITYMECH.cultureCollectionID__url,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.cultureCollectionID__notes = Slot(
-    uri=COMMUNITYMECH.notes,
-    name="cultureCollectionID__notes",
-    curie=COMMUNITYMECH.curie("notes"),
-    model_uri=COMMUNITYMECH.cultureCollectionID__notes,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.strainDesignation__strain_name = Slot(
-    uri=COMMUNITYMECH.strain_name,
-    name="strainDesignation__strain_name",
-    curie=COMMUNITYMECH.curie("strain_name"),
-    model_uri=COMMUNITYMECH.strainDesignation__strain_name,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.strainDesignation__culture_collections = Slot(
-    uri=COMMUNITYMECH.culture_collections,
-    name="strainDesignation__culture_collections",
-    curie=COMMUNITYMECH.curie("culture_collections"),
-    model_uri=COMMUNITYMECH.strainDesignation__culture_collections,
-    domain=None,
-    range=Optional[dict | CultureCollectionID | list[dict | CultureCollectionID]],
-)
-
-slots.strainDesignation__type_strain = Slot(
-    uri=COMMUNITYMECH.type_strain,
-    name="strainDesignation__type_strain",
-    curie=COMMUNITYMECH.curie("type_strain"),
-    model_uri=COMMUNITYMECH.strainDesignation__type_strain,
-    domain=None,
-    range=Optional[bool | Bool],
-)
-
-slots.strainDesignation__genome_accession = Slot(
-    uri=COMMUNITYMECH.genome_accession,
-    name="strainDesignation__genome_accession",
-    curie=COMMUNITYMECH.curie("genome_accession"),
-    model_uri=COMMUNITYMECH.strainDesignation__genome_accession,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.strainDesignation__genome_url = Slot(
-    uri=COMMUNITYMECH.genome_url,
-    name="strainDesignation__genome_url",
-    curie=COMMUNITYMECH.curie("genome_url"),
-    model_uri=COMMUNITYMECH.strainDesignation__genome_url,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.strainDesignation__genetic_modification = Slot(
-    uri=COMMUNITYMECH.genetic_modification,
-    name="strainDesignation__genetic_modification",
-    curie=COMMUNITYMECH.curie("genetic_modification"),
-    model_uri=COMMUNITYMECH.strainDesignation__genetic_modification,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.strainDesignation__isolation_source = Slot(
-    uri=COMMUNITYMECH.isolation_source,
-    name="strainDesignation__isolation_source",
-    curie=COMMUNITYMECH.curie("isolation_source"),
-    model_uri=COMMUNITYMECH.strainDesignation__isolation_source,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.strainDesignation__notes = Slot(
-    uri=COMMUNITYMECH.notes,
-    name="strainDesignation__notes",
-    curie=COMMUNITYMECH.curie("notes"),
-    model_uri=COMMUNITYMECH.strainDesignation__notes,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.taxonomicComposition__taxon_term = Slot(
-    uri=COMMUNITYMECH.taxon_term,
-    name="taxonomicComposition__taxon_term",
-    curie=COMMUNITYMECH.curie("taxon_term"),
-    model_uri=COMMUNITYMECH.taxonomicComposition__taxon_term,
-    domain=None,
-    range=Union[dict, TaxonDescriptor],
-)
-
-slots.taxonomicComposition__strain_designation = Slot(
-    uri=COMMUNITYMECH.strain_designation,
-    name="taxonomicComposition__strain_designation",
-    curie=COMMUNITYMECH.curie("strain_designation"),
-    model_uri=COMMUNITYMECH.taxonomicComposition__strain_designation,
-    domain=None,
-    range=Optional[dict | StrainDesignation],
-)
-
-slots.taxonomicComposition__abundance_level = Slot(
-    uri=COMMUNITYMECH.abundance_level,
-    name="taxonomicComposition__abundance_level",
-    curie=COMMUNITYMECH.curie("abundance_level"),
-    model_uri=COMMUNITYMECH.taxonomicComposition__abundance_level,
-    domain=None,
-    range=Optional[Union[str, "AbundanceEnum"]],
-)
-
-slots.taxonomicComposition__abundance_value = Slot(
-    uri=COMMUNITYMECH.abundance_value,
-    name="taxonomicComposition__abundance_value",
-    curie=COMMUNITYMECH.curie("abundance_value"),
-    model_uri=COMMUNITYMECH.taxonomicComposition__abundance_value,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.taxonomicComposition__functional_role = Slot(
-    uri=COMMUNITYMECH.functional_role,
-    name="taxonomicComposition__functional_role",
-    curie=COMMUNITYMECH.curie("functional_role"),
-    model_uri=COMMUNITYMECH.taxonomicComposition__functional_role,
-    domain=None,
-    range=Optional[Union[str, "FunctionalRoleEnum"] | list[Union[str, "FunctionalRoleEnum"]]],
-)
-
-slots.taxonomicComposition__evidence = Slot(
-    uri=COMMUNITYMECH.evidence,
-    name="taxonomicComposition__evidence",
-    curie=COMMUNITYMECH.curie("evidence"),
-    model_uri=COMMUNITYMECH.taxonomicComposition__evidence,
-    domain=None,
-    range=Optional[dict | EvidenceItem | list[dict | EvidenceItem]],
-)
-
-slots.interactionDownstream__target = Slot(
-    uri=COMMUNITYMECH.target,
-    name="interactionDownstream__target",
-    curie=COMMUNITYMECH.curie("target"),
-    model_uri=COMMUNITYMECH.interactionDownstream__target,
-    domain=None,
-    range=str,
-)
-
-slots.interactionDownstream__description = Slot(
-    uri=COMMUNITYMECH.description,
-    name="interactionDownstream__description",
-    curie=COMMUNITYMECH.curie("description"),
-    model_uri=COMMUNITYMECH.interactionDownstream__description,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.ecologicalInteraction__name = Slot(
-    uri=COMMUNITYMECH.name,
-    name="ecologicalInteraction__name",
-    curie=COMMUNITYMECH.curie("name"),
-    model_uri=COMMUNITYMECH.ecologicalInteraction__name,
-    domain=None,
-    range=str,
-)
-
-slots.ecologicalInteraction__description = Slot(
-    uri=COMMUNITYMECH.description,
-    name="ecologicalInteraction__description",
-    curie=COMMUNITYMECH.curie("description"),
-    model_uri=COMMUNITYMECH.ecologicalInteraction__description,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.ecologicalInteraction__interaction_type = Slot(
-    uri=COMMUNITYMECH.interaction_type,
-    name="ecologicalInteraction__interaction_type",
-    curie=COMMUNITYMECH.curie("interaction_type"),
-    model_uri=COMMUNITYMECH.ecologicalInteraction__interaction_type,
-    domain=None,
-    range=Optional[Union[str, "InteractionTypeEnum"]],
-)
-
-slots.ecologicalInteraction__source_taxon = Slot(
-    uri=COMMUNITYMECH.source_taxon,
-    name="ecologicalInteraction__source_taxon",
-    curie=COMMUNITYMECH.curie("source_taxon"),
-    model_uri=COMMUNITYMECH.ecologicalInteraction__source_taxon,
-    domain=None,
-    range=Optional[dict | TaxonDescriptor],
-)
-
-slots.ecologicalInteraction__target_taxon = Slot(
-    uri=COMMUNITYMECH.target_taxon,
-    name="ecologicalInteraction__target_taxon",
-    curie=COMMUNITYMECH.curie("target_taxon"),
-    model_uri=COMMUNITYMECH.ecologicalInteraction__target_taxon,
-    domain=None,
-    range=Optional[dict | TaxonDescriptor],
-)
-
-slots.ecologicalInteraction__metabolites = Slot(
-    uri=COMMUNITYMECH.metabolites,
-    name="ecologicalInteraction__metabolites",
-    curie=COMMUNITYMECH.curie("metabolites"),
-    model_uri=COMMUNITYMECH.ecologicalInteraction__metabolites,
-    domain=None,
-    range=Optional[dict | MetaboliteDescriptor | list[dict | MetaboliteDescriptor]],
-)
-
-slots.ecologicalInteraction__biological_processes = Slot(
-    uri=COMMUNITYMECH.biological_processes,
-    name="ecologicalInteraction__biological_processes",
-    curie=COMMUNITYMECH.curie("biological_processes"),
-    model_uri=COMMUNITYMECH.ecologicalInteraction__biological_processes,
-    domain=None,
-    range=Optional[dict | BiologicalProcessDescriptor | list[dict | BiologicalProcessDescriptor]],
-)
-
-slots.ecologicalInteraction__downstream = Slot(
-    uri=COMMUNITYMECH.downstream,
-    name="ecologicalInteraction__downstream",
-    curie=COMMUNITYMECH.curie("downstream"),
-    model_uri=COMMUNITYMECH.ecologicalInteraction__downstream,
-    domain=None,
-    range=Optional[dict | InteractionDownstream | list[dict | InteractionDownstream]],
-)
-
-slots.ecologicalInteraction__evidence = Slot(
-    uri=COMMUNITYMECH.evidence,
-    name="ecologicalInteraction__evidence",
-    curie=COMMUNITYMECH.curie("evidence"),
-    model_uri=COMMUNITYMECH.ecologicalInteraction__evidence,
-    domain=None,
-    range=Optional[dict | EvidenceItem | list[dict | EvidenceItem]],
-)
-
-slots.environmentalFactor__name = Slot(
-    uri=COMMUNITYMECH.name,
-    name="environmentalFactor__name",
-    curie=COMMUNITYMECH.curie("name"),
-    model_uri=COMMUNITYMECH.environmentalFactor__name,
-    domain=None,
-    range=str,
-)
-
-slots.environmentalFactor__value = Slot(
-    uri=COMMUNITYMECH.value,
-    name="environmentalFactor__value",
-    curie=COMMUNITYMECH.curie("value"),
-    model_uri=COMMUNITYMECH.environmentalFactor__value,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.environmentalFactor__unit = Slot(
-    uri=COMMUNITYMECH.unit,
-    name="environmentalFactor__unit",
-    curie=COMMUNITYMECH.curie("unit"),
-    model_uri=COMMUNITYMECH.environmentalFactor__unit,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.environmentalFactor__description = Slot(
-    uri=COMMUNITYMECH.description,
-    name="environmentalFactor__description",
-    curie=COMMUNITYMECH.curie("description"),
-    model_uri=COMMUNITYMECH.environmentalFactor__description,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.environmentalFactor__evidence = Slot(
-    uri=COMMUNITYMECH.evidence,
-    name="environmentalFactor__evidence",
-    curie=COMMUNITYMECH.curie("evidence"),
-    model_uri=COMMUNITYMECH.environmentalFactor__evidence,
-    domain=None,
-    range=Optional[dict | EvidenceItem | list[dict | EvidenceItem]],
-)
-
-slots.growthMediaComponent__name = Slot(
-    uri=COMMUNITYMECH.name,
-    name="growthMediaComponent__name",
-    curie=COMMUNITYMECH.curie("name"),
-    model_uri=COMMUNITYMECH.growthMediaComponent__name,
-    domain=None,
-    range=str,
-)
-
-slots.growthMediaComponent__media_ingredient_mech_id = Slot(
-    uri=COMMUNITYMECH.media_ingredient_mech_id,
-    name="growthMediaComponent__media_ingredient_mech_id",
-    curie=COMMUNITYMECH.curie("media_ingredient_mech_id"),
-    model_uri=COMMUNITYMECH.growthMediaComponent__media_ingredient_mech_id,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMediaComponent__media_ingredient_mech_url = Slot(
-    uri=COMMUNITYMECH.media_ingredient_mech_url,
-    name="growthMediaComponent__media_ingredient_mech_url",
-    curie=COMMUNITYMECH.curie("media_ingredient_mech_url"),
-    model_uri=COMMUNITYMECH.growthMediaComponent__media_ingredient_mech_url,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMediaComponent__concentration = Slot(
-    uri=COMMUNITYMECH.concentration,
-    name="growthMediaComponent__concentration",
-    curie=COMMUNITYMECH.curie("concentration"),
-    model_uri=COMMUNITYMECH.growthMediaComponent__concentration,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMediaComponent__unit = Slot(
-    uri=COMMUNITYMECH.unit,
-    name="growthMediaComponent__unit",
-    curie=COMMUNITYMECH.curie("unit"),
-    model_uri=COMMUNITYMECH.growthMediaComponent__unit,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMediaComponent__chebi_term = Slot(
-    uri=COMMUNITYMECH.chebi_term,
-    name="growthMediaComponent__chebi_term",
-    curie=COMMUNITYMECH.curie("chebi_term"),
-    model_uri=COMMUNITYMECH.growthMediaComponent__chebi_term,
-    domain=None,
-    range=Optional[dict | MetaboliteDescriptor],
-)
-
-slots.growthMediaComponent__from_source = Slot(
-    uri=COMMUNITYMECH["from"],
-    name="growthMediaComponent__from_source",
-    curie=COMMUNITYMECH.curie("from"),
-    model_uri=COMMUNITYMECH.growthMediaComponent__from_source,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__name = Slot(
-    uri=COMMUNITYMECH.name,
-    name="growthMedia__name",
-    curie=COMMUNITYMECH.curie("name"),
-    model_uri=COMMUNITYMECH.growthMedia__name,
-    domain=None,
-    range=str,
-)
-
-slots.growthMedia__culturemech_id = Slot(
-    uri=COMMUNITYMECH.culturemech_id,
-    name="growthMedia__culturemech_id",
-    curie=COMMUNITYMECH.curie("culturemech_id"),
-    model_uri=COMMUNITYMECH.growthMedia__culturemech_id,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__culturemech_url = Slot(
-    uri=COMMUNITYMECH.culturemech_url,
-    name="growthMedia__culturemech_url",
-    curie=COMMUNITYMECH.curie("culturemech_url"),
-    model_uri=COMMUNITYMECH.growthMedia__culturemech_url,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__composition = Slot(
-    uri=COMMUNITYMECH.composition,
-    name="growthMedia__composition",
-    curie=COMMUNITYMECH.curie("composition"),
-    model_uri=COMMUNITYMECH.growthMedia__composition,
-    domain=None,
-    range=Optional[dict | GrowthMediaComponent | list[dict | GrowthMediaComponent]],
-)
-
-slots.growthMedia__ph = Slot(
-    uri=COMMUNITYMECH.ph,
-    name="growthMedia__ph",
-    curie=COMMUNITYMECH.curie("ph"),
-    model_uri=COMMUNITYMECH.growthMedia__ph,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__ph_range = Slot(
-    uri=COMMUNITYMECH.ph_range,
-    name="growthMedia__ph_range",
-    curie=COMMUNITYMECH.curie("ph_range"),
-    model_uri=COMMUNITYMECH.growthMedia__ph_range,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__temperature = Slot(
-    uri=COMMUNITYMECH.temperature,
-    name="growthMedia__temperature",
-    curie=COMMUNITYMECH.curie("temperature"),
-    model_uri=COMMUNITYMECH.growthMedia__temperature,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__temperature_unit = Slot(
-    uri=COMMUNITYMECH.temperature_unit,
-    name="growthMedia__temperature_unit",
-    curie=COMMUNITYMECH.curie("temperature_unit"),
-    model_uri=COMMUNITYMECH.growthMedia__temperature_unit,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__temperature_range = Slot(
-    uri=COMMUNITYMECH.temperature_range,
-    name="growthMedia__temperature_range",
-    curie=COMMUNITYMECH.curie("temperature_range"),
-    model_uri=COMMUNITYMECH.growthMedia__temperature_range,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__atmosphere = Slot(
-    uri=COMMUNITYMECH.atmosphere,
-    name="growthMedia__atmosphere",
-    curie=COMMUNITYMECH.curie("atmosphere"),
-    model_uri=COMMUNITYMECH.growthMedia__atmosphere,
-    domain=None,
-    range=Optional[Union[str, "AtmosphereEnum"]],
-)
-
-slots.growthMedia__headspace_gas = Slot(
-    uri=COMMUNITYMECH.headspace_gas,
-    name="growthMedia__headspace_gas",
-    curie=COMMUNITYMECH.curie("headspace_gas"),
-    model_uri=COMMUNITYMECH.growthMedia__headspace_gas,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__salinity = Slot(
-    uri=COMMUNITYMECH.salinity,
-    name="growthMedia__salinity",
-    curie=COMMUNITYMECH.curie("salinity"),
-    model_uri=COMMUNITYMECH.growthMedia__salinity,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__salinity_unit = Slot(
-    uri=COMMUNITYMECH.salinity_unit,
-    name="growthMedia__salinity_unit",
-    curie=COMMUNITYMECH.curie("salinity_unit"),
-    model_uri=COMMUNITYMECH.growthMedia__salinity_unit,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__pressure = Slot(
-    uri=COMMUNITYMECH.pressure,
-    name="growthMedia__pressure",
-    curie=COMMUNITYMECH.curie("pressure"),
-    model_uri=COMMUNITYMECH.growthMedia__pressure,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__pressure_unit = Slot(
-    uri=COMMUNITYMECH.pressure_unit,
-    name="growthMedia__pressure_unit",
-    curie=COMMUNITYMECH.curie("pressure_unit"),
-    model_uri=COMMUNITYMECH.growthMedia__pressure_unit,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__light_regime = Slot(
-    uri=COMMUNITYMECH.light_regime,
-    name="growthMedia__light_regime",
-    curie=COMMUNITYMECH.curie("light_regime"),
-    model_uri=COMMUNITYMECH.growthMedia__light_regime,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__light_intensity = Slot(
-    uri=COMMUNITYMECH.light_intensity,
-    name="growthMedia__light_intensity",
-    curie=COMMUNITYMECH.curie("light_intensity"),
-    model_uri=COMMUNITYMECH.growthMedia__light_intensity,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__light_intensity_unit = Slot(
-    uri=COMMUNITYMECH.light_intensity_unit,
-    name="growthMedia__light_intensity_unit",
-    curie=COMMUNITYMECH.curie("light_intensity_unit"),
-    model_uri=COMMUNITYMECH.growthMedia__light_intensity_unit,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__redox_potential = Slot(
-    uri=COMMUNITYMECH.redox_potential,
-    name="growthMedia__redox_potential",
-    curie=COMMUNITYMECH.curie("redox_potential"),
-    model_uri=COMMUNITYMECH.growthMedia__redox_potential,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__redox_potential_unit = Slot(
-    uri=COMMUNITYMECH.redox_potential_unit,
-    name="growthMedia__redox_potential_unit",
-    curie=COMMUNITYMECH.curie("redox_potential_unit"),
-    model_uri=COMMUNITYMECH.growthMedia__redox_potential_unit,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__inoculum_source = Slot(
-    uri=COMMUNITYMECH.inoculum_source,
-    name="growthMedia__inoculum_source",
-    curie=COMMUNITYMECH.curie("inoculum_source"),
-    model_uri=COMMUNITYMECH.growthMedia__inoculum_source,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__inoculum_size = Slot(
-    uri=COMMUNITYMECH.inoculum_size,
-    name="growthMedia__inoculum_size",
-    curie=COMMUNITYMECH.curie("inoculum_size"),
-    model_uri=COMMUNITYMECH.growthMedia__inoculum_size,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__inoculum_unit = Slot(
-    uri=COMMUNITYMECH.inoculum_unit,
-    name="growthMedia__inoculum_unit",
-    curie=COMMUNITYMECH.curie("inoculum_unit"),
-    model_uri=COMMUNITYMECH.growthMedia__inoculum_unit,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__incubation_time = Slot(
-    uri=COMMUNITYMECH.incubation_time,
-    name="growthMedia__incubation_time",
-    curie=COMMUNITYMECH.curie("incubation_time"),
-    model_uri=COMMUNITYMECH.growthMedia__incubation_time,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__incubation_time_unit = Slot(
-    uri=COMMUNITYMECH.incubation_time_unit,
-    name="growthMedia__incubation_time_unit",
-    curie=COMMUNITYMECH.curie("incubation_time_unit"),
-    model_uri=COMMUNITYMECH.growthMedia__incubation_time_unit,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__shaking_speed = Slot(
-    uri=COMMUNITYMECH.shaking_speed,
-    name="growthMedia__shaking_speed",
-    curie=COMMUNITYMECH.curie("shaking_speed"),
-    model_uri=COMMUNITYMECH.growthMedia__shaking_speed,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__shaking_speed_unit = Slot(
-    uri=COMMUNITYMECH.shaking_speed_unit,
-    name="growthMedia__shaking_speed_unit",
-    curie=COMMUNITYMECH.curie("shaking_speed_unit"),
-    model_uri=COMMUNITYMECH.growthMedia__shaking_speed_unit,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__vessel_type = Slot(
-    uri=COMMUNITYMECH.vessel_type,
-    name="growthMedia__vessel_type",
-    curie=COMMUNITYMECH.curie("vessel_type"),
-    model_uri=COMMUNITYMECH.growthMedia__vessel_type,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__preparation_notes = Slot(
-    uri=COMMUNITYMECH.preparation_notes,
-    name="growthMedia__preparation_notes",
-    curie=COMMUNITYMECH.curie("preparation_notes"),
-    model_uri=COMMUNITYMECH.growthMedia__preparation_notes,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__protocol_url = Slot(
-    uri=COMMUNITYMECH.protocol_url,
-    name="growthMedia__protocol_url",
-    curie=COMMUNITYMECH.curie("protocol_url"),
-    model_uri=COMMUNITYMECH.growthMedia__protocol_url,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__evidence = Slot(
-    uri=COMMUNITYMECH.evidence,
-    name="growthMedia__evidence",
-    curie=COMMUNITYMECH.curie("evidence"),
-    model_uri=COMMUNITYMECH.growthMedia__evidence,
-    domain=None,
-    range=Optional[dict | EvidenceItem | list[dict | EvidenceItem]],
-)
-
-slots.relatedMedia__preferred_term = Slot(
-    uri=COMMUNITYMECH.preferred_term,
-    name="relatedMedia__preferred_term",
-    curie=COMMUNITYMECH.curie("preferred_term"),
-    model_uri=COMMUNITYMECH.relatedMedia__preferred_term,
-    domain=None,
-    range=str,
-)
-
-slots.relatedMedia__culturemech_id = Slot(
-    uri=COMMUNITYMECH.culturemech_id,
-    name="relatedMedia__culturemech_id",
-    curie=COMMUNITYMECH.curie("culturemech_id"),
-    model_uri=COMMUNITYMECH.relatedMedia__culturemech_id,
-    domain=None,
-    range=Optional[str],
-    pattern=re.compile(r"^CultureMech:\d{6}$"),
-)
-
-slots.relatedMedia__relationship_type = Slot(
-    uri=COMMUNITYMECH.relationship_type,
-    name="relatedMedia__relationship_type",
-    curie=COMMUNITYMECH.curie("relationship_type"),
-    model_uri=COMMUNITYMECH.relatedMedia__relationship_type,
-    domain=None,
-    range=Optional[Union[str, "MediaRelationshipEnum"]],
-)
-
-slots.relatedMedia__shared_environment_term = Slot(
-    uri=COMMUNITYMECH.shared_environment_term,
-    name="relatedMedia__shared_environment_term",
-    curie=COMMUNITYMECH.curie("shared_environment_term"),
-    model_uri=COMMUNITYMECH.relatedMedia__shared_environment_term,
-    domain=None,
-    range=Optional[dict | Term],
-)
-
-slots.relatedMedia__relevance_notes = Slot(
-    uri=COMMUNITYMECH.relevance_notes,
-    name="relatedMedia__relevance_notes",
-    curie=COMMUNITYMECH.curie("relevance_notes"),
-    model_uri=COMMUNITYMECH.relatedMedia__relevance_notes,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.relatedMedia__evidence = Slot(
-    uri=COMMUNITYMECH.evidence,
-    name="relatedMedia__evidence",
-    curie=COMMUNITYMECH.curie("evidence"),
-    model_uri=COMMUNITYMECH.relatedMedia__evidence,
-    domain=None,
-    range=Optional[dict | EvidenceItem | list[dict | EvidenceItem]],
-)
-
-slots.relatedIngredient__preferred_term = Slot(
-    uri=COMMUNITYMECH.preferred_term,
-    name="relatedIngredient__preferred_term",
-    curie=COMMUNITYMECH.curie("preferred_term"),
-    model_uri=COMMUNITYMECH.relatedIngredient__preferred_term,
-    domain=None,
-    range=str,
-)
-
-slots.relatedIngredient__mediaingredientmech_id = Slot(
-    uri=COMMUNITYMECH.mediaingredientmech_id,
-    name="relatedIngredient__mediaingredientmech_id",
-    curie=COMMUNITYMECH.curie("mediaingredientmech_id"),
-    model_uri=COMMUNITYMECH.relatedIngredient__mediaingredientmech_id,
-    domain=None,
-    range=Optional[str],
-    pattern=re.compile(r"^MediaIngredientMech:\d{6}$"),
-)
-
-slots.relatedIngredient__chebi_term = Slot(
-    uri=COMMUNITYMECH.chebi_term,
-    name="relatedIngredient__chebi_term",
-    curie=COMMUNITYMECH.curie("chebi_term"),
-    model_uri=COMMUNITYMECH.relatedIngredient__chebi_term,
-    domain=None,
-    range=Optional[dict | Term],
-)
-
-slots.relatedIngredient__relevance = Slot(
-    uri=COMMUNITYMECH.relevance,
-    name="relatedIngredient__relevance",
-    curie=COMMUNITYMECH.curie("relevance"),
-    model_uri=COMMUNITYMECH.relatedIngredient__relevance,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.relatedIngredient__evidence = Slot(
-    uri=COMMUNITYMECH.evidence,
-    name="relatedIngredient__evidence",
-    curie=COMMUNITYMECH.curie("evidence"),
-    model_uri=COMMUNITYMECH.relatedIngredient__evidence,
-    domain=None,
-    range=Optional[dict | EvidenceItem | list[dict | EvidenceItem]],
-)
-
-slots.associatedDataset__name = Slot(
-    uri=COMMUNITYMECH.name,
-    name="associatedDataset__name",
-    curie=COMMUNITYMECH.curie("name"),
-    model_uri=COMMUNITYMECH.associatedDataset__name,
-    domain=None,
-    range=str,
-)
-
-slots.associatedDataset__dataset_type = Slot(
-    uri=COMMUNITYMECH.dataset_type,
-    name="associatedDataset__dataset_type",
-    curie=COMMUNITYMECH.curie("dataset_type"),
-    model_uri=COMMUNITYMECH.associatedDataset__dataset_type,
-    domain=None,
-    range=Union[str, "DatasetTypeEnum"],
-)
-
-slots.associatedDataset__repository = Slot(
-    uri=COMMUNITYMECH.repository,
-    name="associatedDataset__repository",
-    curie=COMMUNITYMECH.curie("repository"),
-    model_uri=COMMUNITYMECH.associatedDataset__repository,
-    domain=None,
-    range=Optional[Union[str, "DatasetRepositoryEnum"]],
-)
-
-slots.associatedDataset__accession = Slot(
-    uri=COMMUNITYMECH.accession,
-    name="associatedDataset__accession",
-    curie=COMMUNITYMECH.curie("accession"),
-    model_uri=COMMUNITYMECH.associatedDataset__accession,
-    domain=None,
-    range=str,
-)
-
-slots.associatedDataset__url = Slot(
-    uri=COMMUNITYMECH.url,
-    name="associatedDataset__url",
-    curie=COMMUNITYMECH.curie("url"),
-    model_uri=COMMUNITYMECH.associatedDataset__url,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.associatedDataset__description = Slot(
-    uri=COMMUNITYMECH.description,
-    name="associatedDataset__description",
-    curie=COMMUNITYMECH.curie("description"),
-    model_uri=COMMUNITYMECH.associatedDataset__description,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.associatedDataset__evidence = Slot(
-    uri=COMMUNITYMECH.evidence,
-    name="associatedDataset__evidence",
-    curie=COMMUNITYMECH.curie("evidence"),
-    model_uri=COMMUNITYMECH.associatedDataset__evidence,
-    domain=None,
-    range=Optional[dict | EvidenceItem | list[dict | EvidenceItem]],
-)
-
-slots.externalResource__name = Slot(
-    uri=COMMUNITYMECH.name,
-    name="externalResource__name",
-    curie=COMMUNITYMECH.curie("name"),
-    model_uri=COMMUNITYMECH.externalResource__name,
-    domain=None,
-    range=str,
-)
-
-slots.externalResource__repository = Slot(
-    uri=COMMUNITYMECH.repository,
-    name="externalResource__repository",
-    curie=COMMUNITYMECH.curie("repository"),
-    model_uri=COMMUNITYMECH.externalResource__repository,
-    domain=None,
-    range=Union[str, "ExternalResourceRepositoryEnum"],
-)
-
-slots.externalResource__resource_id = Slot(
-    uri=COMMUNITYMECH.resource_id,
-    name="externalResource__resource_id",
-    curie=COMMUNITYMECH.curie("resource_id"),
-    model_uri=COMMUNITYMECH.externalResource__resource_id,
-    domain=None,
-    range=str,
-)
-
-slots.externalResource__url = Slot(
-    uri=COMMUNITYMECH.url,
-    name="externalResource__url",
-    curie=COMMUNITYMECH.curie("url"),
-    model_uri=COMMUNITYMECH.externalResource__url,
-    domain=None,
-    range=str,
-)
-
-slots.externalResource__description = Slot(
-    uri=COMMUNITYMECH.description,
-    name="externalResource__description",
-    curie=COMMUNITYMECH.curie("description"),
-    model_uri=COMMUNITYMECH.externalResource__description,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.externalResource__evidence = Slot(
-    uri=COMMUNITYMECH.evidence,
-    name="externalResource__evidence",
-    curie=COMMUNITYMECH.curie("evidence"),
-    model_uri=COMMUNITYMECH.externalResource__evidence,
-    domain=None,
-    range=Optional[dict | EvidenceItem | list[dict | EvidenceItem]],
-)
-
-slots.communityEngineeringDesign__objective = Slot(
-    uri=COMMUNITYMECH.objective,
-    name="communityEngineeringDesign__objective",
-    curie=COMMUNITYMECH.curie("objective"),
-    model_uri=COMMUNITYMECH.communityEngineeringDesign__objective,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.communityEngineeringDesign__assembly_strategy = Slot(
-    uri=COMMUNITYMECH.assembly_strategy,
-    name="communityEngineeringDesign__assembly_strategy",
-    curie=COMMUNITYMECH.curie("assembly_strategy"),
-    model_uri=COMMUNITYMECH.communityEngineeringDesign__assembly_strategy,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.communityEngineeringDesign__inoculation_strategy = Slot(
-    uri=COMMUNITYMECH.inoculation_strategy,
-    name="communityEngineeringDesign__inoculation_strategy",
-    curie=COMMUNITYMECH.curie("inoculation_strategy"),
-    model_uri=COMMUNITYMECH.communityEngineeringDesign__inoculation_strategy,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.communityEngineeringDesign__passaging_regimen = Slot(
-    uri=COMMUNITYMECH.passaging_regimen,
-    name="communityEngineeringDesign__passaging_regimen",
-    curie=COMMUNITYMECH.curie("passaging_regimen"),
-    model_uri=COMMUNITYMECH.communityEngineeringDesign__passaging_regimen,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.communityEngineeringDesign__perturbation_design = Slot(
-    uri=COMMUNITYMECH.perturbation_design,
-    name="communityEngineeringDesign__perturbation_design",
-    curie=COMMUNITYMECH.curie("perturbation_design"),
-    model_uri=COMMUNITYMECH.communityEngineeringDesign__perturbation_design,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.communityEngineeringDesign__measurement_endpoints = Slot(
-    uri=COMMUNITYMECH.measurement_endpoints,
-    name="communityEngineeringDesign__measurement_endpoints",
-    curie=COMMUNITYMECH.curie("measurement_endpoints"),
-    model_uri=COMMUNITYMECH.communityEngineeringDesign__measurement_endpoints,
-    domain=None,
-    range=Optional[str | list[str]],
-)
-
-slots.communityEngineeringDesign__protocol_url = Slot(
-    uri=COMMUNITYMECH.protocol_url,
-    name="communityEngineeringDesign__protocol_url",
-    curie=COMMUNITYMECH.curie("protocol_url"),
-    model_uri=COMMUNITYMECH.communityEngineeringDesign__protocol_url,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.communityEngineeringDesign__notes = Slot(
-    uri=COMMUNITYMECH.notes,
-    name="communityEngineeringDesign__notes",
-    curie=COMMUNITYMECH.curie("notes"),
-    model_uri=COMMUNITYMECH.communityEngineeringDesign__notes,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.communityEngineeringDesign__evidence = Slot(
-    uri=COMMUNITYMECH.evidence,
-    name="communityEngineeringDesign__evidence",
-    curie=COMMUNITYMECH.curie("evidence"),
-    model_uri=COMMUNITYMECH.communityEngineeringDesign__evidence,
-    domain=None,
-    range=Optional[dict | EvidenceItem | list[dict | EvidenceItem]],
-)
-
-slots.microbialCommunity__id = Slot(
-    uri=COMMUNITYMECH.id,
-    name="microbialCommunity__id",
-    curie=COMMUNITYMECH.curie("id"),
-    model_uri=COMMUNITYMECH.microbialCommunity__id,
-    domain=None,
-    range=URIRef,
-    pattern=re.compile(r"^CommunityMech:\d{6}$"),
-)
-
-slots.microbialCommunity__name = Slot(
-    uri=COMMUNITYMECH.name,
-    name="microbialCommunity__name",
-    curie=COMMUNITYMECH.curie("name"),
-    model_uri=COMMUNITYMECH.microbialCommunity__name,
-    domain=None,
-    range=str,
-)
-
-slots.microbialCommunity__description = Slot(
-    uri=COMMUNITYMECH.description,
-    name="microbialCommunity__description",
-    curie=COMMUNITYMECH.curie("description"),
-    model_uri=COMMUNITYMECH.microbialCommunity__description,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.microbialCommunity__ecological_state = Slot(
-    uri=COMMUNITYMECH.ecological_state,
-    name="microbialCommunity__ecological_state",
-    curie=COMMUNITYMECH.curie("ecological_state"),
-    model_uri=COMMUNITYMECH.microbialCommunity__ecological_state,
-    domain=None,
-    range=Optional[Union[str, "EcologicalStateEnum"]],
-)
-
-slots.microbialCommunity__community_origin = Slot(
-    uri=COMMUNITYMECH.community_origin,
-    name="microbialCommunity__community_origin",
-    curie=COMMUNITYMECH.curie("community_origin"),
-    model_uri=COMMUNITYMECH.microbialCommunity__community_origin,
-    domain=None,
-    range=Optional[Union[str, "CommunityOriginEnum"]],
-)
-
-slots.microbialCommunity__community_category = Slot(
-    uri=COMMUNITYMECH.community_category,
-    name="microbialCommunity__community_category",
-    curie=COMMUNITYMECH.curie("community_category"),
-    model_uri=COMMUNITYMECH.microbialCommunity__community_category,
-    domain=None,
-    range=Optional[Union[str, "CommunityCategoryEnum"]],
-)
-
-slots.microbialCommunity__engineering_design = Slot(
-    uri=COMMUNITYMECH.engineering_design,
-    name="microbialCommunity__engineering_design",
-    curie=COMMUNITYMECH.curie("engineering_design"),
-    model_uri=COMMUNITYMECH.microbialCommunity__engineering_design,
-    domain=None,
-    range=Optional[dict | CommunityEngineeringDesign],
-)
-
-slots.microbialCommunity__environment_term = Slot(
-    uri=COMMUNITYMECH.environment_term,
-    name="microbialCommunity__environment_term",
-    curie=COMMUNITYMECH.curie("environment_term"),
-    model_uri=COMMUNITYMECH.microbialCommunity__environment_term,
-    domain=None,
-    range=Optional[dict | EnvironmentDescriptor],
-)
-
-slots.microbialCommunity__taxonomy = Slot(
-    uri=COMMUNITYMECH.taxonomy,
-    name="microbialCommunity__taxonomy",
-    curie=COMMUNITYMECH.curie("taxonomy"),
-    model_uri=COMMUNITYMECH.microbialCommunity__taxonomy,
-    domain=None,
-    range=Optional[dict | TaxonomicComposition | list[dict | TaxonomicComposition]],
-)
-
-slots.microbialCommunity__ecological_interactions = Slot(
-    uri=COMMUNITYMECH.ecological_interactions,
-    name="microbialCommunity__ecological_interactions",
-    curie=COMMUNITYMECH.curie("ecological_interactions"),
-    model_uri=COMMUNITYMECH.microbialCommunity__ecological_interactions,
-    domain=None,
-    range=Optional[dict | EcologicalInteraction | list[dict | EcologicalInteraction]],
-)
-
-slots.microbialCommunity__environmental_factors = Slot(
-    uri=COMMUNITYMECH.environmental_factors,
-    name="microbialCommunity__environmental_factors",
-    curie=COMMUNITYMECH.curie("environmental_factors"),
-    model_uri=COMMUNITYMECH.microbialCommunity__environmental_factors,
-    domain=None,
-    range=Optional[dict | EnvironmentalFactor | list[dict | EnvironmentalFactor]],
-)
-
-slots.microbialCommunity__growth_media = Slot(
-    uri=COMMUNITYMECH.growth_media,
-    name="microbialCommunity__growth_media",
-    curie=COMMUNITYMECH.curie("growth_media"),
-    model_uri=COMMUNITYMECH.microbialCommunity__growth_media,
-    domain=None,
-    range=Optional[dict | GrowthMedia | list[dict | GrowthMedia]],
-)
-
-slots.microbialCommunity__related_media = Slot(
-    uri=COMMUNITYMECH.related_media,
-    name="microbialCommunity__related_media",
-    curie=COMMUNITYMECH.curie("related_media"),
-    model_uri=COMMUNITYMECH.microbialCommunity__related_media,
-    domain=None,
-    range=Optional[dict | RelatedMedia | list[dict | RelatedMedia]],
-)
-
-slots.microbialCommunity__related_ingredients = Slot(
-    uri=COMMUNITYMECH.related_ingredients,
-    name="microbialCommunity__related_ingredients",
-    curie=COMMUNITYMECH.curie("related_ingredients"),
-    model_uri=COMMUNITYMECH.microbialCommunity__related_ingredients,
-    domain=None,
-    range=Optional[dict | RelatedIngredient | list[dict | RelatedIngredient]],
-)
-
-slots.microbialCommunity__associated_datasets = Slot(
-    uri=COMMUNITYMECH.associated_datasets,
-    name="microbialCommunity__associated_datasets",
-    curie=COMMUNITYMECH.curie("associated_datasets"),
-    model_uri=COMMUNITYMECH.microbialCommunity__associated_datasets,
-    domain=None,
-    range=Optional[dict | AssociatedDataset | list[dict | AssociatedDataset]],
-)
-
-slots.microbialCommunity__external_resources = Slot(
-    uri=COMMUNITYMECH.external_resources,
-    name="microbialCommunity__external_resources",
-    curie=COMMUNITYMECH.curie("external_resources"),
-    model_uri=COMMUNITYMECH.microbialCommunity__external_resources,
-    domain=None,
-    range=Optional[dict | ExternalResource | list[dict | ExternalResource]],
-)
-
-slots.microbialCommunity__metals_present = Slot(
-    uri=COMMUNITYMECH.metals_present,
-    name="microbialCommunity__metals_present",
-    curie=COMMUNITYMECH.curie("metals_present"),
-    model_uri=COMMUNITYMECH.microbialCommunity__metals_present,
-    domain=None,
-    range=Optional[Union[str, "MetalElementEnum"] | list[Union[str, "MetalElementEnum"]]],
-)
-
-slots.microbialCommunity__rare_earth_elements_present = Slot(
-    uri=COMMUNITYMECH.rare_earth_elements_present,
-    name="microbialCommunity__rare_earth_elements_present",
-    curie=COMMUNITYMECH.curie("rare_earth_elements_present"),
-    model_uri=COMMUNITYMECH.microbialCommunity__rare_earth_elements_present,
-    domain=None,
-    range=Optional[Union[str, "RareEarthElementEnum"] | list[Union[str, "RareEarthElementEnum"]]],
-)
-
-slots.microbialCommunity__metal_relevance = Slot(
-    uri=COMMUNITYMECH.metal_relevance,
-    name="microbialCommunity__metal_relevance",
-    curie=COMMUNITYMECH.curie("metal_relevance"),
-    model_uri=COMMUNITYMECH.microbialCommunity__metal_relevance,
-    domain=None,
-    range=Optional[Union[str, "MetalRelevanceEnum"]],
-)
-
-slots.microbialCommunity__metal_notes = Slot(
-    uri=COMMUNITYMECH.metal_notes,
-    name="microbialCommunity__metal_notes",
-    curie=COMMUNITYMECH.curie("metal_notes"),
-    model_uri=COMMUNITYMECH.microbialCommunity__metal_notes,
-    domain=None,
-    range=Optional[str],
-)
+slots.term__label = Slot(uri=COMMUNITYMECH.label, name="term__label", curie=COMMUNITYMECH.curie('label'),
+                   model_uri=COMMUNITYMECH.term__label, domain=None, range=str)
+
+slots.evidenceItem__reference = Slot(uri=COMMUNITYMECH.reference, name="evidenceItem__reference", curie=COMMUNITYMECH.curie('reference'),
+                   model_uri=COMMUNITYMECH.evidenceItem__reference, domain=None, range=str,
+                   pattern=re.compile(r'^(PMID:|doi:|bioproject:).*'))
+
+slots.evidenceItem__supports = Slot(uri=COMMUNITYMECH.supports, name="evidenceItem__supports", curie=COMMUNITYMECH.curie('supports'),
+                   model_uri=COMMUNITYMECH.evidenceItem__supports, domain=None, range=Union[str, "EvidenceItemSupportEnum"])
+
+slots.evidenceItem__evidence_source = Slot(uri=COMMUNITYMECH.evidence_source, name="evidenceItem__evidence_source", curie=COMMUNITYMECH.curie('evidence_source'),
+                   model_uri=COMMUNITYMECH.evidenceItem__evidence_source, domain=None, range=Union[str, "EvidenceSourceEnum"])
+
+slots.evidenceItem__snippet = Slot(uri=COMMUNITYMECH.snippet, name="evidenceItem__snippet", curie=COMMUNITYMECH.curie('snippet'),
+                   model_uri=COMMUNITYMECH.evidenceItem__snippet, domain=None, range=str)
+
+slots.evidenceItem__explanation = Slot(uri=COMMUNITYMECH.explanation, name="evidenceItem__explanation", curie=COMMUNITYMECH.curie('explanation'),
+                   model_uri=COMMUNITYMECH.evidenceItem__explanation, domain=None, range=Optional[str])
+
+slots.evidenceItem__confidence_score = Slot(uri=COMMUNITYMECH.confidence_score, name="evidenceItem__confidence_score", curie=COMMUNITYMECH.curie('confidence_score'),
+                   model_uri=COMMUNITYMECH.evidenceItem__confidence_score, domain=None, range=Optional[float])
+
+slots.taxonDescriptor__preferred_term = Slot(uri=COMMUNITYMECH.preferred_term, name="taxonDescriptor__preferred_term", curie=COMMUNITYMECH.curie('preferred_term'),
+                   model_uri=COMMUNITYMECH.taxonDescriptor__preferred_term, domain=None, range=str)
+
+slots.taxonDescriptor__term = Slot(uri=COMMUNITYMECH.term, name="taxonDescriptor__term", curie=COMMUNITYMECH.curie('term'),
+                   model_uri=COMMUNITYMECH.taxonDescriptor__term, domain=None, range=Union[dict, Term])
+
+slots.taxonDescriptor__notes = Slot(uri=COMMUNITYMECH.notes, name="taxonDescriptor__notes", curie=COMMUNITYMECH.curie('notes'),
+                   model_uri=COMMUNITYMECH.taxonDescriptor__notes, domain=None, range=Optional[str])
+
+slots.metaboliteDescriptor__preferred_term = Slot(uri=COMMUNITYMECH.preferred_term, name="metaboliteDescriptor__preferred_term", curie=COMMUNITYMECH.curie('preferred_term'),
+                   model_uri=COMMUNITYMECH.metaboliteDescriptor__preferred_term, domain=None, range=str)
+
+slots.metaboliteDescriptor__term = Slot(uri=COMMUNITYMECH.term, name="metaboliteDescriptor__term", curie=COMMUNITYMECH.curie('term'),
+                   model_uri=COMMUNITYMECH.metaboliteDescriptor__term, domain=None, range=Union[dict, Term])
+
+slots.metaboliteDescriptor__concentration = Slot(uri=COMMUNITYMECH.concentration, name="metaboliteDescriptor__concentration", curie=COMMUNITYMECH.curie('concentration'),
+                   model_uri=COMMUNITYMECH.metaboliteDescriptor__concentration, domain=None, range=Optional[str])
+
+slots.metaboliteDescriptor__notes = Slot(uri=COMMUNITYMECH.notes, name="metaboliteDescriptor__notes", curie=COMMUNITYMECH.curie('notes'),
+                   model_uri=COMMUNITYMECH.metaboliteDescriptor__notes, domain=None, range=Optional[str])
+
+slots.biologicalProcessDescriptor__preferred_term = Slot(uri=COMMUNITYMECH.preferred_term, name="biologicalProcessDescriptor__preferred_term", curie=COMMUNITYMECH.curie('preferred_term'),
+                   model_uri=COMMUNITYMECH.biologicalProcessDescriptor__preferred_term, domain=None, range=str)
+
+slots.biologicalProcessDescriptor__term = Slot(uri=COMMUNITYMECH.term, name="biologicalProcessDescriptor__term", curie=COMMUNITYMECH.curie('term'),
+                   model_uri=COMMUNITYMECH.biologicalProcessDescriptor__term, domain=None, range=Union[dict, Term])
+
+slots.biologicalProcessDescriptor__notes = Slot(uri=COMMUNITYMECH.notes, name="biologicalProcessDescriptor__notes", curie=COMMUNITYMECH.curie('notes'),
+                   model_uri=COMMUNITYMECH.biologicalProcessDescriptor__notes, domain=None, range=Optional[str])
+
+slots.environmentDescriptor__preferred_term = Slot(uri=COMMUNITYMECH.preferred_term, name="environmentDescriptor__preferred_term", curie=COMMUNITYMECH.curie('preferred_term'),
+                   model_uri=COMMUNITYMECH.environmentDescriptor__preferred_term, domain=None, range=str)
+
+slots.environmentDescriptor__term = Slot(uri=COMMUNITYMECH.term, name="environmentDescriptor__term", curie=COMMUNITYMECH.curie('term'),
+                   model_uri=COMMUNITYMECH.environmentDescriptor__term, domain=None, range=Union[dict, Term])
+
+slots.environmentDescriptor__notes = Slot(uri=COMMUNITYMECH.notes, name="environmentDescriptor__notes", curie=COMMUNITYMECH.curie('notes'),
+                   model_uri=COMMUNITYMECH.environmentDescriptor__notes, domain=None, range=Optional[str])
+
+slots.cultureCollectionID__collection = Slot(uri=COMMUNITYMECH.collection, name="cultureCollectionID__collection", curie=COMMUNITYMECH.curie('collection'),
+                   model_uri=COMMUNITYMECH.cultureCollectionID__collection, domain=None, range=Union[str, "CultureCollectionEnum"])
+
+slots.cultureCollectionID__accession = Slot(uri=COMMUNITYMECH.accession, name="cultureCollectionID__accession", curie=COMMUNITYMECH.curie('accession'),
+                   model_uri=COMMUNITYMECH.cultureCollectionID__accession, domain=None, range=str)
+
+slots.cultureCollectionID__url = Slot(uri=COMMUNITYMECH.url, name="cultureCollectionID__url", curie=COMMUNITYMECH.curie('url'),
+                   model_uri=COMMUNITYMECH.cultureCollectionID__url, domain=None, range=Optional[str])
+
+slots.cultureCollectionID__notes = Slot(uri=COMMUNITYMECH.notes, name="cultureCollectionID__notes", curie=COMMUNITYMECH.curie('notes'),
+                   model_uri=COMMUNITYMECH.cultureCollectionID__notes, domain=None, range=Optional[str])
+
+slots.strainDesignation__strain_name = Slot(uri=COMMUNITYMECH.strain_name, name="strainDesignation__strain_name", curie=COMMUNITYMECH.curie('strain_name'),
+                   model_uri=COMMUNITYMECH.strainDesignation__strain_name, domain=None, range=Optional[str])
+
+slots.strainDesignation__culture_collections = Slot(uri=COMMUNITYMECH.culture_collections, name="strainDesignation__culture_collections", curie=COMMUNITYMECH.curie('culture_collections'),
+                   model_uri=COMMUNITYMECH.strainDesignation__culture_collections, domain=None, range=Optional[Union[Union[dict, CultureCollectionID], list[Union[dict, CultureCollectionID]]]])
+
+slots.strainDesignation__type_strain = Slot(uri=COMMUNITYMECH.type_strain, name="strainDesignation__type_strain", curie=COMMUNITYMECH.curie('type_strain'),
+                   model_uri=COMMUNITYMECH.strainDesignation__type_strain, domain=None, range=Optional[Union[bool, Bool]])
+
+slots.strainDesignation__genome_accession = Slot(uri=COMMUNITYMECH.genome_accession, name="strainDesignation__genome_accession", curie=COMMUNITYMECH.curie('genome_accession'),
+                   model_uri=COMMUNITYMECH.strainDesignation__genome_accession, domain=None, range=Optional[str])
+
+slots.strainDesignation__genome_url = Slot(uri=COMMUNITYMECH.genome_url, name="strainDesignation__genome_url", curie=COMMUNITYMECH.curie('genome_url'),
+                   model_uri=COMMUNITYMECH.strainDesignation__genome_url, domain=None, range=Optional[str])
+
+slots.strainDesignation__genetic_modification = Slot(uri=COMMUNITYMECH.genetic_modification, name="strainDesignation__genetic_modification", curie=COMMUNITYMECH.curie('genetic_modification'),
+                   model_uri=COMMUNITYMECH.strainDesignation__genetic_modification, domain=None, range=Optional[str])
+
+slots.strainDesignation__isolation_source = Slot(uri=COMMUNITYMECH.isolation_source, name="strainDesignation__isolation_source", curie=COMMUNITYMECH.curie('isolation_source'),
+                   model_uri=COMMUNITYMECH.strainDesignation__isolation_source, domain=None, range=Optional[str])
+
+slots.strainDesignation__notes = Slot(uri=COMMUNITYMECH.notes, name="strainDesignation__notes", curie=COMMUNITYMECH.curie('notes'),
+                   model_uri=COMMUNITYMECH.strainDesignation__notes, domain=None, range=Optional[str])
+
+slots.taxonomicComposition__taxon_term = Slot(uri=COMMUNITYMECH.taxon_term, name="taxonomicComposition__taxon_term", curie=COMMUNITYMECH.curie('taxon_term'),
+                   model_uri=COMMUNITYMECH.taxonomicComposition__taxon_term, domain=None, range=Union[dict, TaxonDescriptor])
+
+slots.taxonomicComposition__strain_designation = Slot(uri=COMMUNITYMECH.strain_designation, name="taxonomicComposition__strain_designation", curie=COMMUNITYMECH.curie('strain_designation'),
+                   model_uri=COMMUNITYMECH.taxonomicComposition__strain_designation, domain=None, range=Optional[Union[dict, StrainDesignation]])
+
+slots.taxonomicComposition__abundance_level = Slot(uri=COMMUNITYMECH.abundance_level, name="taxonomicComposition__abundance_level", curie=COMMUNITYMECH.curie('abundance_level'),
+                   model_uri=COMMUNITYMECH.taxonomicComposition__abundance_level, domain=None, range=Optional[Union[str, "AbundanceEnum"]])
+
+slots.taxonomicComposition__abundance_value = Slot(uri=COMMUNITYMECH.abundance_value, name="taxonomicComposition__abundance_value", curie=COMMUNITYMECH.curie('abundance_value'),
+                   model_uri=COMMUNITYMECH.taxonomicComposition__abundance_value, domain=None, range=Optional[str])
+
+slots.taxonomicComposition__functional_role = Slot(uri=COMMUNITYMECH.functional_role, name="taxonomicComposition__functional_role", curie=COMMUNITYMECH.curie('functional_role'),
+                   model_uri=COMMUNITYMECH.taxonomicComposition__functional_role, domain=None, range=Optional[Union[Union[str, "FunctionalRoleEnum"], list[Union[str, "FunctionalRoleEnum"]]]])
+
+slots.taxonomicComposition__evidence = Slot(uri=COMMUNITYMECH.evidence, name="taxonomicComposition__evidence", curie=COMMUNITYMECH.curie('evidence'),
+                   model_uri=COMMUNITYMECH.taxonomicComposition__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+
+slots.interactionDownstream__target = Slot(uri=COMMUNITYMECH.target, name="interactionDownstream__target", curie=COMMUNITYMECH.curie('target'),
+                   model_uri=COMMUNITYMECH.interactionDownstream__target, domain=None, range=str)
+
+slots.interactionDownstream__description = Slot(uri=COMMUNITYMECH.description, name="interactionDownstream__description", curie=COMMUNITYMECH.curie('description'),
+                   model_uri=COMMUNITYMECH.interactionDownstream__description, domain=None, range=Optional[str])
+
+slots.ecologicalInteraction__name = Slot(uri=COMMUNITYMECH.name, name="ecologicalInteraction__name", curie=COMMUNITYMECH.curie('name'),
+                   model_uri=COMMUNITYMECH.ecologicalInteraction__name, domain=None, range=str)
+
+slots.ecologicalInteraction__description = Slot(uri=COMMUNITYMECH.description, name="ecologicalInteraction__description", curie=COMMUNITYMECH.curie('description'),
+                   model_uri=COMMUNITYMECH.ecologicalInteraction__description, domain=None, range=Optional[str])
+
+slots.ecologicalInteraction__interaction_type = Slot(uri=COMMUNITYMECH.interaction_type, name="ecologicalInteraction__interaction_type", curie=COMMUNITYMECH.curie('interaction_type'),
+                   model_uri=COMMUNITYMECH.ecologicalInteraction__interaction_type, domain=None, range=Optional[Union[str, "InteractionTypeEnum"]])
+
+slots.ecologicalInteraction__scope = Slot(uri=COMMUNITYMECH.scope, name="ecologicalInteraction__scope", curie=COMMUNITYMECH.curie('scope'),
+                   model_uri=COMMUNITYMECH.ecologicalInteraction__scope, domain=None, range=Optional[Union[str, "InteractionScopeEnum"]])
+
+slots.ecologicalInteraction__source_taxon = Slot(uri=COMMUNITYMECH.source_taxon, name="ecologicalInteraction__source_taxon", curie=COMMUNITYMECH.curie('source_taxon'),
+                   model_uri=COMMUNITYMECH.ecologicalInteraction__source_taxon, domain=None, range=Optional[Union[dict, TaxonDescriptor]])
+
+slots.ecologicalInteraction__target_taxon = Slot(uri=COMMUNITYMECH.target_taxon, name="ecologicalInteraction__target_taxon", curie=COMMUNITYMECH.curie('target_taxon'),
+                   model_uri=COMMUNITYMECH.ecologicalInteraction__target_taxon, domain=None, range=Optional[Union[dict, TaxonDescriptor]])
+
+slots.ecologicalInteraction__metabolites = Slot(uri=COMMUNITYMECH.metabolites, name="ecologicalInteraction__metabolites", curie=COMMUNITYMECH.curie('metabolites'),
+                   model_uri=COMMUNITYMECH.ecologicalInteraction__metabolites, domain=None, range=Optional[Union[Union[dict, MetaboliteDescriptor], list[Union[dict, MetaboliteDescriptor]]]])
+
+slots.ecologicalInteraction__biological_processes = Slot(uri=COMMUNITYMECH.biological_processes, name="ecologicalInteraction__biological_processes", curie=COMMUNITYMECH.curie('biological_processes'),
+                   model_uri=COMMUNITYMECH.ecologicalInteraction__biological_processes, domain=None, range=Optional[Union[Union[dict, BiologicalProcessDescriptor], list[Union[dict, BiologicalProcessDescriptor]]]])
+
+slots.ecologicalInteraction__downstream = Slot(uri=COMMUNITYMECH.downstream, name="ecologicalInteraction__downstream", curie=COMMUNITYMECH.curie('downstream'),
+                   model_uri=COMMUNITYMECH.ecologicalInteraction__downstream, domain=None, range=Optional[Union[Union[dict, InteractionDownstream], list[Union[dict, InteractionDownstream]]]])
+
+slots.ecologicalInteraction__evidence = Slot(uri=COMMUNITYMECH.evidence, name="ecologicalInteraction__evidence", curie=COMMUNITYMECH.curie('evidence'),
+                   model_uri=COMMUNITYMECH.ecologicalInteraction__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+
+slots.environmentalFactor__name = Slot(uri=COMMUNITYMECH.name, name="environmentalFactor__name", curie=COMMUNITYMECH.curie('name'),
+                   model_uri=COMMUNITYMECH.environmentalFactor__name, domain=None, range=str)
+
+slots.environmentalFactor__value = Slot(uri=COMMUNITYMECH.value, name="environmentalFactor__value", curie=COMMUNITYMECH.curie('value'),
+                   model_uri=COMMUNITYMECH.environmentalFactor__value, domain=None, range=Optional[str])
+
+slots.environmentalFactor__unit = Slot(uri=COMMUNITYMECH.unit, name="environmentalFactor__unit", curie=COMMUNITYMECH.curie('unit'),
+                   model_uri=COMMUNITYMECH.environmentalFactor__unit, domain=None, range=Optional[str])
+
+slots.environmentalFactor__description = Slot(uri=COMMUNITYMECH.description, name="environmentalFactor__description", curie=COMMUNITYMECH.curie('description'),
+                   model_uri=COMMUNITYMECH.environmentalFactor__description, domain=None, range=Optional[str])
+
+slots.environmentalFactor__evidence = Slot(uri=COMMUNITYMECH.evidence, name="environmentalFactor__evidence", curie=COMMUNITYMECH.curie('evidence'),
+                   model_uri=COMMUNITYMECH.environmentalFactor__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+
+slots.growthMediaComponent__name = Slot(uri=COMMUNITYMECH.name, name="growthMediaComponent__name", curie=COMMUNITYMECH.curie('name'),
+                   model_uri=COMMUNITYMECH.growthMediaComponent__name, domain=None, range=str)
+
+slots.growthMediaComponent__media_ingredient_mech_id = Slot(uri=COMMUNITYMECH.media_ingredient_mech_id, name="growthMediaComponent__media_ingredient_mech_id", curie=COMMUNITYMECH.curie('media_ingredient_mech_id'),
+                   model_uri=COMMUNITYMECH.growthMediaComponent__media_ingredient_mech_id, domain=None, range=Optional[str])
+
+slots.growthMediaComponent__media_ingredient_mech_url = Slot(uri=COMMUNITYMECH.media_ingredient_mech_url, name="growthMediaComponent__media_ingredient_mech_url", curie=COMMUNITYMECH.curie('media_ingredient_mech_url'),
+                   model_uri=COMMUNITYMECH.growthMediaComponent__media_ingredient_mech_url, domain=None, range=Optional[str])
+
+slots.growthMediaComponent__concentration = Slot(uri=COMMUNITYMECH.concentration, name="growthMediaComponent__concentration", curie=COMMUNITYMECH.curie('concentration'),
+                   model_uri=COMMUNITYMECH.growthMediaComponent__concentration, domain=None, range=Optional[str])
+
+slots.growthMediaComponent__unit = Slot(uri=COMMUNITYMECH.unit, name="growthMediaComponent__unit", curie=COMMUNITYMECH.curie('unit'),
+                   model_uri=COMMUNITYMECH.growthMediaComponent__unit, domain=None, range=Optional[str])
+
+slots.growthMediaComponent__chebi_term = Slot(uri=COMMUNITYMECH.chebi_term, name="growthMediaComponent__chebi_term", curie=COMMUNITYMECH.curie('chebi_term'),
+                   model_uri=COMMUNITYMECH.growthMediaComponent__chebi_term, domain=None, range=Optional[Union[dict, MetaboliteDescriptor]])
+
+slots.growthMediaComponent__from = Slot(uri=getattr(COMMUNITYMECH, 'from'), name="growthMediaComponent__from", curie=COMMUNITYMECH.curie('from'),
+                   model_uri=COMMUNITYMECH.growthMediaComponent__from, domain=None, range=Optional[str])
+
+slots.growthMedia__name = Slot(uri=COMMUNITYMECH.name, name="growthMedia__name", curie=COMMUNITYMECH.curie('name'),
+                   model_uri=COMMUNITYMECH.growthMedia__name, domain=None, range=str)
+
+slots.growthMedia__culturemech_id = Slot(uri=COMMUNITYMECH.culturemech_id, name="growthMedia__culturemech_id", curie=COMMUNITYMECH.curie('culturemech_id'),
+                   model_uri=COMMUNITYMECH.growthMedia__culturemech_id, domain=None, range=Optional[str])
+
+slots.growthMedia__culturemech_url = Slot(uri=COMMUNITYMECH.culturemech_url, name="growthMedia__culturemech_url", curie=COMMUNITYMECH.curie('culturemech_url'),
+                   model_uri=COMMUNITYMECH.growthMedia__culturemech_url, domain=None, range=Optional[str])
+
+slots.growthMedia__composition = Slot(uri=COMMUNITYMECH.composition, name="growthMedia__composition", curie=COMMUNITYMECH.curie('composition'),
+                   model_uri=COMMUNITYMECH.growthMedia__composition, domain=None, range=Optional[Union[Union[dict, GrowthMediaComponent], list[Union[dict, GrowthMediaComponent]]]])
+
+slots.growthMedia__ph = Slot(uri=COMMUNITYMECH.ph, name="growthMedia__ph", curie=COMMUNITYMECH.curie('ph'),
+                   model_uri=COMMUNITYMECH.growthMedia__ph, domain=None, range=Optional[str])
+
+slots.growthMedia__ph_range = Slot(uri=COMMUNITYMECH.ph_range, name="growthMedia__ph_range", curie=COMMUNITYMECH.curie('ph_range'),
+                   model_uri=COMMUNITYMECH.growthMedia__ph_range, domain=None, range=Optional[str])
+
+slots.growthMedia__temperature = Slot(uri=COMMUNITYMECH.temperature, name="growthMedia__temperature", curie=COMMUNITYMECH.curie('temperature'),
+                   model_uri=COMMUNITYMECH.growthMedia__temperature, domain=None, range=Optional[str])
+
+slots.growthMedia__temperature_unit = Slot(uri=COMMUNITYMECH.temperature_unit, name="growthMedia__temperature_unit", curie=COMMUNITYMECH.curie('temperature_unit'),
+                   model_uri=COMMUNITYMECH.growthMedia__temperature_unit, domain=None, range=Optional[str])
+
+slots.growthMedia__temperature_range = Slot(uri=COMMUNITYMECH.temperature_range, name="growthMedia__temperature_range", curie=COMMUNITYMECH.curie('temperature_range'),
+                   model_uri=COMMUNITYMECH.growthMedia__temperature_range, domain=None, range=Optional[str])
+
+slots.growthMedia__atmosphere = Slot(uri=COMMUNITYMECH.atmosphere, name="growthMedia__atmosphere", curie=COMMUNITYMECH.curie('atmosphere'),
+                   model_uri=COMMUNITYMECH.growthMedia__atmosphere, domain=None, range=Optional[Union[str, "AtmosphereEnum"]])
+
+slots.growthMedia__headspace_gas = Slot(uri=COMMUNITYMECH.headspace_gas, name="growthMedia__headspace_gas", curie=COMMUNITYMECH.curie('headspace_gas'),
+                   model_uri=COMMUNITYMECH.growthMedia__headspace_gas, domain=None, range=Optional[str])
+
+slots.growthMedia__salinity = Slot(uri=COMMUNITYMECH.salinity, name="growthMedia__salinity", curie=COMMUNITYMECH.curie('salinity'),
+                   model_uri=COMMUNITYMECH.growthMedia__salinity, domain=None, range=Optional[str])
+
+slots.growthMedia__salinity_unit = Slot(uri=COMMUNITYMECH.salinity_unit, name="growthMedia__salinity_unit", curie=COMMUNITYMECH.curie('salinity_unit'),
+                   model_uri=COMMUNITYMECH.growthMedia__salinity_unit, domain=None, range=Optional[str])
+
+slots.growthMedia__pressure = Slot(uri=COMMUNITYMECH.pressure, name="growthMedia__pressure", curie=COMMUNITYMECH.curie('pressure'),
+                   model_uri=COMMUNITYMECH.growthMedia__pressure, domain=None, range=Optional[str])
+
+slots.growthMedia__pressure_unit = Slot(uri=COMMUNITYMECH.pressure_unit, name="growthMedia__pressure_unit", curie=COMMUNITYMECH.curie('pressure_unit'),
+                   model_uri=COMMUNITYMECH.growthMedia__pressure_unit, domain=None, range=Optional[str])
+
+slots.growthMedia__light_regime = Slot(uri=COMMUNITYMECH.light_regime, name="growthMedia__light_regime", curie=COMMUNITYMECH.curie('light_regime'),
+                   model_uri=COMMUNITYMECH.growthMedia__light_regime, domain=None, range=Optional[str])
+
+slots.growthMedia__light_intensity = Slot(uri=COMMUNITYMECH.light_intensity, name="growthMedia__light_intensity", curie=COMMUNITYMECH.curie('light_intensity'),
+                   model_uri=COMMUNITYMECH.growthMedia__light_intensity, domain=None, range=Optional[str])
+
+slots.growthMedia__light_intensity_unit = Slot(uri=COMMUNITYMECH.light_intensity_unit, name="growthMedia__light_intensity_unit", curie=COMMUNITYMECH.curie('light_intensity_unit'),
+                   model_uri=COMMUNITYMECH.growthMedia__light_intensity_unit, domain=None, range=Optional[str])
+
+slots.growthMedia__redox_potential = Slot(uri=COMMUNITYMECH.redox_potential, name="growthMedia__redox_potential", curie=COMMUNITYMECH.curie('redox_potential'),
+                   model_uri=COMMUNITYMECH.growthMedia__redox_potential, domain=None, range=Optional[str])
+
+slots.growthMedia__redox_potential_unit = Slot(uri=COMMUNITYMECH.redox_potential_unit, name="growthMedia__redox_potential_unit", curie=COMMUNITYMECH.curie('redox_potential_unit'),
+                   model_uri=COMMUNITYMECH.growthMedia__redox_potential_unit, domain=None, range=Optional[str])
+
+slots.growthMedia__inoculum_source = Slot(uri=COMMUNITYMECH.inoculum_source, name="growthMedia__inoculum_source", curie=COMMUNITYMECH.curie('inoculum_source'),
+                   model_uri=COMMUNITYMECH.growthMedia__inoculum_source, domain=None, range=Optional[str])
+
+slots.growthMedia__inoculum_size = Slot(uri=COMMUNITYMECH.inoculum_size, name="growthMedia__inoculum_size", curie=COMMUNITYMECH.curie('inoculum_size'),
+                   model_uri=COMMUNITYMECH.growthMedia__inoculum_size, domain=None, range=Optional[str])
+
+slots.growthMedia__inoculum_unit = Slot(uri=COMMUNITYMECH.inoculum_unit, name="growthMedia__inoculum_unit", curie=COMMUNITYMECH.curie('inoculum_unit'),
+                   model_uri=COMMUNITYMECH.growthMedia__inoculum_unit, domain=None, range=Optional[str])
+
+slots.growthMedia__incubation_time = Slot(uri=COMMUNITYMECH.incubation_time, name="growthMedia__incubation_time", curie=COMMUNITYMECH.curie('incubation_time'),
+                   model_uri=COMMUNITYMECH.growthMedia__incubation_time, domain=None, range=Optional[str])
+
+slots.growthMedia__incubation_time_unit = Slot(uri=COMMUNITYMECH.incubation_time_unit, name="growthMedia__incubation_time_unit", curie=COMMUNITYMECH.curie('incubation_time_unit'),
+                   model_uri=COMMUNITYMECH.growthMedia__incubation_time_unit, domain=None, range=Optional[str])
+
+slots.growthMedia__shaking_speed = Slot(uri=COMMUNITYMECH.shaking_speed, name="growthMedia__shaking_speed", curie=COMMUNITYMECH.curie('shaking_speed'),
+                   model_uri=COMMUNITYMECH.growthMedia__shaking_speed, domain=None, range=Optional[str])
+
+slots.growthMedia__shaking_speed_unit = Slot(uri=COMMUNITYMECH.shaking_speed_unit, name="growthMedia__shaking_speed_unit", curie=COMMUNITYMECH.curie('shaking_speed_unit'),
+                   model_uri=COMMUNITYMECH.growthMedia__shaking_speed_unit, domain=None, range=Optional[str])
+
+slots.growthMedia__vessel_type = Slot(uri=COMMUNITYMECH.vessel_type, name="growthMedia__vessel_type", curie=COMMUNITYMECH.curie('vessel_type'),
+                   model_uri=COMMUNITYMECH.growthMedia__vessel_type, domain=None, range=Optional[str])
+
+slots.growthMedia__preparation_notes = Slot(uri=COMMUNITYMECH.preparation_notes, name="growthMedia__preparation_notes", curie=COMMUNITYMECH.curie('preparation_notes'),
+                   model_uri=COMMUNITYMECH.growthMedia__preparation_notes, domain=None, range=Optional[str])
+
+slots.growthMedia__protocol_url = Slot(uri=COMMUNITYMECH.protocol_url, name="growthMedia__protocol_url", curie=COMMUNITYMECH.curie('protocol_url'),
+                   model_uri=COMMUNITYMECH.growthMedia__protocol_url, domain=None, range=Optional[str])
+
+slots.growthMedia__evidence = Slot(uri=COMMUNITYMECH.evidence, name="growthMedia__evidence", curie=COMMUNITYMECH.curie('evidence'),
+                   model_uri=COMMUNITYMECH.growthMedia__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+
+slots.relatedMedia__preferred_term = Slot(uri=COMMUNITYMECH.preferred_term, name="relatedMedia__preferred_term", curie=COMMUNITYMECH.curie('preferred_term'),
+                   model_uri=COMMUNITYMECH.relatedMedia__preferred_term, domain=None, range=str)
+
+slots.relatedMedia__culturemech_id = Slot(uri=COMMUNITYMECH.culturemech_id, name="relatedMedia__culturemech_id", curie=COMMUNITYMECH.curie('culturemech_id'),
+                   model_uri=COMMUNITYMECH.relatedMedia__culturemech_id, domain=None, range=Optional[str],
+                   pattern=re.compile(r'^CultureMech:\d{6}$'))
+
+slots.relatedMedia__relationship_type = Slot(uri=COMMUNITYMECH.relationship_type, name="relatedMedia__relationship_type", curie=COMMUNITYMECH.curie('relationship_type'),
+                   model_uri=COMMUNITYMECH.relatedMedia__relationship_type, domain=None, range=Optional[Union[str, "MediaRelationshipEnum"]])
+
+slots.relatedMedia__shared_environment_term = Slot(uri=COMMUNITYMECH.shared_environment_term, name="relatedMedia__shared_environment_term", curie=COMMUNITYMECH.curie('shared_environment_term'),
+                   model_uri=COMMUNITYMECH.relatedMedia__shared_environment_term, domain=None, range=Optional[Union[dict, Term]])
+
+slots.relatedMedia__relevance_notes = Slot(uri=COMMUNITYMECH.relevance_notes, name="relatedMedia__relevance_notes", curie=COMMUNITYMECH.curie('relevance_notes'),
+                   model_uri=COMMUNITYMECH.relatedMedia__relevance_notes, domain=None, range=Optional[str])
+
+slots.relatedMedia__evidence = Slot(uri=COMMUNITYMECH.evidence, name="relatedMedia__evidence", curie=COMMUNITYMECH.curie('evidence'),
+                   model_uri=COMMUNITYMECH.relatedMedia__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+
+slots.relatedIngredient__preferred_term = Slot(uri=COMMUNITYMECH.preferred_term, name="relatedIngredient__preferred_term", curie=COMMUNITYMECH.curie('preferred_term'),
+                   model_uri=COMMUNITYMECH.relatedIngredient__preferred_term, domain=None, range=str)
+
+slots.relatedIngredient__mediaingredientmech_id = Slot(uri=COMMUNITYMECH.mediaingredientmech_id, name="relatedIngredient__mediaingredientmech_id", curie=COMMUNITYMECH.curie('mediaingredientmech_id'),
+                   model_uri=COMMUNITYMECH.relatedIngredient__mediaingredientmech_id, domain=None, range=Optional[str],
+                   pattern=re.compile(r'^MediaIngredientMech:\d{6}$'))
+
+slots.relatedIngredient__chebi_term = Slot(uri=COMMUNITYMECH.chebi_term, name="relatedIngredient__chebi_term", curie=COMMUNITYMECH.curie('chebi_term'),
+                   model_uri=COMMUNITYMECH.relatedIngredient__chebi_term, domain=None, range=Optional[Union[dict, Term]])
+
+slots.relatedIngredient__relevance = Slot(uri=COMMUNITYMECH.relevance, name="relatedIngredient__relevance", curie=COMMUNITYMECH.curie('relevance'),
+                   model_uri=COMMUNITYMECH.relatedIngredient__relevance, domain=None, range=Optional[str])
+
+slots.relatedIngredient__evidence = Slot(uri=COMMUNITYMECH.evidence, name="relatedIngredient__evidence", curie=COMMUNITYMECH.curie('evidence'),
+                   model_uri=COMMUNITYMECH.relatedIngredient__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+
+slots.associatedDataset__name = Slot(uri=COMMUNITYMECH.name, name="associatedDataset__name", curie=COMMUNITYMECH.curie('name'),
+                   model_uri=COMMUNITYMECH.associatedDataset__name, domain=None, range=str)
+
+slots.associatedDataset__dataset_type = Slot(uri=COMMUNITYMECH.dataset_type, name="associatedDataset__dataset_type", curie=COMMUNITYMECH.curie('dataset_type'),
+                   model_uri=COMMUNITYMECH.associatedDataset__dataset_type, domain=None, range=Union[str, "DatasetTypeEnum"])
+
+slots.associatedDataset__repository = Slot(uri=COMMUNITYMECH.repository, name="associatedDataset__repository", curie=COMMUNITYMECH.curie('repository'),
+                   model_uri=COMMUNITYMECH.associatedDataset__repository, domain=None, range=Optional[Union[str, "DatasetRepositoryEnum"]])
+
+slots.associatedDataset__accession = Slot(uri=COMMUNITYMECH.accession, name="associatedDataset__accession", curie=COMMUNITYMECH.curie('accession'),
+                   model_uri=COMMUNITYMECH.associatedDataset__accession, domain=None, range=str)
+
+slots.associatedDataset__url = Slot(uri=COMMUNITYMECH.url, name="associatedDataset__url", curie=COMMUNITYMECH.curie('url'),
+                   model_uri=COMMUNITYMECH.associatedDataset__url, domain=None, range=Optional[str])
+
+slots.associatedDataset__description = Slot(uri=COMMUNITYMECH.description, name="associatedDataset__description", curie=COMMUNITYMECH.curie('description'),
+                   model_uri=COMMUNITYMECH.associatedDataset__description, domain=None, range=Optional[str])
+
+slots.associatedDataset__evidence = Slot(uri=COMMUNITYMECH.evidence, name="associatedDataset__evidence", curie=COMMUNITYMECH.curie('evidence'),
+                   model_uri=COMMUNITYMECH.associatedDataset__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+
+slots.externalResource__name = Slot(uri=COMMUNITYMECH.name, name="externalResource__name", curie=COMMUNITYMECH.curie('name'),
+                   model_uri=COMMUNITYMECH.externalResource__name, domain=None, range=str)
+
+slots.externalResource__repository = Slot(uri=COMMUNITYMECH.repository, name="externalResource__repository", curie=COMMUNITYMECH.curie('repository'),
+                   model_uri=COMMUNITYMECH.externalResource__repository, domain=None, range=Union[str, "ExternalResourceRepositoryEnum"])
+
+slots.externalResource__resource_id = Slot(uri=COMMUNITYMECH.resource_id, name="externalResource__resource_id", curie=COMMUNITYMECH.curie('resource_id'),
+                   model_uri=COMMUNITYMECH.externalResource__resource_id, domain=None, range=str)
+
+slots.externalResource__url = Slot(uri=COMMUNITYMECH.url, name="externalResource__url", curie=COMMUNITYMECH.curie('url'),
+                   model_uri=COMMUNITYMECH.externalResource__url, domain=None, range=str)
+
+slots.externalResource__description = Slot(uri=COMMUNITYMECH.description, name="externalResource__description", curie=COMMUNITYMECH.curie('description'),
+                   model_uri=COMMUNITYMECH.externalResource__description, domain=None, range=Optional[str])
+
+slots.externalResource__evidence = Slot(uri=COMMUNITYMECH.evidence, name="externalResource__evidence", curie=COMMUNITYMECH.curie('evidence'),
+                   model_uri=COMMUNITYMECH.externalResource__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+
+slots.communityEngineeringDesign__objective = Slot(uri=COMMUNITYMECH.objective, name="communityEngineeringDesign__objective", curie=COMMUNITYMECH.curie('objective'),
+                   model_uri=COMMUNITYMECH.communityEngineeringDesign__objective, domain=None, range=Optional[str])
+
+slots.communityEngineeringDesign__assembly_strategy = Slot(uri=COMMUNITYMECH.assembly_strategy, name="communityEngineeringDesign__assembly_strategy", curie=COMMUNITYMECH.curie('assembly_strategy'),
+                   model_uri=COMMUNITYMECH.communityEngineeringDesign__assembly_strategy, domain=None, range=Optional[str])
+
+slots.communityEngineeringDesign__inoculation_strategy = Slot(uri=COMMUNITYMECH.inoculation_strategy, name="communityEngineeringDesign__inoculation_strategy", curie=COMMUNITYMECH.curie('inoculation_strategy'),
+                   model_uri=COMMUNITYMECH.communityEngineeringDesign__inoculation_strategy, domain=None, range=Optional[str])
+
+slots.communityEngineeringDesign__passaging_regimen = Slot(uri=COMMUNITYMECH.passaging_regimen, name="communityEngineeringDesign__passaging_regimen", curie=COMMUNITYMECH.curie('passaging_regimen'),
+                   model_uri=COMMUNITYMECH.communityEngineeringDesign__passaging_regimen, domain=None, range=Optional[str])
+
+slots.communityEngineeringDesign__perturbation_design = Slot(uri=COMMUNITYMECH.perturbation_design, name="communityEngineeringDesign__perturbation_design", curie=COMMUNITYMECH.curie('perturbation_design'),
+                   model_uri=COMMUNITYMECH.communityEngineeringDesign__perturbation_design, domain=None, range=Optional[str])
+
+slots.communityEngineeringDesign__measurement_endpoints = Slot(uri=COMMUNITYMECH.measurement_endpoints, name="communityEngineeringDesign__measurement_endpoints", curie=COMMUNITYMECH.curie('measurement_endpoints'),
+                   model_uri=COMMUNITYMECH.communityEngineeringDesign__measurement_endpoints, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.communityEngineeringDesign__protocol_url = Slot(uri=COMMUNITYMECH.protocol_url, name="communityEngineeringDesign__protocol_url", curie=COMMUNITYMECH.curie('protocol_url'),
+                   model_uri=COMMUNITYMECH.communityEngineeringDesign__protocol_url, domain=None, range=Optional[str])
+
+slots.communityEngineeringDesign__notes = Slot(uri=COMMUNITYMECH.notes, name="communityEngineeringDesign__notes", curie=COMMUNITYMECH.curie('notes'),
+                   model_uri=COMMUNITYMECH.communityEngineeringDesign__notes, domain=None, range=Optional[str])
+
+slots.communityEngineeringDesign__evidence = Slot(uri=COMMUNITYMECH.evidence, name="communityEngineeringDesign__evidence", curie=COMMUNITYMECH.curie('evidence'),
+                   model_uri=COMMUNITYMECH.communityEngineeringDesign__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+
+slots.microbialCommunity__id = Slot(uri=COMMUNITYMECH.id, name="microbialCommunity__id", curie=COMMUNITYMECH.curie('id'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__id, domain=None, range=URIRef,
+                   pattern=re.compile(r'^CommunityMech:\d{6}$'))
+
+slots.microbialCommunity__name = Slot(uri=COMMUNITYMECH.name, name="microbialCommunity__name", curie=COMMUNITYMECH.curie('name'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__name, domain=None, range=str)
+
+slots.microbialCommunity__description = Slot(uri=COMMUNITYMECH.description, name="microbialCommunity__description", curie=COMMUNITYMECH.curie('description'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__description, domain=None, range=Optional[str])
+
+slots.microbialCommunity__ecological_state = Slot(uri=COMMUNITYMECH.ecological_state, name="microbialCommunity__ecological_state", curie=COMMUNITYMECH.curie('ecological_state'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__ecological_state, domain=None, range=Optional[Union[str, "EcologicalStateEnum"]])
+
+slots.microbialCommunity__community_origin = Slot(uri=COMMUNITYMECH.community_origin, name="microbialCommunity__community_origin", curie=COMMUNITYMECH.curie('community_origin'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__community_origin, domain=None, range=Optional[Union[str, "CommunityOriginEnum"]])
+
+slots.microbialCommunity__community_category = Slot(uri=COMMUNITYMECH.community_category, name="microbialCommunity__community_category", curie=COMMUNITYMECH.curie('community_category'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__community_category, domain=None, range=Optional[Union[str, "CommunityCategoryEnum"]])
+
+slots.microbialCommunity__engineering_design = Slot(uri=COMMUNITYMECH.engineering_design, name="microbialCommunity__engineering_design", curie=COMMUNITYMECH.curie('engineering_design'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__engineering_design, domain=None, range=Optional[Union[dict, CommunityEngineeringDesign]])
+
+slots.microbialCommunity__environment_term = Slot(uri=COMMUNITYMECH.environment_term, name="microbialCommunity__environment_term", curie=COMMUNITYMECH.curie('environment_term'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__environment_term, domain=None, range=Optional[Union[dict, EnvironmentDescriptor]])
+
+slots.microbialCommunity__taxonomy = Slot(uri=COMMUNITYMECH.taxonomy, name="microbialCommunity__taxonomy", curie=COMMUNITYMECH.curie('taxonomy'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__taxonomy, domain=None, range=Optional[Union[Union[dict, TaxonomicComposition], list[Union[dict, TaxonomicComposition]]]])
+
+slots.microbialCommunity__ecological_interactions = Slot(uri=COMMUNITYMECH.ecological_interactions, name="microbialCommunity__ecological_interactions", curie=COMMUNITYMECH.curie('ecological_interactions'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__ecological_interactions, domain=None, range=Optional[Union[Union[dict, EcologicalInteraction], list[Union[dict, EcologicalInteraction]]]])
+
+slots.microbialCommunity__environmental_factors = Slot(uri=COMMUNITYMECH.environmental_factors, name="microbialCommunity__environmental_factors", curie=COMMUNITYMECH.curie('environmental_factors'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__environmental_factors, domain=None, range=Optional[Union[Union[dict, EnvironmentalFactor], list[Union[dict, EnvironmentalFactor]]]])
+
+slots.microbialCommunity__growth_media = Slot(uri=COMMUNITYMECH.growth_media, name="microbialCommunity__growth_media", curie=COMMUNITYMECH.curie('growth_media'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__growth_media, domain=None, range=Optional[Union[Union[dict, GrowthMedia], list[Union[dict, GrowthMedia]]]])
+
+slots.microbialCommunity__related_media = Slot(uri=COMMUNITYMECH.related_media, name="microbialCommunity__related_media", curie=COMMUNITYMECH.curie('related_media'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__related_media, domain=None, range=Optional[Union[Union[dict, RelatedMedia], list[Union[dict, RelatedMedia]]]])
+
+slots.microbialCommunity__related_ingredients = Slot(uri=COMMUNITYMECH.related_ingredients, name="microbialCommunity__related_ingredients", curie=COMMUNITYMECH.curie('related_ingredients'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__related_ingredients, domain=None, range=Optional[Union[Union[dict, RelatedIngredient], list[Union[dict, RelatedIngredient]]]])
+
+slots.microbialCommunity__associated_datasets = Slot(uri=COMMUNITYMECH.associated_datasets, name="microbialCommunity__associated_datasets", curie=COMMUNITYMECH.curie('associated_datasets'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__associated_datasets, domain=None, range=Optional[Union[Union[dict, AssociatedDataset], list[Union[dict, AssociatedDataset]]]])
+
+slots.microbialCommunity__external_resources = Slot(uri=COMMUNITYMECH.external_resources, name="microbialCommunity__external_resources", curie=COMMUNITYMECH.curie('external_resources'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__external_resources, domain=None, range=Optional[Union[Union[dict, ExternalResource], list[Union[dict, ExternalResource]]]])
+
+slots.microbialCommunity__metals_present = Slot(uri=COMMUNITYMECH.metals_present, name="microbialCommunity__metals_present", curie=COMMUNITYMECH.curie('metals_present'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__metals_present, domain=None, range=Optional[Union[Union[str, "MetalElementEnum"], list[Union[str, "MetalElementEnum"]]]])
+
+slots.microbialCommunity__rare_earth_elements_present = Slot(uri=COMMUNITYMECH.rare_earth_elements_present, name="microbialCommunity__rare_earth_elements_present", curie=COMMUNITYMECH.curie('rare_earth_elements_present'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__rare_earth_elements_present, domain=None, range=Optional[Union[Union[str, "RareEarthElementEnum"], list[Union[str, "RareEarthElementEnum"]]]])
+
+slots.microbialCommunity__metal_relevance = Slot(uri=COMMUNITYMECH.metal_relevance, name="microbialCommunity__metal_relevance", curie=COMMUNITYMECH.curie('metal_relevance'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__metal_relevance, domain=None, range=Optional[Union[str, "MetalRelevanceEnum"]])
+
+slots.microbialCommunity__metal_notes = Slot(uri=COMMUNITYMECH.metal_notes, name="microbialCommunity__metal_notes", curie=COMMUNITYMECH.curie('metal_notes'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__metal_notes, domain=None, range=Optional[str])
+

--- a/src/communitymech/network/auditor.py
+++ b/src/communitymech/network/auditor.py
@@ -111,18 +111,20 @@ class NetworkIntegrityAuditor:
 
         for idx, interaction in enumerate(interactions):
             int_name = interaction.get("name", f"Interaction {idx+1}")
+            scope = interaction.get("scope", "PAIRWISE")
 
-            # Check source_taxon
+            # Check source_taxon (only required for PAIRWISE interactions)
             source = interaction.get("source_taxon")
             if not source:
-                issues.append(
-                    {
-                        "type": IssueType.MISSING_SOURCE,
-                        "interaction": int_name,
-                        "interaction_index": idx,
-                        "message": "Interaction has no source_taxon",
-                    }
-                )
+                if scope != "COMMUNITY_LEVEL":
+                    issues.append(
+                        {
+                            "type": IssueType.MISSING_SOURCE,
+                            "interaction": int_name,
+                            "interaction_index": idx,
+                            "message": "Interaction has no source_taxon",
+                        }
+                    )
             else:
                 source_term = source.get("preferred_term") or source.get("term", {}).get("label")
                 source_id = source.get("term", {}).get("id")

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -164,6 +164,17 @@ enums:
           colonization, cross-feeding that supports establishment, or metabolic cooperation during
           initial colonization phases. Can be inter- or intraspecific.
 
+  InteractionScopeEnum:
+    description: Whether an interaction is a pairwise organism-to-organism edge or a community-level phenomenon
+    permissible_values:
+      PAIRWISE:
+        description: Standard pairwise interaction between a source organism and (usually) a target. Requires source_taxon.
+      COMMUNITY_LEVEL:
+        description: >-
+          Community-wide or emergent phenomenon (e.g., division of labor, host-microbiota
+          colonization patterns, abiotic-input-driven processes such as electrolysis-supplied H2).
+          source_taxon may be omitted because no single organism is the source.
+
   AbundanceEnum:
     description: Relative abundance categories
     permissible_values:
@@ -604,8 +615,17 @@ classes:
       interaction_type:
         description: Type of ecological interaction
         range: InteractionTypeEnum
+      scope:
+        description: Whether this interaction is a pairwise organism-to-organism edge
+          or a community-level/emergent phenomenon. PAIRWISE interactions require a
+          source_taxon. COMMUNITY_LEVEL interactions describe behaviors that emerge
+          from the whole consortium (or are driven by abiotic inputs such as
+          electrolysis-supplied H2) and need not have source_taxon set.
+        range: InteractionScopeEnum
+        ifabsent: string(PAIRWISE)
       source_taxon:
-        description: Source organism (if applicable)
+        description: Source organism (if applicable; required for PAIRWISE interactions,
+          omitted for COMMUNITY_LEVEL interactions)
         range: TaxonDescriptor
       target_taxon:
         description: Target organism (if applicable)

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -681,7 +681,7 @@ classes:
       chebi_term:
         description: CHEBI term for the component
         range: MetaboliteDescriptor
-      from:
+      from_source:
         description: Source of this ingredient (e.g., "CultureMech", "community_curated")
 
   GrowthMedia:

--- a/tests/test_network_auditor.py
+++ b/tests/test_network_auditor.py
@@ -102,6 +102,25 @@ def test_missing_source_detected(temp_communities_dir, valid_community):
     assert len(source_issues) == 1
 
 
+def test_missing_source_skipped_for_community_level_scope(
+    temp_communities_dir, valid_community
+):
+    """COMMUNITY_LEVEL interactions describe emergent/community-wide phenomena
+    and need not have source_taxon set."""
+    del valid_community["ecological_interactions"][0]["source_taxon"]
+    valid_community["ecological_interactions"][0]["scope"] = "COMMUNITY_LEVEL"
+
+    test_file = temp_communities_dir / "test_community_level.yaml"
+    with open(test_file, "w") as f:
+        yaml.dump(valid_community, f)
+
+    auditor = NetworkIntegrityAuditor(communities_dir=temp_communities_dir)
+    issues = auditor.audit_community(test_file)
+
+    missing_source = [i for i in issues if i["type"] == IssueType.MISSING_SOURCE]
+    assert missing_source == []
+
+
 def test_unknown_source_detected(temp_communities_dir, valid_community):
     """Test that unknown source taxon is detected."""
     # Add interaction with unknown source


### PR DESCRIPTION
## Summary
Replaces the previous network-audit heuristic for source-less interactions with an explicit schema marker.

- Schema: add `InteractionScopeEnum { PAIRWISE, COMMUNITY_LEVEL }` and `scope` attribute on `EcologicalInteraction` (default `PAIRWISE`).
- Auditor (`src/communitymech/network/auditor.py` and `scripts/audit_network_integrity.py`): skip `MISSING_SOURCE` when `scope == COMMUNITY_LEVEL`.
- Backfill: 86 source-less interactions across 67 community YAMLs get `scope: COMMUNITY_LEVEL`. Includes the one previously-malformed interaction "Electrolysis-Generated Hydrogen Supply" — its H2 source is abiotic (electrolysis), correctly described as community-level.
- Tests: new auditor test covering the relaxation; existing tests still pass.
- Datamodel: regenerated via `just gen-python` with post-patch for the `from:` Python keyword issue in `GrowthMediaComponent` (pre-existing — same approach as before).

## Audit impact
- Before: 148 issues across 76 communities
- After: 62 issues across 14 communities
- All 67 MISSING_SOURCE issues eliminated; remaining 62 are UNKNOWN_SOURCE (8), UNKNOWN_TARGET (9), and DISCONNECTED bullets (mostly the GLBRC Variovorax SynCom28 where 21 strains lack abundance/role metadata).

## Test plan
- [x] `just validate-all` — 210/210 community files pass
- [x] `uv run pytest tests/test_network_auditor.py tests/test_validators.py` — 23/23 pass (includes new `test_missing_source_skipped_for_community_level_scope`)
- [x] `uv run python scripts/audit_network_integrity.py` — reports 62 issues across 14 communities

🤖 Generated with [Claude Code](https://claude.com/claude-code)