### PR TITLE
Cite Marinobacter HP15 genome paper for diatom-aggregation evidence

### DIFF
--- a/kb/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.yaml
+++ b/kb/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.yaml
@@ -126,6 +126,14 @@ ecological_interactions:
     evidence_source: IN_VITRO
     snippet: T. weissflogii did not aggregate in axenic culture
     explanation: Supports the contrast between axenic diatom controls and bacteria-containing treatments.
+  - reference: doi:10.4056/sigs.922139
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: it showed specific attachment to diatom cells. In vitro it led to exopolymer
+      formation and aggregation of these algal cells to form marine snow particles
+    explanation: HP15 type-strain genome paper directly describes HP15's diatom-cell
+      attachment and resulting exopolymer-mediated aggregation into marine snow particles,
+      supporting the bacteria-dependent aggregation phenotype.
 - name: Transparent Exopolymer Particle Enhancement
   description: >
     M. adhaerens HP15 is linked to transparent exopolymeric particle formation


### PR DESCRIPTION
## Summary

Wire the orphan \`references_cache/DOI_10.4056_sigs.922139.md\` cache into the curated knowledge base by citing the HP15 type-strain genome paper (Gärdes et al. 2010, Stand Genomic Sci) on the Bacteria-Dependent Diatom Aggregation interaction in the Thalassiosira-Marinobacter coculture community.

The HP15 genome paper directly describes:
- HP15's specific attachment to diatom cells
- In vitro exopolymer formation and aggregation of algal cells into marine snow particles

These are the same phenotypes anchoring the COLONIZATION_FACILITATION interaction in the community, so adding this reference gives the assertion an orthogonal source (the strain's characterization itself) on top of the two PMID:20827289 assay-based items already present.

## Test plan

- [x] \`just validate kb/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.yaml\` — no schema issues
- [x] \`just validate-references kb/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.yaml\` — passes (snippet is a verbatim substring of the cached abstract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)