### PR TITLE
Fix malformed PMID:PMC6336744 identifier

### DIFF
--- a/kb/communities/Industrial_Bioreactor_Consortium.yaml
+++ b/kb/communities/Industrial_Bioreactor_Consortium.yaml
@@ -246,7 +246,7 @@ taxonomy:
       Cuniculiplasma, and A-plasma group) and bacteria of the genera Leptospirillum, with Sulfobacillus
       and Acidithiobacillus among the dominant groups in the community
     explanation: Confirms complete genome sequencing from industrial reactor
-  - reference: PMID:PMC6336744
+  - reference: PMID:30499003
     supports: SUPPORT
     evidence_source: IN_VIVO
     snippet: Comparisons of the amino acid content of this crithidial superoxide dismutase with those
@@ -671,7 +671,7 @@ ecological_interactions:
       id: GO:0019318
       label: hexose biosynthetic process
   evidence:
-  - reference: PMID:PMC6336744
+  - reference: PMID:30499003
     supports: SUPPORT
     evidence_source: IN_VIVO
     snippet: 'fasciculata have revealed that: 1) the enzyme is located in the cytosol; 2) isozymes exist;

--- a/references_cache/PMID_30499003.md
+++ b/references_cache/PMID_30499003.md
@@ -1,0 +1,51 @@
+---
+reference_id: PMID:30499003
+title: ''
+authors: []
+journal: ''
+year: ''
+content_type: abstract_only
+---
+
+# PMID:30499003
+
+## Content
+
+1. Extremophiles. 2019 Jan;23(1):1-7. doi: 10.1007/s00792-018-1071-2. Epub 2018
+Nov  29.
+
+Cuniculiplasmataceae, their ecogenomic and metabolic patterns, and interactions 
+with 'ARMAN'.
+
+Golyshina OV(1), Bargiela R(2), Golyshin PN(2).
+
+Author information:
+(1)School of Natural Sciences, Bangor University, Deiniol Road, Bangor, LL57 
+2UW, UK. o.golyshina@bangor.ac.uk.
+(2)School of Natural Sciences, Bangor University, Deiniol Road, Bangor, LL57 
+2UW, UK.
+
+Recently, the order Thermoplasmatales was expanded through the cultivation and 
+description of species Cuniculiplasma divulgatum and corresponding family 
+Cuniculiplasmataceae. Initially isolated from acidic streamers, signatures of 
+these archaea were ubiquitously found in various low-pH settings. Eight genomes 
+with various levels of completeness are currently available, all of which 
+exhibit very high sequence identities and genomic conservation. Co-existence of 
+Cuniculiplasmataceae with archaeal Richmond Mine acidophilic nanoorganisms 
+('ARMAN')-related archaea representing an intriguing group within the "microbial 
+dark matter" suggests their common fundamental environmental strategy and 
+metabolic networking. The specific case of "Candidatus Mancarchaeum acidiphilum" 
+Mia14 phylogenetically affiliated with "Ca. Micrarchaeota" from the superphylum 
+"Ca. Diapherotrites" along with the presence of other representatives of 'DPANN' 
+with significantly reduced genomes points at a high probability of close 
+interactions between the latter and various Thermoplasmatales abundant in situ. 
+This review critically assesses our knowledge on specific functional role and 
+potential of the members of Cuniculiplasmataceae abundant in acidophilic 
+microbiomes through the analysis of distribution, physiological and genomic 
+patterns, and their interactions with 'ARMAN'-related archaea.
+
+DOI: 10.1007/s00792-018-1071-2
+PMCID: PMC6336744
+PMID: 30499003 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no conflicts of interest.

--- a/references_cache/PMID_30499003.md
+++ b/references_cache/PMID_30499003.md
@@ -1,13 +1,20 @@
 ---
 reference_id: PMID:30499003
-title: ''
-authors: []
-journal: ''
-year: ''
+title: Cuniculiplasmataceae, their ecogenomic and metabolic patterns, and interactions with 'ARMAN'.
+authors:
+- Golyshina OV
+- Bargiela R
+- Golyshin PN
+journal: Extremophiles
+year: '2019'
+doi: 10.1007/s00792-018-1071-2
 content_type: abstract_only
 ---
 
-# PMID:30499003
+# Cuniculiplasmataceae, their ecogenomic and metabolic patterns, and interactions with 'ARMAN'.
+**Authors:** Golyshina OV, Bargiela R, Golyshin PN
+**Journal:** Extremophiles (2019)
+**DOI:** [10.1007/s00792-018-1071-2](https://doi.org/10.1007/s00792-018-1071-2)
 
 ## Content
 


### PR DESCRIPTION
## Summary

The Industrial_Bioreactor_Consortium curation cited `PMID:PMC6336744`, which conflates a PMID with a PMC identifier and is rejected by the reference fetcher (`Invalid uid PMC6336744 at position= 0`). PMC ID `PMC6336744` corresponds to PMID `30499003` (Golyshina et al. 2019, Extremophiles, "Cuniculiplasmataceae, their ecogenomic and metabolic patterns, and interactions with 'ARMAN'"). This PR:

- Replaces the malformed identifier in both citing evidence blocks.
- Caches the abstract for PMID:30499003 so the reference validator can resolve it.

## Scope notes

The broader 320-error reference-snippet cleanup is out of scope here. Categorized for follow-up:
- **182 errors / 40 refs**: cache `content_type: unavailable` (paywalled or unfetchable abstracts) — would need Unpaywall/PMC full-text fetcher or curation-time access.
- **101 errors / ~22 refs**: paraphrased snippets that don't exact-match the cached abstract — per-file curation work.
- **37 errors / 11 refs** (now 10 after this PR): "Could not fetch" — paywalled DOIs or non-CrossRef DOIs (ResearchGate `10.13140/RG.*`); refetch is unlikely to succeed without a different fetcher.

The Industrial_Bioreactor_Consortium snippets formerly attributed to `PMID:PMC6336744` describe industrial-bioleach-consortium concepts and don't match the Cuniculiplasmataceae/ARMAN abstract they now resolve to. That miscitation is also out of scope here.

## Test plan
- [x] `just validate kb/communities/Industrial_Bioreactor_Consortium.yaml` passes
- [x] References cache `PMID_30499003.md` populated from PubMed

🤖 Generated with [Claude Code](https://claude.com/claude-code)