### PR TITLE
Add 7 more Banfield post-2020 community entries (round 4)

### DIFF
--- a/kb/communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.yaml
+++ b/kb/communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.yaml
@@ -27,8 +27,6 @@ taxonomy:
       label: Severe acute respiratory syndrome coronavirus 2
     notes: Complete and nearly complete SARS-CoV-2 genomes assembled from
       municipal sewage metatranscriptomes.
-  functional_role:
-  - PRIMARY_DEGRADER
   evidence:
   - reference: PMID:33468686
     supports: SUPPORT

--- a/kb/communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.yaml
+++ b/kb/communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.yaml
@@ -1,0 +1,101 @@
+id: CommunityMech:000249
+name: San Francisco Bay Area Sewage SARS-CoV-2 Metagenomic Surveillance Community
+description: >
+  A metatranscriptomic surveillance community in municipal sewage from the
+  San Francisco Bay Area used to detect regionally prevalent SARS-CoV-2
+  variants during the COVID-19 pandemic. RNA was sequenced directly from
+  sewage collected by municipal utility districts to generate complete and
+  nearly complete SARS-CoV-2 genomes. The major consensus SARS-CoV-2
+  genotypes detected in sewage were identical to clinical genotypes, showing
+  that wastewater metatranscriptomics can profile viral genetic diversity at
+  the community scale.
+ecological_state: STABLE
+community_origin: NATURAL
+community_category: OTHER
+environment_term:
+  preferred_term: municipal wastewater sewage
+  term:
+    id: ENVO:00002047
+    label: waste water
+  notes: Municipal sewage from utility districts in the San Francisco Bay
+    Area collected for direct RNA sequencing.
+taxonomy:
+- taxon_term:
+    preferred_term: SARS-CoV-2 sewage population
+    term:
+      id: NCBITaxon:2697049
+      label: Severe acute respiratory syndrome coronavirus 2
+    notes: Complete and nearly complete SARS-CoV-2 genomes assembled from
+      municipal sewage metatranscriptomes.
+  functional_role:
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:33468686
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: generate complete and nearly complete SARS-CoV-2 genomes
+    explanation: Supports the SARS-CoV-2 population recovered from sewage.
+ecological_interactions:
+- name: Wastewater Genotype Matches Clinical Consensus
+  description: The major consensus SARS-CoV-2 genotypes detected in sewage
+    were identical to clinical genotypes, validating wastewater metatranscriptomics
+    as a community-scale surveillance approach.
+  interaction_type: COMMENSALISM
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:33468686
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: The major consensus SARS-CoV-2 genotypes detected in the sewage
+      were identical to clinical
+    explanation: Supports the sewage-versus-clinical genotype concordance.
+- name: Metatranscriptomic Profiling of Viral Genetic Diversity
+  description: Direct RNA sequencing of municipal wastewater can be used to
+    profile viral genetic diversity across infected communities, extending
+    earlier qPCR-based abundance quantification.
+  interaction_type: COMMENSALISM
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:33468686
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: metatranscriptomic sequencing of wastewater can be used to profile
+      the viral genetic diversity across infected communities
+    explanation: Supports the metatranscriptomic surveillance approach.
+environmental_factors:
+- name: Sampling region
+  value: San Francisco Bay Area municipal utility districts
+  description: Sewage was collected by municipal utility districts in the San
+    Francisco Bay Area.
+  evidence:
+  - reference: PMID:33468686
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: sewage collected by municipal utility districts in the San
+      Francisco Bay Area
+    explanation: Supports the sampling locale.
+growth_media: []
+external_resources:
+- name: Primary publication for the Bay Area sewage SARS-CoV-2 community
+  repository: OTHER
+  resource_id: PMID:33468686
+  url: https://pubmed.ncbi.nlm.nih.gov/33468686/
+  description: PubMed record for the Crits-Christoph et al. 2021 mBio paper.
+  evidence:
+  - reference: PMID:33468686
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Genome Sequencing of Sewage Detects Regionally Prevalent
+      SARS-CoV-2 Variants
+    explanation: Lists the primary publication.
+- name: DOI landing page
+  repository: OTHER
+  resource_id: doi:10.1128/mBio.02703-20
+  url: https://doi.org/10.1128/mBio.02703-20
+  description: DOI link to the mBio paper.
+associated_datasets: []
+metals_present: []
+rare_earth_elements_present: []
+metal_relevance: NOT_APPLICABLE
+metal_notes: No metal or rare earth element processing role is curated for this
+  wastewater SARS-CoV-2 surveillance community.

--- a/kb/communities/Candida_Parapsilosis_Hospitalized_Infant_Microbiome.yaml
+++ b/kb/communities/Candida_Parapsilosis_Hospitalized_Infant_Microbiome.yaml
@@ -1,0 +1,107 @@
+id: CommunityMech:000248
+name: Candida parapsilosis Hospitalized Infant Gut Microbiome Community
+description: >
+  An in situ infant gut microbiome study of Candida parapsilosis colonization
+  in hospitalized infants, combining genomics, transcriptomics, and proteomics.
+  Five unique C. parapsilosis genomes were assembled from infant gut samples
+  and compared, providing the first multi-omics characterization of how this
+  common cause of invasive candidiasis adapts genetically and behaviorally to
+  the developing infant microbiome context. The work fills a gap left by
+  pure-culture studies and informs understanding of how C. parapsilosis
+  functions in a microbiome rather than in isolation.
+ecological_state: STABLE
+community_origin: NATURAL
+community_category: OTHER
+environment_term:
+  preferred_term: hospitalized infant gut microbiome
+  term:
+    id: ENVO:00002009
+    label: feces environment
+  notes: In situ infant gut samples from hospitalized infants, profiled with
+    genomics, transcriptomics, and proteomics to characterize C. parapsilosis
+    behavior within the resident microbiome.
+taxonomy:
+- taxon_term:
+    preferred_term: Candida parapsilosis
+    term:
+      id: NCBITaxon:5480
+      label: Candida parapsilosis
+    notes: A common cause of invasive candidiasis, especially in newborn
+      infants, with five unique genomes assembled from this cohort.
+  functional_role:
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:34154658
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Candida parapsilosis is a common cause of invasive candidiasis,
+      especially in newborn infants
+    explanation: Supports the C. parapsilosis identity and clinical relevance.
+  - reference: PMID:34154658
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: we compare five unique C. parapsilosis genomes assembled from
+    explanation: Supports the five-genome strain-resolved analysis.
+ecological_interactions:
+- name: Genetic and Behavioral Adaptation in Microbiome Context
+  description: C. parapsilosis exhibits genetic and behavioral adaptation
+    revealed by in situ genomics, transcriptomics, and proteomics that pure-
+    culture work has missed, indicating microbiome-specific functions.
+  interaction_type: COMMENSALISM
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:34154658
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Genetic and behavioral adaptation of Candida parapsilosis to the
+      microbiome of hospitalized infants revealed by in situ genomics,
+      transcriptomics, and proteomics
+    explanation: Supports the multi-omics-based adaptation finding.
+- name: Microbiome Context Versus Pure Culture
+  description: Pure-culture studies leave gaps about how C. parapsilosis
+    behaves in a microbiome context; this study addresses those gaps with
+    in situ data.
+  interaction_type: COMMENSALISM
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:34154658
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: C. parapsilosis has been primarily studied in pure culture,
+      leaving gaps in understanding of its function in a microbiome context
+    explanation: Supports the curated gap-and-fill rationale.
+environmental_factors:
+- name: Clinical setting
+  value: hospitalized infants
+  description: Infants in a hospitalized setting provided the in situ samples
+    used to study C. parapsilosis colonization.
+  evidence:
+  - reference: PMID:34154658
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: microbiome of hospitalized infants
+    explanation: Supports the hospitalized-infant cohort.
+growth_media: []
+external_resources:
+- name: Primary publication for the C. parapsilosis hospitalized-infant community
+  repository: OTHER
+  resource_id: PMID:34154658
+  url: https://pubmed.ncbi.nlm.nih.gov/34154658/
+  description: PubMed record for the West et al. 2021 Microbiome paper.
+  evidence:
+  - reference: PMID:34154658
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Genetic and behavioral adaptation of Candida parapsilosis
+    explanation: Lists the primary publication.
+- name: DOI landing page
+  repository: OTHER
+  resource_id: doi:10.1186/s40168-021-01085-y
+  url: https://doi.org/10.1186/s40168-021-01085-y
+  description: DOI link to the Microbiome paper.
+associated_datasets: []
+metals_present: []
+rare_earth_elements_present: []
+metal_relevance: NOT_APPLICABLE
+metal_notes: No metal or rare earth element processing role is curated for this
+  hospitalized-infant Candida community.

--- a/kb/communities/Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community.yaml
+++ b/kb/communities/Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community.yaml
@@ -1,0 +1,174 @@
+id: CommunityMech:000252
+name: Crystal Geyser CO2-Rich Aquifer Autotrophic CPR Lysolipid Community
+description: >
+  A deep CO2-rich subsurface aquifer community below the Colorado Plateau,
+  sampled from groundwater brought to the surface by eruptions of Crystal
+  Geyser. Coupled lipidomic and metagenomic analyses show that bacterial and
+  archaeal CO2 fixation in the deep subsurface provides the organic carbon
+  pool, supporting an autotrophy-based deep biosphere. Candidate Phyla
+  Radiation (CPR) bacterial putative symbionts lack complete lipid
+  biosynthesis pathways but still possess regular lipid membranes, which may
+  originate from other community members; these other members also adapt to
+  high in situ pressure by increasing fatty acid unsaturation. An unusually
+  high abundance of lysolipids attributed to CPR bacteria may represent an
+  adaptation to membrane curvature stress induced by their small cell sizes.
+ecological_state: STABLE
+community_origin: NATURAL
+community_category: EXTREME_ENVIRONMENT
+environment_term:
+  preferred_term: deep CO2-rich subsurface aquifer
+  term:
+    id: ENVO:01001004
+    label: groundwater
+  notes: Sediment-hosted CO2-rich aquifers deep below the Colorado Plateau,
+    sampled at Crystal Geyser eruptions.
+taxonomy:
+- taxon_term:
+    preferred_term: deep-aquifer CPR bacteria
+    term:
+      id: NCBITaxon:1783234
+      label: Patescibacteria
+    notes: CPR bacterial putative symbionts unable to synthesize complete
+      membrane lipids; carry unusually abundant lysolipids.
+  functional_role:
+  - SYNTROPHIC_PARTNER
+  evidence:
+  - reference: PMID:32203118
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Candidate Phyla Radiation (CPR) bacteria that are putative
+      symbionts unable to synthesize membrane lipids
+    explanation: Supports the CPR bacterial members and their lipid-synthesis
+      deficit.
+- taxon_term:
+    preferred_term: deep-aquifer CO2-fixing bacteria and archaea
+    term:
+      id: NCBITaxon:131567
+      label: cellular organisms
+    notes: Bacteria and archaea performing CO2 fixation in the deep
+      subsurface and contributing membrane lipids to CPR partners.
+  functional_role:
+  - PRIMARY_PRODUCER
+  evidence:
+  - reference: PMID:32203118
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: bacterial and archaeal CO2 fixation ongoing in the deep subsurface
+      provides organic carbon
+    explanation: Supports the CO2-fixing autotrophic members.
+ecological_interactions:
+- name: Autotrophy-Based Deep Biosphere
+  description: Microbial lipid stable-carbon-isotope compositions show that
+    bacterial and archaeal CO2 fixation in the deep subsurface provides the
+    organic carbon for the complex communities residing there.
+  interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
+  metabolites:
+  - preferred_term: carbon dioxide
+    term:
+      id: CHEBI:16526
+      label: carbon dioxide
+  biological_processes:
+  - preferred_term: carbon fixation
+    term:
+      id: GO:0015977
+      label: carbon fixation
+  evidence:
+  - reference: PMID:32203118
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: bacterial and archaeal CO2 fixation ongoing in the deep
+      subsurface provides organic carbon for the complex communities that
+      reside there
+    explanation: Supports the curated autotrophy-driven carbon source.
+- name: Lipid Redistribution to CPR Symbionts
+  description: CPR bacteria possess regular lipid membranes despite lacking
+    complete lipid biosynthesis pathways; lipids likely originate from other
+    community members, with the partner bacteria/archaea also adapting to
+    high in situ pressure via increased fatty acid unsaturation.
+  interaction_type: SYNTROPHY
+  source_taxon:
+    preferred_term: deep-aquifer CO2-fixing bacteria and archaea
+    term:
+      id: NCBITaxon:131567
+      label: cellular organisms
+  target_taxon:
+    preferred_term: deep-aquifer CPR bacteria
+    term:
+      id: NCBITaxon:1783234
+      label: Patescibacteria
+  evidence:
+  - reference: PMID:32203118
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: CPR bacteria lack complete lipid biosynthesis pathways but still
+      possess regular lipid membranes
+    explanation: Supports the curated CPR lipid sourcing.
+  - reference: PMID:32203118
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: adapt to high in situ pressure by increasing fatty acid
+      unsaturation
+    explanation: Supports the pressure-adaptive unsaturation of partner lipids.
+- name: CPR Lysolipid Enrichment as Curvature Adaptation
+  description: Unusually high abundance of lysolipids attributed to CPR
+    bacteria may represent an adaptation to membrane curvature stress induced
+    by their small cell sizes.
+  interaction_type: COMMENSALISM
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:32203118
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: An unusually high abundance of lysolipids attributed to CPR
+      bacteria may represent an adaptation to membrane curvature stress
+      induced by their small cell sizes
+    explanation: Supports the curated lysolipid-curvature-adaptation hypothesis.
+environmental_factors:
+- name: Aquifer chemistry
+  value: CO2-rich Colorado Plateau aquifers
+  description: Sediment-hosted CO2-rich aquifers below the Colorado Plateau
+    sustain the deep-biosphere community.
+  evidence:
+  - reference: PMID:32203118
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Sediment-hosted CO2-rich aquifers deep below the Colorado Plateau
+    explanation: Supports the curated aquifer setting.
+- name: Sampling vehicle
+  value: Crystal Geyser eruptions
+  description: Cells were collected from deep groundwater brought to the
+    surface by eruptions of Crystal Geyser.
+  evidence:
+  - reference: PMID:32203118
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: deep groundwater brought to the surface by eruptions of Crystal
+      Geyser
+    explanation: Supports the curated sampling locale.
+growth_media: []
+external_resources:
+- name: Primary publication for the Crystal Geyser CPR lipid community
+  repository: OTHER
+  resource_id: PMID:32203118
+  url: https://pubmed.ncbi.nlm.nih.gov/32203118/
+  description: PubMed record for the Probst et al. 2020 ISME J paper.
+  evidence:
+  - reference: PMID:32203118
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Lipid analysis of CO(2)-rich subsurface aquifers suggests an
+      autotrophy-based deep biosphere with lysolipids enriched in CPR
+      bacteria
+    explanation: Lists the primary publication.
+- name: DOI landing page
+  repository: OTHER
+  resource_id: doi:10.1038/s41396-020-0624-4
+  url: https://doi.org/10.1038/s41396-020-0624-4
+  description: DOI link to the ISME J paper.
+associated_datasets: []
+metals_present: []
+rare_earth_elements_present: []
+metal_relevance: NOT_APPLICABLE
+metal_notes: No metal or rare earth element processing role is curated for this
+  deep-biosphere CPR community.

--- a/kb/communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.yaml
+++ b/kb/communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.yaml
@@ -1,0 +1,131 @@
+id: CommunityMech:000253
+name: Premature Infant Gut Escherichia In-Situ Physiological-Condition Community
+description: >
+  A premature infant gut microbiome study that combines metagenomic and
+  metatranscriptomic sequencing to probe the in situ physiological
+  conditions experienced by Escherichia spp. in four premature infants
+  (two of whom developed necrotizing enterocolitis, NEC). Twenty fecal
+  samples spanning 4-6 time points per infant were analyzed using
+  sample-specific metagenome-assembled genomes (MAGs) as references for
+  transcript mapping, and a "diametric ratio" method that compares
+  transcript ratios of genes with opposite transcription responses to
+  eliminate biases related to organism abundance. Diametric ratios of genes
+  associated with low oxygen levels were significantly higher in samples
+  from infants later diagnosed with NEC than in samples without NEC, and
+  the method extends to other physiological conditions such as nitric
+  oxide exposure and osmotic pressure.
+ecological_state: PERTURBED
+community_origin: NATURAL
+community_category: OTHER
+environment_term:
+  preferred_term: premature infant gut microbiome
+  term:
+    id: ENVO:00002009
+    label: feces environment
+  notes: Twenty fecal samples (4-6 time points each) from four premature
+    infants; two infants later developed necrotizing enterocolitis.
+taxonomy:
+- taxon_term:
+    preferred_term: premature-infant-gut Escherichia spp.
+    term:
+      id: NCBITaxon:561
+      label: Escherichia
+    notes: Escherichia spp. whose in situ physiological conditions were
+      probed via metagenomic and metatranscriptomic sequencing.
+  functional_role:
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:32130257
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: the environmental conditions experienced by Escherichia spp. in
+      the gut of 4 premature infants
+    explanation: Supports the Escherichia spp. members and cohort.
+ecological_interactions:
+- name: Higher Low-Oxygen Diametric Ratios in NEC Samples
+  description: Diametric ratios of genes associated with low oxygen levels
+    were significantly higher in samples from infants later diagnosed with
+    NEC than in samples without NEC, suggesting hypoxic conditions in the
+    NEC-developing gut.
+  interaction_type: COMMENSALISM
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:32130257
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: significantly higher diametric ratios of genes associated with
+      low oxygen levels in samples of infants later diagnosed with NEC than
+      in samples without NEC
+    explanation: Supports the curated NEC-versus-non-NEC oxygen-condition
+      difference.
+- name: Diametric-Ratio Generalizes to Other Conditions
+  description: The diametric-ratio method extends beyond oxygen to examine
+    other physiological conditions such as nitric oxide exposure and
+    osmotic pressure.
+  interaction_type: COMMENSALISM
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:32130257
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: this method can be used for examining other physiological
+      conditions, such as exposure to nitric oxide and osmotic pressure
+    explanation: Supports the method generalization.
+- name: MAG-Anchored Diametric-Ratio In Situ Physiology
+  description: Sample-specific metagenome-assembled genomes (MAGs) anchored
+    transcript mapping, and transcript ratios of genes with opposite
+    transcription responses (the diametric-ratio method) eliminated biases
+    related to organism abundance.
+  interaction_type: COMMENSALISM
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:32130257
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Sample-specific meta-genomic assembled genomes (MAGs) were used
+      as reference genomes to accurately identify the origin of RNA reads
+    explanation: Supports the MAG-anchored mapping.
+  - reference: PMID:32130257
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: transcript ratios of genes with opposite transcription responses
+      were compared to eliminate biases related to differences in organismal
+      abundance
+    explanation: Supports the curated diametric-ratio method.
+environmental_factors:
+- name: Cohort composition
+  value: 4 premature infants, 2 with NEC, 20 fecal samples
+  description: Four premature infants, two of whom developed necrotizing
+    enterocolitis; 20 fecal samples (4-6 time points per infant).
+  evidence:
+  - reference: PMID:32130257
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: twenty fecal samples taken from four premature infants
+    explanation: Supports the cohort design.
+growth_media: []
+external_resources:
+- name: Primary publication for the premature-infant Escherichia community
+  repository: OTHER
+  resource_id: PMID:32130257
+  url: https://pubmed.ncbi.nlm.nih.gov/32130257/
+  description: PubMed record for the 2020 PLoS ONE paper.
+  evidence:
+  - reference: PMID:32130257
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Combined analysis of microbial metagenomic and metatranscriptomic
+      sequencing data to assess in situ physiological conditions in the
+      premature infant gut
+    explanation: Lists the primary publication.
+- name: DOI landing page
+  repository: OTHER
+  resource_id: doi:10.1371/journal.pone.0229537
+  url: https://doi.org/10.1371/journal.pone.0229537
+  description: DOI link to the PLoS ONE paper.
+associated_datasets: []
+metals_present: []
+rare_earth_elements_present: []
+metal_relevance: NOT_APPLICABLE
+metal_notes: No metal or rare earth element processing role is curated for this
+  premature-infant gut community.

--- a/kb/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.yaml
+++ b/kb/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.yaml
@@ -1,0 +1,158 @@
+id: CommunityMech:000250
+name: Soil Biosynthetic Gene Cluster Phylum-Depth-Vegetation Community
+description: >
+  A soil bacterial community surveyed for secondary-metabolite biosynthetic
+  gene cluster (BGC) content across three sites in a northern California
+  Critical Zone Observatory with varying vegetation and bedrock. 1,334
+  metagenome-assembled genomes were reconstructed and screened for BGCs,
+  including genomes for prolific producers among Actinobacteria, Chloroflexi,
+  and candidate phylum Candidatus Dormibacteraeota. One Candidate Phyla
+  Radiation (CPR) bacterial genome encoded a ribosomally synthesized linear
+  azole/azoline-containing peptide, a capacity also found in other publicly
+  available CPR genomes. Bacteria with higher biosynthetic potential were
+  enriched in shallow soils and grassland soils, with BGC-type patterns
+  varying by taxonomy.
+ecological_state: STABLE
+community_origin: NATURAL
+community_category: RHIZOSPHERE
+environment_term:
+  preferred_term: California Critical Zone Observatory soil and saprolite
+  term:
+    id: ENVO:00005750
+    label: grassland soil
+  notes: Soils and saprolite from three sites in a northern California
+    Critical Zone Observatory with various vegetation and bedrock.
+taxonomy:
+- taxon_term:
+    preferred_term: Actinobacteria (prolific BGC producers)
+    term:
+      id: NCBITaxon:201174
+      label: Actinomycetota
+  functional_role:
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:32546614
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: novel groups within the Actinobacteria, Chloroflexi, and candidate
+      phylum "Candidatus Dormibacteraeota."
+    explanation: Supports Actinobacteria as a prolific BGC-producing phylum.
+- taxon_term:
+    preferred_term: Chloroflexi (prolific BGC producers)
+    term:
+      id: NCBITaxon:200795
+      label: Chloroflexota
+  functional_role:
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:32546614
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: novel groups within the Actinobacteria, Chloroflexi, and candidate
+      phylum "Candidatus Dormibacteraeota."
+    explanation: Supports Chloroflexi as a prolific BGC-producing phylum.
+- taxon_term:
+    preferred_term: Candidatus Dormibacteraeota (prolific BGC producers)
+    term:
+      id: NCBITaxon:1798711
+      label: Dormibacterota
+  functional_role:
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:32546614
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: candidate phylum "Candidatus Dormibacteraeota."
+    explanation: Supports Dormibacteraeota as a prolific BGC-producing
+      candidate phylum.
+- taxon_term:
+    preferred_term: BGC-encoding CPR bacterium
+    term:
+      id: NCBITaxon:1783234
+      label: Patescibacteria
+    notes: A CPR genome encoded a ribosomally synthesized linear
+      azole/azoline-containing peptide BGC, a capacity also seen in other
+      publicly available CPR genomes.
+  functional_role:
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:32546614
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: one genome of a candidate phyla radiation (CPR) bacterium coded
+      for a ribosomally synthesized linear azole/azoline-containing peptide
+    explanation: Supports the curated CPR BGC capacity.
+ecological_interactions:
+- name: BGC Biosynthetic Potential Varies with Phylum, Depth, and Vegetation
+  description: The genetic potential to produce specialized metabolites
+    differs with soil depth and vegetation type within a geographic region,
+    and across the phylogenetic diversity of soil bacteria.
+  interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:32546614
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Bacterial Secondary Metabolite Biosynthetic Potential in Soil
+      Varies with Phylum, Depth, and Vegetation Type
+    explanation: Supports the curated phylum-depth-vegetation axes.
+- name: Shallow and Grassland Soils Enrich BGC-Rich Bacteria
+  description: Bacteria with higher biosynthetic potential are enriched in
+    shallow soils and grassland soils, with BGC-type patterns of abundance
+    varying by taxonomy.
+  interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:32546614
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: bacteria with higher biosynthetic potential were enriched in
+      shallow soils and grassland soils, with patterns of abundance of BGC
+      type varying by taxonomy
+    explanation: Supports the depth and vegetation enrichment.
+environmental_factors:
+- name: Site number
+  value: three Critical Zone Observatory sites
+  description: Soils and saprolite from three sites with various vegetation
+    and bedrock characteristics.
+  evidence:
+  - reference: PMID:32546614
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: three sites in a northern California Critical Zone Observatory
+      with various vegetation and bedrock characteristics
+    explanation: Supports the three-site design.
+- name: Genome count
+  value: 1,334 metagenome-assembled genomes
+  description: 1,334 MAGs were reconstructed and screened for BGCs.
+  evidence:
+  - reference: PMID:32546614
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: 1,334 metagenome-assembled genomes containing diverse biosynthetic
+      gene clusters (BGCs) for secondary metabolite production
+    explanation: Supports the genome-resolution scale.
+growth_media: []
+external_resources:
+- name: Primary publication for the soil BGC community
+  repository: OTHER
+  resource_id: PMID:32546614
+  url: https://pubmed.ncbi.nlm.nih.gov/32546614/
+  description: PubMed record for the Sharrar et al. 2020 mBio paper.
+  evidence:
+  - reference: PMID:32546614
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Bacterial Secondary Metabolite Biosynthetic Potential in Soil
+    explanation: Lists the primary publication.
+- name: DOI landing page
+  repository: OTHER
+  resource_id: doi:10.1128/mBio.00416-20
+  url: https://doi.org/10.1128/mBio.00416-20
+  description: DOI link to the mBio paper.
+associated_datasets: []
+metals_present: []
+rare_earth_elements_present: []
+metal_relevance: NOT_APPLICABLE
+metal_notes: No metal or rare earth element processing role is curated for this
+  soil-BGC community.

--- a/kb/communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.yaml
+++ b/kb/communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.yaml
@@ -1,0 +1,125 @@
+id: CommunityMech:000247
+name: Soil CPR Bacteria and Nanoarchaea Rare-Biosphere Community
+description: >
+  A rare-biosphere community of Candidate Phyla Radiation (CPR) bacteria and
+  DPANN archaea recovered from grassland soil by concentrating particles
+  smaller than 0.2 micrometers prior to metagenomic sequencing. CPR and
+  DPANN sequences were enriched 100- to 1,000-fold compared to bulk soil
+  (estimated at roughly 1 to 100 cells per gram of soil for each lineage)
+  and include Doudnabacteria (SM2F11) and Pacearchaeota - organisms rarely
+  reported in soil - alongside Saccharibacteria, Parcubacteria, and
+  Microgenomates as well as Diapherotrites, Parvarchaeota, Aenigmarchaeota,
+  Nanoarchaeota, and Nanohaloarchaeota. Most members likely live symbiotic
+  anaerobic lifestyles, but some Saccharibacteria, Parcubacteria, and
+  Doudnabacteria encode components of aerobic metabolism that may be
+  particularly relevant in oxic soil habitats.
+ecological_state: STABLE
+community_origin: NATURAL
+community_category: RHIZOSPHERE
+environment_term:
+  preferred_term: grassland soil rare biosphere (< 0.2 um fraction)
+  term:
+    id: ENVO:00005750
+    label: grassland soil
+  notes: Sub-0.2-micrometer fraction of grassland soil enriched for CPR
+    bacteria and DPANN archaea.
+taxonomy:
+- taxon_term:
+    preferred_term: soil Candidate Phyla Radiation (CPR) bacteria
+    term:
+      id: NCBITaxon:1783234
+      label: Patescibacteria
+    notes: Includes Doudnabacteria (SM2F11), Saccharibacteria, Parcubacteria,
+      and Microgenomates recovered from grassland soil.
+  functional_role:
+  - SYNTROPHIC_PARTNER
+  evidence:
+  - reference: PMID:34402646
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Doudnabacteria (SM2F11) and Pacearchaeota, organisms rarely
+      reported in soil, as well as Saccharibacteria, Parcubacteria, and
+      Microgenomates
+    explanation: Supports the soil CPR membership.
+- taxon_term:
+    preferred_term: soil DPANN archaea
+    term:
+      id: NCBITaxon:1934217
+      label: DPANN group
+    notes: DPANN archaea recovered from the rare biosphere include
+      Diapherotrites, Parvarchaeota, Aenigmarchaeota, Nanoarchaeota, and
+      Nanohaloarchaeota.
+  functional_role:
+  - SYNTROPHIC_PARTNER
+  evidence:
+  - reference: PMID:34402646
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: archaea of the phyla Diapherotrites, Parvarchaeota, Aenigmarchaeota,
+      Nanoarchaeota, and Nanohaloarchaeota (DPANN)
+    explanation: Supports the soil DPANN archaeal membership.
+ecological_interactions:
+- name: Rare-Biosphere Enrichment via Size Filtration
+  description: Particles smaller than 0.2 micrometers concentrated from
+    grassland soil enriched CPR and DPANN sequences 100- to 1,000-fold
+    compared to bulk soil, exposing organisms estimated at 1 to 100 cells
+    per gram.
+  interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:34402646
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: enriched 100- to 1,000-fold compared to that in bulk soil
+    explanation: Supports the enrichment factor of size-filtration.
+- name: Aerobic-Metabolism Components in Soil CPR
+  description: Some soil Saccharibacteria, Parcubacteria, and Doudnabacteria
+    encode components of aerobic metabolism, indicating adaptation to oxic
+    soil conditions despite the predominantly anaerobic lifestyles of CPR
+    elsewhere.
+  interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:34402646
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Soil Candidate Phyla Radiation Bacteria Encode Components of
+      Aerobic Metabolism
+    explanation: Supports the aerobic-metabolism component finding.
+environmental_factors:
+- name: Particle size filtration
+  value: < 0.2 micrometer fraction
+  description: Particles smaller than 0.2 micrometers were concentrated to
+    target ultra-small CPR bacteria and DPANN archaea.
+  evidence:
+  - reference: PMID:34402646
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: concentrated particles of less than 0.2 μm in size from grassland
+      soil
+    explanation: Supports the size-fractionation perturbation.
+growth_media: []
+external_resources:
+- name: Primary publication for the soil CPR/DPANN rare-biosphere community
+  repository: OTHER
+  resource_id: PMID:34402646
+  url: https://pubmed.ncbi.nlm.nih.gov/34402646/
+  description: PubMed record for the Nicolas et al. 2021 mSystems paper.
+  evidence:
+  - reference: PMID:34402646
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Soil Candidate Phyla Radiation Bacteria Encode Components of
+      Aerobic Metabolism and Co-occur with Nanoarchaea
+    explanation: Lists the primary publication.
+- name: DOI landing page
+  repository: OTHER
+  resource_id: doi:10.1128/mSystems.01205-20
+  url: https://doi.org/10.1128/mSystems.01205-20
+  description: DOI link to the mSystems paper.
+associated_datasets: []
+metals_present: []
+rare_earth_elements_present: []
+metal_relevance: NOT_APPLICABLE
+metal_notes: No metal or rare earth element processing role is curated for this
+  CPR/DPANN soil rare-biosphere community.

--- a/kb/communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.yaml
+++ b/kb/communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.yaml
@@ -95,9 +95,10 @@ environmental_factors:
   - reference: PMID:34402646
     supports: SUPPORT
     evidence_source: IN_VIVO
-    snippet: concentrated particles of less than 0.2 μm in size from grassland
-      soil
-    explanation: Supports the size-fractionation perturbation.
+    snippet: concentrated particles of less than 0.2
+    explanation: Supports the size-fractionation perturbation (the 0.2 micrometer
+      threshold; the full abstract phrase contains a non-ASCII Greek mu character
+      and is shortened here to preserve ASCII-only files).
 growth_media: []
 external_resources:
 - name: Primary publication for the soil CPR/DPANN rare-biosphere community

--- a/kb/communities/Subsurface_Carboxydocella_CO_Aquifer_Community.yaml
+++ b/kb/communities/Subsurface_Carboxydocella_CO_Aquifer_Community.yaml
@@ -1,0 +1,119 @@
+id: CommunityMech:000251
+name: Subsurface Carboxydocella CO-Oxidation Aquifer Community
+description: >
+  A deep subsurface (1.4 km) aquifer microbial community perturbed by
+  injection of 150 tons of supercritical CO2 (scCO2) in a geosequestration
+  experiment. Detailed genome-resolved metagenomics resolved the native
+  carboxydotrophic Carboxydocella, a thermophilic CO-utilizing anaerobe
+  whose relative abundance decreased post-scCO2 injection. Analysis of its
+  carbon monoxide dehydrogenase (CODH) gene before and after the experiment
+  documented a switch in CO-oxidation potential by Carboxydocella, with
+  implications for subsurface flow of carbon and electrons from oxidation
+  of the metabolic intermediate CO.
+ecological_state: PERTURBED
+community_origin: NATURAL
+community_category: CARBON_SEQUESTRATION
+environment_term:
+  preferred_term: deep aquifer geosequestration test bed
+  term:
+    id: ENVO:01001004
+    label: groundwater
+  notes: A 1.4 km deep aquifer used for a 150-ton supercritical CO2
+    injection experiment.
+taxonomy:
+- taxon_term:
+    preferred_term: Carboxydocella (thermophilic CO-utilizing anaerobe)
+    term:
+      id: NCBITaxon:341113
+      label: Carboxydocella
+    notes: Native carboxydotrophic Carboxydocella whose relative abundance
+      decreased post-scCO2 injection.
+  functional_role:
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:32633030
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: the thermophilic CO-utilizing anaerobe Carboxydocella, which
+      decreased in relative abundance post-scCO2 injection
+    explanation: Supports the Carboxydocella member and its post-injection
+      decline.
+ecological_interactions:
+- name: CODH-Mediated Subsurface CO Oxidation
+  description: Carboxydocella performs CO oxidation in the deep aquifer via
+    its carbon monoxide dehydrogenase (CODH) gene, with the CODH activity
+    switching after the scCO2 injection experiment.
+  interaction_type: CROSS_FEEDING
+  scope: COMMUNITY_LEVEL
+  biological_processes:
+  - preferred_term: oxidation-reduction process
+    term:
+      id: GO:0055114
+      label: oxidation-reduction process
+  evidence:
+  - reference: PMID:32633030
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: a switch in CO-oxidation potential by Carboxydocella through
+      analysis of its carbon monoxide dehydrogenase (CODH) gene before and
+      after the geosequestration experiment
+    explanation: Supports the CODH-driven CO-oxidation function and its switch.
+- name: scCO2 Injection Reshapes Subsurface Community
+  description: Injection of 150 tons of supercritical CO2 in a geosequestration
+    experiment changed the microbial community structure of the deep aquifer,
+    with Carboxydocella playing a key role.
+  interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
+  evidence:
+  - reference: PMID:32633030
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: changes to the microbial community structure of a deep aquifer
+      (1.4 km) receiving 150 tons of injected supercritical CO2
+    explanation: Supports the scCO2 injection effect on community structure.
+environmental_factors:
+- name: Supercritical CO2 injection
+  value: 150 tons of injected scCO2
+  description: 150 tons of supercritical CO2 were injected into the deep
+    aquifer in a geosequestration experiment.
+  evidence:
+  - reference: PMID:32633030
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: 150 tons of injected supercritical CO2 (scCO2 )
+    explanation: Supports the scCO2 perturbation magnitude.
+- name: Aquifer depth
+  value: 1.4 km below surface
+  description: The host aquifer is 1.4 km below the surface.
+  evidence:
+  - reference: PMID:32633030
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: a deep aquifer (1.4 km)
+    explanation: Supports the aquifer depth.
+growth_media: []
+external_resources:
+- name: Primary publication for the Carboxydocella aquifer community
+  repository: OTHER
+  resource_id: PMID:32633030
+  url: https://pubmed.ncbi.nlm.nih.gov/32633030/
+  description: PubMed record for the Mu et al. 2020 Environmental Microbiology
+    Reports paper.
+  evidence:
+  - reference: PMID:32633030
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Subsurface carbon monoxide oxidation capacity revealed through
+      genome-resolved metagenomics of a carboxydotroph
+    explanation: Lists the primary publication.
+- name: DOI landing page
+  repository: OTHER
+  resource_id: doi:10.1111/1758-2229.12868
+  url: https://doi.org/10.1111/1758-2229.12868
+  description: DOI link to the Environmental Microbiology Reports paper.
+associated_datasets: []
+metals_present: []
+rare_earth_elements_present: []
+metal_relevance: NOT_APPLICABLE
+metal_notes: No metal or rare earth element processing role is curated for this
+  Carboxydocella aquifer community.

--- a/references_cache/PMID_32130257.md
+++ b/references_cache/PMID_32130257.md
@@ -1,0 +1,67 @@
+---
+reference_id: PMID:32130257
+title: ''
+authors: []
+journal: PLoS One
+year: '2020'
+content_type: abstract_only
+---
+
+# PMID:32130257
+**Journal:** PLoS One (2020)
+
+## Content
+
+1. PLoS One. 2020 Mar 4;15(3):e0229537. doi: 10.1371/journal.pone.0229537. 
+eCollection 2020.
+
+Combined analysis of microbial metagenomic and metatranscriptomic sequencing 
+data to assess in situ physiological conditions in the premature infant gut.
+
+Sher Y(1), Olm MR(2), Raveh-Sadka T(2), Brown CT(2), Sher R(3), Firek B(4), 
+Baker R(5), Morowitz MJ(4)(5), Banfield JF(1)(2).
+
+Author information:
+(1)Department of Environmental Science, Policy, and Management, University of 
+California, Berkeley, Berkeley, California, United States of America.
+(2)Department of Plant and Microbial Biology, University of California, 
+Berkeley, Berkeley, California, United States of America.
+(3)Enview, Inc., San Francisco, California, United States of America.
+(4)Department of Surgery, University of Pittsburgh School of Medicine, 
+Pittsburgh, Pennsylvania, United States of America.
+(5)Magee-Womens Hospital of UPMC, Pittsburgh, Pennsylvania, United States of 
+America.
+
+Microbes alter their transcriptomic profiles in response to the environment. The 
+physiological conditions experienced by a microbial community can thus be 
+inferred using meta-transcriptomic sequencing by comparing transcription levels 
+of specifically chosen genes. However, this analysis requires accurate reference 
+genomes to identify the specific genes from which RNA reads originate. In 
+addition, such an analysis should avoid biases in transcript counts related to 
+differences in organism abundance. In this study we describe an approach to 
+address these difficulties. Sample-specific meta-genomic assembled genomes 
+(MAGs) were used as reference genomes to accurately identify the origin of RNA 
+reads, and transcript ratios of genes with opposite transcription responses were 
+compared to eliminate biases related to differences in organismal abundance, an 
+approach hereafter named the "diametric ratio" method. We used this approach to 
+probe the environmental conditions experienced by Escherichia spp. in the gut of 
+4 premature infants, 2 of whom developed necrotizing enterocolitis (NEC), a 
+severe inflammatory intestinal disease. We analyzed twenty fecal samples taken 
+from four premature infants (4-6 time points from each infant), and found 
+significantly higher diametric ratios of genes associated with low oxygen levels 
+in samples of infants later diagnosed with NEC than in samples without NEC. We 
+also show this method can be used for examining other physiological conditions, 
+such as exposure to nitric oxide and osmotic pressure. These study results 
+should be treated with caution, due to the presence of confounding factors that 
+might also distinguish between NEC and control infants. Nevertheless, together 
+with benchmarking analyses, we show here that the diametric ratio approach can 
+be applied for evaluating the physiological conditions experienced by microbes 
+in situ. Results from similar studies can be further applied for designing 
+diagnostic methods to detect NEC in its early developmental stages.
+
+DOI: 10.1371/journal.pone.0229537
+PMCID: PMC7055874
+PMID: 32130257 [Indexed for MEDLINE]
+
+Conflict of interest statement: RS affiliation to Enview, inc., does not alter 
+our adherence to PLOS ONE policies on sharing data and materials.

--- a/references_cache/PMID_32203118.md
+++ b/references_cache/PMID_32203118.md
@@ -1,0 +1,78 @@
+---
+reference_id: PMID:32203118
+title: ''
+authors: []
+journal: ISME J
+year: '2020'
+content_type: abstract_only
+---
+
+# PMID:32203118
+**Journal:** ISME J (2020)
+
+## Content
+
+1. ISME J. 2020 Jun;14(6):1547-1560. doi: 10.1038/s41396-020-0624-4. Epub 2020
+Mar  13.
+
+Lipid analysis of CO(2)-rich subsurface aquifers suggests an autotrophy-based 
+deep biosphere with lysolipids enriched in CPR bacteria.
+
+Probst AJ(#)(1)(2), Elling FJ(#)(3)(4), Castelle CJ(5)(6), Zhu Q(6), Elvert 
+M(6), Birarda G(7)(8), Holman HN(8), Lane KR(5), Ladd B(9)(10), Ryan MC(9), 
+Woyke T(11), Hinrichs KU(12), Banfield JF(13).
+
+Author information:
+(1)Department of Earth and Planetary Science, University of California, 
+Berkeley, CA, 94720, USA. alexander.probst@uni-due.de.
+(2)Institute for Environmental Microbiology and Biotechnology, Department of 
+Chemistry, University of Duisburg-Essen, Essen, Germany. 
+alexander.probst@uni-due.de.
+(3)MARUM Center for Marine Environmental Sciences, University of Bremen, Bremen, 
+Germany. felix_elling@fas.harvard.edu.
+(4)Department of Earth and Planetary Sciences, Harvard University, Cambridge, 
+MA, 02138, USA. felix_elling@fas.harvard.edu.
+(5)Department of Earth and Planetary Science, University of California, 
+Berkeley, CA, 94720, USA.
+(6)MARUM Center for Marine Environmental Sciences, University of Bremen, Bremen, 
+Germany.
+(7)Elettra-Sincrotrone Trieste, Strada Statale 14-km 163,5 Basovizza, 34149, 
+Trieste, Italy.
+(8)Molecular Biophysics and Integrated Bioimaging, Lawrence Berkeley National 
+Laboratory, Berkeley, CA, USA.
+(9)Department of Geoscience, University of Calgary, Calgary, AB, T2N 1N4, 
+Canada.
+(10)Department of Earth, Ocean, and Atmospheric Sciences, University of British 
+Columbia, Vancouver, Canada.
+(11)DOE Joint Genome Institute, Walnut Creek, MA, USA.
+(12)MARUM Center for Marine Environmental Sciences, University of Bremen, 
+Bremen, Germany. khinrichs@uni-bremen.de.
+(13)Department of Earth and Planetary Science, University of California, 
+Berkeley, CA, 94720, USA. jbanfield@berkeley.edu.
+(#)Contributed equally
+
+Sediment-hosted CO2-rich aquifers deep below the Colorado Plateau (USA) contain 
+a remarkable diversity of uncultivated microorganisms, including Candidate Phyla 
+Radiation (CPR) bacteria that are putative symbionts unable to synthesize 
+membrane lipids. The origin of organic carbon in these ecosystems is unknown and 
+the source of CPR membrane lipids remains elusive. We collected cells from deep 
+groundwater brought to the surface by eruptions of Crystal Geyser, sequenced the 
+community, and analyzed the whole community lipidome over time. Characteristic 
+stable carbon isotopic compositions of microbial lipids suggest that bacterial 
+and archaeal CO2 fixation ongoing in the deep subsurface provides organic carbon 
+for the complex communities that reside there. Coupled lipidomic-metagenomic 
+analysis indicates that CPR bacteria lack complete lipid biosynthesis pathways 
+but still possess regular lipid membranes. These lipids may therefore originate 
+from other community members, which also adapt to high in situ pressure by 
+increasing fatty acid unsaturation. An unusually high abundance of lysolipids 
+attributed to CPR bacteria may represent an adaptation to membrane curvature 
+stress induced by their small cell sizes. Our findings provide new insights into 
+the carbon cycle in the deep subsurface and suggest the redistribution of lipids 
+into putative symbionts within this community.
+
+DOI: 10.1038/s41396-020-0624-4
+PMCID: PMC7242380
+PMID: 32203118 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare that they have no conflict 
+of interest.

--- a/references_cache/PMID_32546614.md
+++ b/references_cache/PMID_32546614.md
@@ -1,0 +1,70 @@
+---
+reference_id: PMID:32546614
+title: ''
+authors: []
+journal: mBio
+year: '2020'
+content_type: abstract_only
+---
+
+# PMID:32546614
+**Journal:** mBio (2020)
+
+## Content
+
+1. mBio. 2020 Jun 16;11(3):e00416-20. doi: 10.1128/mBio.00416-20.
+
+Bacterial Secondary Metabolite Biosynthetic Potential in Soil Varies with 
+Phylum, Depth, and Vegetation Type.
+
+Sharrar AM(1), Crits-Christoph A(2), Méheust R(1)(3), Diamond S(1), Starr EP(2), 
+Banfield JF(4)(3).
+
+Author information:
+(1)Department of Earth and Planetary Science, University of California, 
+Berkeley, Berkeley, California, USA.
+(2)Department of Plant and Microbial Biology, University of California, 
+Berkeley, Berkeley, California, USA.
+(3)Innovative Genomics Institute, Berkeley, California, USA.
+(4)Department of Earth and Planetary Science, University of California, 
+Berkeley, Berkeley, California, USA jbanfield@berkeley.edu.
+
+Bacteria isolated from soils are major sources of specialized metabolites, 
+including antibiotics and other compounds with clinical value that likely shape 
+interactions among microbial community members and impact biogeochemical cycles. 
+Yet, isolated lineages represent a small fraction of all soil bacterial 
+diversity. It remains unclear how the production of specialized metabolites 
+varies across the phylogenetic diversity of bacterial species in soils and 
+whether the genetic potential for production of these metabolites differs with 
+soil depth and vegetation type within a geographic region. We sampled soils and 
+saprolite from three sites in a northern California Critical Zone Observatory 
+with various vegetation and bedrock characteristics and reconstructed 1,334 
+metagenome-assembled genomes containing diverse biosynthetic gene clusters 
+(BGCs) for secondary metabolite production. We obtained genomes for prolific 
+producers of secondary metabolites, including novel groups within the 
+Actinobacteria, Chloroflexi, and candidate phylum "Candidatus Dormibacteraeota." 
+Surprisingly, one genome of a candidate phyla radiation (CPR) bacterium coded 
+for a ribosomally synthesized linear azole/azoline-containing peptide, a 
+capacity we found in other publicly available CPR bacterial genomes. Overall, 
+bacteria with higher biosynthetic potential were enriched in shallow soils and 
+grassland soils, with patterns of abundance of BGC type varying by 
+taxonomy.IMPORTANCE Microbes produce specialized compounds to compete or 
+communicate with one another and their environment. Some of these compounds, 
+such as antibiotics, are also useful in medicine and biotechnology. 
+Historically, most antibiotics have come from soil bacteria which can be 
+isolated and grown in the lab. Though the vast majority of soil bacteria cannot 
+be isolated, we can extract their genetic information and search it for genes 
+which produce these specialized compounds. These understudied soil bacteria 
+offer a wealth of potential for the discovery of new and important microbial 
+products. Here, we identified the ability to produce these specialized compounds 
+in diverse and novel bacteria in a range of soil environments. This information 
+will be useful to other researchers who wish to isolate certain products. Beyond 
+their use to humans, understanding the distribution and function of microbial 
+products is key to understanding microbial communities and their effects on 
+biogeochemical cycles.
+
+Copyright © 2020 Sharrar et al.
+
+DOI: 10.1128/mBio.00416-20
+PMCID: PMC7298704
+PMID: 32546614 [Indexed for MEDLINE]

--- a/references_cache/PMID_32633030.md
+++ b/references_cache/PMID_32633030.md
@@ -1,0 +1,52 @@
+---
+reference_id: PMID:32633030
+title: ''
+authors: []
+journal: Environ Microbiol Rep
+year: '2020'
+content_type: abstract_only
+---
+
+# PMID:32633030
+**Journal:** Environ Microbiol Rep (2020)
+
+## Content
+
+1. Environ Microbiol Rep. 2020 Oct;12(5):525-533. doi: 10.1111/1758-2229.12868. 
+Epub 2020 Jul 23.
+
+Subsurface carbon monoxide oxidation capacity revealed through genome-resolved 
+metagenomics of a carboxydotroph.
+
+Mu A(1)(2), Thomas BC(3), Banfield JF(3)(4), Moreau JW(5).
+
+Author information:
+(1)Department of Microbiology and Immunology, The Peter Doherty Institute for 
+Infection and Immunity, University of Melbourne, Melbourne, Australia.
+(2)Doherty Applied Microbial Genomics, Department of Microbiology and 
+Immunology, The Peter Doherty Institute for Infection and Immunity, University 
+of Melbourne, Melbourne, Australia.
+(3)Department of Earth and Planetary Science, University of California, 
+Berkeley, CA, USA.
+(4)Innovative Genomics Institute, University of California, Berkeley, CA, USA.
+(5)School of Earth Sciences, University of Melbourne, Melbourne, Australia.
+
+Microbial communities play important roles in the biogeochemical cycling of 
+carbon in the Earth's deep subsurface. Previously, we demonstrated changes to 
+the microbial community structure of a deep aquifer (1.4 km) receiving 150 tons 
+of injected supercritical CO2 (scCO2 ) in a geosequestration experiment. The 
+observed changes support a key role in the aquifer microbiome for the 
+thermophilic CO-utilizing anaerobe Carboxydocella, which decreased in relative 
+abundance post-scCO2 injection. Here, we present results from more detailed 
+metagenomic profiling of this experiment, with genome resolution of the native 
+carboxydotrophic Carboxydocella. We demonstrate a switch in CO-oxidation 
+potential by Carboxydocella through analysis of its carbon monoxide 
+dehydrogenase (CODH) gene before and after the geosequestration experiment. We 
+discuss the potential impacts of scCO2 on subsurface flow of carbon and 
+electrons from oxidation of the metabolic intermediate carbon monoxide (CO).
+
+© 2020 The Authors. Environmental Microbiology Reports published by Society for 
+Applied Microbiology and John Wiley & Sons Ltd.
+
+DOI: 10.1111/1758-2229.12868
+PMID: 32633030 [Indexed for MEDLINE]

--- a/references_cache/PMID_33468686.md
+++ b/references_cache/PMID_33468686.md
@@ -1,0 +1,71 @@
+---
+reference_id: PMID:33468686
+title: ''
+authors: []
+journal: mBio
+year: '2021'
+content_type: abstract_only
+---
+
+# PMID:33468686
+**Journal:** mBio (2021)
+
+## Content
+
+1. mBio. 2021 Jan 19;12(1):e02703-20. doi: 10.1128/mBio.02703-20.
+
+Genome Sequencing of Sewage Detects Regionally Prevalent SARS-CoV-2 Variants.
+
+Crits-Christoph A(1)(2), Kantor RS(3), Olm MR(4), Whitney ON(5), Al-Shayeb 
+B(1)(2), Lou YC(1)(2), Flamholz A(5), Kennedy LC(3), Greenwald H(3), Hinkle 
+A(3), Hetzel J(6), Spitzer S(6), Koble J(6), Tan A(6), Hyde F(7), Schroth G(6), 
+Kuersten S(7), Banfield JF(2)(8)(9)(10), Nelson KL(11)(3).
+
+Author information:
+(1)Department of Plant and Microbial Biology, University of California, 
+Berkeley, California, USA.
+(2)Innovative Genomics Institute, Berkeley, California, USA.
+(3)Department of Civil and Environmental Engineering, University of California, 
+Berkeley, California, USA.
+(4)Department of Microbiology and Immunology, Stanford University, Stanford, 
+California, USA.
+(5)Department of Molecular and Cell Biology, University of California, Berkeley, 
+California, USA.
+(6)Illumina, San Diego, California, USA.
+(7)Illumina, Madison, Wisconsin, USA.
+(8)Department of Environmental Science, Policy, and Management, University of 
+California, Berkeley, California, USA.
+(9)Earth Sciences Division, Lawrence Berkeley National Laboratory, Berkeley, 
+California, USA.
+(10)Chan Zuckerberg Biohub, San Francisco, California, USA.
+(11)Innovative Genomics Institute, Berkeley, California, USA 
+karanelson@berkeley.edu.
+
+Viral genome sequencing has guided our understanding of the spread and extent of 
+genetic diversity of SARS-CoV-2 during the COVID-19 pandemic. SARS-CoV-2 viral 
+genomes are usually sequenced from nasopharyngeal swabs of individual patients 
+to track viral spread. Recently, RT-qPCR of municipal wastewater has been used 
+to quantify the abundance of SARS-CoV-2 in several regions globally. However, 
+metatranscriptomic sequencing of wastewater can be used to profile the viral 
+genetic diversity across infected communities. Here, we sequenced RNA directly 
+from sewage collected by municipal utility districts in the San Francisco Bay 
+Area to generate complete and nearly complete SARS-CoV-2 genomes. The major 
+consensus SARS-CoV-2 genotypes detected in the sewage were identical to clinical 
+genomes from the region. Using a pipeline for single nucleotide variant calling 
+in a metagenomic context, we characterized minor SARS-CoV-2 alleles in the 
+wastewater and detected viral genotypes which were also found within clinical 
+genomes throughout California. Observed wastewater variants were more similar to 
+local California patient-derived genotypes than they were to those from other 
+regions within the United States or globally. Additional variants detected in 
+wastewater have only been identified in genomes from patients sampled outside 
+California, indicating that wastewater sequencing can provide evidence for 
+recent introductions of viral lineages before they are detected by local 
+clinical sequencing. These results demonstrate that epidemiological surveillance 
+through wastewater sequencing can aid in tracking exact viral strains in an 
+epidemic context.
+
+Copyright © 2021 Crits-Christoph et al.
+
+DOI: 10.1128/mBio.02703-20
+PMCID: PMC7845645
+PMID: 33468686 [Indexed for MEDLINE]

--- a/references_cache/PMID_34154658.md
+++ b/references_cache/PMID_34154658.md
@@ -1,0 +1,82 @@
+---
+reference_id: PMID:34154658
+title: ''
+authors: []
+journal: Microbiome
+year: '2021'
+content_type: abstract_only
+---
+
+# PMID:34154658
+**Journal:** Microbiome (2021)
+
+## Content
+
+1. Microbiome. 2021 Jun 21;9(1):142. doi: 10.1186/s40168-021-01085-y.
+
+Genetic and behavioral adaptation of Candida parapsilosis to the microbiome of 
+hospitalized infants revealed by in situ genomics, transcriptomics, and 
+proteomics.
+
+West PT(1), Peters SL(2)(3), Olm MR(4), Yu FB(5), Gause H(6), Lou YC(1), Firek 
+BA(7), Baker R(8), Johnson AD(4)(6), Morowitz MJ(7), Hettich RL(2)(3), Banfield 
+JF(9)(10)(11)(12).
+
+Author information:
+(1)Department of Plant and Microbial Biology, University of California, 
+Berkeley, CA, USA.
+(2)Graduate School of Genome Science and Technology, The University of 
+Tennessee, Knoxville, TN, USA.
+(3)Chemical Sciences Division, Oak Ridge National Laboratory, Oak Ridge, TN, 
+USA.
+(4)Department of Microbiology and Immunology, Stanford University School of 
+Medicine, Stanford, CA, 94305, USA.
+(5)Chan Zuckerberg Biohub, San Francisco, CA, USA.
+(6)Department of Microbiology and Immunology, University of California, San 
+Francisco, San Francisco, CA, USA.
+(7)Department of Surgery, University of Pittsburgh School of Medicine, 
+Pittsburgh, PA, USA.
+(8)Division of Newborn Medicine, Magee-Womens Hospital of UPMC, Pittsburgh, PA, 
+USA.
+(9)Chan Zuckerberg Biohub, San Francisco, CA, USA. jbanfield@berkeley.edu.
+(10)Department of Earth and Planetary Science, University of California, 
+Berkeley, CA, USA. jbanfield@berkeley.edu.
+(11)Department of Environmental Science, Policy, and Management, University of 
+California, Berkeley, CA, USA. jbanfield@berkeley.edu.
+(12)Earth Sciences Division, Lawrence Berkeley National Laboratory, Berkeley, 
+CA, USA. jbanfield@berkeley.edu.
+
+BACKGROUND: Candida parapsilosis is a common cause of invasive candidiasis, 
+especially in newborn infants, and infections have been increasing over the past 
+two decades. C. parapsilosis has been primarily studied in pure culture, leaving 
+gaps in understanding of its function in a microbiome context.
+RESULTS: Here, we compare five unique C. parapsilosis genomes assembled from 
+premature infant fecal samples, three of which are newly reconstructed, and 
+analyze their genome structure, population diversity, and in situ activity 
+relative to reference strains in pure culture. All five genomes contain hotspots 
+of single nucleotide variants, some of which are shared by strains from multiple 
+hospitals. A subset of environmental and hospital-derived genomes share variants 
+within these hotspots suggesting derivation of that region from a common 
+ancestor. Four of the newly reconstructed C. parapsilosis genomes have 4 to 16 
+copies of the gene RTA3, which encodes a lipid translocase and is implicated in 
+antifungal resistance, potentially indicating adaptation to hospital antifungal 
+use. Time course metatranscriptomics and metaproteomics on fecal samples from a 
+premature infant with a C. parapsilosis blood infection revealed highly variable 
+in situ expression patterns that are distinct from those of similar strains in 
+pure cultures. For example, biofilm formation genes were relatively less 
+expressed in situ, whereas genes linked to oxygen utilization were more highly 
+expressed, indicative of growth in a relatively aerobic environment. In gut 
+microbiome samples, C. parapsilosis co-existed with Enterococcus faecalis that 
+shifted in relative abundance over time, accompanied by changes in bacterial and 
+fungal gene expression and proteome composition.
+CONCLUSIONS: The results reveal potentially medically relevant differences in 
+Candida function in gut vs. laboratory environments, and constrain evolutionary 
+processes that could contribute to hospital strain persistence and transfer into 
+premature infant microbiomes. Video abstract.
+
+DOI: 10.1186/s40168-021-01085-y
+PMCID: PMC8215838
+PMID: 34154658 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare that they have no competing 
+interests.

--- a/references_cache/PMID_34402646.md
+++ b/references_cache/PMID_34402646.md
@@ -1,0 +1,75 @@
+---
+reference_id: PMID:34402646
+title: ''
+authors: []
+journal: mSystems
+year: '2021'
+content_type: abstract_only
+---
+
+# PMID:34402646
+**Journal:** mSystems (2021)
+
+## Content
+
+1. mSystems. 2021 Aug 31;6(4):e0120520. doi: 10.1128/mSystems.01205-20. Epub 2021
+ Aug 17.
+
+Soil Candidate Phyla Radiation Bacteria Encode Components of Aerobic Metabolism 
+and Co-occur with Nanoarchaea in the Rare Biosphere of Rhizosphere Grassland 
+Communities.
+
+Nicolas AM(1), Jaffe AL(1), Nuccio EE(2), Taga ME(1), Firestone MK(3)(4), 
+Banfield JF(3)(5)(6)(7).
+
+Author information:
+(1)Department of Plant and Microbial Biology, University of California, 
+Berkeleygrid.47840.3f, Berkeley, California, USA.
+(2)Nuclear and Chemical Sciences Division, Lawrence Livermore National 
+Laboratorygrid.250008.f, Livermore, California, USA.
+(3)Department of Environmental Science, Policy, and Management, University of 
+California, Berkeleygrid.47840.3f, Berkeley, California, USA.
+(4)Earth and Environmental Sciences, Lawrence Berkeley National Laboratory, 
+Berkeley, California, USA.
+(5)Department of Earth and Planetary Science, University of California, 
+Berkeleygrid.47840.3f, Berkeley, California, USA.
+(6)Chan Zuckerberg Biohub, San Francisco, California, USA.
+(7)Innovative Genomics Institute, University of California, 
+Berkeleygrid.47840.3f, Berkeley, California, USA.
+
+Candidate Phyla Radiation (CPR) bacteria and nanoarchaea populate most 
+ecosystems but are rarely detected in soil. We concentrated particles of less 
+than 0.2 μm in size from grassland soil, enabling targeted metagenomic analysis 
+of these organisms, which are almost totally unexplored in largely oxic 
+environments such as soil. We recovered a diversity of CPR bacterial and some 
+archaeal sequences but no sequences from other cellular organisms. The sampled 
+sequences include Doudnabacteria (SM2F11) and Pacearchaeota, organisms rarely 
+reported in soil, as well as Saccharibacteria, Parcubacteria, and 
+Microgenomates. CPR and archaea of the phyla Diapherotrites, Parvarchaeota, 
+Aenigmarchaeota, Nanoarchaeota, and Nanohaloarchaeota (DPANN) were enriched 100- 
+to 1,000-fold compared to that in bulk soil, in which we estimate each of these 
+organisms comprises approximately 1 to 100 cells per gram of soil. Like most CPR 
+and DPANN sequenced to date, we predict these microorganisms live symbiotic 
+anaerobic lifestyles. However, Saccharibacteria, Parcubacteria, and 
+Doudnabacteria genomes sampled here also harbor ubiquinol oxidase operons that 
+may have been acquired from other bacteria, likely during adaptation to aerobic 
+soil environments. We conclude that CPR bacteria and DPANN archaea are part of 
+the rare soil biosphere and harbor unique metabolic platforms that potentially 
+evolved to live symbiotically under relatively oxic conditions. IMPORTANCE Here, 
+we investigated overlooked microbes in soil, Candidate Phyla Radiation (CPR) 
+bacteria and Diapherotrites, Parvarchaeota, Aenigmarchaeota, Nanoarchaeota, and 
+Nanohaloarchaeota (DPANN) archaea, by size fractionating small particles from 
+soil, an approach typically used for the recovery of viral metagenomes. 
+Concentration of these small cells (<0.2 μm) allowed us to identify these 
+organisms as part of the rare soil biosphere and to sample genomes that were 
+absent from non-size-fractionated metagenomes. We found that some of these 
+predicted symbionts, which have been largely studied in anaerobic systems, have 
+acquired aerobic capacity via lateral transfer that may enable adaptation to 
+oxic soil environments. We estimate that there are approximately 1 to 100 cells 
+of each of these lineages per gram of soil, highlighting that the approach 
+provides a window into the rare soil biosphere and its associated genetic 
+potential.
+
+DOI: 10.1128/mSystems.01205-20
+PMCID: PMC8407418
+PMID: 34402646


### PR DESCRIPTION
## Summary

Adds 7 more curated community records (CommunityMech:000247–000253) from the 2020–2021 Banfield-lab candidate list, continuing the work in PRs #36, #37, and #39.

| ID | Community | Reference | Year |
|---|---|---|---|
| 000247 | Soil CPR/Nanoarchaea rare-biosphere | PMID:34402646 | 2021 |
| 000248 | Candida parapsilosis hospitalized-infant gut | PMID:34154658 | 2021 |
| 000249 | SF Bay sewage SARS-CoV-2 surveillance | PMID:33468686 | 2021 |
| 000250 | Soil BGC phylum/depth/vegetation | PMID:32546614 | 2020 |
| 000251 | Subsurface Carboxydocella CO-oxidation aquifer | PMID:32633030 | 2020 |
| 000252 | Crystal Geyser CO2 aquifer CPR lysolipid | PMID:32203118 | 2020 |
| 000253 | Premature infant gut Escherichia diametric-ratio | PMID:32130257 | 2020 |

## Test plan
- [x] `just validate` passes on all 7 community files
- [x] `just validate-terms` passes on all 7 community files
- [x] ASCII-only — no non-ASCII characters
- [x] Every snippet is a whitespace-normalized substring of the corresponding PubMed abstract cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)