### PR TITLE
Add 5 more Banfield post-2020 community entries (round 2)

### DIFF
--- a/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
+++ b/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
@@ -108,10 +108,10 @@ ecological_interactions:
       id: CHEBI:17300
       label: tetrachloroethene
   biological_processes:
-  - preferred_term: organohalide respiration
+  - preferred_term: anaerobic respiration
     term:
-      id: GO:0019410
-      label: alkane catabolic process
+      id: GO:0009061
+      label: anaerobic respiration
   evidence:
   - reference: PMID:33531396
     supports: SUPPORT

--- a/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
+++ b/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
@@ -1,0 +1,189 @@
+id: CommunityMech:000238
+name: Acetylene-Fueled Trichloroethene Dechlorination Groundwater Enrichment
+description: >
+  A microbial community enriched from TCE/PCE-contaminated groundwater and
+  amended with acetylene (C2H2) as the sole electron donor and organic
+  carbon source. The stable enrichment performs reductive dechlorination of
+  trichloroethene (TCE) and tetrachloroethene (PCE), coupling acetylenotrophy
+  to organohalide respiration. Metagenomic analysis of the stable community
+  identified a novel anaerobic acetylenotroph in the phylum Actinobacteria,
+  expanding the known diversity of this metabolism beyond previously
+  documented Pelobacter SFB93 + Dehalococcoides mccartyi laboratory cocultures.
+ecological_state: ENGINEERED
+community_origin: NATURAL
+community_category: BIOREMEDIATION
+engineering_design:
+  objective: Demonstrate that the coupling of acetylenotrophy and reductive
+    dechlorination, previously documented in synthetic cocultures, can occur
+    in a native community enriched from contaminated groundwater.
+  assembly_strategy: Enrich a microbial community from contaminated groundwater
+    by repeated transfer with acetylene as the sole electron donor and organic
+    carbon source.
+  perturbation_design: Provide C2H2 as the sole electron donor and organic
+    carbon source while supplying TCE and PCE as electron acceptors for
+    reductive dechlorination.
+  measurement_endpoints:
+  - TCE reductive dechlorination
+  - PCE reductive dechlorination
+  - Metagenome-resolved community composition and function
+  - Identification of anaerobic acetylenotroph lineages
+  evidence:
+  - reference: PMID:33531396
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: a microbial community enriched from contaminated groundwater and
+      amended with C2H2 as the sole electron donor and organic carbon source
+    explanation: Supports the enrichment design and C2H2 sole-substrate
+      strategy.
+environment_term:
+  preferred_term: contaminated groundwater enrichment culture
+  term:
+    id: ENVO:01001405
+    label: laboratory bioreactor
+  notes: Stable laboratory enrichment from TCE/PCE-contaminated groundwater fed
+    with C2H2 as sole electron donor and carbon source.
+taxonomy:
+- taxon_term:
+    preferred_term: novel anaerobic acetylenotroph (Actinobacteria)
+    term:
+      id: NCBITaxon:201174
+      label: Actinomycetota
+    notes: A novel anaerobic acetylenotroph in the phylum Actinobacteria was
+      identified by metagenomic analysis of the stable enrichment.
+  functional_role:
+  - PRIMARY_DEGRADER
+  - CROSS_FEEDER
+  evidence:
+  - reference: PMID:33531396
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: A novel anaerobic acetylenotroph in the phylum Actinobacteria was
+      identified using metagenomic analysis
+    explanation: Supports the novel Actinobacteria acetylenotroph member.
+- taxon_term:
+    preferred_term: reductive dechlorinating community members
+    term:
+      id: NCBITaxon:2
+      label: Bacteria
+    notes: Community members that perform reductive dechlorination of TCE and
+      PCE. Previous synthetic-coculture work used Dehalococcoides mccartyi
+      strains 195 and BAV1; the abstract does not explicitly enumerate the
+      dechlorinating members of this native enrichment.
+  functional_role:
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:33531396
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: TCE and perchloroethene (PCE) reductive dechlorination by a
+      microbial community enriched from contaminated groundwater
+    explanation: Supports the dechlorinating function of the enrichment members.
+ecological_interactions:
+- name: Acetylenotrophy Provides Reductant for Dechlorination
+  description: An Actinobacteria acetylenotroph oxidizes C2H2 to provide
+    reductant and organic carbon that support reductive dechlorination of TCE
+    and PCE by the community.
+  interaction_type: SYNTROPHY
+  source_taxon:
+    preferred_term: novel anaerobic acetylenotroph (Actinobacteria)
+    term:
+      id: NCBITaxon:201174
+      label: Actinomycetota
+  target_taxon:
+    preferred_term: reductive dechlorinating community members
+    term:
+      id: NCBITaxon:2
+      label: Bacteria
+  metabolites:
+  - preferred_term: acetylene
+    term:
+      id: CHEBI:27518
+      label: acetylene
+  - preferred_term: trichloroethene
+    term:
+      id: CHEBI:16602
+      label: trichloroethene
+  - preferred_term: tetrachloroethene
+    term:
+      id: CHEBI:17300
+      label: tetrachloroethene
+  biological_processes:
+  - preferred_term: organohalide respiration
+    term:
+      id: GO:0019410
+      label: alkane catabolic process
+  evidence:
+  - reference: PMID:33531396
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the coupling of acetylenotrophy and reductive dechlorination can
+      occur in the environment with native bacteria
+    explanation: Supports the curated syntrophic coupling.
+- name: Acetylene as Sole Electron Donor and Carbon Source
+  description: C2H2 alone supports the stable enrichment as the sole electron
+    donor and organic carbon source.
+  interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
+  metabolites:
+  - preferred_term: acetylene
+    term:
+      id: CHEBI:27518
+      label: acetylene
+  evidence:
+  - reference: PMID:33531396
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: amended with C2H2 as the sole electron donor and organic carbon
+      source
+    explanation: Supports C2H2 as the sole substrate.
+environmental_factors:
+- name: Acetylene source
+  value: C2H2 supplied as sole electron donor and carbon source
+  description: Acetylene is supplied as the sole electron donor and organic
+    carbon source, simulating in situ TCE abiotic-degradation products in
+    aquifers.
+  evidence:
+  - reference: PMID:33531396
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: acetylene (C2H2) is a product of abiotic degradation of
+      trichloroethene (TCE) catalyzed by in situ minerals
+    explanation: Supports the in situ origin of C2H2 as a TCE degradation
+      product.
+- name: Chlorinated electron acceptors
+  value: TCE and PCE
+  description: TCE and PCE are supplied as electron acceptors for reductive
+    dechlorination by the enrichment.
+  evidence:
+  - reference: PMID:33531396
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: TCE and perchloroethene (PCE) reductive dechlorination
+    explanation: Supports the chlorinated electron acceptors.
+growth_media: []
+external_resources:
+- name: Primary publication for the acetylene TCE-dechlorination community
+  repository: OTHER
+  resource_id: PMID:33531396
+  url: https://pubmed.ncbi.nlm.nih.gov/33531396/
+  description: PubMed record for the Gushgari-Doyle et al. 2021 mBio paper on
+    acetylene-fueled TCE reductive dechlorination in a groundwater enrichment
+    culture.
+  evidence:
+  - reference: PMID:33531396
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Acetylene-Fueled Trichloroethene Reductive Dechlorination in a
+      Groundwater Enrichment Culture
+    explanation: Lists the primary publication for the curated enrichment.
+- name: DOI landing page
+  repository: OTHER
+  resource_id: doi:10.1128/mBio.02724-20
+  url: https://doi.org/10.1128/mBio.02724-20
+  description: DOI link to the mBio paper.
+associated_datasets: []
+metals_present: []
+rare_earth_elements_present: []
+metal_relevance: NOT_APPLICABLE
+metal_notes: No metal or rare earth element processing role is curated for this
+  acetylene/TCE enrichment.

--- a/kb/communities/Angelarchaeales_Thermoplasmata_CuMMO_Soil_Sediment_Community.yaml
+++ b/kb/communities/Angelarchaeales_Thermoplasmata_CuMMO_Soil_Sediment_Community.yaml
@@ -1,0 +1,145 @@
+id: CommunityMech:000234
+name: Angelarchaeales Thermoplasmata CuMMO Soil and Sediment Community
+description: >
+  A soil and aquifer-sediment microbial community in which a newly defined
+  Thermoplasmatota archaeal order, Ca. Angelarchaeales, encodes divergent
+  copper membrane monooxygenases (CuMMOs). Twenty genomes from distinct
+  archaeal species were recovered from grassland and hillslope soils and
+  aquifer sediments. The CuMMO proteins resemble Nitrososphaerales (ammonia
+  monooxygenase) enzymes more than bacterial CuMMOs and retain all functional
+  residues required for monooxygenase activity. Angelarchaeales genomes are
+  enriched in blue copper proteins (BCPs) including plastocyanin-like electron
+  carriers and divergent nitrite reductase-like (nirK) 2-domain cupredoxin
+  proteins, encode strong peptide and amino-acid uptake/degradation capacity,
+  and share electron transport mechanisms with Nitrososphaerales.
+  Angelarchaeales are abundant in some of the source environments.
+ecological_state: STABLE
+community_origin: NATURAL
+community_category: EXTREME_ENVIRONMENT
+environment_term:
+  preferred_term: grassland and hillslope soils and aquifer sediments
+  term:
+    id: ENVO:00005750
+    label: grassland soil
+  notes: Genomes were recovered from grassland and hillslope soils and from
+    aquifer sediments.
+taxonomy:
+- taxon_term:
+    preferred_term: Ca. Angelarchaeales (Thermoplasmatota)
+    term:
+      id: NCBITaxon:2283796
+      label: Thermoplasmatota
+    notes: Newly defined Thermoplasmatota archaeal order encoding divergent
+      CuMMO sequences across 20 species-level genomes.
+  abundance_level: ABUNDANT
+  functional_role:
+  - PRIMARY_PRODUCER
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:34987183
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: 20 genomes from distinct archaeal species encoding divergent CuMMO
+      sequences
+    explanation: Supports the Angelarchaeales membership recovered as 20
+      archaeal genomes.
+  - reference: PMID:34987183
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: phylogenetically clustered in a previously unnamed Thermoplasmatota
+      order, herein named the Ca. Angelarchaeales
+    explanation: Supports the newly named order placement.
+ecological_interactions:
+- name: Archaeal CuMMO-Driven Aerobic Oxidation
+  description: Angelarchaeales encode divergent CuMMOs structurally similar to
+    Nitrososphaerales ammonia monooxygenases, suggesting an aerobic oxidation
+    role in soils and sediments. Substrate specificity is not resolved in the
+    abstract.
+  interaction_type: COMMENSALISM
+  scope: COMMUNITY_LEVEL
+  biological_processes:
+  - preferred_term: oxidation-reduction process
+    term:
+      id: GO:0055114
+      label: oxidation-reduction process
+  evidence:
+  - reference: PMID:34987183
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: The CuMMO proteins in Ca. Angelarchaeales are more similar in
+      structure to those in Nitrososphaerales than those of bacteria
+    explanation: Supports the structural similarity to Nitrososphaerales CuMMOs.
+- name: Blue Copper Protein Electron Transport Repertoire
+  description: Angelarchaeales genomes are enriched in blue copper proteins
+    including plastocyanin-like electron carriers and divergent nitrite
+    reductase-like (nirK) 2-domain cupredoxin proteins co-located with
+    electron-transport machinery.
+  interaction_type: COMMENSALISM
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:34987183
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: significantly enriched in blue copper proteins (BCPs) relative to
+      sibling lineages
+    explanation: Supports the BCP enrichment within Angelarchaeales.
+- name: Peptide and Amino Acid Heterotrophy
+  description: Angelarchaeales encode significant capacity for peptide and
+    amino-acid uptake and degradation, suggesting heterotrophic contributions
+    to soil and sediment carbon cycling.
+  interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
+  metabolites:
+  - preferred_term: amino acid
+    term:
+      id: CHEBI:33709
+      label: amino acid
+  biological_processes:
+  - preferred_term: cellular amino acid catabolic process
+    term:
+      id: GO:0009063
+      label: cellular amino acid catabolic process
+  evidence:
+  - reference: PMID:34987183
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: significant capacity for peptide/amino acid uptake and degradation
+    explanation: Supports the peptide and amino acid metabolic repertoire.
+environmental_factors:
+- name: Source environment
+  value: grassland and hillslope soils plus aquifer sediments
+  description: Multiple terrestrial soil environments and aquifer sediments
+    contributed genomes to the Angelarchaeales analysis.
+  evidence:
+  - reference: PMID:34987183
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: From grassland and hillslope soils and aquifer sediments
+    explanation: Supports the curated source environments.
+growth_media: []
+external_resources:
+- name: Primary publication for the Angelarchaeales soil/sediment community
+  repository: OTHER
+  resource_id: PMID:34987183
+  url: https://pubmed.ncbi.nlm.nih.gov/34987183/
+  description: PubMed record for the Diamond et al. 2022 ISME J paper on
+    Angelarchaeales (Thermoplasmatota) encoding novel CuMMOs.
+  evidence:
+  - reference: PMID:34987183
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Soils and sediments host Thermoplasmata archaea encoding novel
+      copper membrane monooxygenases (CuMMOs)
+    explanation: Lists the primary publication for the curated community.
+- name: DOI landing page
+  repository: OTHER
+  resource_id: doi:10.1038/s41396-021-01177-5
+  url: https://doi.org/10.1038/s41396-021-01177-5
+  description: DOI link to the ISME J paper.
+associated_datasets: []
+metals_present:
+- COPPER
+rare_earth_elements_present: []
+metal_relevance: SIGNIFICANT
+metal_notes: Copper is the central metal cofactor of the CuMMO and blue copper
+  proteins enriched in Angelarchaeales genomes.

--- a/kb/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.yaml
+++ b/kb/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.yaml
@@ -1,0 +1,219 @@
+id: CommunityMech:000236
+name: Avena Rhizosphere Cross-Kingdom 13C-SIP Community
+description: >
+  A rhizosphere community of Avena fatua traced with stable isotope probing
+  (SIP) by growing the plant in a 13CO2 atmosphere. Paired rhizosphere and
+  nonrhizosphere soils sampled at 6 and 9 weeks were density-fractionated and
+  sequenced to recover 55 bacterial genomes (>=70 percent complete), complete
+  18S rRNA sequences of 13C-enriched microeukaryotic bacterivores and fungi,
+  and 10 circularized bacteriophage genomes. Some phages were the most labeled
+  entities in the rhizosphere, suggesting phage are important agents of
+  turnover of plant-derived carbon in soil. CRISPR spacer targeting linked one
+  phage to a Burkholderiales host predicted to be a plant pathogen and another
+  to a Catenulispora sp. predicted to be a plant growth-promoting bacterium.
+  Heavily 13C-labeled bacterial genes include those involved in modulating
+  plant signaling hormones, plant pathogenicity, and defense against
+  microeukaryote grazing.
+ecological_state: STABLE
+community_origin: NATURAL
+community_category: RHIZOSPHERE
+environment_term:
+  preferred_term: Avena fatua root rhizosphere
+  term:
+    id: ENVO:00002233
+    label: rhizosphere
+  notes: Rhizosphere and nonrhizosphere soils collected at 6 and 9 weeks from
+    Avena fatua grown in a 13CO2 atmosphere for genome-resolved SIP.
+taxonomy:
+- taxon_term:
+    preferred_term: 13C-labeled rhizosphere bacteria
+    term:
+      id: NCBITaxon:2
+      label: Bacteria
+    notes: 55 bacterial genomes at least 70 percent complete were recovered from
+      density-fractionated SIP samples.
+  functional_role:
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:34468166
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: 55 unique bacterial genomes that were ≥70% complete
+    explanation: Supports the bacterial members recovered.
+- taxon_term:
+    preferred_term: 13C-labeled rhizosphere microeukaryotic bacterivores and
+      fungi
+    term:
+      id: NCBITaxon:2759
+      label: Eukaryota
+    notes: 18S rRNA gene sequences of 13C-enriched microeukaryotic bacterivores
+      and fungi were identified in the SIP fractions.
+  evidence:
+  - reference: PMID:34468166
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: complete 18S rRNA sequences of several 13C-enriched microeukaryotic
+      bacterivores and fungi
+    explanation: Supports the microeukaryotic membership.
+- taxon_term:
+    preferred_term: 13C-labeled rhizosphere bacteriophages
+    term:
+      id: NCBITaxon:10239
+      label: Viruses
+    notes: 10 circularized phage genomes were recovered; some were the most
+      labeled entities in the rhizosphere.
+  evidence:
+  - reference: PMID:34468166
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: 10 circularized bacteriophage (phage) genomes, some of which were
+      the most labeled entities in the rhizosphere
+    explanation: Supports the phage members and their high 13C labeling.
+- taxon_term:
+    preferred_term: Burkholderiales (predicted plant pathogen)
+    term:
+      id: NCBITaxon:80840
+      label: Burkholderiales
+  functional_role:
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:34468166
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: a Burkholderiales host predicted to be a plant pathogen
+    explanation: Supports the Burkholderiales pathogenic host.
+- taxon_term:
+    preferred_term: Catenulispora sp. (predicted PGPR)
+    term:
+      id: NCBITaxon:223957
+      label: Catenulispora
+  functional_role:
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:34468166
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: a Catenulispora sp., a possible plant growth-promoting bacterium
+    explanation: Supports the Catenulispora PGPR member.
+ecological_interactions:
+- name: Phage Lysis Turns Over Plant-Derived Carbon
+  description: Phages with high 13C labeling rapidly turn over plant-derived
+    carbon in the rhizosphere, supporting an important agent role for phage in
+    carbon cycling.
+  interaction_type: PREDATION
+  scope: COMMUNITY_LEVEL
+  metabolites:
+  - preferred_term: carbon dioxide
+    term:
+      id: CHEBI:16526
+      label: carbon dioxide
+  evidence:
+  - reference: PMID:34468166
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: phage may be important agents of turnover of plant-derived C in soil
+    explanation: Supports the phage role in plant-derived C turnover.
+- name: Phage Targets Burkholderiales Plant Pathogen
+  description: CRISPR spacer targeting connected one phage to a Burkholderiales
+    host predicted to be a plant pathogen.
+  interaction_type: PREDATION
+  source_taxon:
+    preferred_term: 13C-labeled rhizosphere bacteriophages
+    term:
+      id: NCBITaxon:10239
+      label: Viruses
+  target_taxon:
+    preferred_term: Burkholderiales (predicted plant pathogen)
+    term:
+      id: NCBITaxon:80840
+      label: Burkholderiales
+  evidence:
+  - reference: PMID:34468166
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: CRISPR locus targeting connected one of these phage to a
+      Burkholderiales host predicted to be a plant pathogen
+    explanation: Supports the CRISPR-based phage-host linkage to Burkholderiales.
+- name: Phage Replicates in Catenulispora PGPR
+  description: Another highly labeled phage is predicted to replicate in a
+    Catenulispora sp. predicted to be a plant growth-promoting bacterium.
+  interaction_type: PREDATION
+  source_taxon:
+    preferred_term: 13C-labeled rhizosphere bacteriophages
+    term:
+      id: NCBITaxon:10239
+      label: Viruses
+  target_taxon:
+    preferred_term: Catenulispora sp. (predicted PGPR)
+    term:
+      id: NCBITaxon:223957
+      label: Catenulispora
+  evidence:
+  - reference: PMID:34468166
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Another highly labeled phage is predicted to replicate in a
+      Catenulispora sp.
+    explanation: Supports the predicted Catenulispora phage host.
+- name: 13C-Labeled Plant-Signaling and Defense Functions
+  description: 13C-labeled bacterial genomes encode genes involved in
+    modulating plant signaling hormones, plant pathogenicity, and defense
+    against microeukaryote grazing.
+  interaction_type: COMMENSALISM
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:34468166
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: bacterial genes thought to be involved in modulating plant
+      signaling hormones, plant pathogenicity, and defense against
+      microeukaryote grazing
+    explanation: Supports the curated cross-kingdom interaction functions.
+environmental_factors:
+- name: Plant growth atmosphere
+  value: 13CO2 labeling
+  description: Avena fatua was grown in a 13CO2 atmosphere to trace plant-
+    fixed carbon into the rhizosphere community.
+  evidence:
+  - reference: PMID:34468166
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Avena fatua grown in a 13CO2 atmosphere
+    explanation: Supports the 13CO2 SIP design.
+- name: Sampling time
+  value: 6 and 9 weeks of growth
+  description: Paired rhizosphere and nonrhizosphere soils were sampled at 6
+    and 9 weeks of plant growth.
+  evidence:
+  - reference: PMID:34468166
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: paired rhizosphere and nonrhizosphere soil at 6 and 9 weeks of
+      plant growth
+    explanation: Supports the time-course sampling design.
+growth_media: []
+external_resources:
+- name: Primary publication for the Avena rhizosphere cross-kingdom SIP community
+  repository: OTHER
+  resource_id: PMID:34468166
+  url: https://pubmed.ncbi.nlm.nih.gov/34468166/
+  description: PubMed record for the Starr et al. 2021 mSphere paper on
+    stable-isotope-informed genome-resolved metagenomics of the Avena fatua
+    rhizosphere.
+  evidence:
+  - reference: PMID:34468166
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Cross-Kingdom Interactions in Rhizosphere Soil
+    explanation: Lists the primary publication for the curated community.
+- name: DOI landing page
+  repository: OTHER
+  resource_id: doi:10.1128/mSphere.00085-21
+  url: https://doi.org/10.1128/mSphere.00085-21
+  description: DOI link to the mSphere paper.
+associated_datasets: []
+metals_present: []
+rare_earth_elements_present: []
+metal_relevance: NOT_APPLICABLE
+metal_notes: No metal or rare earth element processing role is curated for this
+  rhizosphere SIP community.

--- a/kb/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.yaml
+++ b/kb/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.yaml
@@ -38,7 +38,7 @@ taxonomy:
   - reference: PMID:34468166
     supports: SUPPORT
     evidence_source: IN_VIVO
-    snippet: 55 unique bacterial genomes that were ≥70% complete
+    snippet: 55 unique bacterial genomes
     explanation: Supports the bacterial members recovered.
 - taxon_term:
     preferred_term: 13C-labeled rhizosphere microeukaryotic bacterivores and

--- a/kb/communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.yaml
+++ b/kb/communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.yaml
@@ -1,0 +1,172 @@
+id: CommunityMech:000235
+name: Drought-Induced Rhizosphere Iron-Enriched Actinobacteria Community
+description: >
+  A root-associated rhizosphere microbial community in which drought stress
+  drives reproducible enrichment of bacterial lineages whose iron transport
+  and metabolism functionalities are overrepresented. Genome-resolved
+  metagenomics and comparative genomics show carbohydrate and secondary-
+  metabolite transport functions also dominate drought-enriched taxa. Time-
+  series root RNA-Seq data show that root iron homeostasis is impacted by
+  drought, and loss of a plant phytosiderophore iron transporter increases
+  Actinobacteria abundance. Exogenous iron application disrupts the drought-
+  induced Actinobacteria enrichment and removes their host phenotype
+  improvement, implicating iron metabolism as a microbiome-drought axis.
+ecological_state: PERTURBED
+community_origin: NATURAL
+community_category: RHIZOSPHERE
+environment_term:
+  preferred_term: drought-stressed root rhizosphere
+  term:
+    id: ENVO:00002233
+    label: rhizosphere
+  notes: Plant root rhizosphere under imposed drought stress, with
+    phytosiderophore-transporter mutants and exogenous iron amendments used
+    to test iron-dependent microbial enrichment.
+taxonomy:
+- taxon_term:
+    preferred_term: drought-enriched rhizosphere Actinobacteria
+    term:
+      id: NCBITaxon:201174
+      label: Actinomycetota
+    notes: Drought-enriched Actinobacteria lineage whose abundance is amplified
+      by loss of a plant phytosiderophore iron transporter and suppressed by
+      exogenous iron amendment.
+  functional_role:
+  - PRIMARY_DEGRADER
+  - CROSS_FEEDER
+  evidence:
+  - reference: PMID:34050180
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: leading to significant increases in the drought-enriched lineage,
+      Actinobacteria
+    explanation: Supports the drought-enriched Actinobacteria lineage.
+ecological_interactions:
+- name: Drought Selection on Iron- and Carbohydrate-Transport Functions
+  description: Drought stress enriches rhizosphere taxa whose genomes are
+    enriched in carbohydrate transport, secondary-metabolite transport, and
+    iron transport and metabolism functions.
+  interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
+  metabolites:
+  - preferred_term: iron
+    term:
+      id: CHEBI:24875
+      label: iron atom
+  biological_processes:
+  - preferred_term: iron ion transport
+    term:
+      id: GO:0006826
+      label: iron ion transport
+  - preferred_term: carbohydrate transport
+    term:
+      id: GO:0008643
+      label: carbohydrate transport
+  evidence:
+  - reference: PMID:34050180
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: bacterial iron transport and metabolism functionality is highly
+      correlated with drought enrichment
+    explanation: Supports iron metabolism as a drought-enrichment correlate.
+  - reference: PMID:34050180
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: carbohydrate and secondary metabolite transport functionalities
+      are overrepresented within drought-enriched taxa
+    explanation: Supports carbohydrate and secondary-metabolite transport
+      overrepresentation.
+- name: Plant Phytosiderophore Transporter Loss Promotes Actinobacteria
+  description: Loss of a plant phytosiderophore iron transporter alters root
+    iron homeostasis under drought stress and reshapes the microbiome,
+    increasing Actinobacteria abundance.
+  interaction_type: COLONIZATION_FACILITATION
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:34050180
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: loss of a plant phytosiderophore iron transporter impacts microbial
+      community composition
+    explanation: Supports the host-transporter knockout effect on community
+      composition.
+- name: Exogenous Iron Disrupts Drought-Induced Actinobacteria
+  description: Exogenous application of iron disrupts the drought-induced
+    enrichment of Actinobacteria and abolishes their improvement of host
+    phenotype during drought stress.
+  interaction_type: COMPETITION
+  scope: COMMUNITY_LEVEL
+  metabolites:
+  - preferred_term: iron
+    term:
+      id: CHEBI:24875
+      label: iron atom
+  evidence:
+  - reference: PMID:34050180
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: exogenous application of iron disrupts the drought-induced
+      enrichment of Actinobacteria, as well as their improvement in host
+      phenotype during drought stress
+    explanation: Supports the iron-amendment disruption of the drought-induced
+      enrichment.
+environmental_factors:
+- name: Drought stress
+  value: drought versus well-watered conditions
+  description: Drought stress is the primary perturbation driving rhizosphere
+    microbiome shifts.
+  evidence:
+  - reference: PMID:34050180
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: drought leads to dramatic, highly conserved shifts in the root
+      microbiome
+    explanation: Supports drought as the curated perturbation.
+- name: Plant phytosiderophore transporter genotype
+  value: phytosiderophore-transporter mutant versus wild type
+  description: Plant phytosiderophore transporter genotype modulates root iron
+    homeostasis and microbiome composition.
+  evidence:
+  - reference: PMID:34050180
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: iron homeostasis within the root is impacted by drought stress
+    explanation: Supports root iron homeostasis as a drought-modulated factor.
+- name: Iron amendment
+  value: exogenous iron application
+  description: Exogenous iron amendment was used to test the iron-dependent
+    drought enrichment of Actinobacteria.
+  evidence:
+  - reference: PMID:34050180
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: exogenous application of iron disrupts the drought-induced
+      enrichment of Actinobacteria
+    explanation: Supports the iron-amendment perturbation design.
+growth_media: []
+external_resources:
+- name: Primary publication for the drought rhizosphere iron community
+  repository: OTHER
+  resource_id: PMID:34050180
+  url: https://pubmed.ncbi.nlm.nih.gov/34050180/
+  description: PubMed record for the Xu et al. 2021 Nature Communications paper
+    on iron metabolism in drought-induced rhizosphere microbiome dynamics.
+  evidence:
+  - reference: PMID:34050180
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: iron metabolism in the root microbiome's response to drought
+    explanation: Lists the primary publication for the curated community.
+- name: DOI landing page
+  repository: OTHER
+  resource_id: doi:10.1038/s41467-021-23553-7
+  url: https://doi.org/10.1038/s41467-021-23553-7
+  description: DOI link to the Nature Communications paper.
+associated_datasets: []
+metals_present:
+- IRON
+rare_earth_elements_present: []
+metal_relevance: SIGNIFICANT
+metal_notes: Iron transport and metabolism are central to the drought-induced
+  microbiome enrichment, and exogenous iron disrupts the drought-induced
+  Actinobacteria enrichment.

--- a/kb/communities/Episymbiotic_CPR_DPANN_Groundwater_Community.yaml
+++ b/kb/communities/Episymbiotic_CPR_DPANN_Groundwater_Community.yaml
@@ -1,0 +1,151 @@
+id: CommunityMech:000237
+name: Episymbiotic CPR Bacteria and DPANN Archaea Groundwater Community
+description: >
+  A groundwater microbial community framework combining genome-resolved
+  metagenomics from one agricultural and seven pristine groundwater sites,
+  yielding 746 Candidate Phyla Radiation (CPR) bacterial and DPANN archaeal
+  genomes. Pristine sites, which serve as local sources of drinking water,
+  contained up to 31 percent CPR bacteria and 4 percent DPANN archaea. Little
+  species-level overlap of metagenome-assembled genomes was observed across
+  the sites, indicating that CPR and DPANN communities are differentiated
+  according to physicochemical conditions and host populations. Cryogenic
+  transmission electron microscopy and genomic analysis identified CPR and
+  DPANN lineages that reproducibly attach to host cells, with attachment
+  apparently stimulating CPR bacterial growth.
+ecological_state: STABLE
+community_origin: NATURAL
+community_category: EXTREME_ENVIRONMENT
+environment_term:
+  preferred_term: pristine and agricultural groundwater aquifer
+  term:
+    id: ENVO:01001004
+    label: groundwater
+  notes: Eight groundwater microbial communities (one agricultural, seven
+    pristine) sampled for genome-resolved metagenomics.
+taxonomy:
+- taxon_term:
+    preferred_term: groundwater CPR (Candidate Phyla Radiation) bacteria
+    term:
+      id: NCBITaxon:1783234
+      label: Patescibacteria
+    notes: 31 percent of pristine groundwater communities; episymbionts that
+      attach to host cells.
+  abundance_level: DOMINANT
+  functional_role:
+  - SYNTROPHIC_PARTNER
+  evidence:
+  - reference: PMID:33495623
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: The pristine sites, which serve as local sources of drinking water,
+      contained up to 31% CPR bacteria
+    explanation: Supports CPR membership and high relative abundance.
+- taxon_term:
+    preferred_term: groundwater DPANN archaea
+    term:
+      id: NCBITaxon:1934217
+      label: DPANN group
+    notes: Up to 4 percent of pristine groundwater communities; episymbionts
+      that attach to host cells.
+  abundance_level: ABUNDANT
+  functional_role:
+  - SYNTROPHIC_PARTNER
+  evidence:
+  - reference: PMID:33495623
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: 4% DPANN archaea
+    explanation: Supports DPANN membership and abundance.
+- taxon_term:
+    preferred_term: groundwater CPR/DPANN host bacteria and archaea
+    term:
+      id: NCBITaxon:131567
+      label: cellular organisms
+    notes: Diverse non-CPR/non-DPANN cellular hosts to which CPR bacteria and
+      DPANN archaea reproducibly attach.
+  functional_role:
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:33495623
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: coexist with diverse hosts in groundwater aquifers
+    explanation: Supports the diverse host community membership.
+ecological_interactions:
+- name: CPR/DPANN Episymbiotic Attachment to Hosts
+  description: Cryogenic transmission electron microscopy imaging and genomic
+    analyses identified CPR and DPANN lineages that reproducibly attach to
+    host cells, with growth of CPR bacteria apparently stimulated by
+    attachment.
+  interaction_type: SYNTROPHY
+  source_taxon:
+    preferred_term: groundwater CPR (Candidate Phyla Radiation) bacteria
+    term:
+      id: NCBITaxon:1783234
+      label: Patescibacteria
+  target_taxon:
+    preferred_term: groundwater CPR/DPANN host bacteria and archaea
+    term:
+      id: NCBITaxon:131567
+      label: cellular organisms
+  evidence:
+  - reference: PMID:33495623
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: CPR and DPANN lineages that reproducibly attach to host cells
+    explanation: Supports the curated episymbiotic attachment.
+  - reference: PMID:33495623
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: the growth of CPR bacteria seems to be stimulated by attachment to
+      host-cell surfaces
+    explanation: Supports the curated growth-stimulation effect.
+- name: Site-Specific CPR/DPANN Differentiation
+  description: Little species-level overlap of MAGs across the eight groundwater
+    sites indicates that CPR and DPANN communities are differentiated according
+    to physicochemical conditions and host populations.
+  interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:33495623
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: little species-level overlap of metagenome-assembled genomes (MAGs)
+      across the groundwater sites
+    explanation: Supports the site-specific differentiation pattern.
+environmental_factors:
+- name: Site land use
+  value: one agricultural and seven pristine groundwater sites
+  description: The study combines one agricultural and seven pristine
+    groundwater sites that serve as local drinking-water sources.
+  evidence:
+  - reference: PMID:33495623
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: one agricultural and seven pristine groundwater microbial
+      communities
+    explanation: Supports the eight groundwater sites used in the study.
+growth_media: []
+external_resources:
+- name: Primary publication for the episymbiotic CPR/DPANN groundwater community
+  repository: OTHER
+  resource_id: PMID:33495623
+  url: https://pubmed.ncbi.nlm.nih.gov/33495623/
+  description: PubMed record for the He et al. 2021 Nature Microbiology paper.
+  evidence:
+  - reference: PMID:33495623
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: site-specific diversity of CPR bacteria and DPANN archaea
+    explanation: Lists the primary publication for the curated community.
+- name: DOI landing page
+  repository: OTHER
+  resource_id: doi:10.1038/s41564-020-00840-5
+  url: https://doi.org/10.1038/s41564-020-00840-5
+  description: DOI link to the Nature Microbiology paper.
+associated_datasets: []
+metals_present: []
+rare_earth_elements_present: []
+metal_relevance: NOT_APPLICABLE
+metal_notes: No metal or rare earth element processing role is curated for this
+  CPR/DPANN groundwater community.

--- a/references_cache/PMID_33495623.md
+++ b/references_cache/PMID_33495623.md
@@ -1,0 +1,70 @@
+---
+reference_id: PMID:33495623
+title: ''
+authors: []
+journal: Nat Microbiol
+year: '2021'
+content_type: abstract_only
+---
+
+# PMID:33495623
+**Journal:** Nat Microbiol (2021)
+
+## Content
+
+1. Nat Microbiol. 2021 Mar;6(3):354-365. doi: 10.1038/s41564-020-00840-5. Epub
+2021  Jan 25.
+
+Genome-resolved metagenomics reveals site-specific diversity of episymbiotic CPR 
+bacteria and DPANN archaea in groundwater ecosystems.
+
+He C(1), Keren R(2), Whittaker ML(3)(4), Farag IF(1), Doudna JA(1)(5)(6)(7)(8), 
+Cate JHD(1)(5)(6)(7), Banfield JF(9)(10)(11).
+
+Author information:
+(1)Innovative Genomics Institute, University of California, Berkeley, CA, USA.
+(2)Department of Civil and Environmental Engineering, University of California, 
+Berkeley, CA, USA.
+(3)Energy Geoscience Division, Lawrence Berkeley National Laboratory, Berkeley, 
+CA, USA.
+(4)Department of Earth and Planetary Sciences, University of California, 
+Berkeley, CA, USA.
+(5)Department of Molecular and Cell Biology, University of California, Berkeley, 
+CA, USA.
+(6)Department of Chemistry, University of California, Berkeley, CA, USA.
+(7)Molecular Biophysics and Integrated Bioimaging Division, Lawrence Berkeley 
+National Laboratory, Berkeley, CA, USA.
+(8)Howard Hughes Medical Institute, University of California Berkeley, Berkeley, 
+CA, USA.
+(9)Innovative Genomics Institute, University of California, Berkeley, CA, USA. 
+jbanfield@berkeley.edu.
+(10)Department of Earth and Planetary Sciences, University of California, 
+Berkeley, CA, USA. jbanfield@berkeley.edu.
+(11)Department of Plant and Microbial Biology, University of California, 
+Berkeley, CA, USA. jbanfield@berkeley.edu.
+
+Candidate phyla radiation (CPR) bacteria and DPANN archaea are unisolated, 
+small-celled symbionts that are often detected in groundwater. The effects of 
+groundwater geochemistry on the abundance, distribution, taxonomic diversity and 
+host association of CPR bacteria and DPANN archaea has not been studied. Here, 
+we performed genome-resolved metagenomic analysis of one agricultural and seven 
+pristine groundwater microbial communities and recovered 746 CPR and DPANN 
+genomes in total. The pristine sites, which serve as local sources of drinking 
+water, contained up to 31% CPR bacteria and 4% DPANN archaea. We observed little 
+species-level overlap of metagenome-assembled genomes (MAGs) across the 
+groundwater sites, indicating that CPR and DPANN communities may be 
+differentiated according to physicochemical conditions and host populations. 
+Cryogenic transmission electron microscopy imaging and genomic analyses enabled 
+us to identify CPR and DPANN lineages that reproducibly attach to host cells and 
+showed that the growth of CPR bacteria seems to be stimulated by attachment to 
+host-cell surfaces. Our analysis reveals site-specific diversity of CPR bacteria 
+and DPANN archaea that coexist with diverse hosts in groundwater aquifers. Given 
+that CPR and DPANN organisms have been identified in human microbiomes and their 
+presence is correlated with diseases such as periodontitis, our findings are 
+relevant to considerations of drinking water quality and human health.
+
+DOI: 10.1038/s41564-020-00840-5
+PMCID: PMC7906910
+PMID: 33495623 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no competing interests.

--- a/references_cache/PMID_33531396.md
+++ b/references_cache/PMID_33531396.md
@@ -48,7 +48,8 @@ acetylenotroph in the phylum Actinobacteria was identified using metagenomic
 analysis. These results demonstrate that the coupling of acetylenotrophy and 
 reductive dechlorination can occur in the environment with native bacteria and 
 broaden our understanding of biotransformation at contaminated sites containing 
-both TCE and C2H2IMPORTANCE Understanding the complex metabolisms of microbial 
+both TCE and C2H2.
+IMPORTANCE Understanding the complex metabolisms of microbial 
 communities in contaminated groundwaters is a challenge. PCE and TCE are among 
 the most common groundwater contaminants in the United States that, when exposed 
 to certain minerals, exhibit a unique abiotic degradation pathway in which C2H2 

--- a/references_cache/PMID_33531396.md
+++ b/references_cache/PMID_33531396.md
@@ -1,0 +1,69 @@
+---
+reference_id: PMID:33531396
+title: ''
+authors: []
+journal: mBio
+year: '2021'
+content_type: abstract_only
+---
+
+# PMID:33531396
+**Journal:** mBio (2021)
+
+## Content
+
+1. mBio. 2021 Feb 2;12(1):e02724-20. doi: 10.1128/mBio.02724-20.
+
+Acetylene-Fueled Trichloroethene Reductive Dechlorination in a Groundwater 
+Enrichment Culture.
+
+Gushgari-Doyle S(1), Oremland RS(2), Keren R(1)(3), Baesman SM(2), Akob DM(4), 
+Banfield JF(3), Alvarez-Cohen L(5)(6).
+
+Author information:
+(1)Department of Civil and Environmental Engineering, University of California, 
+Berkeley, California, USA.
+(2)U. S. Geological Survey, Menlo Park, California, USA.
+(3)Department of Earth and Planetary Sciences, University of California, 
+Berkeley, California, USA.
+(4)U. S. Geological Survey, Reston, Virginia, USA.
+(5)Department of Civil and Environmental Engineering, University of California, 
+Berkeley, California, USA alvarez@ce.berkeley.edu.
+(6)Earth and Environmental Sciences Division, Lawrence Berkeley National 
+Laboratory, Berkeley, California, USA.
+
+In aquifers, acetylene (C2H2) is a product of abiotic degradation of 
+trichloroethene (TCE) catalyzed by in situ minerals. C2H2 can, in turn, inhibit 
+multiple microbial processes including TCE dechlorination and metabolisms that 
+commonly support dechlorination, in addition to supporting the growth of 
+acetylenotrophic microorganisms. Previously, C2H2 was shown to support TCE 
+reductive dechlorination in synthetic, laboratory-constructed cocultures 
+containing the acetylenotroph Pelobacter sp. strain SFB93 and Dehalococcoides 
+mccartyi strain 195 or strain BAV1. In this study, we demonstrate TCE and 
+perchloroethene (PCE) reductive dechlorination by a microbial community enriched 
+from contaminated groundwater and amended with C2H2 as the sole electron donor 
+and organic carbon source. The metagenome of the stable, enriched community was 
+analyzed to elucidate putative community functions. A novel anaerobic 
+acetylenotroph in the phylum Actinobacteria was identified using metagenomic 
+analysis. These results demonstrate that the coupling of acetylenotrophy and 
+reductive dechlorination can occur in the environment with native bacteria and 
+broaden our understanding of biotransformation at contaminated sites containing 
+both TCE and C2H2IMPORTANCE Understanding the complex metabolisms of microbial 
+communities in contaminated groundwaters is a challenge. PCE and TCE are among 
+the most common groundwater contaminants in the United States that, when exposed 
+to certain minerals, exhibit a unique abiotic degradation pathway in which C2H2 
+is a product. C2H2 can act as both an inhibitor of TCE dechlorination and of 
+supporting metabolisms and an energy source for acetylenotrophic bacteria. Here, 
+we combine laboratory microcosm studies with computational approaches to enrich 
+and characterize an environmental microbial community that couples two uncommon 
+metabolisms, demonstrating unique metabolic interactions only yet reported in 
+synthetic, laboratory-constructed settings. Using this comprehensive approach, 
+we have identified the first reported anaerobic acetylenotroph in the phylum 
+Actinobacteria, demonstrating the yet-undescribed diversity of this metabolism 
+that is widely considered to be uncommon.
+
+Copyright © 2021 Gushgari-Doyle et al.
+
+DOI: 10.1128/mBio.02724-20
+PMCID: PMC7858054
+PMID: 33531396 [Indexed for MEDLINE]

--- a/references_cache/PMID_34050180.md
+++ b/references_cache/PMID_34050180.md
@@ -1,0 +1,70 @@
+---
+reference_id: PMID:34050180
+title: ''
+authors: []
+journal: Nat Commun
+year: '2021'
+content_type: abstract_only
+---
+
+# PMID:34050180
+**Journal:** Nat Commun (2021)
+
+## Content
+
+1. Nat Commun. 2021 May 28;12(1):3209. doi: 10.1038/s41467-021-23553-7.
+
+Genome-resolved metagenomics reveals role of iron metabolism in drought-induced 
+rhizosphere microbiome dynamics.
+
+Xu L(1)(2), Dong Z(3), Chiniquy D(4), Pierroz G(3), Deng S(3), Gao C(3), Diamond 
+S(5), Simmons T(3), Wipf HM(3), Caddell D(6), Varoquaux N(7), Madera MA(3), 
+Hutmacher R(8), Deutschbauer A(4), Dahlberg JA(9), Guerinot ML(10), Purdom 
+E(11), Banfield JF(5), Taylor JW(3), Lemaux PG(3), Coleman-Derr D(12)(13).
+
+Author information:
+(1)Department of Plant and Microbial Biology, University of California, 
+Berkeley, CA, USA. xuling@berkeley.edu.
+(2)State Key Laboratory of Plant Physiology and Biochemistry, Department of 
+Microbiology and Immunology, College of Biological Sciences, China Agricultural 
+University, Beijing, China. xuling@berkeley.edu.
+(3)Department of Plant and Microbial Biology, University of California, 
+Berkeley, CA, USA.
+(4)Department of Energy, Environmental Genomics and Systems Biology Division, 
+Lawrence Berkeley National Laboratory, Berkeley, CA, USA.
+(5)Department of Earth and Planetary Science, University of California, 
+Berkeley, CA, USA.
+(6)Plant Gene Expression Center, USDA-ARS, Albany, CA, USA.
+(7)CNRS, University Grenoble Alpes, TIMC-IMAG, Grenoble, France.
+(8)Westside Research & Extension Center, UC Department of Plant Sciences, 
+University of California, Davis, CA, USA.
+(9)Kearney Agricultural Research & Extension Center, Parlier, CA, USA.
+(10)Department of Biological Scienes, Dartmouth College, Hanover, NH, USA.
+(11)Department of Statistics, University of California, Berkeley, CA, USA.
+(12)Department of Plant and Microbial Biology, University of California, 
+Berkeley, CA, USA. colemanderr@berkeley.edu.
+(13)Plant Gene Expression Center, USDA-ARS, Albany, CA, USA. 
+colemanderr@berkeley.edu.
+
+Recent studies have demonstrated that drought leads to dramatic, highly 
+conserved shifts in the root microbiome. At present, the molecular mechanisms 
+underlying these responses remain largely uncharacterized. Here we employ 
+genome-resolved metagenomics and comparative genomics to demonstrate that 
+carbohydrate and secondary metabolite transport functionalities are 
+overrepresented within drought-enriched taxa. These data also reveal that 
+bacterial iron transport and metabolism functionality is highly correlated with 
+drought enrichment. Using time-series root RNA-Seq data, we demonstrate that 
+iron homeostasis within the root is impacted by drought stress, and that loss of 
+a plant phytosiderophore iron transporter impacts microbial community 
+composition, leading to significant increases in the drought-enriched lineage, 
+Actinobacteria. Finally, we show that exogenous application of iron disrupts the 
+drought-induced enrichment of Actinobacteria, as well as their improvement in 
+host phenotype during drought stress. Collectively, our findings implicate iron 
+metabolism in the root microbiome's response to drought and may inform efforts 
+to improve plant drought tolerance to increase food security.
+
+DOI: 10.1038/s41467-021-23553-7
+PMCID: PMC8163885
+PMID: 34050180 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no competing interest.

--- a/references_cache/PMID_34468166.md
+++ b/references_cache/PMID_34468166.md
@@ -1,0 +1,83 @@
+---
+reference_id: PMID:34468166
+title: ''
+authors: []
+journal: mSphere
+year: '2021'
+content_type: abstract_only
+---
+
+# PMID:34468166
+**Journal:** mSphere (2021)
+
+## Content
+
+1. mSphere. 2021 Oct 27;6(5):e0008521. doi: 10.1128/mSphere.00085-21. Epub 2021
+Sep  1.
+
+Stable-Isotope-Informed, Genome-Resolved Metagenomics Uncovers Potential 
+Cross-Kingdom Interactions in Rhizosphere Soil.
+
+Starr EP(1), Shi S(2), Blazewicz SJ(3), Koch BJ(4)(5), Probst AJ(6), Hungate 
+BA(4)(5), Pett-Ridge J(3), Firestone MK(7)(8), Banfield JF(7)(8)(9)(10)(11).
+
+Author information:
+(1)Department of Plant and Microbial Biology, University of California, 
+Berkeleygrid.47840.3f, California, USA.
+(2)Lincoln Science Centre, AgResearch Ltd., Christchurch, New Zealand.
+(3)Physical and Life Sciences Directorate, Lawrence Livermore National 
+Laboratorygrid.250008.f, Livermore, California, USA.
+(4)Department of Biological Sciences, Northern Arizona Universitygrid.261120.6, 
+Flagstaff, Arizona, USA.
+(5)Center for Ecosystem Science and Society, Northern Arizona 
+Universitygrid.261120.6, Flagstaff, Arizona, USA.
+(6)Biofilm Center, University of Duisburg-Essen, Essen, Germany.
+(7)Department of Environmental Science, Policy, and Management, University of 
+California, Berkeleygrid.47840.3f, California, USA.
+(8)Earth and Environmental Sciences, Lawrence Berkeley National Laboratory, 
+Berkeley, California, USA.
+(9)Department of Earth and Planetary Science, University of California, 
+Berkeleygrid.47840.3f, California, USA.
+(10)Innovative Genomics Institute, Berkeley, California, USA.
+(11)Chan Zuckerberg Biohub, San Francisco, California, USA.
+
+The functioning, health, and productivity of soil are intimately tied to a 
+complex network of interactions, particularly in plant root-associated 
+rhizosphere soil. We conducted a stable-isotope-informed, genome-resolved 
+metagenomic study to trace carbon from Avena fatua grown in a 13CO2 atmosphere 
+into soil. We collected paired rhizosphere and nonrhizosphere soil at 6 and 9 
+weeks of plant growth and extracted DNA that was then separated by density using 
+ultracentrifugation. Thirty-two fractions from each of five samples were grouped 
+by density, sequenced, assembled, and binned to generate 55 unique bacterial 
+genomes that were ≥70% complete. We also identified complete 18S rRNA sequences 
+of several 13C-enriched microeukaryotic bacterivores and fungi. We generated 10 
+circularized bacteriophage (phage) genomes, some of which were the most labeled 
+entities in the rhizosphere, suggesting that phage may be important agents of 
+turnover of plant-derived C in soil. CRISPR locus targeting connected one of 
+these phage to a Burkholderiales host predicted to be a plant pathogen. Another 
+highly labeled phage is predicted to replicate in a Catenulispora sp., a 
+possible plant growth-promoting bacterium. We searched the genome bins for 
+traits known to be used in interactions involving bacteria, microeukaryotes, and 
+plant roots and found DNA from heavily 13C-labeled bacterial genes thought to be 
+involved in modulating plant signaling hormones, plant pathogenicity, and 
+defense against microeukaryote grazing. Stable-isotope-informed, genome-resolved 
+metagenomics indicated that phage can be important agents of turnover of 
+plant-derived carbon in soil. IMPORTANCE Plants grow in intimate association 
+with soil microbial communities; these microbes can facilitate the availability 
+of essential resources to plants. Thus, plant productivity commonly depends on 
+interactions with rhizosphere bacteria, viruses, and eukaryotes. Our work is 
+significant because we identified the organisms that took up plant-derived 
+organic C in rhizosphere soil and determined that many of the active bacteria 
+are plant pathogens or can impact plant growth via hormone modulation. Further, 
+by showing that bacteriophage accumulate CO2-derived carbon, we demonstrated 
+their vital roles in redistribution of plant-derived C into the soil environment 
+through bacterial cell lysis. The use of stable-isotope probing (SIP) to 
+identify consumption (or lack thereof) of root-derived C by key microbial 
+community members within highly complex microbial communities opens the way for 
+assessing manipulations of bacteria and phage with potentially beneficial and 
+detrimental traits, ultimately providing a path to improved plant health and 
+soil carbon storage.
+
+DOI: 10.1128/mSphere.00085-21
+PMCID: PMC8550312
+PMID: 34468166 [Indexed for MEDLINE]

--- a/references_cache/PMID_34987183.md
+++ b/references_cache/PMID_34987183.md
@@ -1,0 +1,76 @@
+---
+reference_id: PMID:34987183
+title: ''
+authors: []
+journal: ISME J
+year: '2022'
+content_type: abstract_only
+---
+
+# PMID:34987183
+**Journal:** ISME J (2022)
+
+## Content
+
+1. ISME J. 2022 May;16(5):1348-1362. doi: 10.1038/s41396-021-01177-5. Epub 2022
+Jan  5.
+
+Soils and sediments host Thermoplasmata archaea encoding novel copper membrane 
+monooxygenases (CuMMOs).
+
+Diamond S(1)(2), Lavy A(3), Crits-Christoph A(4), Matheus Carnevali PB(3), 
+Sharrar A(3), Williams KH(5), Banfield JF(6)(7)(8)(9).
+
+Author information:
+(1)Innovative Genomics Institute, University of California, Berkeley, CA, USA. 
+sdiamond@berkeley.edu.
+(2)Department of Earth and Planetary Science, University of California, 
+Berkeley, CA, USA. sdiamond@berkeley.edu.
+(3)Department of Earth and Planetary Science, University of California, 
+Berkeley, CA, USA.
+(4)Department of Plant and Microbial Biology, University of California, 
+Berkeley, CA, USA.
+(5)Climate and Ecosystem Sciences Division, Lawrence Berkeley National 
+Laboratory, Berkeley, CA, USA.
+(6)Innovative Genomics Institute, University of California, Berkeley, CA, USA. 
+jbanfield@berkeley.edu.
+(7)Department of Earth and Planetary Science, University of California, 
+Berkeley, CA, USA. jbanfield@berkeley.edu.
+(8)Department of Environmental Science, Policy and Management, University of 
+California, Berkeley, CA, USA. jbanfield@berkeley.edu.
+(9)School of Earth Sciences, University of Melbourne, Melbourne, VIC, Australia. 
+jbanfield@berkeley.edu.
+
+Copper membrane monooxygenases (CuMMOs) play critical roles in the global carbon 
+and nitrogen cycles. Organisms harboring these enzymes perform the first, and 
+rate limiting, step in aerobic oxidation of ammonia, methane, or other simple 
+hydrocarbons. Within archaea, only organisms in the order Nitrososphaerales 
+(Thaumarchaeota) encode CuMMOs, which function exclusively as ammonia 
+monooxygenases. From grassland and hillslope soils and aquifer sediments, we 
+identified 20 genomes from distinct archaeal species encoding divergent CuMMO 
+sequences. These archaea are phylogenetically clustered in a previously unnamed 
+Thermoplasmatota order, herein named the Ca. Angelarchaeales. The CuMMO proteins 
+in Ca. Angelarchaeales are more similar in structure to those in 
+Nitrososphaerales than those of bacteria, and contain all functional residues 
+required for general monooxygenase activity. Ca. Angelarchaeales genomes are 
+significantly enriched in blue copper proteins (BCPs) relative to sibling 
+lineages, including plastocyanin-like electron carriers and divergent nitrite 
+reductase-like (nirK) 2-domain cupredoxin proteins co-located with electron 
+transport machinery. Ca. Angelarchaeales also encode significant capacity for 
+peptide/amino acid uptake and degradation and share numerous electron transport 
+mechanisms with the Nitrososphaerales. Ca. Angelarchaeales are detected at high 
+relative abundance in some of the environments where their genomes originated 
+from. While the exact substrate specificities of the novel CuMMOs identified 
+here have yet to be determined, activity on ammonia is possible given their 
+metabolic and ecological context. The identification of an archaeal CuMMO 
+outside of the Nitrososphaerales significantly expands the known diversity of 
+CuMMO enzymes in archaea and suggests previously unaccounted organisms 
+contribute to critical global nitrogen and/or carbon cycling functions.
+
+© 2022. The Author(s).
+
+DOI: 10.1038/s41396-021-01177-5
+PMCID: PMC9038741
+PMID: 34987183 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no competing interests.


### PR DESCRIPTION
## Summary

Adds 5 more microbial community records (CommunityMech:000234–000238) curated from post-2020 Banfield-lab co-authored publications, continuing the curation thread from PR #36. Covers Thermoplasmatota archaea, drought-rhizosphere iron, cross-kingdom rhizosphere SIP, CPR/DPANN episymbiosis, and acetylene-driven dechlorination.

| ID | Community | Reference | Year |
|---|---|---|---|
| 000234 | Angelarchaeales Thermoplasmata CuMMO soil/sediment | PMID:34987183 | 2022 |
| 000235 | Drought rhizosphere iron-enriched Actinobacteria | PMID:34050180 | 2021 |
| 000236 | Avena rhizosphere cross-kingdom 13C-SIP | PMID:34468166 | 2021 |
| 000237 | Episymbiotic CPR/DPANN groundwater | PMID:33495623 | 2021 |
| 000238 | Acetylene-fueled TCE/PCE dechlorination | PMID:33531396 | 2021 |

## Test plan
- [x] `just validate` passes on all 5 community files
- [x] `just validate-terms` passes on all 5 community files
- [x] ASCII-only — no non-ASCII characters
- [x] Every snippet is a whitespace-normalized substring of the corresponding PubMed abstract cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)