### PR TITLE
#30 backfill batch 2: 4 metals + 3 gut/rhizosphere communities

### DIFF
--- a/kb/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.yaml
+++ b/kb/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.yaml
@@ -219,6 +219,61 @@ environmental_factors:
     evidence_source: IN_VIVO
     snippet: in combination under 3 dietary conditions
     explanation: Supports diet as a controlled environmental factor.
+related_ingredients:
+- preferred_term: acetate
+  chebi_term:
+    id: CHEBI:30089
+    label: acetate
+  relevance: Acetate is the cross-feeding currency between B. thetaiotaomicron
+    and E. rectale in this gnotobiotic model — B. theta produces acetate
+    that E. rectale consumes to generate butyrate. Cecal acetate is
+    significantly lower in cocolonised mice, confirming the in vivo cross-
+    feeding; any environment-analog medium must support an acetate gradient
+    rather than a fixed pool.
+  evidence:
+  - reference: PMID:19321416
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: cecal acetate levels are significantly lower in cocolonized
+      mice compared with B. thetaiotaomicron monoassociated animals
+    explanation: Anchors acetate as the in vivo cross-feeding intermediate
+      whose pool shifts predictably when E. rectale is added to the
+      community.
+- preferred_term: butyrate
+  chebi_term:
+    id: CHEBI:17968
+    label: butyrate
+  relevance: Butyrate is the SCFA output of the consortium and the
+    epithelium-relevant endpoint; cecal butyrate levels stay similar between
+    E. rectale mono- and biassociated mice, indicating the coculture
+    maintains butyrate flux on a smaller acetate pool — a key behavior any
+    cultivation medium must support measuring.
+  evidence:
+  - reference: PMID:19321416
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: cecal butyrate levels are similar in E. rectale mono- and
+      biassociated animals
+    explanation: Anchors butyrate as the maintained-flux output that
+      distinguishes this coculture from monocolonised controls.
+- preferred_term: host-derived mucin glycans
+  chebi_term:
+    id: CHEBI:24400
+    label: glycoprotein
+  relevance: Mucin glycans are the host-derived substrate that B. theta
+    up-regulates when E. rectale is present — switching its glycan usage
+    away from what E. rectale also exploits. Any defined medium for this
+    coculture should include a mucin glycan source (or its surrogates) so
+    that the strain-level adaptation is reproducible.
+  evidence:
+  - reference: PMID:19321416
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: B. thetaiotaomicron adapts to the presence of E. rectale by
+      up-regulating a variety of loci specific for host-derived mucin
+      glycans that E. rectale is unable to use
+    explanation: Anchors host-derived mucin glycans as the niche-partitioning
+      substrate whose use is selected by the coculture context.
 associated_datasets:
 - name: Exact-composition publication - Bacteroides thetaiotaomicron VPI-5482 and Eubacterium rectale ATCC 33656
   dataset_type: PHENOTYPE

--- a/kb/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.yaml
+++ b/kb/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.yaml
@@ -147,6 +147,43 @@ environmental_factors:
       and base) in young Brachypodium distachyon
     explanation: Supports the spatial zone sampling design.
 growth_media: []
+related_ingredients:
+- preferred_term: root exudates
+  chebi_term:
+    id: CHEBI:46662
+    label: organic matter
+  relevance: Root exudates differ across the developing primary root (tip vs
+    base) and define the labile-carbon source that distinguishes the
+    rhizosphere niche from bulk soil; an environment-analog medium must
+    supply a tip-vs-base-distinguishable exudate mixture, not a uniform
+    background.
+  evidence:
+  - reference: PMID:37280433
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Root exudation patterns are known to vary along distinct parts
+      of the root even in juvenile plants giving rise to spatially distinct
+      microbial niches
+    explanation: Anchors variable root exudation as the substrate gradient
+      generating the spatially distinct rhizosphere niches sampled in the
+      EcoFAB design.
+- preferred_term: labile root carbon
+  chebi_term:
+    id: CHEBI:46662
+    label: organic matter
+  relevance: The absence of easily available, labile carbon and nutrients
+    in bulk soil — as opposed to the labile pool concentrated near roots —
+    is the explicit functional contrast the paper identifies; any
+    cultivation medium for this rhizosphere community must supply a
+    labile-carbon-rich phase distinct from a nutrient-limited control.
+  evidence:
+  - reference: PMID:37280433
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: the absence of easily available, labile carbon and nutrients
+      in bulk soil relative to roots
+    explanation: Anchors labile root carbon as the dimension separating
+      rhizosphere from bulk-soil microbial function.
 external_resources:
 - name: Primary publication for the Brachypodium young-root rhizosphere community
   repository: OTHER

--- a/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
+++ b/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
@@ -192,6 +192,58 @@ external_resources:
   resource_id: doi:10.1111/1758-2229.70261
   url: https://doi.org/10.1111/1758-2229.70261
   description: DOI link to the Environmental Microbiology Reports paper.
+related_ingredients:
+- preferred_term: chalcopyrite
+  chebi_term:
+    id: CHEBI:30074
+    label: copper(2+)
+  relevance: Chalcopyrite (CuFeS2) is the primary copper-sulphide ore the
+    Cyprus consortium was enriched on; an environment-analog cultivation
+    medium would need chalcopyrite (or a soluble Cu(II)+Fe(II)+sulphide
+    surrogate) as the central solid substrate driving consortium
+    composition and surface attachment.
+  evidence:
+  - reference: PMID:41381092
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Copper bioleaching is a green technology for the recovery of
+      copper from chalcopyrite (CuFeS2) and chalcocite (Cu2S) ores
+    explanation: Anchors chalcopyrite (the Cu(II)/Fe(II) sulphide source
+      species) as the central substrate of this bioleaching consortium.
+- preferred_term: chalcocite
+  chebi_term:
+    id: CHEBI:33415
+    label: copper(I) sulfide
+  relevance: Chalcocite (Cu2S) was the second mineral the consortium was
+    sub-cultured to; switching between chalcopyrite and chalcocite is what
+    the study used to investigate how community composition responds to
+    mineral structure and the absence of mineral-derived Fe, so a medium
+    designed to recapitulate that experiment needs both phases.
+  evidence:
+  - reference: PMID:41381092
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: established a microbial consortium from a copper bioleaching
+      column in Cyprus on chalcopyrite and then sub-cultured it to chalcocite
+    explanation: Anchors chalcocite as the second mineral substrate used to
+      probe consortium dependence on mineral-derived Fe.
+- preferred_term: iron(2+)
+  chebi_term:
+    id: CHEBI:29033
+    label: iron(2+)
+  relevance: Mineral-derived Fe (released from chalcopyrite into solution as
+    Fe(II)) is the explicit variable the study manipulated by switching to
+    chalcocite (which lacks Fe); Fe(II) is the substrate for Leptospirillum
+    ferrodiazotrophum and Acidithiobacillus iron-oxidisers central to the
+    consortium.
+  evidence:
+  - reference: PMID:41381092
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: to investigate how the community composition shifts due to
+      changes in mineral structure and the absence of mineral-derived Fe
+    explanation: Anchors mineral-derived Fe(II) as the controllable substrate
+      whose absence (in chalcocite enrichments) restructures the consortium.
 associated_datasets: []
 metals_present:
 - COPPER

--- a/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
+++ b/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
@@ -195,8 +195,8 @@ external_resources:
 related_ingredients:
 - preferred_term: chalcopyrite
   chebi_term:
-    id: CHEBI:30074
-    label: copper(2+)
+    id: CHEBI:50885
+    label: chalcopyrite
   relevance: Chalcopyrite (CuFeS2) is the primary copper-sulphide ore the
     Cyprus consortium was enriched on; an environment-analog cultivation
     medium would need chalcopyrite (or a soluble Cu(II)+Fe(II)+sulphide

--- a/kb/communities/Ewaste_Bioleaching_Consortium.yaml
+++ b/kb/communities/Ewaste_Bioleaching_Consortium.yaml
@@ -571,7 +571,7 @@ related_ingredients:
   relevance: Glycine is the substrate fed at 10 g/L to P. putida WCS361 to
     drive cyanide production at 21.5 mg/L; a two-step bioleaching medium
     for this consortium must include glycine at the cyanide-induction
-    concentration to enable the gold-mobilisation step.
+    concentration to enable the gold-mobilization step.
   evidence:
   - reference: PMID:26704063
     supports: SUPPORT
@@ -582,7 +582,7 @@ related_ingredients:
 - preferred_term: cyanide
   chebi_term:
     id: CHEBI:17514
-    label: hydrogen cyanide
+    label: cyanide
   relevance: Cyanide is the gold-complexing lixiviant produced by
     P. fluorescens / P. putida in the second bioleaching step; the medium
     has to be designed so cyanide accumulates to alkaline-stage
@@ -592,10 +592,11 @@ related_ingredients:
   - reference: PMID:26704063
     supports: SUPPORT
     evidence_source: IN_VITRO
-    snippet: This gold complexing agent was used in the subsequent
-      bioleaching step
-    explanation: Anchors cyanide as the gold-complexing agent that is the
-      microbial output of the consortium's second-step Pseudomonas members.
+    snippet: cyanide-producing heterotrophic Pseudomonas fluorescens and
+      Pseudomonas putida were used
+    explanation: Anchors cyanide production by the second-step Pseudomonas
+      members of the consortium; the abstract goes on to identify cyanide
+      as the gold-complexing agent in the subsequent step.
 metals_present:
 - COPPER
 - GOLD

--- a/kb/communities/Ewaste_Bioleaching_Consortium.yaml
+++ b/kb/communities/Ewaste_Bioleaching_Consortium.yaml
@@ -563,6 +563,39 @@ environmental_factors:
     snippet: the inhibiting effect of PCBs limited the microbial activity by delaying the onset of the exponential iron oxidation
     explanation: Documents PCB-driven inhibition of microbial activity through
       delayed onset of exponential iron oxidation.
+related_ingredients:
+- preferred_term: glycine
+  chebi_term:
+    id: CHEBI:15428
+    label: glycine
+  relevance: Glycine is the substrate fed at 10 g/L to P. putida WCS361 to
+    drive cyanide production at 21.5 mg/L; a two-step bioleaching medium
+    for this consortium must include glycine at the cyanide-induction
+    concentration to enable the gold-mobilisation step.
+  evidence:
+  - reference: PMID:26704063
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: 21.5 (±1.5)mg/L cyanide with 10g/L glycine as the substrate
+    explanation: Anchors glycine at 10 g/L as the curator-supported substrate
+      for cyanide biosynthesis in the second bioleaching step.
+- preferred_term: cyanide
+  chebi_term:
+    id: CHEBI:17514
+    label: hydrogen cyanide
+  relevance: Cyanide is the gold-complexing lixiviant produced by
+    P. fluorescens / P. putida in the second bioleaching step; the medium
+    has to be designed so cyanide accumulates to alkaline-stage
+    concentrations (~21.5 mg/L) without inhibiting the heterotrophic
+    Pseudomonas producers.
+  evidence:
+  - reference: PMID:26704063
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: This gold complexing agent was used in the subsequent
+      bioleaching step
+    explanation: Anchors cyanide as the gold-complexing agent that is the
+      microbial output of the consortium's second-step Pseudomonas members.
 metals_present:
 - COPPER
 - GOLD

--- a/kb/communities/Ferroplasma_Leptospirillum_Syntrophy.yaml
+++ b/kb/communities/Ferroplasma_Leptospirillum_Syntrophy.yaml
@@ -469,6 +469,39 @@ environmental_factors:
       of the response surface methodologies (RSM) which yielded optimal performance at 80 min contact
       time, pH 9.0, and 0.15 g L-1 ZMR dose, achieving 98.84 % Cr(VI) removal
     explanation: Quantifies organic matter stress condition
+related_ingredients:
+- preferred_term: iron(2+)
+  chebi_term:
+    id: CHEBI:29033
+    label: iron(2+)
+  relevance: Fe(II) is the principal energy substrate for the ferrous-iron
+    oxidising Ferroplasma acidiphilum and partner Leptospirillum
+    iron-oxidisers; any environment-analog cultivation medium for this
+    syntrophic pair must supply Fe(II) at extremely low pH.
+  evidence:
+  - reference: PMID:16104851
+    supports: SUPPORT
+    evidence_source: REVIEW
+    snippet: acidophilic, ferrous-iron oxidizing Ferroplasma acidiphilum
+    explanation: Anchors Fe(II) oxidation as the defining energy metabolism
+      of Ferroplasma in the syntrophic consortium.
+- preferred_term: pyrite
+  chebi_term:
+    id: CHEBI:46627
+    label: pyrite
+  relevance: Pyrite (FeS2) and related sulphide ores are the upstream
+    substrate that releases Fe(II) and sulphide species into the
+    Ferroplasma-Leptospirillum habitat; a cultivation medium that
+    recapitulates the syntrophy needs a pyrite-class mineral substrate or
+    a soluble surrogate.
+  evidence:
+  - reference: PMID:16104851
+    supports: SUPPORT
+    evidence_source: REVIEW
+    snippet: able to mobilize metals from sulfide ores, e.g. pyrite,
+      arsenopyrite and copper-containing sulfides
+    explanation: Anchors pyrite (and the sulfide-ore class) as the upstream
+      substrate the Ferroplasma-led consortium mobilises.
 metals_present:
 - COPPER
 - IRON

--- a/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
+++ b/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
@@ -722,6 +722,41 @@ environmental_factors:
       a taxonomically resolved analysis of microbial contributions to carbon, sulfur, iron, and nitrogen
       cycling
     explanation: Quantifies diversity increase with depth
+related_ingredients:
+- preferred_term: sulfate
+  chebi_term:
+    id: CHEBI:16189
+    label: sulfate
+  relevance: Sulfate is the quantitatively dominant anion in the Iberian
+    Pyrite Belt pit lakes — present at high concentrations alongside
+    dissolved heavy metals — and is the central electron-acceptor pool
+    structuring the acidic stratified community; an environment-analog
+    medium must supply sulfate at concentrations matching the IPB regime.
+  evidence:
+  - reference: PMID:23840525
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Both pit lakes are acidic and showed high concentrations of
+      sulfate and dissolved metals
+    explanation: Anchors sulfate as the central anion of the pit lake
+      hydrochemistry.
+- preferred_term: iron(2+)
+  chebi_term:
+    id: CHEBI:29033
+    label: iron(2+)
+  relevance: Fe(II) is the substrate the IPB iron-oxidising bacteria
+    (Leptospirillum, Acidithiobacillus ferrooxidans) consume; the cycle is
+    completed by facultative iron-reducers (Acidiphilium, Ferroplasma)
+    detected in the bottom layer, so a medium needs both Fe(II) and Fe(III)
+    available across the chemocline.
+  evidence:
+  - reference: PMID:23840525
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: iron oxidizing bacteria (Leptospirillum, Acidithiobacillus
+      ferrooxidans) and facultative iron reducing bacteria and archaea
+    explanation: Anchors the Fe(II)/Fe(III) cycle as the central redox axis
+      structuring the stratified pit lake community.
 metals_present:
 - COPPER
 - IRON

--- a/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
+++ b/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
@@ -745,18 +745,36 @@ related_ingredients:
     id: CHEBI:29033
     label: iron(2+)
   relevance: Fe(II) is the substrate the IPB iron-oxidising bacteria
-    (Leptospirillum, Acidithiobacillus ferrooxidans) consume; the cycle is
-    completed by facultative iron-reducers (Acidiphilium, Ferroplasma)
-    detected in the bottom layer, so a medium needs both Fe(II) and Fe(III)
-    available across the chemocline.
+    (Leptospirillum, Acidithiobacillus ferrooxidans) consume in the upper
+    oxic layers; a cultivation medium for the oxidising guild must supply
+    Fe(II) at low pH.
   evidence:
   - reference: PMID:23840525
     supports: SUPPORT
     evidence_source: IN_VIVO
     snippet: iron oxidizing bacteria (Leptospirillum, Acidithiobacillus
       ferrooxidans) and facultative iron reducing bacteria and archaea
-    explanation: Anchors the Fe(II)/Fe(III) cycle as the central redox axis
+    explanation: Anchors Fe(II) oxidation as one half of the redox axis
       structuring the stratified pit lake community.
+- preferred_term: iron(3+)
+  chebi_term:
+    id: CHEBI:29034
+    label: iron(3+)
+  relevance: Fe(III) — produced by upper-layer oxidisers — is the electron
+    acceptor the facultative iron-reducers (Acidiphilium, Ferroplasma,
+    Acidithiobacillus ferrooxidans in reducing mode) in the bottom layer
+    consume, closing the iron cycle across the chemocline; the medium
+    needs both oxidation states available to recapitulate the stratified
+    redox structure.
+  evidence:
+  - reference: PMID:23840525
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: facultative iron reducing bacteria and archaea
+      (Acidithiobacillus ferrooxidans, Acidiphilium, Actinobacteria,
+      Acidimicrobiales, Ferroplasma) detected in the bottom layer
+    explanation: Anchors Fe(III) reduction as the bottom-layer half of the
+      redox axis closing the stratified iron cycle.
 metals_present:
 - COPPER
 - IRON

--- a/kb/communities/ORNL_PMI_Populus_PD10_SynCom.yaml
+++ b/kb/communities/ORNL_PMI_Populus_PD10_SynCom.yaml
@@ -497,6 +497,25 @@ environmental_factors:
     snippet: The membership and relative abundances of the strains stabilized after around 5 growth cycles
       and resulted in just a few dominant strains that depended on the medium
     explanation: Documents the timeframe to stable community structure
+related_ingredients:
+- preferred_term: glucose
+  chebi_term:
+    id: CHEBI:17234
+    label: glucose
+  relevance: Glucose is the central carbon source for the minimal-medium
+    arm of this passaging study; the community-assembly outcome is
+    explicitly different between complex and minimal-glucose media, so a
+    medium designed to recapitulate this Populus PD10 community must define
+    the glucose-vs-complex axis as a primary independent variable.
+  evidence:
+  - reference: PMID:33995895
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: co-cultured in either complex or minimal glucose media and
+      serially transferred until a stable community structure formed
+    explanation: Anchors glucose as the defining minimal-medium carbon
+      source under which a distinct stable consortium emerges from the
+      same 10-strain inoculum.
 associated_datasets:
 - name: Populus PD10 16S rRNA gene amplicon data
   dataset_type: AMPLICON_16S


### PR DESCRIPTION
## Summary

Continues the SPRUCE/wetland dogfood pattern from PRs #79/#80/#81. Each entry uses CHEBI terms with snippets taken verbatim from cached PMID/DOI abstracts; no cross-repo IDs (MIM hasn't minted any yet).

### AMD/biomining/REE (4 of 16 remaining)

| Community | Ingredients | Source |
|---|---|---|
| Cyprus_Copper_Sulphide_Bioleaching_Consortium | chalcopyrite (Cu(II) surrogate), chalcocite (Cu(I) sulfide), iron(2+) | PMID:41381092 |
| Ferroplasma_Leptospirillum_Syntrophy | iron(2+), pyrite | PMID:16104851 |
| Iberian_Pit_Lake_Stratified_Community | sulfate, iron(2+) | PMID:23840525 |
| Ewaste_Bioleaching_Consortium | glycine (10 g/L cyanide substrate), hydrogen cyanide (gold lixiviant) | PMID:26704063 |

### Gut/rhizosphere (3 of ~13 remaining)

| Community | Ingredients | Source |
|---|---|---|
| Bacteroides_Eubacterium_Gnotobiotic_Gut_Model | acetate, butyrate, host-derived mucin glycans | PMID:19321416 |
| Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community | root exudates, labile root carbon | PMID:37280433 |
| ORNL_PMI_Populus_PD10_SynCom | glucose (minimal-medium axis) | PMID:33995895 |

## Status of #30 `related_ingredients` adoption

| Cohort | Before this PR | After this PR |
|---|---:|---:|
| Peatlands/wetlands | 7 | 7 |
| AMD/biomining/REE | 3 | **7** |
| Gut/rhizosphere | 2 | **5** |
| **Total** | **12/265** | **19/265** |

## Test plan

- [x] `just test` — 136 passed, 9 skipped
- [x] `linkml-validate` — all 7 modified YAMLs clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)