### PR TITLE
Fix: add required `id` slot to 4 isolate YAMLs

### DIFF
--- a/data/isolates/Aspergillus_Indium_LED_Recovery.yaml
+++ b/data/isolates/Aspergillus_Indium_LED_Recovery.yaml
@@ -1,3 +1,4 @@
+id: CommunityMech:000271
 name: Aspergillus Indium LED Recovery Platform
 description: 'An engineered fungal monoculture bioplatform based on Aspergillus niger for sustainable recovery of indium from
   waste liquid crystal display (LCD) and light-emitting diode (LED) panels through indirect bioleaching. This system represents

--- a/data/isolates/BioModels_MODEL2204300002_Kefir_Rothia_Model.yaml
+++ b/data/isolates/BioModels_MODEL2204300002_Kefir_Rothia_Model.yaml
@@ -1,3 +1,4 @@
+id: CommunityMech:000272
 name: BioModels MODEL2204300002 Kefir Rothia Model
 description: >-
   BioModels record MODEL2204300002 contains a genome-scale metabolic model for Rothia

--- a/data/isolates/Chromobacterium_Gold_Biocyanidation.yaml
+++ b/data/isolates/Chromobacterium_Gold_Biocyanidation.yaml
@@ -1,3 +1,4 @@
+id: CommunityMech:000273
 name: Chromobacterium Gold Biocyanidation Platform
 description: >
   An engineered bioplatform utilizing the purple pigmented bacterium Chromobacterium

--- a/data/isolates/Methylobacterium_REE_Ewaste_Platform.yaml
+++ b/data/isolates/Methylobacterium_REE_Ewaste_Platform.yaml
@@ -1,3 +1,4 @@
+id: CommunityMech:000274
 name: Methylobacterium REE E-waste Platform
 description: 'An engineered monoculture bioplatform based on the mesophilic methylotrophic bacterium Methylobacterium extorquens
   AM1 for sustainable recovery of rare earth elements (REE) from electronic waste. This system represents a paradigm shift


### PR DESCRIPTION
## Summary

- Adds the required `id` slot (pattern `^CommunityMech:\d{6}$`) to the 4 isolate YAMLs that the new `schema-gap-analysis` skill flagged in #68's first end-to-end run.
- Assigned `CommunityMech:000271`–`000274` (next four IDs after the existing max of 000270).
- No other field changes.

## Validation

```
find data/isolates -name "*.yaml" -print0 \
  | xargs -0 .venv/bin/linkml-validate \
      -s src/communitymech/schema/communitymech.yaml \
      -C MicrobialCommunity
# → No issues found
```

All 5 isolate files now validate clean.

## Test plan

- [x] Confirm IDs don't collide with any existing `kb/communities/` or `data/isolates/` ID.
- [x] `linkml-validate -C MicrobialCommunity` on full isolate corpus returns "No issues found".
- [ ] Copilot review pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)