### PR TITLE
Fix snippet substring matching across 8 community YAMLs

### DIFF
--- a/kb/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.yaml
+++ b/kb/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.yaml
@@ -137,7 +137,8 @@ ecological_interactions:
   - reference: PMID:39085194
     supports: SUPPORT
     evidence_source: IN_VIVO
-    snippet: pyruvate oxidation and carbon fixation via the Wood-Ljungdahl pathway
+    snippet: expression of genes..hydrogenases, pyruvate oxidation and carbon fixation
+      via the Wood-Ljungdahl pathway
     explanation: Supports active H2 cycling and Wood-Ljungdahl carbon fixation.
 - name: Carbohydrate Breakdown to Acetate and Formate
   description: Asgard archaea express enzymes for carbohydrate breakdown to

--- a/kb/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.yaml
+++ b/kb/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.yaml
@@ -137,8 +137,7 @@ ecological_interactions:
   - reference: PMID:39085194
     supports: SUPPORT
     evidence_source: IN_VIVO
-    snippet: expression of genes for [NiFe]-hydrogenases, pyruvate oxidation and
-      carbon fixation via the Wood-Ljungdahl pathway
+    snippet: pyruvate oxidation and carbon fixation via the Wood-Ljungdahl pathway
     explanation: Supports active H2 cycling and Wood-Ljungdahl carbon fixation.
 - name: Carbohydrate Breakdown to Acetate and Formate
   description: Asgard archaea express enzymes for carbohydrate breakdown to

--- a/kb/communities/Australian_Lead_Zinc_Polymetallic.yaml
+++ b/kb/communities/Australian_Lead_Zinc_Polymetallic.yaml
@@ -718,11 +718,13 @@ ecological_interactions:
       success of revegetation efforts at tailing sites
     explanation: Documents Acidiphilium distribution in tailings systems
   - reference: doi:10.1128/aem.00294-14
-    supports: SUPPORT
+    supports: PARTIAL
     evidence_source: IN_VIVO
-    snippet: This study investigated the spatial heterogeneity of bacterial and archaeal communities in
-      the acidic mineral tailings at the Red Lake mine site, Ontario, Canada
-    explanation: Establishes heterotroph-autotroph syntrophy in acidic mine systems
+    snippet: pH is primarily responsible for structuring whole communities in the extreme and heterogeneous
+      mine tailings
+    explanation: Supports pH-driven structuring of acidic mine tailing communities;
+      original abstract is about a Chinese copper tailing rather than the Red Lake/Ontario
+      site cited here, so support is partial.
 environmental_factors:
 - name: pH Stratification
   value: 1.5-7.0

--- a/kb/communities/Australian_Lead_Zinc_Polymetallic.yaml
+++ b/kb/communities/Australian_Lead_Zinc_Polymetallic.yaml
@@ -722,9 +722,10 @@ ecological_interactions:
     evidence_source: IN_VIVO
     snippet: pH is primarily responsible for structuring whole communities in the extreme and heterogeneous
       mine tailings
-    explanation: Supports pH-driven structuring of acidic mine tailing communities;
-      original abstract is about a Chinese copper tailing rather than the Red Lake/Ontario
-      site cited here, so support is partial.
+    explanation: Supports pH-driven structuring of acidic mine tailing communities.
+      Partial because the cited abstract characterizes a Chinese copper tailing impoundment
+      rather than the Australian Pb-Zn polymetallic tailing system represented in this
+      record; mechanism transfers but the specific site does not.
 environmental_factors:
 - name: pH Stratification
   value: 1.5-7.0

--- a/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
+++ b/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
@@ -186,12 +186,13 @@ ecological_interactions:
     snippet: lactate considerably boosted (circa three-fold) the growth of L. kefiranofaciens
     explanation: Quantifies the growth enhancement of L. kefiranofaciens by lactate from L. mesenteroides.
   - reference: PMID:33398099
-    supports: SUPPORT
+    supports: PARTIAL
     evidence_source: IN_VITRO
-    snippet: the metabolic cooperation between L. kefiranofaciens and L. mesenteroides is mediated by
-      amino acids and small peptides liberated by proteolytic activity of L. kefiranofaciens, which in
-      turn benefits from lactic acid produced by L. mesenteroides
-    explanation: Summarizes the bidirectional mutualistic exchange between the two species.
+    snippet: early members open the niche for the followers by making available metabolites
+      such as amino acids and lactate
+    explanation: Abstract confirms cross-feeding of amino acids and lactate among kefir
+      members; the specific kefiranofaciens/mesenteroides direction is detailed in the
+      full text but only generically supported by the abstract.
 - name: Acetobacter Lactate Cross-Feeding
   description: Acetobacter fabarum exhibits strong dependency on lactate produced by lactate-generating
     bacteria (L. mesenteroides, L. lactis). The majority of mutualistic interactions involving A. fabarum

--- a/kb/communities/Chlamydomonas_Bacterial_H2_Consortium.yaml
+++ b/kb/communities/Chlamydomonas_Bacterial_H2_Consortium.yaml
@@ -27,8 +27,8 @@ engineering_design:
   - reference: PMID:38159768
     supports: SUPPORT
     evidence_source: IN_VITRO
-    snippet: Still, under non-hydrogen producing conditions (aerobiosis), the Chlamydomonas-bacterial
-      consortium remained stable and sustained algal growth without accumulating hydrogen.
+    snippet: under non-hydrogen producing conditions (aerobiosis) the Chlamydomonas-M.
+      forte sp. nov. consortium allowed algal growth
 environment_term:
   preferred_term: laboratory bioreactor
   term:

--- a/kb/communities/Dangl_SynComm_35.yaml
+++ b/kb/communities/Dangl_SynComm_35.yaml
@@ -33,7 +33,7 @@ engineering_design:
     supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: We report that root-associated commensal bacteria actively suppress the
-      host immune response in the context of a synthetic bacterial community.
+      host immune response in the context of a community
     explanation: Supports use of a defined synthetic community to measure suppression
       of specific plant immune responses.
 environment_term:
@@ -414,7 +414,7 @@ growth_media:
     supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: We report that root-associated commensal bacteria actively suppress the
-      host immune response in the context of a synthetic bacterial community.
+      host immune response in the context of a community
   culturemech_id: CultureMech:008226
   culturemech_url: https://github.com/CultureBotAI/CultureMech/tree/main/kb/media/CultureMech:008226
   composition:

--- a/kb/communities/Dangl_SynComm_35.yaml
+++ b/kb/communities/Dangl_SynComm_35.yaml
@@ -30,12 +30,13 @@ engineering_design:
   perturbation_design: 'Designed condition space included: MAMP Treatment, Plant Age.'
   evidence:
   - reference: doi:10.1073/pnas.2100678118
-    supports: SUPPORT
+    supports: PARTIAL
     evidence_source: IN_VITRO
     snippet: We report that root-associated commensal bacteria actively suppress the
       host immune response in the context of a community
-    explanation: Supports use of a defined synthetic community to measure suppression
-      of specific plant immune responses.
+    explanation: Abstract substantiates immune suppression by a root-associated bacterial
+      community but does not explicitly describe the assay as a "defined synthetic"
+      community; support for the engineering-design framing is therefore partial.
 environment_term:
   preferred_term: rhizosphere
   term:

--- a/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
+++ b/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
@@ -287,8 +287,8 @@ ecological_interactions:
   - reference: PMID:33927032
     supports: SUPPORT
     evidence_source: COMPUTATIONAL
-    snippet: contained either putative heavy metal resistance genes or ATPase efflux
-      pump genes
+    snippet: 27 of the 28 MAGs..contained either putative heavy metal resistance
+      genes or ATPase efflux pump genes
     explanation: Documents near-universal heavy metal resistance in EFPC sediment community
 - name: Selenium Assimilatory Metabolism
   description: '17 of 28 MAGs from EFPC sediment contained traits for selenium assimilatory metabolism,

--- a/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
+++ b/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
@@ -287,7 +287,7 @@ ecological_interactions:
   - reference: PMID:33927032
     supports: SUPPORT
     evidence_source: COMPUTATIONAL
-    snippet: 27 of the 28 MAGs contained either putative heavy metal resistance genes or ATPase efflux
+    snippet: contained either putative heavy metal resistance genes or ATPase efflux
       pump genes
     explanation: Documents near-universal heavy metal resistance in EFPC sediment community
 - name: Selenium Assimilatory Metabolism

--- a/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
+++ b/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
@@ -517,8 +517,9 @@ environmental_factors:
   - reference: doi:10.3389/fmicb.2013.00037
     supports: SUPPORT
     evidence_source: IN_VIVO
-    snippet: the relatively high temperatures and the high nutrient depletion (oligotrophy)
-    explanation: Confirms high nutrient depletion
+    snippet: thermophilic chemolithoautotrophs adapted to thrive in an extremely energy-limited
+      environment
+    explanation: Confirms extreme energy/nutrient limitation in the Naica aquifer.
 - name: Isolation and Geological Stability
   value: 500,000+ years
   unit: years

--- a/kb/communities/PGM_Spent_Catalyst_Bioleaching.yaml
+++ b/kb/communities/PGM_Spent_Catalyst_Bioleaching.yaml
@@ -91,10 +91,13 @@ taxonomy:
       thiooxidans has been reported
     explanation: Establishes At. thiooxidans as primary bioleaching organism
   - reference: doi:10.1016/j.jenvman.2019.04.081
-    supports: SUPPORT
+    supports: PARTIAL
     evidence_source: IN_VITRO
-    snippet: 'Recovery percentages: Pd 93.2%, Ni 82.9%, Al 33.4%, Mo 22.7% from spent petroleum catalyst'
-    explanation: Quantifies PGM and metal recovery performance
+    snippet: about 82.9% of Ni, 33.4% of Al, and 22.7% of Mo were leached after 315 h
+      of column operation
+    explanation: Abstract reports Ni/Al/Mo recovery from petroleum refinery spent catalyst;
+      original Pd 93.2% figure is not in the abstract, so support for the PGM portion
+      of the claim is partial.
   - reference: PMID:38138568
     supports: SUPPORT
     evidence_source: IN_VITRO


### PR DESCRIPTION
## Summary

Repair all remaining \`Text part not found as substring\` reference-validation errors by replacing paraphrased snippets with verbatim substrings of the cited abstracts. Where the abstract doesn't actually support the curated claim, downgrade the evidence to \`PARTIAL\` and rewrite the snippet to match what the abstract does say.

## Files

- **Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.yaml**: drop the bracketed \`[NiFe]-hydrogenases,\` prefix (the validator strips square brackets, which broke adjacency in the substring match).
- **Australian_Lead_Zinc_Polymetallic.yaml** \`doi:10.1128/aem.00294-14\`: abstract is about a Chinese copper tailing, not the Red Lake/Ontario context. Verbatim pH-driven structuring quote, downgrade to PARTIAL.
- **BioModels_MODEL2204300001_Kefir_Community_Model.yaml** PMID:33398099: replace the L. kefiranofaciens / L. mesenteroides paraphrase with the abstract's generic \"amino acids and lactate\" cross-feeding quote, downgrade to PARTIAL.
- **Chlamydomonas_Bacterial_H2_Consortium.yaml** PMID:38159768: use the abstract's exact \"Chlamydomonas-M. forte sp. nov. consortium\" phrasing.
- **Dangl_SynComm_35.yaml** \`doi:10.1073/pnas.2100678118\`: drop \"synthetic bacterial\" — abstract says \"in the context of a community\" (two evidence items).
- **Mercury_SFA_EFPC_Sediment_Community.yaml** PMID:33927032: trim leading clause — abstract has a parenthetical between \"MAGs\" and \"contained\".
- **Naica_Deep_Subsurface_Thermophilic.yaml** \`doi:10.3389/fmicb.2013.00037\`: paraphrase wasn't in abstract; replace with verbatim \"thermophilic chemolithoautotrophs adapted to thrive in an extremely energy-limited environment\".
- **PGM_Spent_Catalyst_Bioleaching.yaml** \`doi:10.1016/j.jenvman.2019.04.081\`: abstract is about Ni/V/Mo/Al recovery from petroleum refinery spent catalyst, not PGM. The \`Pd 93.2%\` figure was fabricated. Replace with the abstract's verbatim Ni/Al/Mo percentages, downgrade to PARTIAL.

## Impact

Net \`just validate-references-all\`: **110 → 101 errors** (0 text-mismatch remaining; 66 \"No content available\" + 35 \"Could not fetch\" continue as upstream availability issues unrelated to curation).

## Test plan

- [x] \`just validate-references-all\` shows 0 text-mismatch errors
- [x] All 8 modified YAMLs still pass \`just validate-all\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)