### PR TITLE
Fix 10 pre-existing test failures (anthropic SDK guard + aggregator coverage)

### DIFF
--- a/tests/test_embedding/test_aggregator.py
+++ b/tests/test_embedding/test_aggregator.py
@@ -85,8 +85,13 @@ taxonomy:
 
     try:
         aggregator = CommunityVectorAggregator(embeddings)
-        # Only 1/3 taxa have embeddings, below 0.5 threshold
-        result = aggregator.aggregate_community(yaml_path, min_coverage=0.5)
+        # Only 1/3 taxa have embeddings, below 0.5 threshold.
+        # Pass exclude_hosts=False so the strict coverage check applies;
+        # the default exclude_hosts=True treats missing taxa as hosts and
+        # would consider this community fully covered.
+        result = aggregator.aggregate_community(
+            yaml_path, min_coverage=0.5, exclude_hosts=False
+        )
 
         assert result is None
 

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -5,9 +5,15 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Try to import anthropic, but don't fail if not installed
+# Try to import anthropic, but don't fail if not installed.
+# Importing AnthropicClient succeeds even without the anthropic package
+# (the wrapper module sets `anthropic = None` in its own try/except), so
+# additionally probe for the underlying package — the tests in this file
+# patch `anthropic.Anthropic` and need the real symbol to exist.
 try:
-    from communitymech.llm.anthropic_client import AnthropicClient
+    import anthropic  # noqa: F401
+
+    from communitymech.llm.anthropic_client import AnthropicClient  # noqa: F401
 
     ANTHROPIC_AVAILABLE = True
 except ImportError:


### PR DESCRIPTION
## Summary

Two minimal test fixes that bring the suite from 10 failures to a clean run.

### `tests/test_llm_client.py`

The `ANTHROPIC_AVAILABLE` guard checked whether the wrapper module `AnthropicClient` could be imported, but that wrapper has its own `try/except` for the `anthropic` package and sets `anthropic = None` on failure — the module import always succeeds. The tests then patch `communitymech.llm.anthropic_client.anthropic.Anthropic`, which fails with `None does not have the attribute 'Anthropic'`. Probe for the underlying `anthropic` package directly so the `pytest.mark.skipif` guard actually skips the tests when the package isn't installed.

### `tests/test_embedding/test_aggregator.py::test_aggregator_low_coverage`

The aggregator's default `exclude_hosts=True` treats missing taxa as host organisms and reports 100% coverage, bypassing the `min_coverage` check. Pass `exclude_hosts=False` to exercise the strict coverage code path the test documents.

## Test plan
- [x] `uv run pytest tests/` — 102 passed, 9 skipped, 0 failed (previously 10 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)