### PR TITLE
Add Lake Washington methane-oxygen methylotroph community

### DIFF
--- a/kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml
+++ b/kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml
@@ -157,10 +157,12 @@ taxonomy:
     snippet: major players were Methylobacter and Methylotenera
     explanation: Supports Methylotenera as a major low-oxygen methylotroph partner.
   - reference: PMID:25058595
-    supports: SUPPORT
+    supports: PARTIAL
     evidence_source: COMPUTATIONAL
     snippet: novel Methylophilaceae ecotypes from a single ecological niche in Lake Washington
-    explanation: Supports Lake Washington Methylophilaceae ecotypes as part of the methylotrophy-active community at this site.
+    explanation: The abstract documents Methylophilaceae ecotypes in the same Lake Washington niche
+      but does not specifically name Methylotenera (a genus within Methylophilaceae); evidence is
+      family-level and therefore downgraded to PARTIAL for this taxon.
 - taxon_term:
     preferred_term: Methylomonas
     term:
@@ -294,6 +296,10 @@ ecological_interactions:
     term:
       id: CHEBI:16526
       label: carbon dioxide
+  - preferred_term: formaldehyde
+    term:
+      id: CHEBI:16842
+      label: formaldehyde
   biological_processes:
   - preferred_term: methane metabolic process
     term:
@@ -309,7 +315,7 @@ ecological_interactions:
     supports: SUPPORT
     evidence_source: COMPUTATIONAL
     snippet: excretion of formaldehyde and carbon di-oxide in the community
-    explanation: Supports predicted extracellular metabolite exchange in the community model.
+    explanation: Supports predicted extracellular metabolite exchange (formaldehyde, CO2) in the community model.
 environmental_factors:
 - name: Methane amendment
   value: methane supplied at the same concentration in each microcosm

--- a/kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml
+++ b/kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml
@@ -1,0 +1,423 @@
+id: CommunityMech:000261
+name: Lake Washington Methane-Oxygen Methylotroph Community
+description: >
+  A methane-consuming freshwater lake sediment community from Lake Washington,
+  Seattle, represented by methane-fed sediment microcosms and follow-up
+  community modeling studies. Methane addition selects both bona fide
+  methane-oxidizing Methylococcaceae and non-methanotrophic methylotrophic
+  Methylophilaceae, supporting a guild-based community rather than a
+  single-organism methane oxidation model. Oxygen tension structures specific
+  partnerships: Methylosarcina and Methylophilus dominate higher-oxygen
+  microcosms, whereas Methylobacter and Methylotenera dominate lower-oxygen
+  microcosms. The system is DOE-relevant because it links methane mitigation,
+  freshwater sediment carbon cycling, methylotroph ecology, and genome-scale
+  modeling of methane-cycling communities.
+ecological_state: PERTURBED
+community_origin: NATURAL
+community_category: CARBON_SEQUESTRATION
+engineering_design:
+  objective: >
+    Enrich Lake Washington sediment microbial communities with methane under
+    controlled oxygen tensions to identify functional methane-consuming guilds
+    and oxygen-dependent methanotroph-methylotroph partnerships.
+  assembly_strategy: >
+    Incubate Lake Washington sediment samples in methane-fed microcosms while
+    varying oxygen tension, then profile community composition through 16S rRNA
+    gene amplicon sequencing.
+  perturbation_design: >
+    Methane was supplied at the same concentration across microcosms while five
+    different oxygen tensions were imposed; community composition was assessed
+    after 10 and 16 weeks.
+  measurement_endpoints:
+  - methane-consuming community composition
+  - 16S rRNA gene amplicon profiles
+  - oxygen-tension-dependent guild dominance
+  - genome-scale metabolic model exchange predictions
+  evidence:
+  - reference: PMID:25755930
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: microcosm incubations with sediment samples from Lake Washington at five different oxygen tensions
+    explanation: Supports the methane-fed oxygen-gradient microcosm design.
+  - reference: PMID:25755930
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Community composition was determined through 16S rRNA gene amplicon sequencing after 10 and 16 weeks
+    explanation: Supports the sequencing endpoint and sampling schedule.
+environment_term:
+  preferred_term: freshwater lake sediment
+  term:
+    id: ENVO:00002007
+    label: sediment
+  notes: >
+    Sediment from Lake Washington, a freshwater lake in Seattle, Washington,
+    was used in methane-fed microcosm incubations. The curated ENVO term is
+    sediment with freshwater lake sediment context in notes.
+taxonomy:
+- taxon_term:
+    preferred_term: Lake Washington methane-consuming microbial community
+    term:
+      id: NCBITaxon:131567
+      label: cellular organisms
+    notes: >
+      Community-level representation of methane-consuming bacteria enriched
+      from Lake Washington sediment under methane and oxygen treatments.
+  functional_role:
+  - PRIMARY_DEGRADER
+  - CROSS_FEEDER
+  evidence:
+  - reference: PMID:25755930
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: methane supplied to lake sediment microbial communities
+    explanation: Supports the broader lake sediment methane-consuming community context.
+  - reference: PMID:32655999
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: Lake Washington is a freshwater lake characterized by a methane-oxygen countergradient
+    explanation: Supports the lake community context in the modeling study.
+- taxon_term:
+    preferred_term: Methylococcaceae methanotrophs
+    term:
+      id: NCBITaxon:403
+      label: Methylococcaceae
+    notes: >
+      Type I methanotroph family represented in methane-consuming Lake
+      Washington sediment microcosms; includes oxygen-dependent genera such as
+      Methylobacter, Methylomonas, and Methylosarcina.
+  functional_role:
+  - PRIMARY_DEGRADER
+  abundance_level: DOMINANT
+  evidence:
+  - reference: PMID:25755930
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the methanotrophs of the family Methylococcaceae
+    explanation: Supports Methylococcaceae as one of the two major methane-consuming community guilds.
+  - reference: PMID:25755930
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: methane-consuming communities were represented by two major types
+    explanation: Supports Methylococcaceae as a major component of the enriched methane-consuming community.
+- taxon_term:
+    preferred_term: Methylophilaceae non-methanotrophic methylotrophs
+    term:
+      id: NCBITaxon:32011
+      label: Methylophilaceae
+    notes: >
+      Non-methane-oxidizing methylotrophic family that co-enriches with
+      Methylococcaceae in methane-fed Lake Washington sediment microcosms.
+  functional_role:
+  - CROSS_FEEDER
+  abundance_level: DOMINANT
+  evidence:
+  - reference: PMID:25755930
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: non-methane-oxidizing bacteria, especially by members of the family Methylophilaceae
+    explanation: Supports Methylophilaceae as non-methane-oxidizing responders to methane-fed sediment microcosms.
+  - reference: PMID:25755930
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: non-methanotrophic methylotrophs of the family Methylophilaceae
+    explanation: Supports Methylophilaceae as the methylotrophic partner guild.
+- taxon_term:
+    preferred_term: Methylobacter
+    term:
+      id: NCBITaxon:429
+      label: Methylobacter
+    notes: Low-oxygen methanotrophic genus in Lake Washington methane-fed microcosms.
+  functional_role:
+  - PRIMARY_DEGRADER
+  abundance_level: DOMINANT
+  evidence:
+  - reference: PMID:25755930
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: major players were Methylobacter and Methylotenera
+    explanation: Supports Methylobacter as a major low-oxygen methanotroph in the microcosms.
+  - reference: PMID:32655999
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: Two significant methanotrophic species in this community are Methylobacter and Methylomonas
+    explanation: Supports Methylobacter as a significant Lake Washington methanotroph in the community model.
+- taxon_term:
+    preferred_term: Methylotenera
+    term:
+      id: NCBITaxon:359407
+      label: Methylotenera
+    notes: Low-oxygen non-methanotrophic methylotroph genus partnered with Methylobacter.
+  functional_role:
+  - CROSS_FEEDER
+  abundance_level: DOMINANT
+  evidence:
+  - reference: PMID:25755930
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: major players were Methylobacter and Methylotenera
+    explanation: Supports Methylotenera as a major low-oxygen methylotroph partner.
+  - reference: PMID:25058595
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: novel Methylophilaceae ecotypes from a single ecological niche in Lake Washington
+    explanation: Supports Lake Washington Methylophilaceae ecotypes as part of the methylotrophy-active community at this site.
+- taxon_term:
+    preferred_term: Methylomonas
+    term:
+      id: NCBITaxon:416
+      label: Methylomonas
+    notes: Methanotrophic genus included in genome-scale modeling of the Lake Washington methane-cycling community.
+  functional_role:
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:32655999
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: Two significant methanotrophic species in this community are Methylobacter and Methylomonas
+    explanation: Supports Methylomonas as a significant methanotroph in the modeled community.
+- taxon_term:
+    preferred_term: Methylosarcina
+    term:
+      id: NCBITaxon:105972
+      label: Methylosarcina
+    notes: Higher-oxygen methanotrophic genus in Lake Washington methane-fed microcosms.
+  functional_role:
+  - PRIMARY_DEGRADER
+  evidence:
+  - reference: PMID:25755930
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: species of the genera Methylosarcina and Methylophilus
+    explanation: Supports Methylosarcina as a higher-oxygen methanotrophic player.
+- taxon_term:
+    preferred_term: Methylophilus
+    term:
+      id: NCBITaxon:16
+      label: Methylophilus
+    notes: Higher-oxygen non-methanotrophic methylotroph genus partnered with Methylosarcina.
+  functional_role:
+  - CROSS_FEEDER
+  evidence:
+  - reference: PMID:25755930
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: species of the genera Methylosarcina and Methylophilus
+    explanation: Supports Methylophilus as a higher-oxygen methylotroph partner.
+ecological_interactions:
+- name: Methanotroph-Methylotroph Guild Coupling
+  description: >
+    Methane-fed Lake Washington sediment communities consistently include both
+    methane-oxidizing Methylococcaceae and non-methanotrophic methylotrophs in
+    Methylophilaceae, supporting a coupled guild model for methane oxidation.
+  interaction_type: CROSS_FEEDING
+  source_taxon:
+    preferred_term: Methylococcaceae methanotrophs
+    term:
+      id: NCBITaxon:403
+      label: Methylococcaceae
+  target_taxon:
+    preferred_term: Methylophilaceae non-methanotrophic methylotrophs
+    term:
+      id: NCBITaxon:32011
+      label: Methylophilaceae
+  metabolites:
+  - preferred_term: methane
+    term:
+      id: CHEBI:16183
+      label: methane
+  - preferred_term: methanol
+    term:
+      id: CHEBI:17790
+      label: methanol
+    notes: Likely one-carbon intermediate supporting methylotroph partners.
+  biological_processes:
+  - preferred_term: methane metabolic process
+    term:
+      id: GO:0015947
+      label: methane metabolic process
+  evidence:
+  - reference: PMID:25755930
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: likely involves communities composed of different functional guilds
+    explanation: Supports the guild-coupling interpretation for methane oxidation.
+  - reference: PMID:25755930
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: rather than a single type of microbe
+    explanation: Supports a community-level methane oxidation model instead of a single taxon model.
+- name: Oxygen-Tension Specific Partnerships
+  description: >
+    Oxygen availability determines which methanotroph and methylotroph genera
+    dominate methane-fed microcosms: Methylosarcina with Methylophilus at higher
+    oxygen tension and Methylobacter with Methylotenera at lower oxygen tension.
+  interaction_type: NICHE_PARTITIONING
+  scope: COMMUNITY_LEVEL
+  biological_processes:
+  - preferred_term: methane metabolic process
+    term:
+      id: GO:0015947
+      label: methane metabolic process
+  evidence:
+  - reference: PMID:25755930
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: different species persisted under different oxygen tensions
+    explanation: Supports oxygen-tension-dependent membership.
+  - reference: PMID:25755930
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: oxygen availability is at least one major factor determining specific partnerships in methane oxidation
+    explanation: Supports oxygen availability as a driver of partnership composition.
+- name: Modeled Methylobacter-Methylomonas Exchange
+  description: >
+    Genome-scale metabolic modeling of Lake Washington methanotrophs predicts
+    competitive and mutualistic interactions between Methylobacter and
+    Methylomonas and condition-dependent extracellular metabolite exchanges.
+  interaction_type: NICHE_PARTITIONING
+  source_taxon:
+    preferred_term: Methylobacter
+    term:
+      id: NCBITaxon:429
+      label: Methylobacter
+  target_taxon:
+    preferred_term: Methylomonas
+    term:
+      id: NCBITaxon:416
+      label: Methylomonas
+  metabolites:
+  - preferred_term: methane
+    term:
+      id: CHEBI:16183
+      label: methane
+  - preferred_term: carbon dioxide
+    term:
+      id: CHEBI:16526
+      label: carbon dioxide
+  biological_processes:
+  - preferred_term: methane metabolic process
+    term:
+      id: GO:0015947
+      label: methane metabolic process
+  evidence:
+  - reference: PMID:32655999
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: competitive and mutualistic metabolic interactions among Methylobacter and Methylomonas
+    explanation: Supports modeled interaction types between the two methanotroph genera.
+  - reference: PMID:32655999
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: excretion of formaldehyde and carbon di-oxide in the community
+    explanation: Supports predicted extracellular metabolite exchange in the community model.
+environmental_factors:
+- name: Methane amendment
+  value: methane supplied at the same concentration in each microcosm
+  description: Methane was the selective carbon and energy substrate for methane-consuming guilds.
+  evidence:
+  - reference: PMID:25755930
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: methane was supplied at the same concentration in each
+    explanation: Supports methane amendment as the controlled substrate.
+- name: Oxygen tension
+  value: five different oxygen tensions
+  description: >
+    Oxygen tension structured which Methylococcaceae and Methylophilaceae
+    genera persisted during methane-fed incubation.
+  evidence:
+  - reference: PMID:25755930
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: five different oxygen tensions
+    explanation: Supports oxygen tension as a controlled environmental factor.
+- name: Methane-oxygen countergradient
+  value: freshwater lake methane-oxygen countergradient
+  description: >
+    Lake Washington is characterized by methane and oxygen gradients that shape
+    methane-cycling community ecology.
+  evidence:
+  - reference: PMID:32655999
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: methane-oxygen countergradient
+    explanation: Supports the natural gradient context used in the modeling study.
+growth_media:
+- name: Lake Washington methane-fed sediment microcosm
+  atmosphere: AEROBIC
+  composition:
+  - name: Methane
+    chebi_term:
+      preferred_term: methane
+      term:
+        id: CHEBI:16183
+        label: methane
+  - name: Oxygen
+    chebi_term:
+      preferred_term: dioxygen
+      term:
+        id: CHEBI:15379
+        label: dioxygen
+  preparation_notes: >
+    Lake Washington sediment was incubated in microcosms with methane supplied
+    at a fixed concentration and oxygen supplied across five different tension
+    treatments. Detailed medium chemistry beyond sediment, methane, and oxygen
+    is not asserted here.
+  evidence:
+  - reference: PMID:25755930
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: microcosm incubations with sediment samples from Lake Washington
+    explanation: Supports sediment microcosm cultivation context.
+  - reference: PMID:25755930
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: methane was supplied at the same concentration in each
+    explanation: Supports methane as the supplied substrate.
+associated_datasets:
+- name: Oxygen-gradient Lake Washington methane-consuming microcosms
+  dataset_type: AMPLICON_16S
+  repository: OTHER
+  accession: PMID:25755930
+  url: https://pubmed.ncbi.nlm.nih.gov/25755930/
+  description: >
+    PubMed-indexed PeerJ study of oxygen availability and community composition
+    in methane-fed Lake Washington sediment microcosms.
+  evidence:
+  - reference: PMID:25755930
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Community composition was determined through 16S rRNA gene amplicon sequencing
+    explanation: Links the amplicon study to the curated community.
+- name: Lake Washington methanotroph genome-scale community modeling
+  dataset_type: OTHER
+  repository: OTHER
+  accession: PMID:32655999
+  url: https://pubmed.ncbi.nlm.nih.gov/32655999/
+  description: >
+    Genome-scale metabolic modeling study of Lake Washington Methylobacter and
+    Methylomonas methane-cycling interactions.
+  evidence:
+  - reference: PMID:32655999
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: developing highly curated genome-scale metabolic models
+    explanation: Links the metabolic modeling publication to this community.
+- name: Lake Washington Methylophilaceae ecotype genomics
+  dataset_type: GENOME
+  repository: OTHER
+  accession: PMID:25058595
+  url: https://pubmed.ncbi.nlm.nih.gov/25058595/
+  description: >
+    Cultivation and genome sequencing study of Lake Washington Methylophilaceae
+    ecotypes relevant to methane oxidation-associated methylotroph communities.
+  evidence:
+  - reference: PMID:25058595
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: Genome-based metabolic reconstruction highlights metabolic versatility of Methylophilaceae
+    explanation: Links Methylophilaceae genomic evidence to the curated methylotroph guild.
+metal_relevance: NOT_APPLICABLE
+metal_notes: >
+  No metal or rare earth element processing role is curated for this
+  methane-consuming freshwater sediment community.

--- a/references_cache/PMID_25058595.md
+++ b/references_cache/PMID_25058595.md
@@ -1,0 +1,64 @@
+---
+reference_id: PMID:25058595
+title: ''
+authors: []
+journal: ''
+year: ''
+content_type: abstract_only
+---
+
+# PMID:25058595
+
+## Content
+
+1. PLoS One. 2014 Jul 24;9(7):e102458. doi: 10.1371/journal.pone.0102458. 
+eCollection 2014.
+
+The expanded diversity of methylophilaceae from Lake Washington through 
+cultivation and genomic sequencing of novel ecotypes.
+
+Beck DA(1), McTaggart TL(2), Setboonsarng U(2), Vorobev A(2), Kalyuzhnaya MG(3), 
+Ivanova N(4), Goodwin L(5), Woyke T(4), Lidstrom ME(6), Chistoserdova L(2).
+
+Author information:
+(1)Department of Chemical Engineering, University of Washington, Seattle, 
+Washington, United States of America; eScience Institute, University of 
+Washington, Seattle, Washington, United States of America.
+(2)Department of Chemical Engineering, University of Washington, Seattle, 
+Washington, United States of America.
+(3)Department of Microbiology, University of Washington, Seattle, Washington, 
+United States of America.
+(4)DOE Joint Genome Institute, Walnut Creek, California, United States of 
+America.
+(5)Los Alamos National Laboratory, Los Alamos, New Mexico, United States of 
+America.
+(6)Department of Chemical Engineering, University of Washington, Seattle, 
+Washington, United States of America; Department of Microbiology, University of 
+Washington, Seattle, Washington, United States of America.
+
+We describe five novel Methylophilaceae ecotypes from a single ecological niche 
+in Lake Washington, USA, and compare them to three previously described 
+ecotypes, in terms of their phenotype and genome sequence divergence. Two of the 
+ecotypes appear to represent novel genera within the Methylophilaceae. 
+Genome-based metabolic reconstruction highlights metabolic versatility of 
+Methylophilaceae with respect to methylotrophy and nitrogen metabolism, 
+different ecotypes possessing different combinations of primary substrate 
+oxidation systems (MxaFI-type methanol dehydrogenase versus XoxF-type methanol 
+dehydrogenase; methylamine dehydrogenase versus N-methylglutamate pathway) and 
+different potentials for denitrification (assimilatory versus respiratory 
+nitrate reduction). By comparing pairs of closely related genomes, we uncover 
+that site-specific recombination is the main means of genomic evolution and 
+strain divergence, including lateral transfers of genes from both closely- and 
+distantly related taxa. The new ecotypes and the new genomes contribute 
+significantly to our understanding of the extent of genomic and metabolic 
+diversity among organisms of the same family inhabiting the same ecological 
+niche. These organisms also provide novel experimental models for studying the 
+complexity and the function of the microbial communities active in 
+methylotrophy.
+
+DOI: 10.1371/journal.pone.0102458
+PMCID: PMC4109929
+PMID: 25058595 [Indexed for MEDLINE]
+
+Conflict of interest statement: Competing Interests: The authors have declared 
+that no competing interests exist.

--- a/references_cache/PMID_25058595.md
+++ b/references_cache/PMID_25058595.md
@@ -1,13 +1,27 @@
 ---
 reference_id: PMID:25058595
-title: ''
-authors: []
-journal: ''
-year: ''
+title: The expanded diversity of methylophilaceae from Lake Washington through cultivation and genomic sequencing of novel ecotypes.
+authors:
+- Beck DA
+- McTaggart TL
+- Setboonsarng U
+- Vorobev A
+- Kalyuzhnaya MG
+- Ivanova N
+- Goodwin L
+- Woyke T
+- Lidstrom ME
+- Chistoserdova L
+journal: PLoS One
+year: '2014'
+doi: 10.1371/journal.pone.0102458
 content_type: abstract_only
 ---
 
-# PMID:25058595
+# The expanded diversity of methylophilaceae from Lake Washington through cultivation and genomic sequencing of novel ecotypes.
+**Authors:** Beck DA, McTaggart TL, Setboonsarng U, Vorobev A, Kalyuzhnaya MG, Ivanova N, Goodwin L, Woyke T, Lidstrom ME, Chistoserdova L
+**Journal:** PLoS One (2014)
+**DOI:** [10.1371/journal.pone.0102458](https://doi.org/10.1371/journal.pone.0102458)
 
 ## Content
 

--- a/references_cache/PMID_25755930.md
+++ b/references_cache/PMID_25755930.md
@@ -1,0 +1,60 @@
+---
+reference_id: PMID:25755930
+title: ''
+authors: []
+journal: ''
+year: ''
+content_type: abstract_only
+---
+
+# PMID:25755930
+
+## Content
+
+1. PeerJ. 2015 Feb 24;3:e801. doi: 10.7717/peerj.801. eCollection 2015.
+
+Oxygen availability is a major factor in determining the composition of 
+microbial communities involved in methane oxidation.
+
+Hernandez ME(1), Beck DA(2), Lidstrom ME(3), Chistoserdova L(4).
+
+Author information:
+(1)Department of Chemical Engineering, University of Washington , Seattle , USA 
+; Biotechnological Management of Resources Network, Institute of Ecology , A.C. 
+Xalapa, Veracruz , Mexico.
+(2)Department of Chemical Engineering, University of Washington , Seattle , USA 
+; eScience Institute, University of Washington , Seattle , USA.
+(3)Department of Chemical Engineering, University of Washington , Seattle , USA 
+; Department of Microbiology, University of Washington , Seattle , USA.
+(4)Department of Chemical Engineering, University of Washington , Seattle , USA.
+
+We have previously observed that methane supplied to lake sediment microbial 
+communities as a substrate not only causes a response by bona fide 
+methanotrophic bacteria, but also by non-methane-oxidizing bacteria, especially 
+by members of the family Methylophilaceae. This result suggested that methane 
+oxidation in this environment likely involves communities composed of different 
+functional guilds, rather than a single type of microbe. To obtain further 
+support for this concept and to obtain further insights into the factors that 
+may define such partnerships, we carried out microcosm incubations with sediment 
+samples from Lake Washington at five different oxygen tensions, while methane 
+was supplied at the same concentration in each. Community composition was 
+determined through 16S rRNA gene amplicon sequencing after 10 and 16 weeks of 
+incubation. We demonstrate that, in support of our prior observations, the 
+methane-consuming communities were represented by two major types: the 
+methanotrophs of the family Methylococcaceae and by non-methanotrophic 
+methylotrophs of the family Methylophilaceae. However, different species 
+persisted under different oxygen tensions. At high initial oxygen tensions (150 
+to 225 µM) the major players were, respectively, species of the genera 
+Methylosarcina and Methylophilus, while at low initial oxygen tensions (15 to 75 
+µM) the major players were Methylobacter and Methylotenera. These data suggest 
+that oxygen availability is at least one major factor determining specific 
+partnerships in methane oxidation. The data also suggest that speciation within 
+Methylococcaceae and Methylophilaceae may be driven by niche adaptation tailored 
+toward specific placements within the oxygen gradient.
+
+DOI: 10.7717/peerj.801
+PMCID: PMC4349146
+PMID: 25755930
+
+Conflict of interest statement: Ludmila Chistoserdova is an Academic Editor for 
+Peer J.

--- a/references_cache/PMID_25755930.md
+++ b/references_cache/PMID_25755930.md
@@ -1,13 +1,21 @@
 ---
 reference_id: PMID:25755930
-title: ''
-authors: []
-journal: ''
-year: ''
+title: Oxygen availability is a major factor in determining the composition of microbial communities involved in methane oxidation.
+authors:
+- Hernandez ME
+- Beck DA
+- Lidstrom ME
+- Chistoserdova L
+journal: PeerJ
+year: '2015'
+doi: 10.7717/peerj.801
 content_type: abstract_only
 ---
 
-# PMID:25755930
+# Oxygen availability is a major factor in determining the composition of microbial communities involved in methane oxidation.
+**Authors:** Hernandez ME, Beck DA, Lidstrom ME, Chistoserdova L
+**Journal:** PeerJ (2015)
+**DOI:** [10.7717/peerj.801](https://doi.org/10.7717/peerj.801)
 
 ## Content
 

--- a/references_cache/PMID_32655999.md
+++ b/references_cache/PMID_32655999.md
@@ -1,0 +1,69 @@
+---
+reference_id: PMID:32655999
+title: ''
+authors: []
+journal: ''
+year: ''
+content_type: abstract_only
+---
+
+# PMID:32655999
+
+## Content
+
+1. PeerJ. 2020 Jun 30;8:e9464. doi: 10.7717/peerj.9464. eCollection 2020.
+
+Investigation of microbial community interactions between Lake Washington 
+methanotrophs using -------genome-scale metabolic modeling.
+
+Islam MM(1), Le T(2), Daggumati SR(1), Saha R(1).
+
+Author information:
+(1)Department of Chemical and Biomolecular Engineering, University of 
+Nebraska-Lincoln, Lincoln, NE, United States of America.
+(2)Department of Biochemistry, University of Nebraska-Lincoln, Lincoln, NE, 
+United States of America.
+
+BACKGROUND: The role of methane in global warming has become paramount to the 
+environment and the human society, especially in the past few decades. Methane 
+cycling microbial communities play an important role in the global methane 
+cycle, which is why the characterization of these communities is critical to 
+understand and manipulate their behavior. Methanotrophs are a major player in 
+these communities and are able to oxidize methane as their primary carbon 
+source.
+RESULTS: Lake Washington is a freshwater lake characterized by a methane-oxygen 
+countergradient that contains a methane cycling microbial community. 
+Methanotrophs are a major part of this community involved in assimilating 
+methane from lake water. Two significant methanotrophic species in this 
+community are Methylobacter and Methylomonas. In this work, these methanotrophs 
+are computationally studied via developing highly curated genome-scale metabolic 
+models. Each model was then integrated to form a community model with a 
+multi-level optimization framework. The competitive and mutualistic metabolic 
+interactions among Methylobacter and Methylomonas were also characterized. The 
+community model was next tested under carbon, oxygen, and nitrogen limited 
+conditions in addition to a nutrient-rich condition to observe the systematic 
+shifts in the internal metabolic pathways and extracellular metabolite 
+exchanges. Each condition showed variations in the methane oxidation pathway, 
+pyruvate metabolism, and the TCA cycle as well as the excretion of formaldehyde 
+and carbon di-oxide in the community. Finally, the community model was simulated 
+under fixed ratios of these two members to reflect the opposing behavior in the 
+two-member synthetic community and in sediment-incubated communities. The 
+community simulations predicted a noticeable switch in intracellular carbon 
+metabolism and formaldehyde transfer between community members in 
+sediment-incubated vs. synthetic condition.
+CONCLUSION: In this work, we attempted to predict the response of a simplified 
+methane cycling microbial community from Lake Washington to varying environments 
+and also provide an insight into the difference of dynamics in 
+sediment-incubated microcosm community and synthetic co-cultures. Overall, this 
+study lays the ground for in silico systems-level studies of freshwater lake 
+ecosystems, which can drive future efforts of understanding, engineering, and 
+modifying these communities for dealing with global warming issues.
+
+©2020 Islam et al.
+
+DOI: 10.7717/peerj.9464
+PMCID: PMC7333651
+PMID: 32655999
+
+Conflict of interest statement: The authors declare there are no competing 
+interests.

--- a/references_cache/PMID_32655999.md
+++ b/references_cache/PMID_32655999.md
@@ -1,20 +1,28 @@
 ---
 reference_id: PMID:32655999
-title: ''
-authors: []
-journal: ''
-year: ''
+title: Investigation of microbial community interactions between Lake Washington methanotrophs using genome-scale metabolic modeling.
+authors:
+- Islam MM
+- Le T
+- Daggumati SR
+- Saha R
+journal: PeerJ
+year: '2020'
+doi: 10.7717/peerj.9464
 content_type: abstract_only
 ---
 
-# PMID:32655999
+# Investigation of microbial community interactions between Lake Washington methanotrophs using genome-scale metabolic modeling.
+**Authors:** Islam MM, Le T, Daggumati SR, Saha R
+**Journal:** PeerJ (2020)
+**DOI:** [10.7717/peerj.9464](https://doi.org/10.7717/peerj.9464)
 
 ## Content
 
 1. PeerJ. 2020 Jun 30;8:e9464. doi: 10.7717/peerj.9464. eCollection 2020.
 
 Investigation of microbial community interactions between Lake Washington 
-methanotrophs using -------genome-scale metabolic modeling.
+methanotrophs using genome-scale metabolic modeling.
 
 Islam MM(1), Le T(2), Daggumati SR(1), Saha R(1).
 


### PR DESCRIPTION
## Summary

Adds `CommunityMech:000261` — Lake Washington methane-oxygen methylotroph community. Methane-fed Lake Washington sediment microcosms in which methane addition selects both bona fide methane-oxidizing *Methylococcaceae* and non-methanotrophic methylotrophic *Methylophilaceae*. Oxygen tension partitions the partnerships:
- High O₂: *Methylosarcina* + *Methylophilus*
- Low O₂: *Methylobacter* + *Methylotenera*

Three references curated:
- PMID:25755930 (sediment microcosm guild dynamics)
- PMID:25058595 (Methylophilaceae ecotype description)
- PMID:32655999 (oxygen-dependent partnership modeling)

## Test plan
- [x] `just validate kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml` passes
- [x] `just validate-terms` passes
- [x] ASCII-only — no non-ASCII characters
- [x] 29/29 snippets verified as whitespace-normalized substrings of the cached PubMed abstracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)