### PR TITLE
Publisher-meta scraper fallback + 3 Springer cache refreshes (43 -> 39)

### DIFF
--- a/kb/communities/AMD_Acidophile_Heterotroph_Network.yaml
+++ b/kb/communities/AMD_Acidophile_Heterotroph_Network.yaml
@@ -229,8 +229,8 @@ taxonomy:
   - reference: doi:10.1007/BF02106205
     supports: SUPPORT
     evidence_source: IN_VITRO
-    snippet: 'Acidobacterium capsulatum gen. nov., sp. nov.: An acidophilic chemoorganotrophic bacterium
-      containing menaquinone from acidic mineral environment'
+    snippet: Acidobacterium is proposed as a new genus for the acidophilic, chemoorganotrophic
+      bacteria containing menaquinone isolated from acidic mineral environments
     explanation: Establishes isolation from acidic mineral environment
   - reference: doi:10.3389/fmicb.2016.00744
     supports: SUPPORT
@@ -622,8 +622,8 @@ ecological_interactions:
   - reference: doi:10.1007/BF02106205
     supports: SUPPORT
     evidence_source: IN_VITRO
-    snippet: 'Acidobacterium capsulatum gen. nov., sp. nov.: An acidophilic chemoorganotrophic bacterium
-      containing menaquinone from acidic mineral environment'
+    snippet: Acidobacterium is proposed as a new genus for the acidophilic, chemoorganotrophic
+      bacteria containing menaquinone isolated from acidic mineral environments
     explanation: Establishes chemoorganotrophic metabolism
   - reference: doi:10.3389/fmicb.2016.00744
     supports: SUPPORT

--- a/kb/communities/Ewaste_Bioleaching_Consortium.yaml
+++ b/kb/communities/Ewaste_Bioleaching_Consortium.yaml
@@ -136,9 +136,11 @@ taxonomy:
   - reference: doi:10.1007/s10311-019-00911-y
     supports: SUPPORT
     evidence_source: IN_VITRO
-    snippet: Enhanced bioleaching of copper from circuit boards of computer waste by Acidithiobacillus
-      ferrooxidans
-    explanation: Establishes At. ferrooxidans efficacy for e-waste copper recovery
+    snippet: Computer circuit boards are a major electronic waste containing higher concentrations
+      of copper, gold and silver. These metals may be recovered by bioleaching
+    explanation: Establishes bioleaching of computer circuit boards for recovery of copper
+      and other metals; the paper specifically evaluates Acidithiobacillus ferrooxidans
+      efficacy.
 - taxon_term:
     preferred_term: Acidithiobacillus thiooxidans
     term:

--- a/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
+++ b/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
@@ -697,10 +697,12 @@ environmental_factors:
       with Proteobacteria
     explanation: Documents meromictic stability
   - reference: doi:10.1007/s10230-008-0059-z
-    supports: PARTIAL
+    supports: SUPPORT
     evidence_source: IN_VIVO
-    snippet: permanently stratified acidic pit lake
-    explanation: Documents thermal stratification maintaining meromixis
+    snippet: A marked vertical trend of increasing temperature and dissolved metal concentrations
+      is observed in the monimolimnia of some meromictic pit lakes of the Iberian
+    explanation: Documents the vertical temperature and metal gradients that maintain
+      meromictic stratification in Iberian acidic pit lakes.
 - name: Microbial Diversity Gradient
   value: 72-206
   unit: ASVs per sample

--- a/references_cache/DOI_10.1007_BF02106205.md
+++ b/references_cache/DOI_10.1007_BF02106205.md
@@ -8,7 +8,7 @@ authors:
 journal: Current Microbiology
 year: '1991'
 doi: 10.1007/BF02106205
-content_type: unavailable
+content_type: abstract_only
 ---
 
 # Acidobacterium capsulatum gen. nov., sp. nov.: An acidophilic chemoorganotrophic bacterium containing menaquinone from acidic mineral environment
@@ -17,3 +17,5 @@ content_type: unavailable
 **DOI:** [10.1007/BF02106205](https://doi.org/10.1007/BF02106205)
 
 ## Content
+
+Acidobacterium is proposed as a new genus for the acidophilic, chemoorganotrophic bacteria containing menaquinone isolated from acidic mineral environments.Acidobacterium

--- a/references_cache/DOI_10.1007_s10230-008-0059-z.md
+++ b/references_cache/DOI_10.1007_s10230-008-0059-z.md
@@ -9,7 +9,7 @@ authors:
 journal: Mine Water and the Environment
 year: '2009'
 doi: 10.1007/s10230-008-0059-z
-content_type: unavailable
+content_type: abstract_only
 ---
 
 # Physico-chemical gradients and meromictic stratification in Cueva de la Mora and other acidic pit lakes of the Iberian Pyrite Belt
@@ -18,3 +18,5 @@ content_type: unavailable
 **DOI:** [10.1007/s10230-008-0059-z](https://doi.org/10.1007/s10230-008-0059-z)
 
 ## Content
+
+A marked vertical trend of increasing temperature and dissolved metal concentrations is observed in the monimolimnia of some meromictic pit lakes of the Iberian

--- a/references_cache/DOI_10.1007_s10311-019-00911-y.md
+++ b/references_cache/DOI_10.1007_s10311-019-00911-y.md
@@ -7,7 +7,7 @@ authors:
 journal: Environmental Chemistry Letters
 year: '2019'
 doi: 10.1007/s10311-019-00911-y
-content_type: unavailable
+content_type: abstract_only
 ---
 
 # Enhanced bioleaching of copper from circuit boards of computer waste by Acidithiobacillus ferrooxidans
@@ -16,3 +16,5 @@ content_type: unavailable
 **DOI:** [10.1007/s10311-019-00911-y](https://doi.org/10.1007/s10311-019-00911-y)
 
 ## Content
+
+Computer circuit boards are a major electronic waste containing higher concentrations of copper, gold and silver. These metals may be recovered by bioleaching, an

--- a/src/communitymech/literature.py
+++ b/src/communitymech/literature.py
@@ -368,6 +368,72 @@ class LiteratureFetcher:
             print(f"Error fetching Europe PMC for {doi}: {e}")
             return None
 
+    def fetch_publisher_meta_abstract(self, doi: str) -> str | None:
+        """
+        Last-resort scrape of the DOI landing page for an abstract excerpt.
+
+        Most publishers expose the abstract (or its first ~200 chars) in
+        page-level meta tags - typically `twitter:description`,
+        `og:description`, or the standard `<meta name="description">` -
+        even when the article itself is paywalled and Crossref / OpenAlex /
+        Semantic Scholar / Europe PMC carry no abstract. Springer/Nature
+        is the most reliable source for this pattern; Elsevier
+        ScienceDirect serves a bot-detection page and yields nothing.
+
+        Args:
+            doi: DOI string (with or without "doi:" prefix)
+
+        Returns:
+            Abstract excerpt (may be truncated to ~200 chars by the
+            publisher) or None.
+        """
+        doi = re.sub(r"^(?i:doi:)", "", doi).replace("https://doi.org/", "").strip()
+        cache_file = self._abstract_cache_path("publisher", doi)
+        if cache_file.exists():
+            return cache_file.read_text() or None
+
+        try:
+            response = self.session.get(
+                f"https://doi.org/{doi}",
+                headers={"User-Agent": "Mozilla/5.0 (Macintosh)"},
+                allow_redirects=True,
+                timeout=30,
+            )
+            response.raise_for_status()
+            html = response.text
+        except requests.exceptions.RequestException as e:
+            print(f"Error scraping publisher page for {doi}: {e}")
+            return None
+
+        for tag in ("twitter:description", "og:description", "description"):
+            match = re.search(
+                rf'<meta\s+[^>]*name=["\']?{tag}["\']?\s+content=["\']([^"\']+)["\']',
+                html,
+                re.IGNORECASE,
+            )
+            if not match:
+                match = re.search(
+                    rf'<meta\s+[^>]*property=["\']?{tag}["\']?\s+content=["\']([^"\']+)["\']',
+                    html,
+                    re.IGNORECASE,
+                )
+            if match:
+                text = match.group(1)
+                # Decode common HTML entities
+                text = (
+                    text.replace("&amp;", "&")
+                    .replace("&quot;", '"')
+                    .replace("&#x27;", "'")
+                    .replace("&lt;", "<")
+                    .replace("&gt;", ">")
+                )
+                # Strip Springer's "Journal Name - " prefix and trailing ellipsis
+                text = re.sub(r"^[^-]+-\s*", "", text).rstrip(" .")
+                if len(text) > 80:  # skip nav-text and similar short snippets
+                    cache_file.write_text(text)
+                    return text
+        return None
+
     def fetch_unpaywall(self, doi: str, email: str = "noreply@example.com") -> str | None:
         """
         Try to fetch open access PDF URL from Unpaywall.
@@ -458,6 +524,8 @@ class LiteratureFetcher:
                 abstract = self.fetch_semantic_scholar_abstract(doi)
             if not abstract:
                 abstract = self.fetch_europepmc_abstract(doi)
+            if not abstract:
+                abstract = self.fetch_publisher_meta_abstract(doi)
 
             return (abstract, pdf_url)
 


### PR DESCRIPTION
## Summary

Drive \`just validate-references-all\` errors from **43 → 39** (and from session-start **101 → 39**, a **−62 net**) by adding a last-resort DOI-page scraper to the literature fetcher and refreshing the three Springer caches it unblocks.

## Fetcher

- **\`fetch_publisher_meta_abstract()\`** — \`GET https://doi.org/<DOI>\`, follow redirects, and pull the abstract excerpt from the page's \`twitter:description\` / \`og:description\` / \`description\` meta tag. Springer publishes the first ~200 chars of the abstract in \`twitter:description\` even for paywalled articles where Crossref / OpenAlex / Semantic Scholar / Europe PMC have no abstract. Includes on-disk caching as \`publisher_<safe-doi>.txt\` and strips the \`Journal Name - \` prefix Springer adds to that field. Elsevier ScienceDirect intentionally serves a bot-detection page and yields nothing — that's the residual cap.
- \`fetch_paper()\` chain now: CrossRef → PMID/PubMed → PMCID/PMC → OpenAlex → Semantic Scholar → Europe PMC → **publisher meta scrape**.

## Cache refreshes (recovers 4 ERROR rows)

- \`DOI_10.1007_s10311-019-00911-y\` (E-waste copper bioleaching, Springer)
- \`DOI_10.1007_s10230-008-0059-z\` (Iberian meromictic pit lakes, Springer)
- \`DOI_10.1007_BF02106205\` (Acidobacterium taxonomy, Current Microbiology / Springer; cited 2× in \`AMD_Acidophile_Heterotroph_Network\`)

## Snippet repairs

- **Ewaste_Bioleaching_Consortium**: replace title quote with the abstract's verbatim e-waste bioleaching framing.
- **Iberian_Pit_Lake_Stratified_Community**: upgrade PARTIAL→SUPPORT and expand snippet to the abstract's vertical-gradient quote.
- **AMD_Acidophile_Heterotroph_Network**: replace two title quotes with the abstract's verbatim genus proposal.

## Remaining 39

All Elsevier 2024-2025 papers (\`j.jece.2025.120403\`, \`j.cej.2024.153492\`, \`j.ibiod.2025.106190\`, \`10889868.2024.2407240\`) plus one ResearchGate preprint — abstracts not in any aggregator we can query and publisher pages serve bot-detection HTML.

## Test plan

- [x] \`just validate-references-all\` reports 39 ERROR rows (was 43 / session-start 101); 0 text-mismatch
- [x] All 3 modified YAMLs still pass \`just validate\`
- [x] Caching smoke-tested: first call hits HTTP, second reads from \`publisher_<doi>.txt\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)