### PR TITLE
Add 7 more Banfield post-2020 community entries (round 3)

### DIFF
--- a/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
+++ b/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
@@ -1,0 +1,180 @@
+id: CommunityMech:000244
+name: Anammox Bioreactor DNRA Destabilization Community
+description: >
+  A laboratory-scale anaerobic ammonium oxidation (anammox) bioreactor
+  community followed from inoculation through a performance destabilization
+  event and back to robust steady-state operation, characterized by
+  metagenomics. Metabolic analyses showed selection for nutrient-acquisition
+  capacities in the core community. Dissimilatory nitrate reduction to
+  ammonium (DNRA) was the primary nitrogen-removal pathway that competed with
+  anammox, and increased replication of DNRA-capable bacteria out-competed
+  anammox bacteria, causing the loss of nitrogen-removal capacity. The
+  DNRA-capable bacteria were closely associated with the anammox bacterium
+  and are considered part of the core microbial community, underscoring how
+  bacteria that are otherwise core members can be detrimental.
+ecological_state: PERTURBED
+community_origin: NATURAL
+community_category: BIOTECHNOLOGY
+engineering_design:
+  objective: Resolve the metabolic roles of core microbial community members
+    in an anammox bioreactor across stable and destabilized performance.
+  assembly_strategy: Operate a laboratory-scale anammox bioreactor and follow
+    it metagenomically from inoculation through destabilization to recovery.
+  perturbation_design: Observe a natural performance destabilization event
+    and the associated shift in community composition and gene replication
+    rates.
+  measurement_endpoints:
+  - Nitrogen-removal performance over time
+  - Core community member identity and abundance
+  - Replication rates of DNRA vs anammox bacteria
+  evidence:
+  - reference: PMID:31980038
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: we used metagenomics to study the microbial community of a
+      laboratory-scale anammox bioreactor from inoculation, through a
+      performance destabilization event, to robust steady-state performance
+    explanation: Supports the destabilization-and-recovery design.
+environment_term:
+  preferred_term: laboratory anammox bioreactor
+  term:
+    id: ENVO:01001405
+    label: laboratory bioreactor
+  notes: Laboratory-scale anammox bioreactor treating reactive nitrogen,
+    followed by metagenomics through destabilization and recovery.
+taxonomy:
+- taxon_term:
+    preferred_term: anammox bacterium
+    term:
+      id: NCBITaxon:67854
+      label: Planctomycetota
+    notes: Anaerobic ammonium-oxidizing bacterium that drives nitrogen removal
+      in the bioreactor; outcompeted during destabilization.
+  abundance_level: DOMINANT
+  functional_role:
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:31980038
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: out-competition of anammox bacteria, and the loss of the
+      bioreactor's nitrogen removal capacity
+    explanation: Supports the anammox-bacterium member and its destabilization
+      dynamics.
+- taxon_term:
+    preferred_term: dissimilatory nitrate reducing (DNRA) bacteria
+    term:
+      id: NCBITaxon:2
+      label: Bacteria
+    notes: Core community bacteria capable of dissimilatory nitrate reduction
+      to ammonium; their replication outcompetes anammox during destabilization.
+  functional_role:
+  - PRIMARY_DEGRADER
+  - CROSS_FEEDER
+  evidence:
+  - reference: PMID:31980038
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Increased replication of bacteria capable of DNRA led to the
+      out-competition of anammox bacteria
+    explanation: Supports the DNRA-capable bacterial members and their
+      competitive impact.
+ecological_interactions:
+- name: DNRA Competes with Anammox for Nitrogen Removal
+  description: Dissimilatory nitrate reduction to ammonium (DNRA) is the
+    primary nitrogen-removal pathway competing with anammox, and increased
+    replication of DNRA bacteria leads to out-competition of anammox bacteria.
+  interaction_type: COMPETITION
+  source_taxon:
+    preferred_term: dissimilatory nitrate reducing (DNRA) bacteria
+    term:
+      id: NCBITaxon:2
+      label: Bacteria
+  target_taxon:
+    preferred_term: anammox bacterium
+    term:
+      id: NCBITaxon:67854
+      label: Planctomycetota
+  metabolites:
+  - preferred_term: nitrate
+    term:
+      id: CHEBI:17632
+      label: nitrate
+  - preferred_term: ammonium
+    term:
+      id: CHEBI:28938
+      label: ammonium
+  biological_processes:
+  - preferred_term: nitrogen compound metabolic process
+    term:
+      id: GO:0006807
+      label: nitrogen compound metabolic process
+  evidence:
+  - reference: PMID:31980038
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Dissimilatory nitrate reduction to ammonium (DNRA) was the primary
+      nitrogen removal pathway that competed with anammox
+    explanation: Supports DNRA as the curated competitive pathway.
+- name: Nutrient Acquisition Selects Core Community Members
+  description: Metabolic analyses revealed that nutrient acquisition from the
+    environment is selected for in the anammox community.
+  interaction_type: COMMENSALISM
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:31980038
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: nutrient acquisition from the environment is selected for in the
+      anammox community
+    explanation: Supports nutrient-acquisition selection of core members.
+- name: DNRA Bacteria Associated with Anammox Core
+  description: The DNRA-capable bacteria are highly associated with the
+    anammox bacterium and are considered part of the core microbial community,
+    illustrating that core members can be detrimental.
+  interaction_type: COMMENSALISM
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:31980038
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: These bacteria were highly associated with the anammox bacterium
+      and considered part of the core microbial community
+    explanation: Supports the core-association status of DNRA bacteria.
+environmental_factors:
+- name: Bioreactor performance state
+  value: stable -> destabilized -> recovered
+  description: The community was followed through inoculation, a destabilization
+    event, and back to robust steady-state performance.
+  evidence:
+  - reference: PMID:31980038
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: from inoculation, through a performance destabilization event,
+      to robust steady-state performance
+    explanation: Supports the curated performance trajectory.
+growth_media: []
+external_resources:
+- name: Primary publication for the anammox/DNRA destabilization community
+  repository: OTHER
+  resource_id: PMID:31980038
+  url: https://pubmed.ncbi.nlm.nih.gov/31980038/
+  description: PubMed record for the Keren et al. 2020 Microbiome paper.
+  evidence:
+  - reference: PMID:31980038
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Increased replication of dissimilatory nitrate-reducing bacteria
+      leads to decreased anammox bioreactor performance
+    explanation: Lists the primary publication.
+- name: DOI landing page
+  repository: OTHER
+  resource_id: doi:10.1186/s40168-020-0786-3
+  url: https://doi.org/10.1186/s40168-020-0786-3
+  description: DOI link to the Microbiome paper.
+associated_datasets: []
+metals_present: []
+rare_earth_elements_present: []
+metal_relevance: NOT_APPLICABLE
+metal_notes: No metal or rare earth element processing role is curated for this
+  anammox/DNRA community.

--- a/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
+++ b/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
@@ -128,19 +128,6 @@ ecological_interactions:
     snippet: nutrient acquisition from the environment is selected for in the
       anammox community
     explanation: Supports nutrient-acquisition selection of core members.
-- name: DNRA Bacteria Associated with Anammox Core
-  description: The DNRA-capable bacteria are highly associated with the
-    anammox bacterium and are considered part of the core microbial community,
-    illustrating that core members can be detrimental.
-  interaction_type: COMMENSALISM
-  scope: COMMUNITY_LEVEL
-  evidence:
-  - reference: PMID:31980038
-    supports: SUPPORT
-    evidence_source: IN_VITRO
-    snippet: These bacteria were highly associated with the anammox bacterium
-      and considered part of the core microbial community
-    explanation: Supports the core-association status of DNRA bacteria.
 environmental_factors:
 - name: Bioreactor performance state
   value: stable -> destabilized -> recovered

--- a/kb/communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.yaml
+++ b/kb/communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.yaml
@@ -1,0 +1,178 @@
+id: CommunityMech:000245
+name: Avena Rhizosphere and Detritusphere Niche-Differentiated Decomposer Guilds
+description: >
+  A rhizosphere and detritusphere microbial community of Avena fatua
+  characterized by time-resolved metatranscriptomics across rhizosphere,
+  detritusphere, and combined rhizosphere-detritusphere habitats. Transcripts
+  were binned using a unique reference database from soil isolate genomes,
+  single-cell amplified genomes, metagenomes, and stable-isotope-probing
+  metagenomes. Soil habitat significantly affected both community composition
+  and overall gene expression, but the succession of microbial functions
+  occurred faster than compositional change. Hierarchical clustering of
+  upregulated decomposition genes resolved four microbial guilds whose
+  functional succession patterns suggest specialization for fresh growing
+  roots, decaying root detritus, the combination of live and decaying root
+  biomass, or aging root material. Carbohydrate depolymerization genes were
+  consistently upregulated in the rhizosphere.
+ecological_state: STABLE
+community_origin: NATURAL
+community_category: RHIZOSPHERE
+environment_term:
+  preferred_term: Avena fatua rhizosphere and detritusphere
+  term:
+    id: ENVO:00002233
+    label: rhizosphere
+  notes: Time-resolved metatranscriptomes of Avena fatua rhizosphere,
+    detritusphere, and combined habitats sampled to compare functional
+    succession.
+taxonomy:
+- taxon_term:
+    preferred_term: fresh-root-specialized decomposer guild
+    term:
+      id: NCBITaxon:2
+      label: Bacteria
+    notes: Microbial guild whose functional succession suggests specialization
+      for fresh growing roots.
+  functional_role:
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:31953507
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: fresh growing roots
+    explanation: Supports the fresh-root specialist guild.
+- taxon_term:
+    preferred_term: decaying-detritus decomposer guild
+    term:
+      id: NCBITaxon:2
+      label: Bacteria
+    notes: Microbial guild specialized for decaying root detritus.
+  functional_role:
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:31953507
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: decaying root detritus
+    explanation: Supports the decaying-detritus guild.
+- taxon_term:
+    preferred_term: live-plus-decaying biomass decomposer guild
+    term:
+      id: NCBITaxon:2
+      label: Bacteria
+    notes: Microbial guild that specializes in the combination of live and
+      decaying root biomass.
+  functional_role:
+  - PRIMARY_DEGRADER
+  - CROSS_FEEDER
+  evidence:
+  - reference: PMID:31953507
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: the combination of live and decaying root biomass
+    explanation: Supports the combined-substrate guild.
+- taxon_term:
+    preferred_term: aging-root-material decomposer guild
+    term:
+      id: NCBITaxon:2
+      label: Bacteria
+    notes: Microbial guild specialized for aging root material.
+  functional_role:
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:31953507
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: aging root material
+    explanation: Supports the aging-root-material guild.
+ecological_interactions:
+- name: Functional Succession Outpaces Compositional Change
+  description: While soil habitat significantly affected both community
+    composition and overall gene expression, the succession of microbial
+    functions occurred at a faster time scale than compositional changes.
+  interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:31953507
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: the succession of microbial functions occurred at a faster time
+      scale than compositional changes
+    explanation: Supports the faster functional-succession dynamic.
+- name: Four Guilds with Substrate-Specific Specialization
+  description: Hierarchical clustering of upregulated decomposition genes
+    resolved four microbial guilds whose functional succession patterns
+    suggest substrate-specific specialization.
+  interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:31953507
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: identified four distinct microbial guilds populated by taxa whose
+      functional succession patterns suggest specialization
+    explanation: Supports the four-guild structure.
+- name: Rhizosphere Upregulates Carbohydrate Depolymerization
+  description: Carbohydrate depolymerization genes were consistently
+    upregulated in the rhizosphere relative to other habitats.
+  interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
+  biological_processes:
+  - preferred_term: carbohydrate metabolic process
+    term:
+      id: GO:0005975
+      label: carbohydrate metabolic process
+  evidence:
+  - reference: PMID:31953507
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Carbohydrate depolymerization genes were consistently upregulated
+      in the rhizosphere
+    explanation: Supports the rhizosphere carbohydrate-depolymerization signal.
+environmental_factors:
+- name: Habitat type
+  value: rhizosphere vs detritusphere vs combined
+  description: Three soil habitats were compared (rhizosphere only,
+    detritusphere only, and combined rhizosphere-detritusphere).
+  evidence:
+  - reference: PMID:31953507
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: time-resolved metatranscriptomes to compare microbial functions
+      in rhizosphere, detritusphere, and combined rhizosphere-detritusphere
+      habitats
+    explanation: Supports the three-habitat comparison.
+- name: Plant host
+  value: Avena fatua
+  description: Avena fatua, a common annual grass, was used as the plant host.
+  evidence:
+  - reference: PMID:31953507
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Using Avena fatua, a common annual grass
+    explanation: Supports the Avena fatua host system.
+growth_media: []
+external_resources:
+- name: Primary publication for the Avena rhizosphere/detritusphere community
+  repository: OTHER
+  resource_id: PMID:31953507
+  url: https://pubmed.ncbi.nlm.nih.gov/31953507/
+  description: PubMed record for the Nuccio et al. 2020 ISME J paper.
+  evidence:
+  - reference: PMID:31953507
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Niche differentiation is spatially and temporally regulated in
+      the rhizosphere
+    explanation: Lists the primary publication.
+- name: DOI landing page
+  repository: OTHER
+  resource_id: doi:10.1038/s41396-019-0582-x
+  url: https://doi.org/10.1038/s41396-019-0582-x
+  description: DOI link to the ISME J paper.
+associated_datasets: []
+metals_present: []
+rare_earth_elements_present: []
+metal_relevance: NOT_APPLICABLE
+metal_notes: No metal or rare earth element processing role is curated for this
+  rhizosphere/detritusphere community.

--- a/kb/communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.yaml
+++ b/kb/communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.yaml
@@ -27,41 +27,17 @@ environment_term:
     succession.
 taxonomy:
 - taxon_term:
-    preferred_term: fresh-root-specialized decomposer guild
+    preferred_term: Avena rhizosphere and detritusphere decomposer community
     term:
       id: NCBITaxon:2
       label: Bacteria
-    notes: Microbial guild whose functional succession suggests specialization
-      for fresh growing roots.
-  functional_role:
-  - PRIMARY_DEGRADER
-  evidence:
-  - reference: PMID:31953507
-    supports: SUPPORT
-    evidence_source: IN_VIVO
-    snippet: fresh growing roots
-    explanation: Supports the fresh-root specialist guild.
-- taxon_term:
-    preferred_term: decaying-detritus decomposer guild
-    term:
-      id: NCBITaxon:2
-      label: Bacteria
-    notes: Microbial guild specialized for decaying root detritus.
-  functional_role:
-  - PRIMARY_DEGRADER
-  evidence:
-  - reference: PMID:31953507
-    supports: SUPPORT
-    evidence_source: IN_VIVO
-    snippet: decaying root detritus
-    explanation: Supports the decaying-detritus guild.
-- taxon_term:
-    preferred_term: live-plus-decaying biomass decomposer guild
-    term:
-      id: NCBITaxon:2
-      label: Bacteria
-    notes: Microbial guild that specializes in the combination of live and
-      decaying root biomass.
+    notes: The aggregate soil decomposer community recovered by
+      metatranscriptomics; the abstract does not enumerate specific taxa per
+      guild, but transcripts were binned using a reference database from soil
+      isolate genomes, single-cell amplified genomes, metagenomes, and stable-
+      isotope-probing metagenomes. The four substrate-specific guilds
+      identified by upregulated-gene clustering are represented as
+      community-level interactions below.
   functional_role:
   - PRIMARY_DEGRADER
   - CROSS_FEEDER
@@ -69,22 +45,11 @@ taxonomy:
   - reference: PMID:31953507
     supports: SUPPORT
     evidence_source: IN_VIVO
-    snippet: the combination of live and decaying root biomass
-    explanation: Supports the combined-substrate guild.
-- taxon_term:
-    preferred_term: aging-root-material decomposer guild
-    term:
-      id: NCBITaxon:2
-      label: Bacteria
-    notes: Microbial guild specialized for aging root material.
-  functional_role:
-  - PRIMARY_DEGRADER
-  evidence:
-  - reference: PMID:31953507
-    supports: SUPPORT
-    evidence_source: IN_VIVO
-    snippet: aging root material
-    explanation: Supports the aging-root-material guild.
+    snippet: Transcripts were binned using a unique reference database
+      generated from soil isolate genomes, single-cell amplified genomes,
+      metagenomes, and stable isotope probing metagenomes
+    explanation: Supports the genome-binned decomposer community recovered by
+      metatranscriptomics.
 ecological_interactions:
 - name: Functional Succession Outpaces Compositional Change
   description: While soil habitat significantly affected both community

--- a/kb/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.yaml
+++ b/kb/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.yaml
@@ -12,7 +12,7 @@ description: >
   HMO utilization depends on synergistic interactions among coexisting species.
 ecological_state: ENGINEERED
 community_origin: SYNTHETIC
-community_category: DIET
+community_category: OTHER
 engineering_design:
   objective: Establish whether human milk oligosaccharide (2'FL) utilization in
     the infant gut can be mediated by synergistic interactions among coexisting

--- a/kb/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.yaml
+++ b/kb/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.yaml
@@ -1,0 +1,189 @@
+id: CommunityMech:000242
+name: Groundwater Elusimicrobia Diverse Metabolisms Community
+description: >
+  A genomic survey of 94 draft-quality, non-redundant Elusimicrobia genomes
+  (30 newly reconstructed) from diverse animal-associated and natural
+  environments. Genomes group into 12 clades, 10 previously lacking
+  reference genomes. Groundwater-associated Elusimicrobia are predicted to be
+  capable of heterotrophic or autotrophic lifestyles, oxygen- or
+  nitrate/nitrite-dependent respiration, degradation of a variety of organic
+  compounds, and Rhodobacter nitrogen fixation (Rnf) complex-dependent
+  acetogenesis using hydrogen and carbon dioxide. Two groundwater-associated
+  clades often encode a new nitrogenase paralog co-occurring with an
+  extensive suite of radical S-Adenosylmethionine (SAM) proteins. Similar
+  genomic loci occur in Gracilibacteria and Myxococcales genomes and are
+  predicted to reduce a tetrapyrrole, possibly to form a novel cofactor. The
+  animal-associated clades nest within free-living clades, supporting an
+  evolutionary trajectory from free-living to animal-associated lifestyles
+  via genome reduction.
+ecological_state: STABLE
+community_origin: NATURAL
+community_category: EXTREME_ENVIRONMENT
+environment_term:
+  preferred_term: groundwater Elusimicrobia habitat
+  term:
+    id: ENVO:01001004
+    label: groundwater
+  notes: 94 Elusimicrobia genomes from diverse animal-associated and natural
+    environments including groundwater, sediments, and soils.
+taxonomy:
+- taxon_term:
+    preferred_term: groundwater-associated Elusimicrobia
+    term:
+      id: NCBITaxon:641853
+      label: Elusimicrobiota
+    notes: Groundwater Elusimicrobia clades with diverse metabolic strategies
+      including aerobic and anaerobic respiration and Rnf-dependent acetogenesis.
+  functional_role:
+  - PRIMARY_DEGRADER
+  - PRIMARY_PRODUCER
+  - CROSS_FEEDER
+  evidence:
+  - reference: PMID:32681159
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Groundwater-associated Elusimicrobia are predicted to be capable
+      of heterotrophic or autotrophic lifestyles
+    explanation: Supports the heterotrophic/autotrophic versatility.
+- taxon_term:
+    preferred_term: animal-associated Elusimicrobia
+    term:
+      id: NCBITaxon:641853
+      label: Elusimicrobiota
+    notes: Animal-associated Elusimicrobia clades whose phylogenetic placement
+      within free-living clades supports an evolutionary trajectory from
+      free-living to animal-associated lifestyles via genome reduction.
+  functional_role:
+  - CROSS_FEEDER
+  evidence:
+  - reference: PMID:32681159
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: The animal-associated Elusimicrobia clades nest phylogenetically
+      within two free-living-associated clades
+    explanation: Supports the animal-associated clades and their nested
+      phylogenetic placement.
+ecological_interactions:
+- name: Versatile Heterotrophic/Autotrophic Respiration
+  description: Groundwater Elusimicrobia can perform heterotrophic or
+    autotrophic respiration with oxygen or nitrate/nitrite as terminal
+    electron acceptors and a variety of organic compounds as substrates.
+  interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
+  metabolites:
+  - preferred_term: nitrate
+    term:
+      id: CHEBI:17632
+      label: nitrate
+  - preferred_term: nitrite
+    term:
+      id: CHEBI:16301
+      label: nitrite
+  - preferred_term: dioxygen
+    term:
+      id: CHEBI:15379
+      label: dioxygen
+  biological_processes:
+  - preferred_term: oxidation-reduction process
+    term:
+      id: GO:0055114
+      label: oxidation-reduction process
+  evidence:
+  - reference: PMID:32681159
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: reliant on oxygen or nitrate/nitrite-dependent respiration, or a
+      variety of organic compounds
+    explanation: Supports the curated heterotrophic/autotrophic respiration
+      modes.
+- name: Rnf-Dependent Acetogenesis from H2 and CO2
+  description: Some groundwater Elusimicrobia encode Rhodobacter nitrogen
+    fixation (Rnf) complex-dependent acetogenesis using H2 and CO2 as
+    substrates.
+  interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
+  metabolites:
+  - preferred_term: dihydrogen
+    term:
+      id: CHEBI:18276
+      label: dihydrogen
+  - preferred_term: carbon dioxide
+    term:
+      id: CHEBI:16526
+      label: carbon dioxide
+  - preferred_term: acetate
+    term:
+      id: CHEBI:30089
+      label: acetate
+  biological_processes:
+  - preferred_term: carbon fixation
+    term:
+      id: GO:0015977
+      label: carbon fixation
+  evidence:
+  - reference: PMID:32681159
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Rhodobacter nitrogen fixation (Rnf) complex-dependent acetogenesis
+      with hydrogen and carbon dioxide as the substrates
+    explanation: Supports Rnf-dependent acetogenesis from H2 and CO2.
+- name: Novel Nitrogenase Paralog and Radical SAM Cluster
+  description: Two groundwater Elusimicrobia clades encode a novel nitrogenase
+    paralog co-occurring with an extensive suite of radical S-Adenosylmethionine
+    proteins; similar genomic loci occur in Gracilibacteria and Myxococcales
+    and are predicted to reduce a tetrapyrrole, possibly to form a novel
+    cofactor.
+  interaction_type: COMMENSALISM
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:32681159
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: a new group of nitrogenase paralogs that co-occur with an
+      extensive suite of radical S-Adenosylmethionine (SAM) proteins
+    explanation: Supports the curated nitrogenase-paralog and radical-SAM
+      cluster.
+  - reference: PMID:32681159
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: predict that the gene clusters reduce a tetrapyrrole, possibly to
+      form a novel cofactor
+    explanation: Supports the predicted tetrapyrrole-reductase function.
+environmental_factors:
+- name: Habitat diversity
+  value: animal-associated, sediments, soils, groundwater
+  description: 94 Elusimicrobia genomes were analyzed across multiple habitat
+    types.
+  evidence:
+  - reference: PMID:32681159
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: 94 draft-quality, non-redundant genomes, including 30 newly
+      reconstructed genomes, from diverse animal-associated and natural
+      environments
+    explanation: Supports the curated multi-habitat genome set.
+growth_media: []
+external_resources:
+- name: Primary publication for the groundwater Elusimicrobia community
+  repository: OTHER
+  resource_id: PMID:32681159
+  url: https://pubmed.ncbi.nlm.nih.gov/32681159/
+  description: PubMed record for the Meheust et al. 2020 ISME J paper.
+  evidence:
+  - reference: PMID:32681159
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Groundwater Elusimicrobia are metabolically diverse compared to
+      gut microbiome Elusimicrobia
+    explanation: Lists the primary publication.
+- name: DOI landing page
+  repository: OTHER
+  resource_id: doi:10.1038/s41396-020-0716-1
+  url: https://doi.org/10.1038/s41396-020-0716-1
+  description: DOI link to the ISME J paper.
+associated_datasets: []
+metals_present: []
+rare_earth_elements_present: []
+metal_relevance: NOT_APPLICABLE
+metal_notes: No metal or rare earth element processing role is curated for this
+  Elusimicrobia community.

--- a/kb/communities/Infant_Gut_Strain_Persistence_Maternal_Community.yaml
+++ b/kb/communities/Infant_Gut_Strain_Persistence_Maternal_Community.yaml
@@ -12,7 +12,7 @@ description: >
   may explain why some strains persist through the first year of life.
 ecological_state: STABLE
 community_origin: NATURAL
-community_category: DIET
+community_category: OTHER
 environment_term:
   preferred_term: infant gut microbiome
   term:

--- a/kb/communities/Infant_Gut_Strain_Persistence_Maternal_Community.yaml
+++ b/kb/communities/Infant_Gut_Strain_Persistence_Maternal_Community.yaml
@@ -1,0 +1,181 @@
+id: CommunityMech:000240
+name: Infant Gut Strain Persistence and Maternal Seeding Community
+description: >
+  A longitudinal infant gut bacterial community studied at strain resolution
+  over the first year of life across 13 full-term and 9 preterm infants and 17
+  mother-infant pairs. Infants' initially distinct microbiomes converge by age
+  1 year. Approximately 11 percent of early colonizers, primarily Bacteroides
+  and Bifidobacterium, persist through the first year and are more prevalent
+  in full-term than in preterm infants. Maternal gut strains are significantly
+  more likely to persist in the infant gut than other strains. Enrichment in
+  genes for surface adhesion, iron acquisition, and carbohydrate degradation
+  may explain why some strains persist through the first year of life.
+ecological_state: STABLE
+community_origin: NATURAL
+community_category: DIET
+environment_term:
+  preferred_term: infant gut microbiome
+  term:
+    id: ENVO:00002009
+    label: feces environment
+  notes: Longitudinal fecal metagenome series from full-term and preterm
+    infants and 17 mother-infant pairs across the first year of life.
+taxonomy:
+- taxon_term:
+    preferred_term: persistent infant Bacteroides colonizers
+    term:
+      id: NCBITaxon:816
+      label: Bacteroides
+    notes: Bacteroides is one of the two main genera among ~11 percent of
+      early colonizers that persist through the first year of life.
+  abundance_level: ABUNDANT
+  functional_role:
+  - PRIMARY_DEGRADER
+  - CROSS_FEEDER
+  evidence:
+  - reference: PMID:34622230
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: 11% of early colonizers, primarily Bacteroides and Bifidobacterium,
+      persist during the first year of life
+    explanation: Supports Bacteroides as a persistent early colonizer.
+- taxon_term:
+    preferred_term: persistent infant Bifidobacterium colonizers
+    term:
+      id: NCBITaxon:1678
+      label: Bifidobacterium
+    notes: Bifidobacterium is the second main genus among ~11 percent of
+      persistent early colonizers.
+  abundance_level: ABUNDANT
+  functional_role:
+  - CROSS_FEEDER
+  evidence:
+  - reference: PMID:34622230
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Bacteroides and Bifidobacterium, persist during the first year of
+      life
+    explanation: Supports Bifidobacterium as a persistent early colonizer.
+- taxon_term:
+    preferred_term: maternal-origin gut bacterial strains
+    term:
+      id: NCBITaxon:2
+      label: Bacteria
+    notes: Maternal gut strains transferred to the infant; significantly more
+      likely to persist in the infant gut than other strains.
+  functional_role:
+  - CROSS_FEEDER
+  evidence:
+  - reference: PMID:34622230
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: maternal gut strains are significantly more likely to persist in
+      the infant gut than other strains
+    explanation: Supports maternal-origin strains as a privileged class.
+ecological_interactions:
+- name: Maternal Strain Seeding Drives Persistence
+  description: Maternal gut strains are significantly more likely to persist
+    in the infant gut than other strains, indicating maternal seeding as a
+    driver of long-term colonization.
+  interaction_type: COLONIZATION_FACILITATION
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:34622230
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: maternal gut strains are significantly more likely to persist in
+      the infant gut than other strains
+    explanation: Supports maternal seeding as the dominant persistence driver.
+- name: Persistence Traits Encoded in Genomes
+  description: Enrichment in genes for surface adhesion, iron acquisition, and
+    carbohydrate degradation may explain persistence of some strains through
+    the first year.
+  interaction_type: COMMENSALISM
+  scope: COMMUNITY_LEVEL
+  biological_processes:
+  - preferred_term: iron ion transport
+    term:
+      id: GO:0006826
+      label: iron ion transport
+  - preferred_term: carbohydrate metabolic process
+    term:
+      id: GO:0005975
+      label: carbohydrate metabolic process
+  evidence:
+  - reference: PMID:34622230
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Enrichment in genes for surface adhesion, iron acquisition, and
+      carbohydrate degradation may explain persistence
+    explanation: Supports the three genomic trait categories curated as
+      persistence determinants.
+- name: Microbiome Convergence by Age One
+  description: Infants' initially distinct microbiomes converge by age 1 year.
+  interaction_type: COLONIZATION_FACILITATION
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:34622230
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: infants' initially distinct microbiomes converge by age 1 year
+    explanation: Supports the developmental convergence trajectory.
+- name: Full-Term Versus Preterm Persistence Disparity
+  description: Persistent early colonizers are more prevalent in full-term
+    than in preterm infants, indicating birth status as a structuring factor.
+  interaction_type: COLONIZATION_FACILITATION
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:34622230
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: those are more prevalent in full-term, compared with preterm
+      infants
+    explanation: Supports the birth-status disparity in persistence.
+environmental_factors:
+- name: Birth status
+  value: full-term (n=13) vs preterm (n=9) infants
+  description: Birth status (full-term vs preterm) shapes the early gut
+    microbiome and persistence of early colonizers.
+  evidence:
+  - reference: PMID:34622230
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: fecal metagenomes collected from 13 full-term and 9 preterm
+      infants
+    explanation: Supports the curated cohort design.
+- name: Mother-infant pairing
+  value: 17 mother-infant pairs
+  description: 17 paired mother-infant fecal metagenome series were used to
+    identify maternal-origin strains.
+  evidence:
+  - reference: PMID:34622230
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Examination of 17 mother-infant pairs reveals maternal gut strains
+    explanation: Supports the mother-infant pair design.
+growth_media: []
+external_resources:
+- name: Primary publication for the infant gut strain persistence community
+  repository: OTHER
+  resource_id: PMID:34622230
+  url: https://pubmed.ncbi.nlm.nih.gov/34622230/
+  description: PubMed record for the Lou et al. 2021 Cell Rep Med paper.
+  evidence:
+  - reference: PMID:34622230
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Infant gut strain persistence is associated with maternal origin,
+      phylogeny, and traits including surface adhesion and iron acquisition
+    explanation: Lists the primary publication.
+- name: DOI landing page
+  repository: OTHER
+  resource_id: doi:10.1016/j.xcrm.2021.100393
+  url: https://doi.org/10.1016/j.xcrm.2021.100393
+  description: DOI link to the Cell Rep Med paper.
+associated_datasets: []
+metals_present:
+- IRON
+rare_earth_elements_present: []
+metal_relevance: SIGNIFICANT
+metal_notes: Iron acquisition genes are among the three trait categories
+  associated with strain persistence in the infant gut.

--- a/kb/communities/Ngawha_Geothermal_Mercury_Cycling_Community.yaml
+++ b/kb/communities/Ngawha_Geothermal_Mercury_Cycling_Community.yaml
@@ -1,0 +1,163 @@
+id: CommunityMech:000243
+name: Ngawha Geothermal Acidic Springs Mercury Cycling Community
+description: >
+  An acidic warm spring microbial community from the Ngawha Geothermal Field
+  (Northland Region, Aotearoa New Zealand) characterized by genome-resolved
+  metagenomics and mercury speciation analysis. Two adjacent springs differ in
+  mercury speciation, with dissolved total and methylated mercury
+  concentrations among the highest reported from natural sources (250 to
+  16,000 ng/L total; 0.5 to 13.9 ng/L methylmercury). Sediment total mercury
+  ranges from 1,274 to 7,000 ug/g. Despite ultrahigh mercury levels, the
+  geothermal microbiome is unexpectedly diverse and dominated by acidophilic
+  and mesophilic sulfur- and iron-cycling bacteria, mercury- and arsenic-
+  resistant bacteria, and thermophilic and acidophilic archaea. A conceptual
+  model integrates community structure and metagenomic potential with abiotic
+  and biotic controls on Hg methylation, demethylation, and reduction to
+  volatile Hg(0).
+ecological_state: STABLE
+community_origin: NATURAL
+community_category: EXTREME_ENVIRONMENT
+environment_term:
+  preferred_term: acidic geothermal warm spring
+  term:
+    id: ENVO:00000051
+    label: hot spring
+  notes: Acidic warm springs (<55 C, pH <4.5) in the Ngawha Geothermal Field,
+    Northland Region, New Zealand, with ultrahigh mercury content.
+taxonomy:
+- taxon_term:
+    preferred_term: acidophilic sulfur- and iron-cycling bacteria
+    term:
+      id: NCBITaxon:2
+      label: Bacteria
+    notes: Acidophilic and mesophilic sulfur- and iron-cycling bacteria
+      dominate the geothermal microbiome.
+  abundance_level: DOMINANT
+  functional_role:
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:32414793
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: acidophilic and mesophilic sulfur- and iron-cycling bacteria
+    explanation: Supports the S/Fe-cycling bacterial members.
+- taxon_term:
+    preferred_term: mercury- and arsenic-resistant bacteria
+    term:
+      id: NCBITaxon:2
+      label: Bacteria
+    notes: Mercury- and arsenic-resistant bacteria persist under ultrahigh
+      mercury and arsenic exposure.
+  functional_role:
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:32414793
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: mercury- and arsenic-resistant bacteria
+    explanation: Supports the Hg/As-resistant bacterial members.
+- taxon_term:
+    preferred_term: thermophilic and acidophilic archaea
+    term:
+      id: NCBITaxon:2157
+      label: Archaea
+    notes: Thermophilic and acidophilic archaeal members of the geothermal
+      community.
+  functional_role:
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:32414793
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: thermophilic and acidophilic archaea
+    explanation: Supports the archaeal members.
+ecological_interactions:
+- name: Mercury Methylation, Demethylation, and Reduction
+  description: Genome-resolved analysis identifies microorganisms genetically
+    equipped for mercury methylation, demethylation, or Hg(II) reduction to
+    volatile Hg(0).
+  interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
+  metabolites:
+  - preferred_term: mercury(2+)
+    term:
+      id: CHEBI:16793
+      label: mercury(2+)
+  - preferred_term: methylmercury
+    term:
+      id: CHEBI:25196
+      label: methylmercury(1+)
+  biological_processes:
+  - preferred_term: mercury ion transport
+    term:
+      id: GO:0015694
+      label: mercury ion transport
+  evidence:
+  - reference: PMID:32414793
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: microorganisms genetically equipped for mercury methylation,
+      demethylation, or Hg(II) reduction to volatile Hg(0)
+    explanation: Supports the three curated Hg-cycling activities.
+- name: Diverse Community Despite Ultrahigh Hg
+  description: Despite ultrahigh dissolved and solid mercury concentrations,
+    the geothermal microbiome is unexpectedly diverse.
+  interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:32414793
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: In the context of such ultrahigh mercury levels, the geothermal
+      microbiome was unexpectedly diverse
+    explanation: Supports the curated high-diversity-under-high-Hg observation.
+environmental_factors:
+- name: Mercury concentration
+  value: ultrahigh dissolved and solid Hg
+  description: Dissolved total mercury 250-16,000 ng/L; dissolved methylmercury
+    0.5-13.9 ng/L; sediment total mercury 1,274-7,000 ug/g.
+  evidence:
+  - reference: PMID:32414793
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: among the highest reported from natural sources (250 to
+      16,000 ng liter-1 and 0.5 to 13.9 ng liter-1, respectively)
+    explanation: Supports the dissolved Hg concentrations.
+- name: Spring chemistry
+  value: pH <4.5, temperature <55 C
+  description: Acidic warm springs with low pH and moderate temperature provide
+    the extreme habitat.
+  evidence:
+  - reference: PMID:32414793
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: acidic warm springs in the Ngawha Geothermal Field
+    explanation: Supports the spring chemistry.
+growth_media: []
+external_resources:
+- name: Primary publication for the Ngawha Hg-cycling community
+  repository: OTHER
+  resource_id: PMID:32414793
+  url: https://pubmed.ncbi.nlm.nih.gov/32414793/
+  description: PubMed record for the Gionfriddo et al. 2020 Appl Environ
+    Microbiol paper.
+  evidence:
+  - reference: PMID:32414793
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Genome-Resolved Metagenomics and Detailed Geochemical Speciation
+      Analyses Yield New Insights into Microbial Mercury Cycling in Geothermal
+      Springs
+    explanation: Lists the primary publication.
+- name: DOI landing page
+  repository: OTHER
+  resource_id: doi:10.1128/AEM.00176-20
+  url: https://doi.org/10.1128/AEM.00176-20
+  description: DOI link to the Applied and Environmental Microbiology paper.
+associated_datasets: []
+metals_present: []
+rare_earth_elements_present: []
+metal_relevance: SIGNIFICANT
+metal_notes: Mercury is the central metal driving community structure and the
+  curated biogeochemical cycle, but the schema's metals_present enum does not
+  include mercury; the metal is described in metal_notes only.

--- a/kb/communities/Ngawha_Geothermal_Mercury_Cycling_Community.yaml
+++ b/kb/communities/Ngawha_Geothermal_Mercury_Cycling_Community.yaml
@@ -155,9 +155,10 @@ external_resources:
   url: https://doi.org/10.1128/AEM.00176-20
   description: DOI link to the Applied and Environmental Microbiology paper.
 associated_datasets: []
-metals_present: []
+metals_present:
+- MERCURY
 rare_earth_elements_present: []
-metal_relevance: SIGNIFICANT
+metal_relevance: PRIMARY
 metal_notes: Mercury is the central metal driving community structure and the
-  curated biogeochemical cycle, but the schema's metals_present enum does not
-  include mercury; the metal is described in metal_notes only.
+  curated biogeochemical cycle, with members performing methylation,
+  demethylation, and Hg(II) reduction to volatile Hg(0).

--- a/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
+++ b/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
@@ -1,0 +1,239 @@
+id: CommunityMech:000241
+name: Rifle Aquifer Bioanode Extracellular Electron Transfer Community
+description: >
+  An electroactive microbial community established and maintained for almost
+  four years in microbial electrochemical cells (MXCs) inoculated with a
+  well-studied aquifer near Rifle, CO. Anodes were poised mostly at -0.2 to
+  -0.25 V vs SHE to mimic iron-oxide mineral redox potentials, with acetate
+  as the sole carbon source. Genome-resolved metagenomics of two biofilm and
+  26 planktonic samples yielded 84 bacterial and 2 archaeal near-complete
+  draft genomes. A novel Geobacter sp. with at least 72 putative multiheme
+  c-type cytochromes dominated the electrode-attached community, while
+  diverse other organisms (Actinobacteria, Ignavibacteria, Chloroflexi,
+  Acidobacteria, Firmicutes, Beta- and Gammaproteobacteria) also encoded
+  multiheme cytochromes, porin-cytochrome complexes, and electrically
+  conductive pili (e-pili), identifying a small subset of Rifle aquifer
+  organisms that may mediate mineral redox transformations.
+ecological_state: ENGINEERED
+community_origin: NATURAL
+community_category: BIOTECHNOLOGY
+engineering_design:
+  objective: Use microbial electrochemical cells (MXCs) coupled with
+    genome-resolved metagenomics to enrich for and study organisms in the
+    Rifle aquifer capable of extracellular electron transfer (EET).
+  assembly_strategy: Inoculate MXCs with Rifle, CO aquifer material and
+    cultivate electroactive biofilms on anodes poised at iron-oxide-like
+    redox potentials with acetate as sole carbon source.
+  perturbation_design: Maintain biofilms for nearly 4 years and sample two
+    biofilm and 26 planktonic time points for metagenomic reconstruction.
+  measurement_endpoints:
+  - Genome-resolved EET-capable organisms in biofilm and planktonic phases
+  - Multiheme c-type cytochrome inventories per genome
+  - Identification of porin-cytochrome complexes and e-pili
+  evidence:
+  - reference: PMID:32849356
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Electroactive biofilms were established and maintained for almost
+      4 years on anodes poised mostly at -0.2 to -0.25 V vs. SHE
+    explanation: Supports the long-term anode-poised electroactive enrichment.
+environment_term:
+  preferred_term: microbial electrochemical cell anode biofilm
+  term:
+    id: ENVO:01001405
+    label: laboratory bioreactor
+  notes: Acetate-fed microbial electrochemical cells inoculated with Rifle, CO
+    aquifer material; anodes poised at iron-oxide-like redox potentials.
+taxonomy:
+- taxon_term:
+    preferred_term: novel multiheme-cytochrome Geobacter sp.
+    term:
+      id: NCBITaxon:28231
+      label: Geobacter
+    notes: Dominant electrode-attached organism encoding at least 72 putative
+      multiheme c-type cytochromes.
+  abundance_level: DOMINANT
+  functional_role:
+  - PRIMARY_DEGRADER
+  - SYNTROPHIC_PARTNER
+  evidence:
+  - reference: PMID:32849356
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: A novel Geobacter sp. with at least 72 putative multiheme c-type
+      cytochromes (MHCs) was the dominant electrode-attached organism
+    explanation: Supports the Geobacter dominant member.
+- taxon_term:
+    preferred_term: EET-capable Rifle aquifer Actinobacteria
+    term:
+      id: NCBITaxon:201174
+      label: Actinomycetota
+  functional_role:
+  - SYNTROPHIC_PARTNER
+  evidence:
+  - reference: PMID:32849356
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: a diverse range of other electrode-associated organisms also
+      harbored putative MHCs with at least 10 heme-binding motifs, as well as
+      porin-cytochrome complexes and e-pili, including Actinobacteria
+    explanation: Supports Actinobacteria membership with EET capacity.
+- taxon_term:
+    preferred_term: EET-capable Rifle aquifer Ignavibacteria
+    term:
+      id: NCBITaxon:1648176
+      label: Ignavibacteriota
+  functional_role:
+  - SYNTROPHIC_PARTNER
+  evidence:
+  - reference: PMID:32849356
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Ignavibacteria
+    explanation: Supports the Ignavibacteria EET membership.
+- taxon_term:
+    preferred_term: EET-capable Rifle aquifer Chloroflexi
+    term:
+      id: NCBITaxon:200795
+      label: Chloroflexota
+  functional_role:
+  - SYNTROPHIC_PARTNER
+  evidence:
+  - reference: PMID:32849356
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Chloroflexi
+    explanation: Supports the Chloroflexi EET membership.
+- taxon_term:
+    preferred_term: EET-capable Rifle aquifer Acidobacteria
+    term:
+      id: NCBITaxon:57723
+      label: Acidobacteriota
+  functional_role:
+  - SYNTROPHIC_PARTNER
+  evidence:
+  - reference: PMID:32849356
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Acidobacteria
+    explanation: Supports the Acidobacteria EET membership.
+- taxon_term:
+    preferred_term: EET-capable Rifle aquifer Firmicutes
+    term:
+      id: NCBITaxon:1239
+      label: Bacillota
+  functional_role:
+  - SYNTROPHIC_PARTNER
+  evidence:
+  - reference: PMID:32849356
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Firmicutes
+    explanation: Supports the Firmicutes EET membership.
+- taxon_term:
+    preferred_term: EET-capable Rifle aquifer Beta- and Gammaproteobacteria
+    term:
+      id: NCBITaxon:1224
+      label: Pseudomonadota
+  functional_role:
+  - SYNTROPHIC_PARTNER
+  evidence:
+  - reference: PMID:32849356
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Beta- and Gammaproteobacteria
+    explanation: Supports the Proteobacteria classes with EET capacity.
+ecological_interactions:
+- name: Acetate Oxidation Coupled to Anode Electron Donation
+  description: Geobacter and other EET-capable organisms oxidize acetate and
+    transfer electrons to the poised anode via multiheme cytochromes,
+    porin-cytochrome complexes, and e-pili.
+  interaction_type: SYNTROPHY
+  scope: COMMUNITY_LEVEL
+  metabolites:
+  - preferred_term: acetate
+    term:
+      id: CHEBI:30089
+      label: acetate
+  biological_processes:
+  - preferred_term: anaerobic respiration
+    term:
+      id: GO:0009061
+      label: anaerobic respiration
+  evidence:
+  - reference: PMID:32849356
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: using acetate as the sole carbon source
+    explanation: Supports acetate as the sole electron donor.
+  - reference: PMID:32849356
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: putative MHCs with at least 10 heme-binding motifs, as well as
+      porin-cytochrome complexes and e-pili
+    explanation: Supports the multiheme-cytochrome, porin-cytochrome, and
+      e-pili EET machinery.
+- name: Subset of Rifle Aquifer Organisms Mediates EET
+  description: Only a small subset of the thousands of organisms previously
+    detected in the Rifle aquifer have the genetic potential to mediate
+    mineral redox transformations.
+  interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:32849356
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: a small subset of the thousands of organisms previously detected
+      in the Rifle aquifer that may have the potential to mediate mineral redox
+      transformations
+    explanation: Supports the selective enrichment of EET-capable organisms.
+environmental_factors:
+- name: Anode redox potential
+  value: -0.2 to -0.25 V vs SHE
+  description: Anodes were poised at potentials that mimic iron-oxide mineral
+    redox potentials.
+  evidence:
+  - reference: PMID:32849356
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: anodes poised mostly at -0.2 to -0.25 V vs. SHE, a range that
+      mimics the redox potential of iron-oxide minerals
+    explanation: Supports the curated anode redox potential range.
+- name: Operating duration
+  value: nearly 4 years of continuous operation
+  description: The biofilms were maintained on poised anodes for almost 4
+    years before metagenomic sampling.
+  evidence:
+  - reference: PMID:32849356
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: maintained for almost 4 years on anodes
+    explanation: Supports the operating duration.
+growth_media: []
+external_resources:
+- name: Primary publication for the Rifle bioanode community
+  repository: OTHER
+  resource_id: PMID:32849356
+  url: https://pubmed.ncbi.nlm.nih.gov/32849356/
+  description: PubMed record for the Arbour et al. 2020 Frontiers in
+    Microbiology paper.
+  evidence:
+  - reference: PMID:32849356
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Diverse Microorganisms in Sediment and Groundwater Are Implicated
+      in Extracellular Redox Processes Based on Genomic Analysis of Bioanode
+      Communities
+    explanation: Lists the primary publication.
+- name: DOI landing page
+  repository: OTHER
+  resource_id: doi:10.3389/fmicb.2020.01694
+  url: https://doi.org/10.3389/fmicb.2020.01694
+  description: DOI link to the Frontiers in Microbiology paper.
+associated_datasets: []
+metals_present:
+- IRON
+rare_earth_elements_present: []
+metal_relevance: SIGNIFICANT
+metal_notes: Anode potentials mimic iron-oxide mineral redox; the EET-capable
+  organisms may mediate mineral redox transformations in the Rifle aquifer.

--- a/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
+++ b/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
@@ -1,0 +1,214 @@
+id: CommunityMech:000239
+name: Thiocyanate-Degrading Afipia and Thiobacillus Bioreactor Community
+description: >
+  A laboratory bioreactor microbial community derived from consortia used to
+  treat thiocyanate-contaminated water, perturbed by systematically increased
+  SCN- input loading and the presence or absence of molasses as organic
+  carbon. Five experiments over 790 days with genome-resolved metagenomics
+  showed that a single Thiobacillus strain proliferated in all reactors at
+  high SCN- loading, while a single Afipia variant dominated the molasses-
+  free reactor at moderate loadings. The Afipia variant is predicted to
+  degrade SCN- via a novel thiocyanate desulfurase, oxidize the resulting
+  reduced sulfur, degrade the cyanate product to ammonia and CO2 via cyanate
+  hydratase, and fix CO2 via the Calvin-Benson-Bassham cycle. Removal of
+  molasses reproducibly selects for this autotrophic strain, although
+  molasses-free reactors did not sustain high-loading SCN- degradation,
+  possibly due to loss of biofilm-associated niche diversity.
+ecological_state: ENGINEERED
+community_origin: NATURAL
+community_category: BIOREMEDIATION
+engineering_design:
+  objective: Test whether specific strains capable of degrading thiocyanate
+    can be reproducibly selected by SCN- loading and the presence or absence
+    of added organic carbon (molasses).
+  assembly_strategy: Use complex microbial communities derived from those
+    used to treat thiocyanate-contaminated water as the starting inoculum and
+    perturb with systematically varied SCN- and molasses inputs.
+  perturbation_design: Increase SCN- input concentration over time in
+    molasses-amended and unamended reactors, and switch some reactors to
+    unamended conditions after the active SCN- degrading consortium has
+    established.
+  measurement_endpoints:
+  - Reproducibility of strain-level selection across reactors
+  - Thiobacillus and Afipia abundance across SCN- loadings
+  - Strain-level community composition over 790 days
+  - SCN- degradation performance under molasses removal
+  evidence:
+  - reference: PMID:33897653
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Complex microbial communities derived from those used to treat
+      SCN--contaminated water were exposed to systematically increased input
+      SCN concentrations in molasses-amended and -unamended reactors
+    explanation: Supports the SCN- consortium and molasses perturbation design.
+environment_term:
+  preferred_term: thiocyanate-fed laboratory bioreactor
+  term:
+    id: ENVO:01001405
+    label: laboratory bioreactor
+  notes: Laboratory bioreactor cultivations of SCN- degrading consortia over
+    790 days with molasses-amended and molasses-free reactors.
+taxonomy:
+- taxon_term:
+    preferred_term: Thiobacillus thiocyanate-degrader strain
+    term:
+      id: NCBITaxon:919
+      label: Thiobacillus
+    notes: A single Thiobacillus strain proliferated in all reactors at high
+      SCN- loadings.
+  abundance_level: DOMINANT
+  functional_role:
+  - PRIMARY_DEGRADER
+  - PRIMARY_PRODUCER
+  evidence:
+  - reference: PMID:33897653
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: A single Thiobacillus strain proliferated in all reactors at high
+      loadings
+    explanation: Supports Thiobacillus dominance at high SCN- loading.
+- taxon_term:
+    preferred_term: Afipia thiocyanate-degrader variant
+    term:
+      id: NCBITaxon:1033
+      label: Afipia
+    notes: A single Afipia variant dominated the molasses-free reactor at
+      moderately high SCN- loadings.
+  abundance_level: DOMINANT
+  functional_role:
+  - PRIMARY_DEGRADER
+  - PRIMARY_PRODUCER
+  evidence:
+  - reference: PMID:33897653
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: a single Afipia variant dominated the molasses-free reactor at
+      moderately high loadings
+    explanation: Supports Afipia dominance under molasses removal.
+- taxon_term:
+    preferred_term: Rhizobiales background strains
+    term:
+      id: NCBITaxon:356
+      label: Rhizobiales
+    notes: Many Rhizobiales strains were present but did not dominate; Afipia
+      (within Rhizobiales) was the molasses-free winner.
+  functional_role:
+  - CROSS_FEEDER
+  evidence:
+  - reference: PMID:33897653
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Despite the presence of many Rhizobiales strains
+    explanation: Supports Rhizobiales background membership.
+ecological_interactions:
+- name: Thiocyanate Degradation and Autotrophic CO2 Fixation by Afipia
+  description: The Afipia variant degrades SCN- via a novel thiocyanate
+    desulfurase, oxidizes the resulting reduced sulfur, breaks down the
+    cyanate product to ammonia and CO2 via cyanate hydratase, and refixes CO2
+    via the Calvin-Benson-Bassham cycle.
+  interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
+  metabolites:
+  - preferred_term: thiocyanate
+    term:
+      id: CHEBI:18022
+      label: thiocyanate
+  - preferred_term: cyanate
+    term:
+      id: CHEBI:29195
+      label: cyanate
+  - preferred_term: ammonia
+    term:
+      id: CHEBI:16134
+      label: ammonia
+  - preferred_term: carbon dioxide
+    term:
+      id: CHEBI:16526
+      label: carbon dioxide
+  biological_processes:
+  - preferred_term: carbon fixation
+    term:
+      id: GO:0015977
+      label: carbon fixation
+  evidence:
+  - reference: PMID:33897653
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: predicted to break down SCN- using a novel thiocyanate desulfurase,
+      oxidize resulting reduced sulfur, degrade product cyanate to ammonia and
+      CO2 via cyanate hydratase, and fix CO2 via the Calvin-Benson-Bassham
+      cycle
+    explanation: Supports the curated four-step Afipia metabolic pathway.
+- name: Molasses Removal Selects for Afipia
+  description: Removal of molasses from input feed solutions reproducibly led
+    to dominance of the autotrophic Afipia variant over heterotrophic
+    competitors.
+  interaction_type: COMPETITION
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:33897653
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Removal of molasses from input feed solutions reproducibly led to
+      dominance of this strain
+    explanation: Supports the molasses-driven Afipia selection.
+- name: Loss of Biofilm Niche Diversity Without Molasses
+  description: Although sustained by autotrophy, molasses-free reactors did not
+    stably degrade SCN- at high loading rates, possibly due to loss of
+    biofilm-associated niche diversity.
+  interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:33897653
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: reactors without molasses did not stably degrade SCN- at high
+      loading rates, perhaps due to loss of biofilm-associated niche diversity
+    explanation: Supports the curated niche-diversity rationale.
+environmental_factors:
+- name: Thiocyanate loading
+  value: systematically increased SCN- input concentration
+  description: SCN- input concentration was increased systematically over
+    790 days across five experiments.
+  evidence:
+  - reference: PMID:33897653
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: systematically increased input SCN concentrations
+    explanation: Supports the SCN- loading perturbation design.
+- name: Molasses amendment
+  value: molasses-amended vs molasses-free
+  description: Reactors were run with or without molasses as organic carbon
+    supplement.
+  evidence:
+  - reference: PMID:33897653
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: molasses-amended and -unamended reactors
+    explanation: Supports the molasses-amendment perturbation.
+growth_media: []
+external_resources:
+- name: Primary publication for the Afipia/Thiobacillus thiocyanate community
+  repository: OTHER
+  resource_id: PMID:33897653
+  url: https://pubmed.ncbi.nlm.nih.gov/33897653/
+  description: PubMed record for the Huddy et al. 2021 Frontiers in Microbiology
+    paper.
+  evidence:
+  - reference: PMID:33897653
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Thiocyanate and Organic Carbon Inputs Drive Convergent Selection
+      for Specific Autotrophic Afipia and Thiobacillus Strains
+    explanation: Lists the primary publication for the curated community.
+- name: DOI landing page
+  repository: OTHER
+  resource_id: doi:10.3389/fmicb.2021.643368
+  url: https://doi.org/10.3389/fmicb.2021.643368
+  description: DOI link to the Frontiers in Microbiology paper.
+associated_datasets: []
+metals_present: []
+rare_earth_elements_present: []
+metal_relevance: NOT_APPLICABLE
+metal_notes: No metal or rare earth element processing role is curated for this
+  thiocyanate bioremediation community.

--- a/references_cache/PMID_31953507.md
+++ b/references_cache/PMID_31953507.md
@@ -1,0 +1,69 @@
+---
+reference_id: PMID:31953507
+title: ''
+authors: []
+journal: ISME J
+year: '2020'
+content_type: abstract_only
+---
+
+# PMID:31953507
+**Journal:** ISME J (2020)
+
+## Content
+
+1. ISME J. 2020 Apr;14(4):999-1014. doi: 10.1038/s41396-019-0582-x. Epub 2020 Jan
+ 17.
+
+Niche differentiation is spatially and temporally regulated in the rhizosphere.
+
+Nuccio EE(1), Starr E(2), Karaoz U(3), Brodie EL(3)(4), Zhou J(3)(5)(6), Tringe 
+SG(7), Malmstrom RR(7), Woyke T(7), Banfield JF(3)(4), Firestone MK(3)(4), 
+Pett-Ridge J(8).
+
+Author information:
+(1)Physical and Life Sciences Directorate, Lawrence Livermore National 
+Laboratory, Livermore, CA, 94551, USA. nuccio1@llnl.gov.
+(2)Department of Plant and Microbial Biology, University of California, 
+Berkeley, CA, 94720, USA.
+(3)Earth and Environmental Sciences, Lawrence Berkeley National Laboratory, 
+Berkeley, CA, 94720, USA.
+(4)Department of Environmental Science, Policy and Management, University of 
+California, Berkeley, CA, 94720, USA.
+(5)Institute for Environmental Genomics, Department of Microbiology and Plant 
+Biology, and School of Civil Engineering and Environmental Sciences, University 
+of Oklahoma, Norman, OK, 73019, USA.
+(6)State Key Joint Laboratory of Environment Simulation and Pollution Control, 
+School of Environment, Tsinghua University, Beijing, 100084, China.
+(7)Department of Energy Joint Genome Institute, Berkeley, CA, 94720, USA.
+(8)Physical and Life Sciences Directorate, Lawrence Livermore National 
+Laboratory, Livermore, CA, 94551, USA. pettridge2@llnl.gov.
+
+The rhizosphere is a hotspot for microbial carbon transformations, and is the 
+entry point for root polysaccharides and polymeric carbohydrates that are 
+important precursors to soil organic matter (SOM). However, the ecological 
+mechanisms that underpin rhizosphere carbohydrate depolymerization are poorly 
+understood. Using Avena fatua, a common annual grass, we analyzed time-resolved 
+metatranscriptomes to compare microbial functions in rhizosphere, detritusphere, 
+and combined rhizosphere-detritusphere habitats. Transcripts were binned using a 
+unique reference database generated from soil isolate genomes, single-cell 
+amplified genomes, metagenomes, and stable isotope probing metagenomes. While 
+soil habitat significantly affected both community composition and overall gene 
+expression, the succession of microbial functions occurred at a faster time 
+scale than compositional changes. Using hierarchical clustering of upregulated 
+decomposition genes, we identified four distinct microbial guilds populated by 
+taxa whose functional succession patterns suggest specialization for substrates 
+provided by fresh growing roots, decaying root detritus, the combination of live 
+and decaying root biomass, or aging root material. Carbohydrate depolymerization 
+genes were consistently upregulated in the rhizosphere, and both taxonomic and 
+functional diversity were highest in the combined rhizosphere-detritusphere, 
+suggesting coexistence of rhizosphere guilds is facilitated by niche 
+differentiation. Metatranscriptome-defined guilds provide a framework to model 
+rhizosphere succession and its consequences for soil carbon cycling.
+
+DOI: 10.1038/s41396-019-0582-x
+PMCID: PMC7082339
+PMID: 31953507 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare that they have no conflict 
+of interest.

--- a/references_cache/PMID_31980038.md
+++ b/references_cache/PMID_31980038.md
@@ -1,0 +1,63 @@
+---
+reference_id: PMID:31980038
+title: ''
+authors: []
+journal: Microbiome
+year: '2020'
+content_type: abstract_only
+---
+
+# PMID:31980038
+**Journal:** Microbiome (2020)
+
+## Content
+
+1. Microbiome. 2020 Jan 24;8(1):7. doi: 10.1186/s40168-020-0786-3.
+
+Increased replication of dissimilatory nitrate-reducing bacteria leads to 
+decreased anammox bioreactor performance.
+
+Keren R(1), Lawrence JE(2), Zhuang W(3), Jenkins D(1), Banfield JF(4), 
+Alvarez-Cohen L(1)(5), Zhou L(6), Yu K(7).
+
+Author information:
+(1)Department of Civil and Environmental Engineering, University of California 
+Berkeley, Berkeley, CA, USA.
+(2)Tighe & Bond, Westwood, MA, USA.
+(3)Department of Civil and Environmental Engineering, The University of 
+Auckland, Auckland, New Zealand.
+(4)Department of Earth and Planetary Sciences, University of California 
+Berkeley, Berkeley, CA, USA.
+(5)Earth and Environmental Sciences Division, Lawrence Berkeley National 
+Laboratory, Berkeley, CA, USA.
+(6)College of Chemistry and Environmental Engineering, Shenzhen University, 
+Shenzhen, China. pakerzhou@szu.edu.cn.
+(7)School of Environment and Energy, Shenzhen Graduate School, Peking 
+University, Shenzhen, GD, China. yuke.sz@pku.edu.cn.
+
+BACKGROUND: Anaerobic ammonium oxidation (anammox) is a biological process 
+employed to remove reactive nitrogen from wastewater. While a substantial body 
+of literature describes the performance of anammox bioreactors under various 
+operational conditions and perturbations, few studies have resolved the 
+metabolic roles of their core microbial community members.
+RESULTS: Here, we used metagenomics to study the microbial community of a 
+laboratory-scale anammox bioreactor from inoculation, through a performance 
+destabilization event, to robust steady-state performance. Metabolic analyses 
+revealed that nutrient acquisition from the environment is selected for in the 
+anammox community. Dissimilatory nitrate reduction to ammonium (DNRA) was the 
+primary nitrogen removal pathway that competed with anammox. Increased 
+replication of bacteria capable of DNRA led to the out-competition of anammox 
+bacteria, and the loss of the bioreactor's nitrogen removal capacity. These 
+bacteria were highly associated with the anammox bacterium and considered part 
+of the core microbial community.
+CONCLUSIONS: Our findings highlight the importance of metabolic 
+interdependencies related to nitrogen- and carbon-cycling within anammox 
+bioreactors and the potentially detrimental effects of bacteria that are 
+otherwise considered core microbial community members.
+
+DOI: 10.1186/s40168-020-0786-3
+PMCID: PMC6982389
+PMID: 31980038 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare that they have no competing 
+interests.

--- a/references_cache/PMID_32414793.md
+++ b/references_cache/PMID_32414793.md
@@ -1,0 +1,81 @@
+---
+reference_id: PMID:32414793
+title: ''
+authors: []
+journal: Appl Environ Microbiol
+year: '2020'
+content_type: abstract_only
+---
+
+# PMID:32414793
+**Journal:** Appl Environ Microbiol (2020)
+
+## Content
+
+1. Appl Environ Microbiol. 2020 Jul 20;86(15):e00176-20. doi:
+10.1128/AEM.00176-20.  Print 2020 Jul 20.
+
+Genome-Resolved Metagenomics and Detailed Geochemical Speciation Analyses Yield 
+New Insights into Microbial Mercury Cycling in Geothermal Springs.
+
+Gionfriddo CM(1), Stott MB(2), Power JF(2), Ogorek JM(3), Krabbenhoft DP(3), 
+Wick R(4), Holt K(4), Chen LX(5), Thomas BC(5), Banfield JF(6)(5)(7), Moreau 
+JW(6).
+
+Author information:
+(1)School of Earth Sciences, The University of Melbourne, Parkville, Victoria, 
+Australia gionfriddocm@ornl.gov.
+(2)GNS Science, Wairakei Research Centre, Taupo, New Zealand.
+(3)Wisconsin Water Science Center, U.S. Geological Survey, Middleton, Wisconsin, 
+USA.
+(4)Department of Biochemistry and Molecular Biology, Bio21 Molecular Science and 
+Biotechnology Institute, University of Melbourne, Parkville, Victoria, 
+Australia.
+(5)Department of Earth and Planetary Science, UC Berkeley, Berkeley, California, 
+USA.
+(6)School of Earth Sciences, The University of Melbourne, Parkville, Victoria, 
+Australia.
+(7)Department of Environmental Science, Policy, and Management, UC Berkeley, 
+Berkeley, California, USA.
+
+Geothermal systems emit substantial amounts of aqueous, gaseous, and methylated 
+mercury, but little is known about microbial influences on mercury speciation. 
+Here, we report results from genome-resolved metagenomics and mercury speciation 
+analysis of acidic warm springs in the Ngawha Geothermal Field (<55°C, pH <4.5), 
+Northland Region, Aotearoa New Zealand. Our aim was to identify the 
+microorganisms genetically equipped for mercury methylation, demethylation, or 
+Hg(II) reduction to volatile Hg(0) in these springs. Dissolved total and 
+methylated mercury concentrations in two adjacent springs with different mercury 
+speciation ranked among the highest reported from natural sources (250 to 
+16,000 ng liter-1 and 0.5 to 13.9 ng liter-1, respectively). Total solid mercury 
+concentrations in spring sediments ranged from 1,274 to 7,000 μg g-1 In the 
+context of such ultrahigh mercury levels, the geothermal microbiome was 
+unexpectedly diverse and dominated by acidophilic and mesophilic sulfur- and 
+iron-cycling bacteria, mercury- and arsenic-resistant bacteria, and thermophilic 
+and acidophilic archaea. By integrating microbiome structure and metagenomic 
+potential with geochemical constraints, we constructed a conceptual model for 
+biogeochemical mercury cycling in geothermal springs. The model includes abiotic 
+and biotic controls on mercury speciation and illustrates how geothermal mercury 
+cycling may couple to microbial community dynamics and sulfur and iron 
+biogeochemistry.IMPORTANCE Little is currently known about biogeochemical 
+mercury cycling in geothermal systems. The manuscript presents a new conceptual 
+model, supported by genome-resolved metagenomic analysis and detailed 
+geochemical measurements. The model illustrates environmental factors that 
+influence mercury cycling in acidic springs, including transitions between solid 
+(mineral) and aqueous phases of mercury, as well as the interconnections among 
+mercury, sulfur, and iron cycles. This work provides a framework for studying 
+natural geothermal mercury emissions globally. Specifically, our findings have 
+implications for mercury speciation in wastewaters from geothermal power plants 
+and the potential environmental impacts of microbially and abiotically formed 
+mercury species, particularly where they are mobilized in spring waters that mix 
+with surface or groundwaters. Furthermore, in the context of thermophilic 
+origins for microbial mercury volatilization, this report yields new insights 
+into how such processes may have evolved alongside microbial mercury 
+methylation/demethylation and the environmental constraints imposed by the 
+geochemistry and mineralogy of geothermal systems.
+
+Copyright © 2020 American Society for Microbiology.
+
+DOI: 10.1128/AEM.00176-20
+PMCID: PMC7376564
+PMID: 32414793 [Indexed for MEDLINE]

--- a/references_cache/PMID_32681159.md
+++ b/references_cache/PMID_32681159.md
@@ -1,0 +1,65 @@
+---
+reference_id: PMID:32681159
+title: ''
+authors: []
+journal: ISME J
+year: '2020'
+content_type: abstract_only
+---
+
+# PMID:32681159
+**Journal:** ISME J (2020)
+
+## Content
+
+1. ISME J. 2020 Dec;14(12):2907-2922. doi: 10.1038/s41396-020-0716-1. Epub 2020
+Jul  17.
+
+Groundwater Elusimicrobia are metabolically diverse compared to gut microbiome 
+Elusimicrobia and some have a novel nitrogenase paralog.
+
+Méheust R(1)(2), Castelle CJ(1)(2), Matheus Carnevali PB(1)(2), Farag IF(3), He 
+C(1), Chen LX(1)(2), Amano Y(4), Hug LA(5), Banfield JF(6)(7).
+
+Author information:
+(1)Department of Earth and Planetary Science, University of California, 
+Berkeley, Berkeley, CA, 94720, USA.
+(2)Innovative Genomics Institute, Berkeley, CA, 94720, USA.
+(3)School of Marine Science and Policy, University of Delaware, Lewes, DE, 
+19968, USA.
+(4)Nuclear Fuel Cycle Engineering Laboratories, Japan Atomic Energy Agency, 
+Tokai-mura, Ibaraki, Japan.
+(5)Department of Biology, University of Waterloo, Waterloo, ON, Canada.
+(6)Department of Earth and Planetary Science, University of California, 
+Berkeley, Berkeley, CA, 94720, USA. jbanfield@berkeley.edu.
+(7)Innovative Genomics Institute, Berkeley, CA, 94720, USA. 
+jbanfield@berkeley.edu.
+
+Currently described members of Elusimicrobia, a relatively recently defined 
+phylum, are animal-associated and rely on fermentation. However, free-living 
+Elusimicrobia have been detected in sediments, soils and groundwater, raising 
+questions regarding their metabolic capacities and evolutionary relationship to 
+animal-associated species. Here, we analyzed 94 draft-quality, non-redundant 
+genomes, including 30 newly reconstructed genomes, from diverse 
+animal-associated and natural environments. Genomes group into 12 clades, 10 of 
+which previously lacked reference genomes. Groundwater-associated Elusimicrobia 
+are predicted to be capable of heterotrophic or autotrophic lifestyles, reliant 
+on oxygen or nitrate/nitrite-dependent respiration, or a variety of organic 
+compounds and Rhodobacter nitrogen fixation (Rnf) complex-dependent acetogenesis 
+with hydrogen and carbon dioxide as the substrates. Genomes from two clades of 
+groundwater-associated Elusimicrobia often encode a new group of nitrogenase 
+paralogs that co-occur with an extensive suite of radical S-Adenosylmethionine 
+(SAM) proteins. We identified similar genomic loci in genomes of bacteria from 
+the Gracilibacteria phylum and the Myxococcales order and predict that the gene 
+clusters reduce a tetrapyrrole, possibly to form a novel cofactor. The 
+animal-associated Elusimicrobia clades nest phylogenetically within two 
+free-living-associated clades. Thus, we propose an evolutionary trajectory in 
+which some Elusimicrobia adapted to animal-associated lifestyles from 
+free-living species via genome reduction.
+
+DOI: 10.1038/s41396-020-0716-1
+PMCID: PMC7785019
+PMID: 32681159 [Indexed for MEDLINE]
+
+Conflict of interest statement: J.F.B. is a founder of Metagenomi. The remaining 
+authors declare no competing interests.

--- a/references_cache/PMID_32849356.md
+++ b/references_cache/PMID_32849356.md
@@ -1,0 +1,60 @@
+---
+reference_id: PMID:32849356
+title: ''
+authors: []
+journal: Front Microbiol
+year: '2020'
+content_type: abstract_only
+---
+
+# PMID:32849356
+**Journal:** Front Microbiol (2020)
+
+## Content
+
+1. Front Microbiol. 2020 Jul 28;11:1694. doi: 10.3389/fmicb.2020.01694.
+eCollection  2020.
+
+Diverse Microorganisms in Sediment and Groundwater Are Implicated in 
+Extracellular Redox Processes Based on Genomic Analysis of Bioanode Communities.
+
+Arbour TJ(1), Gilbert B(1)(2), Banfield JF(1)(2)(3).
+
+Author information:
+(1)Department of Earth and Planetary Science, University of California, 
+Berkeley, Berkeley, CA, United States.
+(2)Energy Geosciences Division, Lawrence Berkeley National Laboratory, Berkeley, 
+CA, United States.
+(3)Department of Environmental Science, Policy, and Management, University of 
+California, Berkeley, Berkeley, CA, United States.
+
+Extracellular electron transfer (EET) between microbes and iron minerals, and 
+syntrophically between species, is a widespread process affecting biogeochemical 
+cycles and microbial ecology. The distribution of this capacity among microbial 
+taxa, and the thermodynamic controls on EET in complex microbial communities, 
+are not fully known. Microbial electrochemical cells (MXCs), in which electrodes 
+serve as the electron acceptor or donor, provide a powerful approach to enrich 
+for organisms capable of EET and to study their metabolism. We used MXCs coupled 
+with genome-resolved metagenomics to investigate the capacity for EET in 
+microorganisms present in a well-studied aquifer near Rifle, CO. Electroactive 
+biofilms were established and maintained for almost 4 years on anodes poised 
+mostly at -0.2 to -0.25 V vs. SHE, a range that mimics the redox potential of 
+iron-oxide minerals, using acetate as the sole carbon source. Here we report the 
+metagenomic characterization of anode-biofilm and planktonic microbial 
+communities from samples collected at timepoints across the study period. From 
+two biofilm and 26 planktonic samples we reconstructed draft-quality and 
+near-complete genomes for 84 bacteria and 2 archaea that represent the majority 
+of organisms present. A novel Geobacter sp. with at least 72 putative multiheme 
+c-type cytochromes (MHCs) was the dominant electrode-attached organism. However, 
+a diverse range of other electrode-associated organisms also harbored putative 
+MHCs with at least 10 heme-binding motifs, as well as porin-cytochrome complexes 
+and e-pili, including Actinobacteria, Ignavibacteria, Chloroflexi, 
+Acidobacteria, Firmicutes, Beta- and Gammaproteobacteria. Our results identify a 
+small subset of the thousands of organisms previously detected in the Rifle 
+aquifer that may have the potential to mediate mineral redox transformations.
+
+Copyright © 2020 Arbour, Gilbert and Banfield.
+
+DOI: 10.3389/fmicb.2020.01694
+PMCID: PMC7399161
+PMID: 32849356

--- a/references_cache/PMID_33897653.md
+++ b/references_cache/PMID_33897653.md
@@ -1,0 +1,70 @@
+---
+reference_id: PMID:33897653
+title: ''
+authors: []
+journal: Front Microbiol
+year: '2021'
+content_type: abstract_only
+---
+
+# PMID:33897653
+**Journal:** Front Microbiol (2021)
+
+## Content
+
+1. Front Microbiol. 2021 Apr 8;12:643368. doi: 10.3389/fmicb.2021.643368. 
+eCollection 2021.
+
+Thiocyanate and Organic Carbon Inputs Drive Convergent Selection for Specific 
+Autotrophic Afipia and Thiobacillus Strains Within Complex Microbiomes.
+
+Huddy RJ(1)(2), Sachdeva R(3), Kadzinga F(1)(2), Kantor RS(4), Harrison 
+STL(1)(2), Banfield JF(3)(4)(5)(6).
+
+Author information:
+(1)Centre for Bioprocess Engineering Research, University of Cape Town, Cape 
+Town, South Africa.
+(2)Future Water Institute, University of Cape Town, Cape Town, South Africa.
+(3)Innovative Genomics Institute, University of California, Berkeley, Berkeley, 
+CA, United States.
+(4)Department of Earth and Planetary Science, University of California, 
+Berkeley, Berkeley, CA, United States.
+(5)Department of Environmental Science, Policy, and Management, University of 
+California, Berkeley, Berkeley, CA, United States.
+(6)School of Earth Sciences, University of Melbourne, Melbourne, VIC, Australia.
+
+Thiocyanate (SCN-) contamination threatens aquatic ecosystems and pollutes vital 
+freshwater supplies. SCN--degrading microbial consortia are commercially adapted 
+for remediation, but the impact of organic amendments on selection within 
+SCN--degrading microbial communities has not been investigated. Here, we tested 
+whether specific strains capable of degrading SCN- could be reproducibly 
+selected for based on SCN- loading and the presence or absence of added organic 
+carbon. Complex microbial communities derived from those used to treat 
+SCN--contaminated water were exposed to systematically increased input SCN 
+concentrations in molasses-amended and -unamended reactors and in reactors 
+switched to unamended conditions after establishing the active SCN--degrading 
+consortium. Five experiments were conducted over 790 days, and genome-resolved 
+metagenomics was used to resolve community composition at the strain level. A 
+single Thiobacillus strain proliferated in all reactors at high loadings. 
+Despite the presence of many Rhizobiales strains, a single Afipia variant 
+dominated the molasses-free reactor at moderately high loadings. This strain is 
+predicted to break down SCN- using a novel thiocyanate desulfurase, oxidize 
+resulting reduced sulfur, degrade product cyanate to ammonia and CO2 via cyanate 
+hydratase, and fix CO2 via the Calvin-Benson-Bassham cycle. Removal of molasses 
+from input feed solutions reproducibly led to dominance of this strain. Although 
+sustained by autotrophy, reactors without molasses did not stably degrade SCN- 
+at high loading rates, perhaps due to loss of biofilm-associated niche 
+diversity. Overall, convergence in environmental conditions led to convergence 
+in the strain composition, although reactor history also impacted the trajectory 
+of community compositional change.
+
+Copyright © 2021 Huddy, Sachdeva, Kadzinga, Kantor, Harrison and Banfield.
+
+DOI: 10.3389/fmicb.2021.643368
+PMCID: PMC8061750
+PMID: 33897653
+
+Conflict of interest statement: JB is a founder of Metagenomi. The remaining 
+authors declare that the research was conducted in the absence of any commercial 
+or financial relationships that could be construed as a potential conflict of 
+interest.

--- a/references_cache/PMID_34622230.md
+++ b/references_cache/PMID_34622230.md
@@ -1,0 +1,62 @@
+---
+reference_id: PMID:34622230
+title: ''
+authors: []
+journal: Cell Rep Med
+year: '2021'
+content_type: abstract_only
+---
+
+# PMID:34622230
+**Journal:** Cell Rep Med (2021)
+
+## Content
+
+1. Cell Rep Med. 2021 Sep 7;2(9):100393. doi: 10.1016/j.xcrm.2021.100393. 
+eCollection 2021 Sep 21.
+
+Infant gut strain persistence is associated with maternal origin, phylogeny, and 
+traits including surface adhesion and iron acquisition.
+
+Lou YC(1), Olm MR(2), Diamond S(3), Crits-Christoph A(1), Firek BA(4), Baker 
+R(4), Morowitz MJ(4), Banfield JF(3)(5)(6)(7).
+
+Author information:
+(1)Department of Plant and Microbial Biology, University of California, 
+Berkeley, Berkeley, CA 94720, USA.
+(2)Department of Microbiology and Immunology, Stanford University School of 
+Medicine, Stanford, CA 94305, USA.
+(3)Department of Earth and Planetary Science, University of California, 
+Berkeley, CA 94709, USA.
+(4)Department of Surgery, University of Pittsburgh School of Medicine, 
+Pittsburgh, PA 15213, USA.
+(5)Department of Environmental Science, Policy, and Management, University of 
+California, Berkeley, Berkeley, CA 94720, USA.
+(6)Earth Sciences Division, Lawrence Berkeley National Laboratory, Berkeley, CA 
+94705, USA.
+(7)Chan Zuckerberg Biohub, San Francisco, CA 94158, USA.
+
+Gut microbiome succession affects infant development. However, it remains 
+unclear what factors promote persistence of initial bacterial colonizers in the 
+developing gut. Here, we perform strain-resolved analyses to compare gut 
+colonization of preterm and full-term infants throughout the first year of life 
+and evaluate associations between strain persistence and strain origin as well 
+as genetic potential. Analysis of fecal metagenomes collected from 13 full-term 
+and 9 preterm infants reveals that infants' initially distinct microbiomes 
+converge by age 1 year. Approximately 11% of early colonizers, primarily 
+Bacteroides and Bifidobacterium, persist during the first year of life, and 
+those are more prevalent in full-term, compared with preterm infants. 
+Examination of 17 mother-infant pairs reveals maternal gut strains are 
+significantly more likely to persist in the infant gut than other strains. 
+Enrichment in genes for surface adhesion, iron acquisition, and carbohydrate 
+degradation may explain persistence of some strains through the first year of 
+life.
+
+© 2021.
+
+DOI: 10.1016/j.xcrm.2021.100393
+PMCID: PMC8484513
+PMID: 34622230 [Indexed for MEDLINE]
+
+Conflict of interest statement: J.F.B. is a cofounder of Metagenomi. The other 
+authors declare no completing interests.

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-11T23:05:18
+# Generation date: 2026-05-13T00:24:48
 # Schema: communitymech
 #
 # id: https://w3id.org/culturebot-ai/communitymech
@@ -495,7 +495,7 @@ class EcologicalInteraction(YAMLRoot):
             self.interaction_type = InteractionTypeEnum(self.interaction_type)
 
         if self.scope is not None and not isinstance(self.scope, InteractionScopeEnum):
-            self.scope = InteractionScopeEnum(self.scope)
+            self.scope = getattr(InteractionScopeEnum, self.scope)
 
         if self.source_taxon is not None and not isinstance(self.source_taxon, TaxonDescriptor):
             self.source_taxon = TaxonDescriptor(**as_dict(self.source_taxon))
@@ -1615,6 +1615,10 @@ class MetalElementEnum(EnumDefinitionImpl):
         text="TITANIUM",
         description="Titanium atom",
         meaning=CHEBI["33341"])
+    MERCURY = PermissibleValue(
+        text="MERCURY",
+        description="Mercury(2+) cation",
+        meaning=CHEBI["16793"])
 
     _defn = EnumDefinition(
         name="MetalElementEnum",

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -372,6 +372,9 @@ enums:
       TITANIUM:
         meaning: CHEBI:33341
         description: Titanium atom
+      MERCURY:
+        meaning: CHEBI:16793
+        description: Mercury(2+) cation
 
   RareEarthElementEnum:
     description: Rare earth elements (lanthanides + Y, Sc)


### PR DESCRIPTION
## Summary

Adds 7 more microbial community records (CommunityMech:000239–000245) curated from the 2020–2021 Banfield-lab post-2020 candidate list, continuing the work in PRs #36 and #37.

| ID | Community | Reference | Year |
|---|---|---|---|
| 000239 | Thiocyanate Afipia/Thiobacillus bioreactor | PMID:33897653 | 2021 |
| 000240 | Infant gut strain persistence + maternal seeding | PMID:34622230 | 2021 |
| 000241 | Rifle aquifer bioanode EET | PMID:32849356 | 2020 |
| 000242 | Groundwater Elusimicrobia diverse metabolisms | PMID:32681159 | 2020 |
| 000243 | Ngawha geothermal acidic-spring Hg cycling | PMID:32414793 | 2020 |
| 000244 | Anammox bioreactor DNRA destabilization | PMID:31980038 | 2020 |
| 000245 | Avena rhizosphere/detritusphere niche succession | PMID:31953507 | 2020 |

## Test plan
- [x] `just validate` passes on all 7 community files
- [x] `just validate-terms` passes on all 7 community files
- [x] ASCII-only — no non-ASCII characters
- [x] Every snippet is a whitespace-normalized substring of the corresponding PubMed abstract cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)