### PR TITLE
.gitignore: stop showing node_modules and data/embeddings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,12 @@ ENV/
 *~
 .DS_Store
 
+# Node tooling (pulled in by docs/web preview scripts)
+node_modules/
+
+# Generated DeepWalk embeddings (large binaries; regenerated via the embedding pipeline)
+data/embeddings/
+
 # Testing
 .pytest_cache/
 .coverage


### PR DESCRIPTION
## Summary

Both `node_modules/` and `data/embeddings/*.tsv.gz` show up as untracked on every `git status`. Neither is intended to be committed (`node_modules/` is web-preview tooling; the DeepWalk embedding archive is regenerated by the embedding pipeline). Adding entries to `.gitignore` so they stop polluting status output.

## Test plan
- [x] `git status --short` no longer lists `node_modules/` or `data/embeddings/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)