### PR TITLE
Port audit machinery from CultureMech (schema extension + validate_strict + write_validated_community + record_curation_event + audit_writers)

### DIFF
--- a/justfile
+++ b/justfile
@@ -23,6 +23,22 @@ validate-all:
         uv run linkml-validate -s src/communitymech/schema/communitymech.yaml "$file"
     done
 
+# Strict in-process validation in *closed* mode (rejects unknown fields).
+# Emits reports/instance_validation_failures.tsv and exits 1 on any ERROR.
+# Catches the same drift class that gave CultureMech 59k silent errors;
+# closed-mode + non-zero exit is what the per-file linkml-validate loop
+# above silently passes today. Use this for the corpus-wide health check.
+validate-strict *args:
+    uv run python scripts/validate_strict.py {{args}}
+
+# Audit every YAML-writing Python module under scripts/ and
+# src/communitymech/ for safeguards (curation_history append,
+# --dry-run/--apply, validates before write, wired into justfile).
+# Writes reports/pipeline_writers_audit.tsv. Useful for tracking
+# adoption of write_validated_community + record_curation_event.
+audit-writers *args:
+    uv run python scripts/audit_writers.py {{args}}
+
 # Validate evidence references in a community file
 validate-references FILE:
     uv run linkml-reference-validator validate data {{FILE}} -s src/communitymech/schema/communitymech.yaml --config conf/reference_validator.yaml
@@ -111,8 +127,8 @@ lint:
     uv run ruff check src/ tests/
     uv run mypy src/
 
-# Full QC (validate + lint + test)
-qc: validate-all validate-terms-all validate-references-all lint test
+# Full QC (validate + strict validate + lint + test)
+qc: validate-all validate-strict validate-terms-all validate-references-all lint test
     @echo "✅ All QC checks passed!"
 
 # Check which community strains are represented in UniProt reference proteomes

--- a/reports/instance_validation_failures.tsv
+++ b/reports/instance_validation_failures.tsv
@@ -1,0 +1,1 @@
+file	category	detail	path	message

--- a/reports/pipeline_writers_audit.tsv
+++ b/reports/pipeline_writers_audit.tsv
@@ -1,0 +1,16 @@
+path	writes_yaml	appends_curation_history	has_write_safeguard	validates_before_write	wired_into_just
+scripts/add_community_ids.py	yes	yes	yes	yes	no
+scripts/add_evidence_source.py	yes	no	yes	no	no
+scripts/apply_pmc_conversions.py	yes	yes	yes	yes	no
+scripts/apply_strain_designations.py	yes	no	no	no	no
+scripts/apply_taxonomy_corrections.py	yes	no	no	no	no
+scripts/backfill_metals.py	yes	no	yes	no	no
+scripts/enhance_strain_data.py	yes	no	no	no	no
+scripts/fix_network_integrity.py	yes	yes	yes	yes	no
+scripts/fix_reference_formats.py	yes	no	yes	no	no
+scripts/intelligent_snippet_fixer.py	yes	no	no	no	no
+scripts/link_growth_media.py	yes	yes	yes	yes	yes
+src/communitymech/cli.py	yes	no	yes	no	yes
+src/communitymech/network/batch_reporter.py	yes	no	no	no	no
+src/communitymech/network/llm_repair.py	yes	yes	yes	yes	no
+src/communitymech/validation/write_validated.py	yes	no	no	yes	yes

--- a/reports/pipeline_writers_audit.tsv
+++ b/reports/pipeline_writers_audit.tsv
@@ -10,7 +10,7 @@ scripts/fix_network_integrity.py	yes	yes	yes	yes	no
 scripts/fix_reference_formats.py	yes	no	yes	no	no
 scripts/intelligent_snippet_fixer.py	yes	no	no	no	no
 scripts/link_growth_media.py	yes	yes	yes	yes	yes
-src/communitymech/cli.py	yes	no	yes	no	yes
+src/communitymech/cli.py	yes	no	yes	no	no
 src/communitymech/network/batch_reporter.py	yes	no	no	no	no
 src/communitymech/network/llm_repair.py	yes	yes	yes	yes	no
-src/communitymech/validation/write_validated.py	yes	no	no	yes	yes
+src/communitymech/validation/write_validated.py	yes	no	no	yes	no

--- a/scripts/add_community_ids.py
+++ b/scripts/add_community_ids.py
@@ -1,11 +1,19 @@
 #!/usr/bin/env python
 """Add sequential CommunityMech IDs to all community YAML files."""
 
-import yaml
+import sys
 from pathlib import Path
 
+import yaml
 
-def add_ids_to_communities(communities_dir: Path = Path("kb/communities")):
+from communitymech.curate.curation_event import record_curation_event
+from communitymech.validation.write_validated import (
+    ValidationFailedError,
+    write_validated_community,
+)
+
+
+def add_ids_to_communities(communities_dir: Path = Path("kb/communities"), dry_run: bool = False):
     """Add sequential IDs to all community YAML files."""
     yaml_files = sorted(communities_dir.glob("*.yaml"))
 
@@ -23,17 +31,27 @@ def add_ids_to_communities(communities_dir: Path = Path("kb/communities")):
         data_with_id = {"id": community_id}
         data_with_id.update(data)
 
-        # Write back with proper formatting
-        with open(yaml_file, "w") as f:
-            # Use default_flow_style=False for block style
-            yaml.dump(
-                data_with_id,
-                f,
-                default_flow_style=False,
-                sort_keys=False,
-                allow_unicode=True,
-                width=100,
+        # Record curation event before write
+        record_curation_event(
+            data_with_id,
+            curator="add_community_ids",
+            action="ASSIGN_COMMUNITY_ID",
+            changes=f"Assigned id={community_id}",
+        )
+
+        if dry_run:
+            print(f"  (dry-run) would assign {community_id} → {yaml_file.name}")
+            continue
+
+        # Write back via validated writer (replaces direct yaml.dump)
+        try:
+            write_validated_community(data_with_id, yaml_file)
+        except ValidationFailedError as exc:
+            print(
+                f"  ✗ validation failed for {yaml_file.name}: {exc.summary()}",
+                file=sys.stderr,
             )
+            continue
 
         print(f"  ✓ {community_id} → {yaml_file.name}")
 
@@ -41,4 +59,14 @@ def add_ids_to_communities(communities_dir: Path = Path("kb/communities")):
 
 
 if __name__ == "__main__":
-    add_ids_to_communities()
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Add sequential CommunityMech IDs to YAML files")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview changes without modifying files",
+    )
+    args = parser.parse_args()
+
+    add_ids_to_communities(dry_run=args.dry_run)

--- a/scripts/add_community_ids.py
+++ b/scripts/add_community_ids.py
@@ -27,7 +27,17 @@ def add_ids_to_communities(communities_dir: Path = Path("kb/communities"), dry_r
         with open(yaml_file) as f:
             data = yaml.safe_load(f)
 
-        # Add ID as first field
+        # If a file already has an id, leave it alone — this script is
+        # an id-minter, not a re-assignment tool. Without this guard the
+        # `{"id": ...}; data_with_id.update(data)` sequence below silently
+        # took the source file's existing id while the curation event
+        # still claimed "Assigned id=<new>" — misleading audit trail.
+        if data.get("id"):
+            print(f"  · {yaml_file.name} already has id={data['id']}, skipping")
+            continue
+
+        # Add ID as first field (data has no `id` per the guard above,
+        # so the .update() will not clobber it).
         data_with_id = {"id": community_id}
         data_with_id.update(data)
 

--- a/scripts/apply_pmc_conversions.py
+++ b/scripts/apply_pmc_conversions.py
@@ -136,12 +136,16 @@ def apply_pmc_conversions(yaml_path: Path, dry_run: bool = True) -> dict:
             ),
         )
 
-        # Write updated via validated writer
+        # Write updated via validated writer. Restore the backup on
+        # validation failure so the original file isn't left missing
+        # (it's still on disk as backup_path until the write succeeds).
         try:
             write_validated_community(data, yaml_path)
         except ValidationFailedError as exc:
+            backup_path.rename(yaml_path)
             print(
-                f"  ✗ validation failed for {yaml_path.name}: {exc.summary()}",
+                f"  ✗ validation failed for {yaml_path.name}: {exc.summary()} "
+                "(original restored from backup)",
                 file=sys.stderr,
             )
 

--- a/scripts/apply_pmc_conversions.py
+++ b/scripts/apply_pmc_conversions.py
@@ -17,12 +17,16 @@ Known conversions:
 - PMC4187173 → PMID:25369810
 """
 
-import yaml
-import re
+import sys
 from pathlib import Path
-from typing import Dict, List
-from collections import defaultdict
 
+import yaml
+
+from communitymech.curate.curation_event import record_curation_event
+from communitymech.validation.write_validated import (
+    ValidationFailedError,
+    write_validated_community,
+)
 
 # Known PMC → PMID conversions from special_references_report.txt
 PMC_TO_PMID = {
@@ -38,10 +42,10 @@ PMC_TO_PMID = {
 }
 
 
-def apply_pmc_conversions(yaml_path: Path, dry_run: bool = True) -> Dict:
+def apply_pmc_conversions(yaml_path: Path, dry_run: bool = True) -> dict:
     """Apply PMC→PMID conversions to a YAML file"""
 
-    with open(yaml_path, 'r') as f:
+    with open(yaml_path) as f:
         data = yaml.safe_load(f)
 
     changes = []
@@ -120,14 +124,26 @@ def apply_pmc_conversions(yaml_path: Path, dry_run: bool = True) -> Dict:
         backup_path = yaml_path.with_suffix('.yaml.bak_pmc')
         yaml_path.rename(backup_path)
 
-        # Write updated
-        with open(yaml_path, 'w') as f:
-            yaml.dump(data, f,
-                     default_flow_style=False,
-                     sort_keys=False,
-                     allow_unicode=True,
-                     width=120,
-                     indent=2)
+        # Record curation event before writing
+        contexts = sorted({ctx for _, _, ctx in changes})
+        record_curation_event(
+            data,
+            curator="apply_pmc_conversions",
+            action="CONVERT_PMC_TO_PMID",
+            changes=(
+                f"Converted {len(changes)} PMC reference(s) to PMID across "
+                f"{', '.join(contexts) if contexts else 'no'} section(s)"
+            ),
+        )
+
+        # Write updated via validated writer
+        try:
+            write_validated_community(data, yaml_path)
+        except ValidationFailedError as exc:
+            print(
+                f"  ✗ validation failed for {yaml_path.name}: {exc.summary()}",
+                file=sys.stderr,
+            )
 
     return {
         'file': yaml_path.name,

--- a/scripts/audit_writers.py
+++ b/scripts/audit_writers.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Audit YAML-writing scripts in CommunityMech.
+
+For every Python module under ``scripts/`` and the central
+``src/communitymech/`` package that writes a YAML (looks for
+``yaml.dump``, ``yaml.safe_dump``, ``write_validated_community``, or a
+``path.write_text(yaml.safe_dump(...))`` flow), record:
+
+- ``appends_curation_history``: does the script append a CurationEvent
+  to ``community['curation_history']``?
+- ``has_write_safeguard``: a ``--dry-run`` opt-out OR ``--apply``/``--write``
+  opt-in flag.
+- ``validates_before_write``: does it route through
+  ``write_validated_community`` or call ``validate_community`` /
+  ``linkml-validate`` first?
+- ``wired_into_just``: is the script invoked from a justfile recipe?
+
+TSV columns: path, writes_yaml, appends_curation_history,
+has_write_safeguard, validates_before_write, wired_into_just.
+
+Output: TSV to stdout (and via ``--out`` to a file).
+
+Ported from CultureMech / MediaIngredientMech / TraitMech.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from pathlib import Path
+
+SEARCH_DIRS = [
+    Path("scripts"),
+    Path("src/communitymech"),
+]
+
+# Patterns
+_WRITE_TEXT_OF_YAML = re.compile(r"\.write_text\s*\(\s*yaml\.(?:safe_)?dump")
+_CURATION_APPEND = re.compile(
+    r"curation_history.*?(append|\+=|\.insert)"
+    r"|['\"]curator['\"]\s*:"
+    r"|append_curation_event"
+    r"|record_curation_event"
+)
+_WRITE_SAFEGUARD = re.compile(
+    r"--dry[-_]run|dry_run\s*[:=]"
+    r"|--apply\b|args\.apply\b"
+    r"|--write\b|args\.write\b"
+)
+_VALIDATE_BEFORE_WRITE = re.compile(
+    r"linkml[._-]?validate"
+    r"|validate_community\("
+    r"|validator\.validate\("
+    r"|write_validated_community\("
+)
+
+
+def script_paths() -> list[Path]:
+    out: list[Path] = []
+    for d in SEARCH_DIRS:
+        if not d.exists():
+            continue
+        out.extend(sorted(p for p in d.rglob("*.py") if "__pycache__" not in str(p)))
+    return out
+
+
+def looks_like_yaml_writer(text: str) -> bool:
+    if "yaml.safe_dump(" in text or "yaml.dump(" in text:
+        return True
+    if _WRITE_TEXT_OF_YAML.search(text):
+        return True
+    # write_validated_community is the closed-schema-gated wrapper that
+    # callers route through instead of yaml.dump directly.
+    return "write_validated_community(" in text
+
+
+def audit(path: Path, justfile_text: str) -> dict | None:
+    # Suppress self-match: this module's regex source contains
+    # `yaml.safe_dump` etc., so it would otherwise appear in its own output.
+    if path.resolve() == Path(__file__).resolve():
+        return None
+    try:
+        text = path.read_text()
+    except (UnicodeDecodeError, OSError):
+        return None
+    if not looks_like_yaml_writer(text):
+        return None
+    return {
+        "path": str(path),
+        "writes_yaml": "yes",
+        "appends_curation_history": "yes" if _CURATION_APPEND.search(text) else "no",
+        "has_write_safeguard": "yes" if _WRITE_SAFEGUARD.search(text) else "no",
+        "validates_before_write": "yes" if _VALIDATE_BEFORE_WRITE.search(text) else "no",
+        "wired_into_just": (
+            "yes" if path.stem in justfile_text or path.name in justfile_text else "no"
+        ),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", type=Path, default=None, help="TSV output path (default stdout)")
+    args = ap.parse_args()
+
+    justfile_path = Path("justfile")
+    justfile_text = justfile_path.read_text() if justfile_path.exists() else ""
+
+    rows: list[dict] = []
+    for p in script_paths():
+        row = audit(p, justfile_text)
+        if row is not None:
+            rows.append(row)
+
+    fields = [
+        "path",
+        "writes_yaml",
+        "appends_curation_history",
+        "has_write_safeguard",
+        "validates_before_write",
+        "wired_into_just",
+    ]
+
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        with args.out.open("w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=fields, delimiter="\t", lineterminator="\n")
+            w.writeheader()
+            for row in rows:
+                w.writerow(row)
+        print(f"Wrote {len(rows)} rows to {args.out}", file=sys.stderr)
+    else:
+        w = csv.DictWriter(sys.stdout, fieldnames=fields, delimiter="\t")
+        w.writeheader()
+        for row in rows:
+            w.writerow(row)
+
+    def count(field: str, val: str) -> int:
+        return sum(1 for r in rows if r[field] == val)
+
+    print("", file=sys.stderr)
+    print(f"=== writers audit summary ({len(rows)} writers) ===", file=sys.stderr)
+    print(f"  appends curation_history:   {count('appends_curation_history', 'yes')} / {len(rows)}",
+          file=sys.stderr)
+    print(f"  has write safeguard:        {count('has_write_safeguard', 'yes')} / {len(rows)}",
+          file=sys.stderr)
+    print(f"  validates before write:     {count('validates_before_write', 'yes')} / {len(rows)}",
+          file=sys.stderr)
+    print(f"  wired into justfile:        {count('wired_into_just', 'yes')} / {len(rows)}",
+          file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit_writers.py
+++ b/scripts/audit_writers.py
@@ -93,10 +93,28 @@ def audit(path: Path, justfile_text: str) -> dict | None:
         "appends_curation_history": "yes" if _CURATION_APPEND.search(text) else "no",
         "has_write_safeguard": "yes" if _WRITE_SAFEGUARD.search(text) else "no",
         "validates_before_write": "yes" if _VALIDATE_BEFORE_WRITE.search(text) else "no",
-        "wired_into_just": (
-            "yes" if path.stem in justfile_text or path.name in justfile_text else "no"
-        ),
+        "wired_into_just": "yes" if _is_wired_into_just(path, justfile_text) else "no",
     }
+
+
+def _is_wired_into_just(path: Path, justfile_text: str) -> bool:
+    """Detect whether a justfile recipe actually invokes this script.
+
+    The earlier substring check (``path.stem in justfile_text``) had false
+    positives — e.g. ``write_validated.py`` matched a justfile comment
+    referencing ``write_validated_community``. Require the filename to
+    appear as an explicit ``python ... <name>.py`` invocation, which is
+    how every justfile recipe actually runs a script.
+    """
+    needle = re.compile(rf"\b{re.escape(path.name)}\b")
+    for line in justfile_text.splitlines():
+        stripped = line.strip()
+        # Ignore comment-only lines so a mention in docs doesn't count.
+        if stripped.startswith("#"):
+            continue
+        if needle.search(stripped):
+            return True
+    return False
 
 
 def main() -> int:

--- a/scripts/fix_network_integrity.py
+++ b/scripts/fix_network_integrity.py
@@ -7,10 +7,17 @@ Fixes:
 2. Reports disconnected taxa and missing source/target for manual review
 """
 
-import yaml
-from pathlib import Path
+import sys
 from collections import defaultdict
-from typing import Dict, List, Set
+from pathlib import Path
+
+import yaml
+
+from communitymech.curate.curation_event import record_curation_event
+from communitymech.validation.write_validated import (
+    ValidationFailedError,
+    write_validated_community,
+)
 
 
 class NetworkIntegrityFixer:
@@ -128,8 +135,25 @@ class NetworkIntegrityFixer:
 
         # Write back if fixes were made and not dry run
         if fixes > 0 and not dry_run:
-            with open(yaml_path, 'w') as f:
-                yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
+            applied = self.fixes_applied.get(yaml_path.stem, [])
+            record_curation_event(
+                data,
+                curator="fix_network_integrity",
+                action="FIX_NETWORK_INTEGRITY",
+                changes=(
+                    f"Repaired {fixes} taxon ID mismatch(es) in ecological_interactions: "
+                    + "; ".join(applied[:5])
+                    + (f"; +{len(applied) - 5} more" if len(applied) > 5 else "")
+                ),
+            )
+            try:
+                write_validated_community(data, yaml_path)
+            except ValidationFailedError as exc:
+                print(
+                    f"  ✗ validation failed for {yaml_path.name}: {exc.summary()}",
+                    file=sys.stderr,
+                )
+                return fixes
             print(f"    Wrote {fixes} fixes to {yaml_path.name}")
 
         return fixes

--- a/scripts/link_growth_media.py
+++ b/scripts/link_growth_media.py
@@ -396,8 +396,12 @@ def process_single_community(
         try:
             update_yaml_with_media(yaml_file, data)
         except ValidationFailedError as exc:
+            # Restore backup so the original file isn't left missing.
+            if backup_path.exists():
+                backup_path.rename(yaml_file)
             print(
-                f"  {RED}✗ validation failed for {yaml_file.name}: {exc.summary()}{RESET}",
+                f"  {RED}✗ validation failed for {yaml_file.name}: {exc.summary()}{RESET} "
+                "(original restored from backup)",
                 file=sys.stderr,
             )
             return
@@ -604,9 +608,12 @@ def process_all_communities(
                 try:
                     update_yaml_with_media(yaml_file, data)
                 except ValidationFailedError as exc:
+                    # Restore backup so the original file isn't left missing.
+                    if backup_path.exists():
+                        backup_path.rename(yaml_file)
                     print(
                         f"  {RED}✗ validation failed for {yaml_file.name}: "
-                        f"{exc.summary()}{RESET}",
+                        f"{exc.summary()}{RESET} (original restored from backup)",
                         file=sys.stderr,
                     )
                     continue

--- a/scripts/link_growth_media.py
+++ b/scripts/link_growth_media.py
@@ -24,12 +24,16 @@ import yaml
 # Add src to path so we can import from communitymech
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
+from communitymech.curate.curation_event import record_curation_event
 from communitymech.utils.media_linker import (
     CompositionMerger,
     MediaFetcher,
     MediaMatcher,
 )
-
+from communitymech.validation.write_validated import (
+    ValidationFailedError,
+    write_validated_community,
+)
 
 # ANSI color codes
 GREEN = "\033[92m"
@@ -251,20 +255,14 @@ def load_manual_overrides(config_path: Path) -> dict:
 def update_yaml_with_media(yaml_path: Path, data: dict) -> None:
     """Update a YAML file with community data including growth media.
 
+    Routes through ``write_validated_community`` so the doc is refused
+    if it would violate the closed-schema contract.
+
     Args:
         yaml_path: Path to community YAML file to write
         data: Community data dict with updated growth_media
     """
-    # Write with clean formatting (same pattern as backfill_metals.py)
-    with open(yaml_path, "w") as f:
-        yaml.dump(
-            data,
-            f,
-            default_flow_style=False,
-            sort_keys=False,
-            allow_unicode=True,
-            width=100,
-        )
+    write_validated_community(data, yaml_path)
 
 
 def process_single_community(
@@ -383,7 +381,26 @@ def process_single_community(
         if yaml_file.exists():
             yaml_file.rename(backup_path)
 
-        update_yaml_with_media(yaml_file, data)
+        media_names = [m.get("name", "") for m in growth_media if m.get("name")]
+        record_curation_event(
+            data,
+            curator="link_growth_media",
+            action="LINK_GROWTH_MEDIA",
+            changes=(
+                f"Linked growth media to CultureMech / MediaIngredientMech for "
+                f"{len(media_names)} media record(s): "
+                + ", ".join(media_names[:5])
+                + (f", +{len(media_names) - 5} more" if len(media_names) > 5 else "")
+            ),
+        )
+        try:
+            update_yaml_with_media(yaml_file, data)
+        except ValidationFailedError as exc:
+            print(
+                f"  {RED}✗ validation failed for {yaml_file.name}: {exc.summary()}{RESET}",
+                file=sys.stderr,
+            )
+            return
         print(f"  {GREEN}✓ Updated {yaml_file.name}{RESET}")
     elif updated:
         print(f"  {YELLOW}Would update {yaml_file.name}{RESET}")
@@ -572,7 +589,27 @@ def process_all_communities(
                 if yaml_file.exists():
                     yaml_file.rename(backup_path)
 
-                update_yaml_with_media(yaml_file, data)
+                media_names = [m.get("name", "") for m in growth_media if m.get("name")]
+                record_curation_event(
+                    data,
+                    curator="link_growth_media",
+                    action="LINK_GROWTH_MEDIA",
+                    changes=(
+                        f"Linked growth media to CultureMech / MediaIngredientMech for "
+                        f"{len(media_names)} media record(s): "
+                        + ", ".join(media_names[:5])
+                        + (f", +{len(media_names) - 5} more" if len(media_names) > 5 else "")
+                    ),
+                )
+                try:
+                    update_yaml_with_media(yaml_file, data)
+                except ValidationFailedError as exc:
+                    print(
+                        f"  {RED}✗ validation failed for {yaml_file.name}: "
+                        f"{exc.summary()}{RESET}",
+                        file=sys.stderr,
+                    )
+                    continue
                 print(f"  {GREEN}✓ Updated{RESET}")
 
     # Print summary

--- a/scripts/validate_strict.py
+++ b/scripts/validate_strict.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Strict LinkML validation harness for CommunityMech instance records.
+
+Wraps the in-process ``linkml.validator`` with
+``JsonschemaValidationPlugin(closed=True)`` so unknown fields are flagged.
+(The existing ``just validate-all`` target shells out to ``linkml-validate``
+per file in open mode and silently lets unknown fields pass.) Emits a
+structured TSV of every ERROR result and exits non-zero if any are found.
+
+Usage::
+
+    python scripts/validate_strict.py [PATH ...]
+    python scripts/validate_strict.py --sample 50
+    python scripts/validate_strict.py --out reports/instance_validation_failures.tsv
+
+Paths may be files or directories; directories are walked for ``*.yaml``.
+
+Default scope when no paths given:
+    kb/communities/
+
+CommunityMech has a single root class (``MicrobialCommunity``); no class
+routing required.
+
+Ported from CultureMech / MediaIngredientMech / TraitMech.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import re
+import sys
+from collections.abc import Iterable
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+import yaml
+from linkml.validator import Validator
+from linkml.validator.plugins import JsonschemaValidationPlugin
+from linkml.validator.report import Severity
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = _REPO_ROOT / "src" / "communitymech" / "schema" / "communitymech.yaml"
+DEFAULT_ROOTS = [_REPO_ROOT / "kb" / "communities"]
+TARGET_CLASS = "MicrobialCommunity"
+
+
+# Per-worker singleton — built lazily after fork so the schema parses once per
+# worker process, not once per file.
+_VALIDATOR: Validator | None = None
+
+
+def _get_validator() -> Validator:
+    global _VALIDATOR
+    if _VALIDATOR is None:
+        _VALIDATOR = Validator(
+            schema=str(SCHEMA_PATH),
+            validation_plugins=[JsonschemaValidationPlugin(closed=True)],
+        )
+    return _VALIDATOR
+
+
+# Classifier regexes — keep narrow so each category is meaningful and the rest
+# fall into "other" for manual review rather than getting silently bucketed.
+_CATEGORY_RULES: list[tuple[str, re.Pattern[str]]] = [
+    (
+        "unexpected_field",
+        re.compile(
+            r"Additional properties are not allowed \('(?P<key>[^']+)'"
+            r" was unexpected\) in (?P<path>\S+)"
+        ),
+    ),
+    ("missing_required",
+     re.compile(r"'(?P<key>[^']+)' is a required property in (?P<path>\S+)")),
+    ("enum_mismatch",
+     re.compile(r"'(?P<value>[^']+)' is not one of \[(?P<choices>[^\]]+)\]")),
+    ("type_mismatch",
+     re.compile(r"(?P<value>'[^']+'|\S+) is not of type '(?P<type>[^']+)'")),
+    ("pattern_mismatch",
+     re.compile(r"(?P<value>'[^']+'|\S+) does not match (?P<pattern>'[^']+')")),
+    ("format_mismatch",
+     re.compile(r"(?P<value>'[^']+'|\S+) is not a '(?P<format>[^']+)'")),
+    ("range_violation",
+     re.compile(r"(?P<value>\S+) is (less than|greater than) (?P<bound>\S+)")),
+]
+
+
+def classify(message: str) -> tuple[str, str]:
+    """Return (category, detail) for a validator message."""
+    for name, rule in _CATEGORY_RULES:
+        m = rule.search(message)
+        if m:
+            parts = m.groupdict()
+            detail = "|".join(f"{k}={v}" for k, v in parts.items())
+            return name, detail
+    return "other", ""
+
+
+def validate_one(path: Path) -> list[dict]:
+    """Validate a single YAML file. Returns one dict per ERROR result."""
+    validator = _get_validator()
+    try:
+        with path.open() as f:
+            instance = yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        return [{
+            "file": str(path),
+            "category": "yaml_parse_error",
+            "detail": "",
+            "path": "",
+            "message": str(e).splitlines()[0][:300],
+        }]
+    if instance is None:
+        return [{
+            "file": str(path),
+            "category": "empty_file",
+            "detail": "",
+            "path": "",
+            "message": "file parsed as None",
+        }]
+
+    try:
+        report = validator.validate(instance, target_class=TARGET_CLASS)
+    except Exception as e:  # noqa: BLE001 — surface anything weird as a row
+        return [{
+            "file": str(path),
+            "category": "validator_crash",
+            "detail": type(e).__name__,
+            "path": "",
+            "message": str(e)[:300],
+        }]
+
+    rows = []
+    for result in report.results:
+        if result.severity != Severity.ERROR:
+            continue
+        category, detail = classify(result.message)
+        rows.append({
+            "file": str(path),
+            "category": category,
+            "detail": detail,
+            "path": result.instance_index or "",
+            "message": result.message[:300],
+        })
+    return rows
+
+
+_DEFAULT_EXCLUDE_PARTS = {"backups", ".backups", "snapshots"}
+
+
+def iter_yaml_files(paths: Iterable[Path]) -> list[Path]:
+    """Walk inputs, filtering out backup / snapshot subtrees."""
+    out: list[Path] = []
+    for p in paths:
+        if p.is_file():
+            out.append(p)
+        elif p.is_dir():
+            for f in sorted(p.rglob("*.yaml")):
+                if _DEFAULT_EXCLUDE_PARTS.intersection(f.parts):
+                    continue
+                out.append(f)
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", type=Path,
+                        help="Files or directories. Defaults to kb/communities/.")
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("reports/instance_validation_failures.tsv"),
+        help="TSV output path.",
+    )
+    parser.add_argument(
+        "--sample",
+        type=int,
+        metavar="N",
+        help="Validate only the first N files (after sorting). Useful for smoke tests.",
+    )
+    parser.add_argument("--workers", type=int, default=max(1, (os.cpu_count() or 4) - 1),
+                        help="Process pool size. Default: ncpu - 1.")
+    parser.add_argument(
+        "--fail-on",
+        choices=("error", "never"),
+        default="error",
+        help="Exit non-zero policy. 'error' (default) exits 1 if any ERROR row was emitted.",
+    )
+    parser.add_argument("--quiet", action="store_true",
+                        help="Suppress per-file progress lines.")
+    args = parser.parse_args()
+
+    roots = args.paths or DEFAULT_ROOTS
+    files = iter_yaml_files(roots)
+    if args.sample:
+        files = files[: args.sample]
+    if not files:
+        print("No YAML files found.", file=sys.stderr)
+        return 2
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+
+    print(f"Validating {len(files)} files with {args.workers} workers; schema={SCHEMA_PATH}",
+          file=sys.stderr)
+
+    all_rows: list[dict] = []
+    with ProcessPoolExecutor(max_workers=args.workers) as pool:
+        futures = {pool.submit(validate_one, p): p for p in files}
+        for done, fut in enumerate(as_completed(futures), 1):
+            rows = fut.result()
+            all_rows.extend(rows)
+            if not args.quiet and done % 50 == 0:
+                print(f"  {done}/{len(files)} files processed, {len(all_rows)} ERROR rows so far",
+                      file=sys.stderr)
+
+    all_rows.sort(key=lambda r: (r["file"], r["path"], r["category"], r["message"]))
+    with args.out.open("w", newline="") as fh:
+        writer = csv.DictWriter(
+            fh,
+            fieldnames=["file", "category", "detail", "path", "message"],
+            delimiter="\t",
+            quoting=csv.QUOTE_MINIMAL,
+            lineterminator="\n",
+        )
+        writer.writeheader()
+        writer.writerows(all_rows)
+
+    by_cat: dict[str, int] = {}
+    files_with_errors: set[str] = set()
+    for row in all_rows:
+        by_cat[row["category"]] = by_cat.get(row["category"], 0) + 1
+        files_with_errors.add(row["file"])
+
+    print("", file=sys.stderr)
+    print("=== validate-strict summary ===", file=sys.stderr)
+    print(f"  files scanned:      {len(files)}", file=sys.stderr)
+    print(f"  files with ERROR:   {len(files_with_errors)}", file=sys.stderr)
+    print(f"  total ERROR rows:   {len(all_rows)}", file=sys.stderr)
+    print(f"  TSV:                {args.out}", file=sys.stderr)
+    if by_cat:
+        print("  by category:", file=sys.stderr)
+        for cat, count in sorted(by_cat.items(), key=lambda kv: -kv[1]):
+            print(f"    {cat:24s} {count:>8d}", file=sys.stderr)
+
+    if args.fail_on == "error" and all_rows:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/communitymech/curate/__init__.py
+++ b/src/communitymech/curate/__init__.py
@@ -1,0 +1,1 @@
+"""Curation helpers shared across CommunityMech writer scripts."""

--- a/src/communitymech/curate/curation_event.py
+++ b/src/communitymech/curate/curation_event.py
@@ -1,0 +1,114 @@
+"""Standard helper for appending CurationEvent entries to a MicrobialCommunity.
+
+Every script that mutates a community YAML should call
+``record_curation_event`` to leave an audit trail. Centralizing here means:
+
+* timestamps are ISO-8601 with UTC tz, consistently;
+* the ``curation_history`` slot is created on demand;
+* re-runs of idempotent migration scripts can short-circuit when the most
+  recent event already matches (``skip_if_recent`` flag);
+* the schema's ``CurationEvent`` field names (timestamp / curator / action /
+  changes / llm_assisted) are honored, so future schema diffs only need to
+  touch one file.
+
+Drop-in usage::
+
+    from communitymech.curate.curation_event import record_curation_event
+
+    record_curation_event(
+        community,
+        curator="add_community_ids",
+        action="ASSIGN_COMMUNITY_ID",
+        changes=f"Assigned id={community['id']}",
+    )
+
+Ported from the sibling helpers in CultureMech, MediaIngredientMech, and
+TraitMech. The CommunityMech ``CurationEvent`` schema does not define
+``notes``, ``source``, ``previous_status``, ``new_status``, or
+``llm_model`` — those keyword arguments are intentionally absent here.
+Pass narrative detail in ``changes``.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+
+__all__ = ["record_curation_event", "now_iso"]
+
+
+def now_iso() -> str:
+    """Current UTC timestamp matching the repo's existing convention.
+
+    Whole-second precision with a ``Z`` suffix
+    (e.g. ``"2026-05-25T05:30:12Z"``). Matches the format used by the
+    sibling Mech repos so cross-repo tooling can read curation events
+    uniformly.
+    """
+    iso = datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
+    return iso.replace("+00:00", "Z")
+
+
+def record_curation_event(
+    doc: dict[str, Any],
+    *,
+    curator: str,
+    action: str,
+    changes: str | None = None,
+    llm_assisted: bool = False,
+    timestamp: str | None = None,
+    skip_if_recent: bool = False,
+) -> dict[str, Any]:
+    """Append a CurationEvent to ``doc['curation_history']``.
+
+    Args:
+        doc: The MicrobialCommunity dict being mutated. Mutated in place.
+        curator: Script / human identifier (e.g. ``"add_community_ids"``
+            or ``"jane.smith"``). Required because the schema requires it.
+        action: SCREAMING_SNAKE_CASE action label (e.g.
+            ``"ASSIGN_COMMUNITY_ID"``, ``"FIX_NETWORK_INTEGRITY"``).
+            Required; must match the schema's pattern
+            ``^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$``.
+        changes: Optional human-readable description of what changed.
+            Maps to ``CurationEvent.changes``.
+        llm_assisted: True when an LLM produced this change. When True
+            the field is emitted; when False the field is omitted so
+            downstream consumers can distinguish "explicitly not LLM"
+            from "older event written before this field existed".
+        timestamp: Override the ISO-8601 timestamp (used for tests /
+            deterministic snapshots). Defaults to current UTC.
+        skip_if_recent: When True, do nothing if the most recent
+            ``curation_history`` entry already matches the same
+            ``(curator, action)`` pair. Useful when refactoring a script
+            into the helper without producing duplicate trail entries
+            during a re-run.
+
+    Returns:
+        The appended event dict (or the most recent matching one if
+        ``skip_if_recent`` short-circuited).
+    """
+    history = doc.setdefault("curation_history", [])
+    if history is None:
+        doc["curation_history"] = history = []
+
+    if skip_if_recent and history:
+        last = history[-1]
+        if (
+            isinstance(last, dict)
+            and last.get("curator") == curator
+            and last.get("action") == action
+        ):
+            return last
+
+    event: dict[str, Any] = {
+        "timestamp": timestamp or now_iso(),
+        "curator": curator,
+        "action": action,
+    }
+    if changes is not None:
+        event["changes"] = changes
+    if llm_assisted:
+        event["llm_assisted"] = True
+
+    history.append(event)
+    return event

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-23T01:23:35
+# Generation date: 2026-05-25T01:44:55
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech
@@ -9,37 +9,71 @@
 import dataclasses
 import re
 from dataclasses import dataclass
-from datetime import date, datetime, time
-from typing import Any, ClassVar, Dict, List, Optional, Union
+from datetime import (
+    date,
+    datetime,
+    time
+)
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+    Union
+)
 
-from jsonasobj2 import JsonObj, as_dict
-from linkml_runtime.linkml_model.meta import EnumDefinition, PermissibleValue, PvFormulaOptions
+from jsonasobj2 import (
+    JsonObj,
+    as_dict
+)
+from linkml_runtime.linkml_model.meta import (
+    EnumDefinition,
+    PermissibleValue,
+    PvFormulaOptions
+)
 from linkml_runtime.utils.curienamespace import CurieNamespace
 from linkml_runtime.utils.enumerations import EnumDefinitionImpl
-from linkml_runtime.utils.formatutils import camelcase, sfx, underscore
-from linkml_runtime.utils.metamodelcore import bnode, empty_dict, empty_list
+from linkml_runtime.utils.formatutils import (
+    camelcase,
+    sfx,
+    underscore
+)
+from linkml_runtime.utils.metamodelcore import (
+    bnode,
+    empty_dict,
+    empty_list
+)
 from linkml_runtime.utils.slot import Slot
-from linkml_runtime.utils.yamlutils import YAMLRoot, extended_float, extended_int, extended_str
-from rdflib import Namespace, URIRef
+from linkml_runtime.utils.yamlutils import (
+    YAMLRoot,
+    extended_float,
+    extended_int,
+    extended_str
+)
+from rdflib import (
+    Namespace,
+    URIRef
+)
 
-from linkml_runtime.linkml_model.types import Boolean, Float, String
-from linkml_runtime.utils.metamodelcore import Bool
+from linkml_runtime.linkml_model.types import Boolean, Datetime, Float, String
+from linkml_runtime.utils.metamodelcore import Bool, XSDDateTime
 
 metamodel_version = "1.7.0"
 version = None
 
 # Namespaces
-CHEBI = CurieNamespace("CHEBI", "http://purl.obolibrary.org/obo/CHEBI_")
-CL = CurieNamespace("CL", "http://purl.obolibrary.org/obo/CL_")
-ENVO = CurieNamespace("ENVO", "http://purl.obolibrary.org/obo/ENVO_")
-GO = CurieNamespace("GO", "http://purl.obolibrary.org/obo/GO_")
-NCBITAXON = CurieNamespace("NCBITaxon", "http://purl.obolibrary.org/obo/NCBITaxon_")
-PMID = CurieNamespace("PMID", "http://www.ncbi.nlm.nih.gov/pubmed/")
-UBERON = CurieNamespace("UBERON", "http://purl.obolibrary.org/obo/UBERON_")
-COMMUNITYMECH = CurieNamespace("communitymech", "https://w3id.org/communitymech/")
-DOI = CurieNamespace("doi", "https://doi.org/")
-LINKML = CurieNamespace("linkml", "https://w3id.org/linkml/")
-XSD = CurieNamespace("xsd", "http://www.w3.org/2001/XMLSchema#")
+CHEBI = CurieNamespace('CHEBI', 'http://purl.obolibrary.org/obo/CHEBI_')
+CL = CurieNamespace('CL', 'http://purl.obolibrary.org/obo/CL_')
+ENVO = CurieNamespace('ENVO', 'http://purl.obolibrary.org/obo/ENVO_')
+GO = CurieNamespace('GO', 'http://purl.obolibrary.org/obo/GO_')
+NCBITAXON = CurieNamespace('NCBITaxon', 'http://purl.obolibrary.org/obo/NCBITaxon_')
+PMID = CurieNamespace('PMID', 'http://www.ncbi.nlm.nih.gov/pubmed/')
+UBERON = CurieNamespace('UBERON', 'http://purl.obolibrary.org/obo/UBERON_')
+COMMUNITYMECH = CurieNamespace('communitymech', 'https://w3id.org/communitymech/')
+DOI = CurieNamespace('doi', 'https://doi.org/')
+LINKML = CurieNamespace('linkml', 'https://w3id.org/linkml/')
+XSD = CurieNamespace('xsd', 'http://www.w3.org/2001/XMLSchema#')
 DEFAULT_ = COMMUNITYMECH
 
 
@@ -61,7 +95,6 @@ class Term(YAMLRoot):
     """
     An ontology term with ID and label
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["Term"]
@@ -91,7 +124,6 @@ class EvidenceItem(YAMLRoot):
     """
     An evidence item linking a claim to a publication
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["EvidenceItem"]
@@ -141,7 +173,6 @@ class TaxonDescriptor(YAMLRoot):
     """
     Describes an organism with NCBITaxon term
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["TaxonDescriptor"]
@@ -175,7 +206,6 @@ class MetaboliteDescriptor(YAMLRoot):
     """
     Describes a metabolite with CHEBI term
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["MetaboliteDescriptor"]
@@ -213,7 +243,6 @@ class BiologicalProcessDescriptor(YAMLRoot):
     """
     Describes a biological process with GO term
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["BiologicalProcessDescriptor"]
@@ -247,7 +276,6 @@ class EnvironmentDescriptor(YAMLRoot):
     """
     Describes an environment with ENVO term
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["EnvironmentDescriptor"]
@@ -281,7 +309,6 @@ class CultureCollectionID(YAMLRoot):
     """
     A culture collection identifier with accession number
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["CultureCollectionID"]
@@ -319,7 +346,6 @@ class StrainDesignation(YAMLRoot):
     """
     Detailed strain-level information for reproducibility
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["StrainDesignation"]
@@ -328,9 +354,7 @@ class StrainDesignation(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.StrainDesignation
 
     strain_name: Optional[str] = None
-    culture_collections: Optional[
-        Union[Union[dict, CultureCollectionID], list[Union[dict, CultureCollectionID]]]
-    ] = empty_list()
+    culture_collections: Optional[Union[Union[dict, CultureCollectionID], list[Union[dict, CultureCollectionID]]]] = empty_list()
     type_strain: Optional[Union[bool, Bool]] = None
     genome_accession: Optional[str] = None
     genome_url: Optional[str] = None
@@ -342,12 +366,7 @@ class StrainDesignation(YAMLRoot):
         if self.strain_name is not None and not isinstance(self.strain_name, str):
             self.strain_name = str(self.strain_name)
 
-        self._normalize_inlined_as_dict(
-            slot_name="culture_collections",
-            slot_type=CultureCollectionID,
-            key_name="collection",
-            keyed=False,
-        )
+        self._normalize_inlined_as_dict(slot_name="culture_collections", slot_type=CultureCollectionID, key_name="collection", keyed=False)
 
         if self.type_strain is not None and not isinstance(self.type_strain, Bool):
             self.type_strain = Bool(self.type_strain)
@@ -375,7 +394,6 @@ class TaxonomicComposition(YAMLRoot):
     """
     A taxon present in the community with abundance and role
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["TaxonomicComposition"]
@@ -387,12 +405,8 @@ class TaxonomicComposition(YAMLRoot):
     strain_designation: Optional[Union[dict, StrainDesignation]] = None
     abundance_level: Optional[Union[str, "AbundanceEnum"]] = None
     abundance_value: Optional[str] = None
-    functional_role: Optional[
-        Union[Union[str, "FunctionalRoleEnum"], list[Union[str, "FunctionalRoleEnum"]]]
-    ] = empty_list()
-    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
-        empty_list()
-    )
+    functional_role: Optional[Union[Union[str, "FunctionalRoleEnum"], list[Union[str, "FunctionalRoleEnum"]]]] = empty_list()
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.taxon_term):
@@ -400,9 +414,7 @@ class TaxonomicComposition(YAMLRoot):
         if not isinstance(self.taxon_term, TaxonDescriptor):
             self.taxon_term = TaxonDescriptor(**as_dict(self.taxon_term))
 
-        if self.strain_designation is not None and not isinstance(
-            self.strain_designation, StrainDesignation
-        ):
+        if self.strain_designation is not None and not isinstance(self.strain_designation, StrainDesignation):
             self.strain_designation = StrainDesignation(**as_dict(self.strain_designation))
 
         if self.abundance_level is not None and not isinstance(self.abundance_level, AbundanceEnum):
@@ -412,17 +424,10 @@ class TaxonomicComposition(YAMLRoot):
             self.abundance_value = str(self.abundance_value)
 
         if not isinstance(self.functional_role, list):
-            self.functional_role = (
-                [self.functional_role] if self.functional_role is not None else []
-            )
-        self.functional_role = [
-            v if isinstance(v, FunctionalRoleEnum) else FunctionalRoleEnum(v)
-            for v in self.functional_role
-        ]
+            self.functional_role = [self.functional_role] if self.functional_role is not None else []
+        self.functional_role = [v if isinstance(v, FunctionalRoleEnum) else FunctionalRoleEnum(v) for v in self.functional_role]
 
-        self._normalize_inlined_as_dict(
-            slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False
-        )
+        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
 
         super().__post_init__(**kwargs)
 
@@ -432,7 +437,6 @@ class InteractionDownstream(YAMLRoot):
     """
     A downstream target in a causal interaction graph
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["InteractionDownstream"]
@@ -460,7 +464,6 @@ class EcologicalInteraction(YAMLRoot):
     """
     An interaction between organisms or metabolic processes
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["EcologicalInteraction"]
@@ -471,23 +474,13 @@ class EcologicalInteraction(YAMLRoot):
     name: str = None
     description: Optional[str] = None
     interaction_type: Optional[Union[str, "InteractionTypeEnum"]] = None
-    scope: Optional[Union[str, "InteractionScopeEnum"]] = "PAIRWISE"
+    scope: Optional[Union[str, "InteractionScopeEnum"]] = 'PAIRWISE'
     source_taxon: Optional[Union[dict, TaxonDescriptor]] = None
     target_taxon: Optional[Union[dict, TaxonDescriptor]] = None
-    metabolites: Optional[
-        Union[Union[dict, MetaboliteDescriptor], list[Union[dict, MetaboliteDescriptor]]]
-    ] = empty_list()
-    biological_processes: Optional[
-        Union[
-            Union[dict, BiologicalProcessDescriptor], list[Union[dict, BiologicalProcessDescriptor]]
-        ]
-    ] = empty_list()
-    downstream: Optional[
-        Union[Union[dict, InteractionDownstream], list[Union[dict, InteractionDownstream]]]
-    ] = empty_list()
-    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
-        empty_list()
-    )
+    metabolites: Optional[Union[Union[dict, MetaboliteDescriptor], list[Union[dict, MetaboliteDescriptor]]]] = empty_list()
+    biological_processes: Optional[Union[Union[dict, BiologicalProcessDescriptor], list[Union[dict, BiologicalProcessDescriptor]]]] = empty_list()
+    downstream: Optional[Union[Union[dict, InteractionDownstream], list[Union[dict, InteractionDownstream]]]] = empty_list()
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.name):
@@ -498,9 +491,7 @@ class EcologicalInteraction(YAMLRoot):
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
 
-        if self.interaction_type is not None and not isinstance(
-            self.interaction_type, InteractionTypeEnum
-        ):
+        if self.interaction_type is not None and not isinstance(self.interaction_type, InteractionTypeEnum):
             self.interaction_type = InteractionTypeEnum(self.interaction_type)
 
         if self.scope is not None and not isinstance(self.scope, InteractionScopeEnum):
@@ -512,27 +503,13 @@ class EcologicalInteraction(YAMLRoot):
         if self.target_taxon is not None and not isinstance(self.target_taxon, TaxonDescriptor):
             self.target_taxon = TaxonDescriptor(**as_dict(self.target_taxon))
 
-        self._normalize_inlined_as_dict(
-            slot_name="metabolites",
-            slot_type=MetaboliteDescriptor,
-            key_name="preferred_term",
-            keyed=False,
-        )
+        self._normalize_inlined_as_dict(slot_name="metabolites", slot_type=MetaboliteDescriptor, key_name="preferred_term", keyed=False)
 
-        self._normalize_inlined_as_dict(
-            slot_name="biological_processes",
-            slot_type=BiologicalProcessDescriptor,
-            key_name="preferred_term",
-            keyed=False,
-        )
+        self._normalize_inlined_as_dict(slot_name="biological_processes", slot_type=BiologicalProcessDescriptor, key_name="preferred_term", keyed=False)
 
-        self._normalize_inlined_as_dict(
-            slot_name="downstream", slot_type=InteractionDownstream, key_name="target", keyed=False
-        )
+        self._normalize_inlined_as_dict(slot_name="downstream", slot_type=InteractionDownstream, key_name="target", keyed=False)
 
-        self._normalize_inlined_as_dict(
-            slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False
-        )
+        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
 
         super().__post_init__(**kwargs)
 
@@ -542,7 +519,6 @@ class EnvironmentalFactor(YAMLRoot):
     """
     An environmental condition or parameter
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["EnvironmentalFactor"]
@@ -554,9 +530,7 @@ class EnvironmentalFactor(YAMLRoot):
     value: Optional[str] = None
     unit: Optional[str] = None
     description: Optional[str] = None
-    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
-        empty_list()
-    )
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.name):
@@ -573,9 +547,7 @@ class EnvironmentalFactor(YAMLRoot):
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
 
-        self._normalize_inlined_as_dict(
-            slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False
-        )
+        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
 
         super().__post_init__(**kwargs)
 
@@ -585,7 +557,6 @@ class GrowthMediaComponent(YAMLRoot):
     """
     A component of growth media (nutrient, salt, buffer, etc.)
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["GrowthMediaComponent"]
@@ -607,14 +578,10 @@ class GrowthMediaComponent(YAMLRoot):
         if not isinstance(self.name, str):
             self.name = str(self.name)
 
-        if self.media_ingredient_mech_id is not None and not isinstance(
-            self.media_ingredient_mech_id, str
-        ):
+        if self.media_ingredient_mech_id is not None and not isinstance(self.media_ingredient_mech_id, str):
             self.media_ingredient_mech_id = str(self.media_ingredient_mech_id)
 
-        if self.media_ingredient_mech_url is not None and not isinstance(
-            self.media_ingredient_mech_url, str
-        ):
+        if self.media_ingredient_mech_url is not None and not isinstance(self.media_ingredient_mech_url, str):
             self.media_ingredient_mech_url = str(self.media_ingredient_mech_url)
 
         if self.concentration is not None and not isinstance(self.concentration, str):
@@ -637,7 +604,6 @@ class GrowthMedia(YAMLRoot):
     """
     Growth media used for cultivation of the community or its members
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["GrowthMedia"]
@@ -648,9 +614,7 @@ class GrowthMedia(YAMLRoot):
     name: str = None
     culturemech_id: Optional[str] = None
     culturemech_url: Optional[str] = None
-    composition: Optional[
-        Union[Union[dict, GrowthMediaComponent], list[Union[dict, GrowthMediaComponent]]]
-    ] = empty_list()
+    composition: Optional[Union[Union[dict, GrowthMediaComponent], list[Union[dict, GrowthMediaComponent]]]] = empty_list()
     ph: Optional[str] = None
     ph_range: Optional[str] = None
     temperature: Optional[str] = None
@@ -677,9 +641,7 @@ class GrowthMedia(YAMLRoot):
     vessel_type: Optional[str] = None
     preparation_notes: Optional[str] = None
     protocol_url: Optional[str] = None
-    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
-        empty_list()
-    )
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.name):
@@ -693,9 +655,7 @@ class GrowthMedia(YAMLRoot):
         if self.culturemech_url is not None and not isinstance(self.culturemech_url, str):
             self.culturemech_url = str(self.culturemech_url)
 
-        self._normalize_inlined_as_dict(
-            slot_name="composition", slot_type=GrowthMediaComponent, key_name="name", keyed=False
-        )
+        self._normalize_inlined_as_dict(slot_name="composition", slot_type=GrowthMediaComponent, key_name="name", keyed=False)
 
         if self.ph is not None and not isinstance(self.ph, str):
             self.ph = str(self.ph)
@@ -775,9 +735,7 @@ class GrowthMedia(YAMLRoot):
         if self.protocol_url is not None and not isinstance(self.protocol_url, str):
             self.protocol_url = str(self.protocol_url)
 
-        self._normalize_inlined_as_dict(
-            slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False
-        )
+        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
 
         super().__post_init__(**kwargs)
 
@@ -789,7 +747,6 @@ class RelatedMedia(YAMLRoot):
     Complements GrowthMedia (which captures media actually used for cultivation) by enabling environment-based
     discovery of potentially useful media across the CultureMech repository.
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["RelatedMedia"]
@@ -802,9 +759,7 @@ class RelatedMedia(YAMLRoot):
     relationship_type: Optional[Union[str, "MediaRelationshipEnum"]] = None
     shared_environment_term: Optional[Union[dict, Term]] = None
     relevance_notes: Optional[str] = None
-    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
-        empty_list()
-    )
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.preferred_term):
@@ -815,22 +770,16 @@ class RelatedMedia(YAMLRoot):
         if self.culturemech_id is not None and not isinstance(self.culturemech_id, str):
             self.culturemech_id = str(self.culturemech_id)
 
-        if self.relationship_type is not None and not isinstance(
-            self.relationship_type, MediaRelationshipEnum
-        ):
+        if self.relationship_type is not None and not isinstance(self.relationship_type, MediaRelationshipEnum):
             self.relationship_type = MediaRelationshipEnum(self.relationship_type)
 
-        if self.shared_environment_term is not None and not isinstance(
-            self.shared_environment_term, Term
-        ):
+        if self.shared_environment_term is not None and not isinstance(self.shared_environment_term, Term):
             self.shared_environment_term = Term(**as_dict(self.shared_environment_term))
 
         if self.relevance_notes is not None and not isinstance(self.relevance_notes, str):
             self.relevance_notes = str(self.relevance_notes)
 
-        self._normalize_inlined_as_dict(
-            slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False
-        )
+        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
 
         super().__post_init__(**kwargs)
 
@@ -842,7 +791,6 @@ class RelatedIngredient(YAMLRoot):
     GrowthMediaComponent (which captures ingredients in actual cultivation media) by linking to environmentally
     significant compounds that may not be in any currently used medium.
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["RelatedIngredient"]
@@ -854,9 +802,7 @@ class RelatedIngredient(YAMLRoot):
     mediaingredientmech_id: Optional[str] = None
     chebi_term: Optional[Union[dict, Term]] = None
     relevance: Optional[str] = None
-    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
-        empty_list()
-    )
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.preferred_term):
@@ -864,9 +810,7 @@ class RelatedIngredient(YAMLRoot):
         if not isinstance(self.preferred_term, str):
             self.preferred_term = str(self.preferred_term)
 
-        if self.mediaingredientmech_id is not None and not isinstance(
-            self.mediaingredientmech_id, str
-        ):
+        if self.mediaingredientmech_id is not None and not isinstance(self.mediaingredientmech_id, str):
             self.mediaingredientmech_id = str(self.mediaingredientmech_id)
 
         if self.chebi_term is not None and not isinstance(self.chebi_term, Term):
@@ -875,9 +819,7 @@ class RelatedIngredient(YAMLRoot):
         if self.relevance is not None and not isinstance(self.relevance, str):
             self.relevance = str(self.relevance)
 
-        self._normalize_inlined_as_dict(
-            slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False
-        )
+        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
 
         super().__post_init__(**kwargs)
 
@@ -887,7 +829,6 @@ class AssociatedDataset(YAMLRoot):
     """
     An omics or other dataset associated with the community
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["AssociatedDataset"]
@@ -901,9 +842,7 @@ class AssociatedDataset(YAMLRoot):
     repository: Optional[Union[str, "DatasetRepositoryEnum"]] = None
     url: Optional[str] = None
     description: Optional[str] = None
-    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
-        empty_list()
-    )
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.name):
@@ -930,9 +869,7 @@ class AssociatedDataset(YAMLRoot):
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
 
-        self._normalize_inlined_as_dict(
-            slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False
-        )
+        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
 
         super().__post_init__(**kwargs)
 
@@ -942,7 +879,6 @@ class ExternalResource(YAMLRoot):
     """
     An external model or narrative resource linked to the community
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["ExternalResource"]
@@ -955,9 +891,7 @@ class ExternalResource(YAMLRoot):
     resource_id: str = None
     url: str = None
     description: Optional[str] = None
-    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
-        empty_list()
-    )
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.name):
@@ -983,9 +917,7 @@ class ExternalResource(YAMLRoot):
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
 
-        self._normalize_inlined_as_dict(
-            slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False
-        )
+        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
 
         super().__post_init__(**kwargs)
 
@@ -995,7 +927,6 @@ class CommunityEngineeringDesign(YAMLRoot):
     """
     Design intent and implementation details for engineered or synthetic communities
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["CommunityEngineeringDesign"]
@@ -1011,9 +942,7 @@ class CommunityEngineeringDesign(YAMLRoot):
     measurement_endpoints: Optional[Union[str, list[str]]] = empty_list()
     protocol_url: Optional[str] = None
     notes: Optional[str] = None
-    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
-        empty_list()
-    )
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.objective is not None and not isinstance(self.objective, str):
@@ -1032,12 +961,8 @@ class CommunityEngineeringDesign(YAMLRoot):
             self.perturbation_design = str(self.perturbation_design)
 
         if not isinstance(self.measurement_endpoints, list):
-            self.measurement_endpoints = (
-                [self.measurement_endpoints] if self.measurement_endpoints is not None else []
-            )
-        self.measurement_endpoints = [
-            v if isinstance(v, str) else str(v) for v in self.measurement_endpoints
-        ]
+            self.measurement_endpoints = [self.measurement_endpoints] if self.measurement_endpoints is not None else []
+        self.measurement_endpoints = [v if isinstance(v, str) else str(v) for v in self.measurement_endpoints]
 
         if self.protocol_url is not None and not isinstance(self.protocol_url, str):
             self.protocol_url = str(self.protocol_url)
@@ -1045,9 +970,7 @@ class CommunityEngineeringDesign(YAMLRoot):
         if self.notes is not None and not isinstance(self.notes, str):
             self.notes = str(self.notes)
 
-        self._normalize_inlined_as_dict(
-            slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False
-        )
+        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
 
         super().__post_init__(**kwargs)
 
@@ -1057,7 +980,6 @@ class MicrobialCommunity(YAMLRoot):
     """
     A microbial community with composition and interactions
     """
-
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["MicrobialCommunity"]
@@ -1073,38 +995,19 @@ class MicrobialCommunity(YAMLRoot):
     community_category: Optional[Union[str, "CommunityCategoryEnum"]] = None
     engineering_design: Optional[Union[dict, CommunityEngineeringDesign]] = None
     environment_term: Optional[Union[dict, EnvironmentDescriptor]] = None
-    taxonomy: Optional[
-        Union[Union[dict, TaxonomicComposition], list[Union[dict, TaxonomicComposition]]]
-    ] = empty_list()
-    ecological_interactions: Optional[
-        Union[Union[dict, EcologicalInteraction], list[Union[dict, EcologicalInteraction]]]
-    ] = empty_list()
-    environmental_factors: Optional[
-        Union[Union[dict, EnvironmentalFactor], list[Union[dict, EnvironmentalFactor]]]
-    ] = empty_list()
-    growth_media: Optional[Union[Union[dict, GrowthMedia], list[Union[dict, GrowthMedia]]]] = (
-        empty_list()
-    )
-    related_media: Optional[Union[Union[dict, RelatedMedia], list[Union[dict, RelatedMedia]]]] = (
-        empty_list()
-    )
-    related_ingredients: Optional[
-        Union[Union[dict, RelatedIngredient], list[Union[dict, RelatedIngredient]]]
-    ] = empty_list()
-    associated_datasets: Optional[
-        Union[Union[dict, AssociatedDataset], list[Union[dict, AssociatedDataset]]]
-    ] = empty_list()
-    external_resources: Optional[
-        Union[Union[dict, ExternalResource], list[Union[dict, ExternalResource]]]
-    ] = empty_list()
-    metals_present: Optional[
-        Union[Union[str, "MetalElementEnum"], list[Union[str, "MetalElementEnum"]]]
-    ] = empty_list()
-    rare_earth_elements_present: Optional[
-        Union[Union[str, "RareEarthElementEnum"], list[Union[str, "RareEarthElementEnum"]]]
-    ] = empty_list()
+    taxonomy: Optional[Union[Union[dict, TaxonomicComposition], list[Union[dict, TaxonomicComposition]]]] = empty_list()
+    ecological_interactions: Optional[Union[Union[dict, EcologicalInteraction], list[Union[dict, EcologicalInteraction]]]] = empty_list()
+    environmental_factors: Optional[Union[Union[dict, EnvironmentalFactor], list[Union[dict, EnvironmentalFactor]]]] = empty_list()
+    growth_media: Optional[Union[Union[dict, GrowthMedia], list[Union[dict, GrowthMedia]]]] = empty_list()
+    related_media: Optional[Union[Union[dict, RelatedMedia], list[Union[dict, RelatedMedia]]]] = empty_list()
+    related_ingredients: Optional[Union[Union[dict, RelatedIngredient], list[Union[dict, RelatedIngredient]]]] = empty_list()
+    associated_datasets: Optional[Union[Union[dict, AssociatedDataset], list[Union[dict, AssociatedDataset]]]] = empty_list()
+    external_resources: Optional[Union[Union[dict, ExternalResource], list[Union[dict, ExternalResource]]]] = empty_list()
+    metals_present: Optional[Union[Union[str, "MetalElementEnum"], list[Union[str, "MetalElementEnum"]]]] = empty_list()
+    rare_earth_elements_present: Optional[Union[Union[str, "RareEarthElementEnum"], list[Union[str, "RareEarthElementEnum"]]]] = empty_list()
     metal_relevance: Optional[Union[str, "MetalRelevanceEnum"]] = None
     metal_notes: Optional[str] = None
+    curation_history: Optional[Union[Union[dict, "CurationEvent"], list[Union[dict, "CurationEvent"]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1120,105 +1023,102 @@ class MicrobialCommunity(YAMLRoot):
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
 
-        if self.ecological_state is not None and not isinstance(
-            self.ecological_state, EcologicalStateEnum
-        ):
+        if self.ecological_state is not None and not isinstance(self.ecological_state, EcologicalStateEnum):
             self.ecological_state = EcologicalStateEnum(self.ecological_state)
 
-        if self.community_origin is not None and not isinstance(
-            self.community_origin, CommunityOriginEnum
-        ):
+        if self.community_origin is not None and not isinstance(self.community_origin, CommunityOriginEnum):
             self.community_origin = CommunityOriginEnum(self.community_origin)
 
-        if self.community_category is not None and not isinstance(
-            self.community_category, CommunityCategoryEnum
-        ):
+        if self.community_category is not None and not isinstance(self.community_category, CommunityCategoryEnum):
             self.community_category = CommunityCategoryEnum(self.community_category)
 
-        if self.engineering_design is not None and not isinstance(
-            self.engineering_design, CommunityEngineeringDesign
-        ):
+        if self.engineering_design is not None and not isinstance(self.engineering_design, CommunityEngineeringDesign):
             self.engineering_design = CommunityEngineeringDesign(**as_dict(self.engineering_design))
 
-        if self.environment_term is not None and not isinstance(
-            self.environment_term, EnvironmentDescriptor
-        ):
+        if self.environment_term is not None and not isinstance(self.environment_term, EnvironmentDescriptor):
             self.environment_term = EnvironmentDescriptor(**as_dict(self.environment_term))
 
-        self._normalize_inlined_as_dict(
-            slot_name="taxonomy", slot_type=TaxonomicComposition, key_name="taxon_term", keyed=False
-        )
+        self._normalize_inlined_as_dict(slot_name="taxonomy", slot_type=TaxonomicComposition, key_name="taxon_term", keyed=False)
 
-        self._normalize_inlined_as_dict(
-            slot_name="ecological_interactions",
-            slot_type=EcologicalInteraction,
-            key_name="name",
-            keyed=False,
-        )
+        self._normalize_inlined_as_dict(slot_name="ecological_interactions", slot_type=EcologicalInteraction, key_name="name", keyed=False)
 
-        self._normalize_inlined_as_dict(
-            slot_name="environmental_factors",
-            slot_type=EnvironmentalFactor,
-            key_name="name",
-            keyed=False,
-        )
+        self._normalize_inlined_as_dict(slot_name="environmental_factors", slot_type=EnvironmentalFactor, key_name="name", keyed=False)
 
-        self._normalize_inlined_as_dict(
-            slot_name="growth_media", slot_type=GrowthMedia, key_name="name", keyed=False
-        )
+        self._normalize_inlined_as_dict(slot_name="growth_media", slot_type=GrowthMedia, key_name="name", keyed=False)
 
         if not isinstance(self.related_media, list):
             self.related_media = [self.related_media] if self.related_media is not None else []
-        self.related_media = [
-            v if isinstance(v, RelatedMedia) else RelatedMedia(**as_dict(v))
-            for v in self.related_media
-        ]
+        self.related_media = [v if isinstance(v, RelatedMedia) else RelatedMedia(**as_dict(v)) for v in self.related_media]
 
         if not isinstance(self.related_ingredients, list):
-            self.related_ingredients = (
-                [self.related_ingredients] if self.related_ingredients is not None else []
-            )
-        self.related_ingredients = [
-            v if isinstance(v, RelatedIngredient) else RelatedIngredient(**as_dict(v))
-            for v in self.related_ingredients
-        ]
+            self.related_ingredients = [self.related_ingredients] if self.related_ingredients is not None else []
+        self.related_ingredients = [v if isinstance(v, RelatedIngredient) else RelatedIngredient(**as_dict(v)) for v in self.related_ingredients]
 
-        self._normalize_inlined_as_dict(
-            slot_name="associated_datasets",
-            slot_type=AssociatedDataset,
-            key_name="name",
-            keyed=False,
-        )
+        self._normalize_inlined_as_dict(slot_name="associated_datasets", slot_type=AssociatedDataset, key_name="name", keyed=False)
 
-        self._normalize_inlined_as_dict(
-            slot_name="external_resources", slot_type=ExternalResource, key_name="name", keyed=False
-        )
+        self._normalize_inlined_as_dict(slot_name="external_resources", slot_type=ExternalResource, key_name="name", keyed=False)
 
         if not isinstance(self.metals_present, list):
             self.metals_present = [self.metals_present] if self.metals_present is not None else []
-        self.metals_present = [
-            v if isinstance(v, MetalElementEnum) else MetalElementEnum(v)
-            for v in self.metals_present
-        ]
+        self.metals_present = [v if isinstance(v, MetalElementEnum) else MetalElementEnum(v) for v in self.metals_present]
 
         if not isinstance(self.rare_earth_elements_present, list):
-            self.rare_earth_elements_present = (
-                [self.rare_earth_elements_present]
-                if self.rare_earth_elements_present is not None
-                else []
-            )
-        self.rare_earth_elements_present = [
-            v if isinstance(v, RareEarthElementEnum) else RareEarthElementEnum(v)
-            for v in self.rare_earth_elements_present
-        ]
+            self.rare_earth_elements_present = [self.rare_earth_elements_present] if self.rare_earth_elements_present is not None else []
+        self.rare_earth_elements_present = [v if isinstance(v, RareEarthElementEnum) else RareEarthElementEnum(v) for v in self.rare_earth_elements_present]
 
-        if self.metal_relevance is not None and not isinstance(
-            self.metal_relevance, MetalRelevanceEnum
-        ):
+        if self.metal_relevance is not None and not isinstance(self.metal_relevance, MetalRelevanceEnum):
             self.metal_relevance = MetalRelevanceEnum(self.metal_relevance)
 
         if self.metal_notes is not None and not isinstance(self.metal_notes, str):
             self.metal_notes = str(self.metal_notes)
+
+        if not isinstance(self.curation_history, list):
+            self.curation_history = [self.curation_history] if self.curation_history is not None else []
+        self.curation_history = [v if isinstance(v, CurationEvent) else CurationEvent(**as_dict(v)) for v in self.curation_history]
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class CurationEvent(YAMLRoot):
+    """
+    A timestamped curator action on a MicrobialCommunity. Mirrors the shape used by sibling Mech repos (CultureMech,
+    MediaIngredientMech, TraitMech) so cross-repo tooling can read curation events uniformly.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["CurationEvent"]
+    class_class_curie: ClassVar[str] = "communitymech:CurationEvent"
+    class_name: ClassVar[str] = "CurationEvent"
+    class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.CurationEvent
+
+    timestamp: Union[str, XSDDateTime] = None
+    curator: str = None
+    action: str = None
+    changes: Optional[str] = None
+    llm_assisted: Optional[Union[bool, Bool]] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.timestamp):
+            self.MissingRequiredField("timestamp")
+        if not isinstance(self.timestamp, XSDDateTime):
+            self.timestamp = XSDDateTime(self.timestamp)
+
+        if self._is_empty(self.curator):
+            self.MissingRequiredField("curator")
+        if not isinstance(self.curator, str):
+            self.curator = str(self.curator)
+
+        if self._is_empty(self.action):
+            self.MissingRequiredField("action")
+        if not isinstance(self.action, str):
+            self.action = str(self.action)
+
+        if self.changes is not None and not isinstance(self.changes, str):
+            self.changes = str(self.changes)
+
+        if self.llm_assisted is not None and not isinstance(self.llm_assisted, Bool):
+            self.llm_assisted = Bool(self.llm_assisted)
 
         super().__post_init__(**kwargs)
 
@@ -1230,1902 +1130,1113 @@ class EvidenceItemSupportEnum(EnumDefinitionImpl):
     the cited paper actively contradicts the claim, while WRONG_STATEMENT means the cited paper is misattributed (it
     does not address the claim).
     """
-
     SUPPORT = PermissibleValue(
         text="SUPPORT",
-        description="""The cited reference directly supports the claim; the snippet is a substring of the reference and the surrounding context endorses the interaction or property as stated.""",
-    )
+        description="""The cited reference directly supports the claim; the snippet is a substring of the reference and the surrounding context endorses the interaction or property as stated.""")
     REFUTE = PermissibleValue(
         text="REFUTE",
-        description="""The cited reference actively contradicts the claim (e.g., reports the opposite effect, or shows the proposed mechanism does not occur under the cited conditions).""",
-    )
+        description="""The cited reference actively contradicts the claim (e.g., reports the opposite effect, or shows the proposed mechanism does not occur under the cited conditions).""")
     PARTIAL = PermissibleValue(
         text="PARTIAL",
-        description="""The cited reference supports part but not all of the claim. Common cases: snippet supports the mechanism but not the specific site, taxa, or quantitative figure asserted; or the reference supports a related but weaker version of the claim.""",
-    )
+        description="""The cited reference supports part but not all of the claim. Common cases: snippet supports the mechanism but not the specific site, taxa, or quantitative figure asserted; or the reference supports a related but weaker version of the claim.""")
     NO_EVIDENCE = PermissibleValue(
         text="NO_EVIDENCE",
-        description="""The cited reference does not contain a passage that addresses the claim. Used when the paper is on-topic and a reference is required by the schema, but the curator could not locate a supporting (or contradicting) excerpt; the snippet records the closest on-topic excerpt examined. Stronger than WRONG_STATEMENT (which signals misattribution) and weaker than REFUTE.""",
-    )
+        description="""The cited reference does not contain a passage that addresses the claim. Used when the paper is on-topic and a reference is required by the schema, but the curator could not locate a supporting (or contradicting) excerpt; the snippet records the closest on-topic excerpt examined. Stronger than WRONG_STATEMENT (which signals misattribution) and weaker than REFUTE.""")
     WRONG_STATEMENT = PermissibleValue(
         text="WRONG_STATEMENT",
-        description="""The cited reference is misattributed - the paper does not address the curated claim at all (e.g., wrong DOI/PMID, paper about a different system). Distinct from REFUTE, which is reserved for references that actively contradict the claim.""",
-    )
+        description="""The cited reference is misattributed - the paper does not address the curated claim at all (e.g., wrong DOI/PMID, paper about a different system). Distinct from REFUTE, which is reserved for references that actively contradict the claim.""")
 
     _defn = EnumDefinition(
         name="EvidenceItemSupportEnum",
         description="""How the cited reference relates to the curated claim. Distinct from the validity of the claim itself: REFUTE means the cited paper actively contradicts the claim, while WRONG_STATEMENT means the cited paper is misattributed (it does not address the claim).""",
     )
 
-
 class EvidenceSourceEnum(EnumDefinitionImpl):
     """
     The provenance/source of the evidence
     """
-
     IN_VITRO = PermissibleValue(
-        text="IN_VITRO", description="In vitro experiments (batch culture, bioreactor, etc.)"
-    )
+        text="IN_VITRO",
+        description="In vitro experiments (batch culture, bioreactor, etc.)")
     IN_VIVO = PermissibleValue(
-        text="IN_VIVO", description="In vivo experiments (field studies, host-associated, etc.)"
-    )
+        text="IN_VIVO",
+        description="In vivo experiments (field studies, host-associated, etc.)")
     COMPUTATIONAL = PermissibleValue(
-        text="COMPUTATIONAL", description="In silico modeling, simulation, or prediction"
-    )
-    REVIEW = PermissibleValue(text="REVIEW", description="Review article or meta-analysis")
-    OTHER = PermissibleValue(text="OTHER", description="Other evidence type")
+        text="COMPUTATIONAL",
+        description="In silico modeling, simulation, or prediction")
+    REVIEW = PermissibleValue(
+        text="REVIEW",
+        description="Review article or meta-analysis")
+    OTHER = PermissibleValue(
+        text="OTHER",
+        description="Other evidence type")
 
     _defn = EnumDefinition(
         name="EvidenceSourceEnum",
         description="The provenance/source of the evidence",
     )
 
-
 class EcologicalStateEnum(EnumDefinitionImpl):
     """
     The ecological or health state of the community
     """
-
-    STABLE = PermissibleValue(text="STABLE", description="Stable, equilibrium community")
+    STABLE = PermissibleValue(
+        text="STABLE",
+        description="Stable, equilibrium community")
     PERTURBED = PermissibleValue(
-        text="PERTURBED", description="Recently perturbed (e.g., antibiotic treatment)"
-    )
+        text="PERTURBED",
+        description="Recently perturbed (e.g., antibiotic treatment)")
     ENGINEERED = PermissibleValue(
-        text="ENGINEERED", description="Synthetic or engineered community"
-    )
-    TRANSIENT = PermissibleValue(text="TRANSIENT", description="Transient or developing community")
+        text="ENGINEERED",
+        description="Synthetic or engineered community")
+    TRANSIENT = PermissibleValue(
+        text="TRANSIENT",
+        description="Transient or developing community")
 
     _defn = EnumDefinition(
         name="EcologicalStateEnum",
         description="The ecological or health state of the community",
     )
 
-
 class CommunityOriginEnum(EnumDefinitionImpl):
     """
     The origin or source of the community
     """
-
     NATURAL = PermissibleValue(
-        text="NATURAL", description="Naturally occurring community from environment"
-    )
+        text="NATURAL",
+        description="Naturally occurring community from environment")
     ENGINEERED = PermissibleValue(
-        text="ENGINEERED", description="Deliberately engineered or synthetic community"
-    )
+        text="ENGINEERED",
+        description="Deliberately engineered or synthetic community")
     SYNTHETIC = PermissibleValue(
-        text="SYNTHETIC", description="Fully synthetic community designed in laboratory"
-    )
+        text="SYNTHETIC",
+        description="Fully synthetic community designed in laboratory")
 
     _defn = EnumDefinition(
         name="CommunityOriginEnum",
         description="The origin or source of the community",
     )
 
-
 class MediaRelationshipEnum(EnumDefinitionImpl):
     """
     Type of relationship between a microbial community and a growth medium. Distinguishes actual cultivation media
     from environmentally related media.
     """
-
     CULTIVATION_MEDIUM = PermissibleValue(
         text="CULTIVATION_MEDIUM",
-        description="Medium actually used for cultivation of community members",
-    )
+        description="Medium actually used for cultivation of community members")
     ISOLATION_MEDIUM = PermissibleValue(
         text="ISOLATION_MEDIUM",
-        description="Medium used for initial isolation of community members from the environment",
-    )
+        description="Medium used for initial isolation of community members from the environment")
     ENVIRONMENT_ANALOG = PermissibleValue(
         text="ENVIRONMENT_ANALOG",
-        description="Medium designed to mimic the community's natural environment",
-    )
+        description="Medium designed to mimic the community's natural environment")
     REFERENCED_IN_STUDY = PermissibleValue(
         text="REFERENCED_IN_STUDY",
-        description="Medium referenced in a study of this community but not necessarily used for cultivation",
-    )
+        description="Medium referenced in a study of this community but not necessarily used for cultivation")
     SELECTIVE_ENRICHMENT = PermissibleValue(
         text="SELECTIVE_ENRICHMENT",
-        description="Medium used for selective enrichment of specific functional groups within the community",
-    )
+        description="Medium used for selective enrichment of specific functional groups within the community")
 
     _defn = EnumDefinition(
         name="MediaRelationshipEnum",
         description="""Type of relationship between a microbial community and a growth medium. Distinguishes actual cultivation media from environmentally related media.""",
     )
 
-
 class CommunityCategoryEnum(EnumDefinitionImpl):
     """
     Broad functional/ecological category of the community
     """
-
     BIOMINING = PermissibleValue(
-        text="BIOMINING", description="Metal extraction and bioleaching systems"
-    )
-    AMD = PermissibleValue(text="AMD", description="Acid mine drainage communities")
-    SYNTROPHY = PermissibleValue(text="SYNTROPHY", description="Syntrophic metabolic cooperation")
+        text="BIOMINING",
+        description="Metal extraction and bioleaching systems")
+    AMD = PermissibleValue(
+        text="AMD",
+        description="Acid mine drainage communities")
+    SYNTROPHY = PermissibleValue(
+        text="SYNTROPHY",
+        description="Syntrophic metabolic cooperation")
     PHYTOPLANKTON = PermissibleValue(
-        text="PHYTOPLANKTON", description="Algae-bacteria associations"
-    )
+        text="PHYTOPLANKTON",
+        description="Algae-bacteria associations")
     RHIZOSPHERE = PermissibleValue(
-        text="RHIZOSPHERE", description="Plant root-associated communities"
-    )
+        text="RHIZOSPHERE",
+        description="Plant root-associated communities")
     ORAL = PermissibleValue(
-        text="ORAL", description="Oral microbiome and dental biofilm communities"
-    )
+        text="ORAL",
+        description="Oral microbiome and dental biofilm communities")
     LIGNOCELLULOSE = PermissibleValue(
-        text="LIGNOCELLULOSE", description="Lignocellulose degradation systems"
-    )
+        text="LIGNOCELLULOSE",
+        description="Lignocellulose degradation systems")
     METHANOGENESIS = PermissibleValue(
-        text="METHANOGENESIS", description="Methane-producing communities"
-    )
-    DIET = PermissibleValue(text="DIET", description="Direct interspecies electron transfer")
+        text="METHANOGENESIS",
+        description="Methane-producing communities")
+    DIET = PermissibleValue(
+        text="DIET",
+        description="Direct interspecies electron transfer")
     METAL_REDUCTION = PermissibleValue(
-        text="METAL_REDUCTION", description="Metal-reducing communities"
-    )
+        text="METAL_REDUCTION",
+        description="Metal-reducing communities")
     BIOREMEDIATION = PermissibleValue(
-        text="BIOREMEDIATION", description="Pollutant degradation and remediation"
-    )
+        text="BIOREMEDIATION",
+        description="Pollutant degradation and remediation")
     CARBON_SEQUESTRATION = PermissibleValue(
-        text="CARBON_SEQUESTRATION", description="Carbon fixation and storage"
-    )
+        text="CARBON_SEQUESTRATION",
+        description="Carbon fixation and storage")
     EXTREME_ENVIRONMENT = PermissibleValue(
-        text="EXTREME_ENVIRONMENT", description="Communities from extreme conditions"
-    )
+        text="EXTREME_ENVIRONMENT",
+        description="Communities from extreme conditions")
     BIOTECHNOLOGY = PermissibleValue(
-        text="BIOTECHNOLOGY", description="Industrial biotechnology applications"
-    )
-    OTHER = PermissibleValue(text="OTHER", description="Other or uncategorized communities")
+        text="BIOTECHNOLOGY",
+        description="Industrial biotechnology applications")
+    OTHER = PermissibleValue(
+        text="OTHER",
+        description="Other or uncategorized communities")
 
     _defn = EnumDefinition(
         name="CommunityCategoryEnum",
         description="Broad functional/ecological category of the community",
     )
 
-
 class InteractionTypeEnum(EnumDefinitionImpl):
     """
     Type of ecological interaction between organisms
     """
-
-    MUTUALISM = PermissibleValue(text="MUTUALISM", description="Both organisms benefit (+/+)")
+    MUTUALISM = PermissibleValue(
+        text="MUTUALISM",
+        description="Both organisms benefit (+/+)")
     COMMENSALISM = PermissibleValue(
-        text="COMMENSALISM", description="One benefits, other unaffected (+/0)"
-    )
+        text="COMMENSALISM",
+        description="One benefits, other unaffected (+/0)")
     CROSS_FEEDING = PermissibleValue(
-        text="CROSS_FEEDING", description="Metabolite exchange between organisms"
-    )
-    COMPETITION = PermissibleValue(text="COMPETITION", description="Both negatively affected (-/-)")
-    PREDATION = PermissibleValue(text="PREDATION", description="One benefits, other harmed (+/-)")
-    SYNTROPHY = PermissibleValue(text="SYNTROPHY", description="Obligate metabolic cooperation")
+        text="CROSS_FEEDING",
+        description="Metabolite exchange between organisms")
+    COMPETITION = PermissibleValue(
+        text="COMPETITION",
+        description="Both negatively affected (-/-)")
+    PREDATION = PermissibleValue(
+        text="PREDATION",
+        description="One benefits, other harmed (+/-)")
+    SYNTROPHY = PermissibleValue(
+        text="SYNTROPHY",
+        description="Obligate metabolic cooperation")
     NICHE_PARTITIONING = PermissibleValue(
         text="NICHE_PARTITIONING",
-        description="""Strains/species occupy distinct ecological niches, reducing competition through spatial or temporal separation""",
-    )
+        description="""Strains/species occupy distinct ecological niches, reducing competition through spatial or temporal separation""")
     STRAIN_COMPETITION = PermissibleValue(
         text="STRAIN_COMPETITION",
-        description="Intraspecific competition between closely related strains of the same species",
-    )
+        description="Intraspecific competition between closely related strains of the same species")
     COLONIZATION_FACILITATION = PermissibleValue(
         text="COLONIZATION_FACILITATION",
-        description="""One organism facilitates the colonization or establishment of another through priority effects or niche modification""",
-    )
+        description="""One organism facilitates the colonization or establishment of another through priority effects or niche modification""")
 
     _defn = EnumDefinition(
         name="InteractionTypeEnum",
         description="Type of ecological interaction between organisms",
     )
 
-
 class InteractionScopeEnum(EnumDefinitionImpl):
     """
     Whether an interaction is a pairwise organism-to-organism edge or a community-level phenomenon
     """
-
     PAIRWISE = PermissibleValue(
         text="PAIRWISE",
-        description="""Standard pairwise interaction between a source organism and (usually) a target. Requires source_taxon.""",
-    )
+        description="""Standard pairwise interaction between a source organism and (usually) a target. Requires source_taxon.""")
     COMMUNITY_LEVEL = PermissibleValue(
         text="COMMUNITY_LEVEL",
-        description="""Community-wide or emergent phenomenon (e.g., division of labor, host-microbiota colonization patterns, abiotic-input-driven processes such as electrolysis-supplied H2). source_taxon may be omitted because no single organism is the source.""",
-    )
+        description="""Community-wide or emergent phenomenon (e.g., division of labor, host-microbiota colonization patterns, abiotic-input-driven processes such as electrolysis-supplied H2). source_taxon may be omitted because no single organism is the source.""")
 
     _defn = EnumDefinition(
         name="InteractionScopeEnum",
         description="Whether an interaction is a pairwise organism-to-organism edge or a community-level phenomenon",
     )
 
-
 class AbundanceEnum(EnumDefinitionImpl):
     """
     Relative abundance categories
     """
-
-    DOMINANT = PermissibleValue(text="DOMINANT", description="Greater than 1% relative abundance")
-    ABUNDANT = PermissibleValue(text="ABUNDANT", description="0.1-1% relative abundance")
-    COMMON = PermissibleValue(text="COMMON", description="0.01-0.1% relative abundance")
-    RARE = PermissibleValue(text="RARE", description="Less than 0.01% relative abundance")
+    DOMINANT = PermissibleValue(
+        text="DOMINANT",
+        description="Greater than 1% relative abundance")
+    ABUNDANT = PermissibleValue(
+        text="ABUNDANT",
+        description="0.1-1% relative abundance")
+    COMMON = PermissibleValue(
+        text="COMMON",
+        description="0.01-0.1% relative abundance")
+    RARE = PermissibleValue(
+        text="RARE",
+        description="Less than 0.01% relative abundance")
 
     _defn = EnumDefinition(
         name="AbundanceEnum",
         description="Relative abundance categories",
     )
 
-
 class FunctionalRoleEnum(EnumDefinitionImpl):
     """
     Functional role in the community
     """
-
     PRIMARY_PRODUCER = PermissibleValue(
-        text="PRIMARY_PRODUCER", description="Fixes carbon (autotroph)"
-    )
+        text="PRIMARY_PRODUCER",
+        description="Fixes carbon (autotroph)")
     PRIMARY_DEGRADER = PermissibleValue(
-        text="PRIMARY_DEGRADER", description="Degrades complex substrates"
-    )
+        text="PRIMARY_DEGRADER",
+        description="Degrades complex substrates")
     SECONDARY_FERMENTER = PermissibleValue(
-        text="SECONDARY_FERMENTER", description="Ferments products from primary degraders"
-    )
+        text="SECONDARY_FERMENTER",
+        description="Ferments products from primary degraders")
     SYNTROPHIC_PARTNER = PermissibleValue(
-        text="SYNTROPHIC_PARTNER", description="Engages in syntrophic metabolism"
-    )
+        text="SYNTROPHIC_PARTNER",
+        description="Engages in syntrophic metabolism")
     CROSS_FEEDER = PermissibleValue(
-        text="CROSS_FEEDER", description="Utilizes metabolites from other taxa"
-    )
+        text="CROSS_FEEDER",
+        description="Utilizes metabolites from other taxa")
 
     _defn = EnumDefinition(
         name="FunctionalRoleEnum",
         description="Functional role in the community",
     )
 
-
 class AtmosphereEnum(EnumDefinitionImpl):
     """
     Atmospheric/oxygen requirements for growth
     """
-
-    AEROBIC = PermissibleValue(text="AEROBIC", description="Requires oxygen for growth")
+    AEROBIC = PermissibleValue(
+        text="AEROBIC",
+        description="Requires oxygen for growth")
     ANAEROBIC = PermissibleValue(
-        text="ANAEROBIC", description="Growth only in absence of oxygen (strict anaerobe)"
-    )
+        text="ANAEROBIC",
+        description="Growth only in absence of oxygen (strict anaerobe)")
     MICROAEROBIC = PermissibleValue(
-        text="MICROAEROBIC", description="Requires low oxygen levels (typically 2-10%)"
-    )
+        text="MICROAEROBIC",
+        description="Requires low oxygen levels (typically 2-10%)")
     FACULTATIVE_ANAEROBIC = PermissibleValue(
-        text="FACULTATIVE_ANAEROBIC", description="Can grow with or without oxygen"
-    )
+        text="FACULTATIVE_ANAEROBIC",
+        description="Can grow with or without oxygen")
     FACULTATIVE_AEROBIC = PermissibleValue(
-        text="FACULTATIVE_AEROBIC", description="Preferentially aerobic but can grow anaerobically"
-    )
-    CAPNOPHILIC = PermissibleValue(text="CAPNOPHILIC", description="Requires elevated CO2 levels")
+        text="FACULTATIVE_AEROBIC",
+        description="Preferentially aerobic but can grow anaerobically")
+    CAPNOPHILIC = PermissibleValue(
+        text="CAPNOPHILIC",
+        description="Requires elevated CO2 levels")
 
     _defn = EnumDefinition(
         name="AtmosphereEnum",
         description="Atmospheric/oxygen requirements for growth",
     )
 
-
 class DatasetTypeEnum(EnumDefinitionImpl):
     """
     Type of omics or other dataset associated with a community
     """
-
-    METAGENOME = PermissibleValue(text="METAGENOME", description="Shotgun metagenomic sequencing")
-    AMPLICON_16S = PermissibleValue(text="AMPLICON_16S", description="16S rRNA amplicon sequencing")
+    METAGENOME = PermissibleValue(
+        text="METAGENOME",
+        description="Shotgun metagenomic sequencing")
+    AMPLICON_16S = PermissibleValue(
+        text="AMPLICON_16S",
+        description="16S rRNA amplicon sequencing")
     AMPLICON_ITS = PermissibleValue(
-        text="AMPLICON_ITS", description="ITS amplicon sequencing (fungal)"
-    )
+        text="AMPLICON_ITS",
+        description="ITS amplicon sequencing (fungal)")
     METATRANSCRIPTOME = PermissibleValue(
-        text="METATRANSCRIPTOME", description="Metatranscriptomic sequencing"
-    )
-    METAPROTEOME = PermissibleValue(text="METAPROTEOME", description="Metaproteomic analysis")
+        text="METATRANSCRIPTOME",
+        description="Metatranscriptomic sequencing")
+    METAPROTEOME = PermissibleValue(
+        text="METAPROTEOME",
+        description="Metaproteomic analysis")
     METABOLOMICS = PermissibleValue(
-        text="METABOLOMICS", description="Metabolomics (LC-MS, GC-MS, etc.)"
-    )
-    GENOME = PermissibleValue(text="GENOME", description="Isolate whole genome sequencing")
+        text="METABOLOMICS",
+        description="Metabolomics (LC-MS, GC-MS, etc.)")
+    GENOME = PermissibleValue(
+        text="GENOME",
+        description="Isolate whole genome sequencing")
     PHENOTYPE = PermissibleValue(
-        text="PHENOTYPE", description="Phenotypic measurements (growth, imaging, etc.)"
-    )
-    OTHER = PermissibleValue(text="OTHER", description="Other dataset type")
+        text="PHENOTYPE",
+        description="Phenotypic measurements (growth, imaging, etc.)")
+    OTHER = PermissibleValue(
+        text="OTHER",
+        description="Other dataset type")
 
     _defn = EnumDefinition(
         name="DatasetTypeEnum",
         description="Type of omics or other dataset associated with a community",
     )
 
-
 class DatasetRepositoryEnum(EnumDefinitionImpl):
     """
     Data repositories for omics and related datasets
     """
-
-    NCBI_SRA = PermissibleValue(text="NCBI_SRA", description="NCBI Sequence Read Archive")
-    NCBI_BIOPROJECT = PermissibleValue(text="NCBI_BIOPROJECT", description="NCBI BioProject")
-    NMDC = PermissibleValue(text="NMDC", description="National Microbiome Data Collaborative")
-    JGI_GOLD = PermissibleValue(text="JGI_GOLD", description="JGI Genomes OnLine Database")
-    JGI_IMG = PermissibleValue(text="JGI_IMG", description="JGI Integrated Microbial Genomes")
-    MGNIFY = PermissibleValue(text="MGNIFY", description="MGnify (EBI metagenomics)")
+    NCBI_SRA = PermissibleValue(
+        text="NCBI_SRA",
+        description="NCBI Sequence Read Archive")
+    NCBI_BIOPROJECT = PermissibleValue(
+        text="NCBI_BIOPROJECT",
+        description="NCBI BioProject")
+    NMDC = PermissibleValue(
+        text="NMDC",
+        description="National Microbiome Data Collaborative")
+    JGI_GOLD = PermissibleValue(
+        text="JGI_GOLD",
+        description="JGI Genomes OnLine Database")
+    JGI_IMG = PermissibleValue(
+        text="JGI_IMG",
+        description="JGI Integrated Microbial Genomes")
+    MGNIFY = PermissibleValue(
+        text="MGNIFY",
+        description="MGnify (EBI metagenomics)")
     METABOLOMICS_WORKBENCH = PermissibleValue(
-        text="METABOLOMICS_WORKBENCH", description="Metabolomics Workbench"
-    )
-    MASSIVE = PermissibleValue(text="MASSIVE", description="MassIVE mass spectrometry data")
+        text="METABOLOMICS_WORKBENCH",
+        description="Metabolomics Workbench")
+    MASSIVE = PermissibleValue(
+        text="MASSIVE",
+        description="MassIVE mass spectrometry data")
     GNPS = PermissibleValue(
-        text="GNPS", description="Global Natural Products Social Molecular Networking"
-    )
-    FIGSHARE = PermissibleValue(text="FIGSHARE", description="Figshare data repository")
-    ZENODO = PermissibleValue(text="ZENODO", description="Zenodo data repository")
-    OTHER = PermissibleValue(text="OTHER", description="Other data repository")
+        text="GNPS",
+        description="Global Natural Products Social Molecular Networking")
+    FIGSHARE = PermissibleValue(
+        text="FIGSHARE",
+        description="Figshare data repository")
+    ZENODO = PermissibleValue(
+        text="ZENODO",
+        description="Zenodo data repository")
+    OTHER = PermissibleValue(
+        text="OTHER",
+        description="Other data repository")
 
     _defn = EnumDefinition(
         name="DatasetRepositoryEnum",
         description="Data repositories for omics and related datasets",
     )
 
-
 class ExternalResourceRepositoryEnum(EnumDefinitionImpl):
     """
     External repositories and platforms that host community model resources
     """
-
-    BIOMODELS = PermissibleValue(text="BIOMODELS", description="BioModels database")
-    KBASE = PermissibleValue(text="KBASE", description="KBase Narrative platform")
-    BIGG = PermissibleValue(text="BIGG", description="BiGG Models")
-    VMH = PermissibleValue(text="VMH", description="Virtual Metabolic Human")
-    MODELSEED = PermissibleValue(text="MODELSEED", description="ModelSEED resources")
-    GITHUB = PermissibleValue(text="GITHUB", description="GitHub repository")
-    OTHER = PermissibleValue(text="OTHER", description="Other resource repository")
+    BIOMODELS = PermissibleValue(
+        text="BIOMODELS",
+        description="BioModels database")
+    KBASE = PermissibleValue(
+        text="KBASE",
+        description="KBase Narrative platform")
+    BIGG = PermissibleValue(
+        text="BIGG",
+        description="BiGG Models")
+    VMH = PermissibleValue(
+        text="VMH",
+        description="Virtual Metabolic Human")
+    MODELSEED = PermissibleValue(
+        text="MODELSEED",
+        description="ModelSEED resources")
+    GITHUB = PermissibleValue(
+        text="GITHUB",
+        description="GitHub repository")
+    OTHER = PermissibleValue(
+        text="OTHER",
+        description="Other resource repository")
 
     _defn = EnumDefinition(
         name="ExternalResourceRepositoryEnum",
         description="External repositories and platforms that host community model resources",
     )
 
-
 class CultureCollectionEnum(EnumDefinitionImpl):
     """
     Major microbial culture collections worldwide
     """
-
-    ATCC = PermissibleValue(text="ATCC", description="American Type Culture Collection (USA)")
+    ATCC = PermissibleValue(
+        text="ATCC",
+        description="American Type Culture Collection (USA)")
     DSM = PermissibleValue(
-        text="DSM", description="Deutsche Sammlung von Mikroorganismen (DSMZ, Germany)"
-    )
-    JCM = PermissibleValue(text="JCM", description="Japan Collection of Microorganisms (Japan)")
-    NCTC = PermissibleValue(text="NCTC", description="National Collection of Type Cultures (UK)")
+        text="DSM",
+        description="Deutsche Sammlung von Mikroorganismen (DSMZ, Germany)")
+    JCM = PermissibleValue(
+        text="JCM",
+        description="Japan Collection of Microorganisms (Japan)")
+    NCTC = PermissibleValue(
+        text="NCTC",
+        description="National Collection of Type Cultures (UK)")
     CCUG = PermissibleValue(
-        text="CCUG", description="Culture Collection University of Gothenburg (Sweden)"
-    )
+        text="CCUG",
+        description="Culture Collection University of Gothenburg (Sweden)")
     PCC = PermissibleValue(
-        text="PCC", description="Pasteur Culture Collection of Cyanobacteria (France)"
-    )
+        text="PCC",
+        description="Pasteur Culture Collection of Cyanobacteria (France)")
     NCIMB = PermissibleValue(
-        text="NCIMB", description="National Collection of Industrial Marine Bacteria (UK)"
-    )
-    LMG = PermissibleValue(text="LMG", description="BCCM/LMG Bacteria Collection (Belgium)")
-    KCTC = PermissibleValue(text="KCTC", description="Korean Collection for Type Cultures (Korea)")
-    CIP = PermissibleValue(text="CIP", description="Collection de l'Institut Pasteur (France)")
-    NBRC = PermissibleValue(text="NBRC", description="NITE Biological Resource Center (Japan)")
+        text="NCIMB",
+        description="National Collection of Industrial Marine Bacteria (UK)")
+    LMG = PermissibleValue(
+        text="LMG",
+        description="BCCM/LMG Bacteria Collection (Belgium)")
+    KCTC = PermissibleValue(
+        text="KCTC",
+        description="Korean Collection for Type Cultures (Korea)")
+    CIP = PermissibleValue(
+        text="CIP",
+        description="Collection de l'Institut Pasteur (France)")
+    NBRC = PermissibleValue(
+        text="NBRC",
+        description="NITE Biological Resource Center (Japan)")
     VKM = PermissibleValue(
-        text="VKM", description="All-Russian Collection of Microorganisms (Russia)"
-    )
+        text="VKM",
+        description="All-Russian Collection of Microorganisms (Russia)")
     CGMCC = PermissibleValue(
-        text="CGMCC", description="China General Microbiological Culture Collection (China)"
-    )
+        text="CGMCC",
+        description="China General Microbiological Culture Collection (China)")
     BCRC = PermissibleValue(
-        text="BCRC", description="Bioresource Collection and Research Center (Taiwan)"
-    )
+        text="BCRC",
+        description="Bioresource Collection and Research Center (Taiwan)")
     CBS = PermissibleValue(
-        text="CBS", description="Westerdijk Fungal Biodiversity Institute (Netherlands)"
-    )
-    OTHER = PermissibleValue(text="OTHER", description="Other culture collection not listed")
+        text="CBS",
+        description="Westerdijk Fungal Biodiversity Institute (Netherlands)")
+    OTHER = PermissibleValue(
+        text="OTHER",
+        description="Other culture collection not listed")
 
     _defn = EnumDefinition(
         name="CultureCollectionEnum",
         description="Major microbial culture collections worldwide",
     )
 
-
 class MetalElementEnum(EnumDefinitionImpl):
     """
     Metal elements relevant to microbial communities
     """
-
     COPPER = PermissibleValue(
-        text="COPPER", description="Copper(2+) cation", meaning=CHEBI["29036"]
-    )
-    IRON = PermissibleValue(text="IRON", description="Iron(2+) cation", meaning=CHEBI["29033"])
-    ZINC = PermissibleValue(text="ZINC", description="Zinc(2+) cation", meaning=CHEBI["27363"])
+        text="COPPER",
+        description="Copper(2+) cation",
+        meaning=CHEBI["29036"])
+    IRON = PermissibleValue(
+        text="IRON",
+        description="Iron(2+) cation",
+        meaning=CHEBI["29033"])
+    ZINC = PermissibleValue(
+        text="ZINC",
+        description="Zinc(2+) cation",
+        meaning=CHEBI["27363"])
     NICKEL = PermissibleValue(
-        text="NICKEL", description="Nickel(2+) cation", meaning=CHEBI["49786"]
-    )
+        text="NICKEL",
+        description="Nickel(2+) cation",
+        meaning=CHEBI["49786"])
     COBALT = PermissibleValue(
-        text="COBALT", description="Cobalt(2+) cation", meaning=CHEBI["48828"]
-    )
+        text="COBALT",
+        description="Cobalt(2+) cation",
+        meaning=CHEBI["48828"])
     VANADIUM = PermissibleValue(
-        text="VANADIUM", description="Vanadium cation", meaning=CHEBI["27698"]
-    )
-    URANIUM = PermissibleValue(text="URANIUM", description="Uranium atom", meaning=CHEBI["27214"])
+        text="VANADIUM",
+        description="Vanadium cation",
+        meaning=CHEBI["27698"])
+    URANIUM = PermissibleValue(
+        text="URANIUM",
+        description="Uranium atom",
+        meaning=CHEBI["27214"])
     CHROMIUM = PermissibleValue(
-        text="CHROMIUM", description="Chromium atom", meaning=CHEBI["28073"]
-    )
-    LEAD = PermissibleValue(text="LEAD", description="Lead(2+) cation", meaning=CHEBI["25016"])
+        text="CHROMIUM",
+        description="Chromium atom",
+        meaning=CHEBI["28073"])
+    LEAD = PermissibleValue(
+        text="LEAD",
+        description="Lead(2+) cation",
+        meaning=CHEBI["25016"])
     LITHIUM = PermissibleValue(
-        text="LITHIUM", description="Lithium(1+) cation", meaning=CHEBI["49713"]
-    )
-    GOLD = PermissibleValue(text="GOLD", description="Gold atom", meaning=CHEBI["29287"])
+        text="LITHIUM",
+        description="Lithium(1+) cation",
+        meaning=CHEBI["49713"])
+    GOLD = PermissibleValue(
+        text="GOLD",
+        description="Gold atom",
+        meaning=CHEBI["29287"])
     SILVER = PermissibleValue(
-        text="SILVER", description="Silver(1+) cation", meaning=CHEBI["30512"]
-    )
+        text="SILVER",
+        description="Silver(1+) cation",
+        meaning=CHEBI["30512"])
     PALLADIUM = PermissibleValue(
-        text="PALLADIUM", description="Palladium atom", meaning=CHEBI["33373"]
-    )
+        text="PALLADIUM",
+        description="Palladium atom",
+        meaning=CHEBI["33373"])
     GALLIUM = PermissibleValue(
-        text="GALLIUM", description="Gallium(3+) cation", meaning=CHEBI["49631"]
-    )
+        text="GALLIUM",
+        description="Gallium(3+) cation",
+        meaning=CHEBI["49631"])
     INDIUM = PermissibleValue(
-        text="INDIUM", description="Indium(3+) cation", meaning=CHEBI["49464"]
-    )
+        text="INDIUM",
+        description="Indium(3+) cation",
+        meaning=CHEBI["49464"])
     TITANIUM = PermissibleValue(
-        text="TITANIUM", description="Titanium atom", meaning=CHEBI["33341"]
-    )
+        text="TITANIUM",
+        description="Titanium atom",
+        meaning=CHEBI["33341"])
     MERCURY = PermissibleValue(
-        text="MERCURY", description="Mercury(2+) cation", meaning=CHEBI["16793"]
-    )
+        text="MERCURY",
+        description="Mercury(2+) cation",
+        meaning=CHEBI["16793"])
 
     _defn = EnumDefinition(
         name="MetalElementEnum",
         description="Metal elements relevant to microbial communities",
     )
 
-
 class RareEarthElementEnum(EnumDefinitionImpl):
     """
     Rare earth elements (lanthanides + Y, Sc)
     """
-
     LANTHANUM = PermissibleValue(
-        text="LANTHANUM", description="Lanthanum(3+) cation", meaning=CHEBI["32359"]
-    )
+        text="LANTHANUM",
+        description="Lanthanum(3+) cation",
+        meaning=CHEBI["32359"])
     CERIUM = PermissibleValue(
-        text="CERIUM", description="Cerium(3+) cation", meaning=CHEBI["32998"]
-    )
+        text="CERIUM",
+        description="Cerium(3+) cation",
+        meaning=CHEBI["32998"])
     PRASEODYMIUM = PermissibleValue(
-        text="PRASEODYMIUM", description="Praseodymium(3+) cation", meaning=CHEBI["49648"]
-    )
+        text="PRASEODYMIUM",
+        description="Praseodymium(3+) cation",
+        meaning=CHEBI["49648"])
     NEODYMIUM = PermissibleValue(
-        text="NEODYMIUM", description="Neodymium(3+) cation", meaning=CHEBI["33372"]
-    )
+        text="NEODYMIUM",
+        description="Neodymium(3+) cation",
+        meaning=CHEBI["33372"])
     SAMARIUM = PermissibleValue(
-        text="SAMARIUM", description="Samarium(3+) cation", meaning=CHEBI["33376"]
-    )
+        text="SAMARIUM",
+        description="Samarium(3+) cation",
+        meaning=CHEBI["33376"])
     EUROPIUM = PermissibleValue(
-        text="EUROPIUM", description="Europium(3+) cation", meaning=CHEBI["30688"]
-    )
+        text="EUROPIUM",
+        description="Europium(3+) cation",
+        meaning=CHEBI["30688"])
     GADOLINIUM = PermissibleValue(
-        text="GADOLINIUM", description="Gadolinium(3+) cation", meaning=CHEBI["33375"]
-    )
+        text="GADOLINIUM",
+        description="Gadolinium(3+) cation",
+        meaning=CHEBI["33375"])
     TERBIUM = PermissibleValue(
-        text="TERBIUM", description="Terbium(3+) cation", meaning=CHEBI["33374"]
-    )
+        text="TERBIUM",
+        description="Terbium(3+) cation",
+        meaning=CHEBI["33374"])
     DYSPROSIUM = PermissibleValue(
-        text="DYSPROSIUM", description="Dysprosium(3+) cation", meaning=CHEBI["49782"]
-    )
+        text="DYSPROSIUM",
+        description="Dysprosium(3+) cation",
+        meaning=CHEBI["49782"])
     HOLMIUM = PermissibleValue(
-        text="HOLMIUM", description="Holmium(3+) cation", meaning=CHEBI["49649"]
-    )
+        text="HOLMIUM",
+        description="Holmium(3+) cation",
+        meaning=CHEBI["49649"])
     ERBIUM = PermissibleValue(
-        text="ERBIUM", description="Erbium(3+) cation", meaning=CHEBI["49650"]
-    )
+        text="ERBIUM",
+        description="Erbium(3+) cation",
+        meaning=CHEBI["49650"])
     THULIUM = PermissibleValue(
-        text="THULIUM", description="Thulium(3+) cation", meaning=CHEBI["33377"]
-    )
+        text="THULIUM",
+        description="Thulium(3+) cation",
+        meaning=CHEBI["33377"])
     YTTERBIUM = PermissibleValue(
-        text="YTTERBIUM", description="Ytterbium(3+) cation", meaning=CHEBI["33378"]
-    )
+        text="YTTERBIUM",
+        description="Ytterbium(3+) cation",
+        meaning=CHEBI["33378"])
     LUTETIUM = PermissibleValue(
-        text="LUTETIUM", description="Lutetium(3+) cation", meaning=CHEBI["33382"]
-    )
+        text="LUTETIUM",
+        description="Lutetium(3+) cation",
+        meaning=CHEBI["33382"])
     YTTRIUM = PermissibleValue(
-        text="YTTRIUM", description="Yttrium(3+) cation", meaning=CHEBI["49976"]
-    )
+        text="YTTRIUM",
+        description="Yttrium(3+) cation",
+        meaning=CHEBI["49976"])
     SCANDIUM = PermissibleValue(
-        text="SCANDIUM", description="Scandium(3+) cation", meaning=CHEBI["33330"]
-    )
+        text="SCANDIUM",
+        description="Scandium(3+) cation",
+        meaning=CHEBI["33330"])
 
     _defn = EnumDefinition(
         name="RareEarthElementEnum",
         description="Rare earth elements (lanthanides + Y, Sc)",
     )
 
-
 class MetalRelevanceEnum(EnumDefinitionImpl):
     """
     Relevance of metals/REE to community function
     """
-
     PRIMARY = PermissibleValue(
-        text="PRIMARY", description="Primary function involves metal/REE extraction or cycling"
-    )
+        text="PRIMARY",
+        description="Primary function involves metal/REE extraction or cycling")
     SIGNIFICANT = PermissibleValue(
-        text="SIGNIFICANT", description="Significant metal/REE metabolism but not primary function"
-    )
-    INCIDENTAL = PermissibleValue(text="INCIDENTAL", description="Incidental metal/REE interaction")
+        text="SIGNIFICANT",
+        description="Significant metal/REE metabolism but not primary function")
+    INCIDENTAL = PermissibleValue(
+        text="INCIDENTAL",
+        description="Incidental metal/REE interaction")
     NOT_APPLICABLE = PermissibleValue(
-        text="NOT_APPLICABLE", description="No significant metal/REE relevance"
-    )
+        text="NOT_APPLICABLE",
+        description="No significant metal/REE relevance")
 
     _defn = EnumDefinition(
         name="MetalRelevanceEnum",
         description="Relevance of metals/REE to community function",
     )
 
-
 # Slots
 class slots:
     pass
 
+slots.term__id = Slot(uri=COMMUNITYMECH.id, name="term__id", curie=COMMUNITYMECH.curie('id'),
+                   model_uri=COMMUNITYMECH.term__id, domain=None, range=str)
 
-slots.term__id = Slot(
-    uri=COMMUNITYMECH.id,
-    name="term__id",
-    curie=COMMUNITYMECH.curie("id"),
-    model_uri=COMMUNITYMECH.term__id,
-    domain=None,
-    range=str,
-)
-
-slots.term__label = Slot(
-    uri=COMMUNITYMECH.label,
-    name="term__label",
-    curie=COMMUNITYMECH.curie("label"),
-    model_uri=COMMUNITYMECH.term__label,
-    domain=None,
-    range=str,
-)
-
-slots.evidenceItem__reference = Slot(
-    uri=COMMUNITYMECH.reference,
-    name="evidenceItem__reference",
-    curie=COMMUNITYMECH.curie("reference"),
-    model_uri=COMMUNITYMECH.evidenceItem__reference,
-    domain=None,
-    range=str,
-    pattern=re.compile(r"^(PMID:|doi:|bioproject:).*"),
-)
-
-slots.evidenceItem__supports = Slot(
-    uri=COMMUNITYMECH.supports,
-    name="evidenceItem__supports",
-    curie=COMMUNITYMECH.curie("supports"),
-    model_uri=COMMUNITYMECH.evidenceItem__supports,
-    domain=None,
-    range=Union[str, "EvidenceItemSupportEnum"],
-)
-
-slots.evidenceItem__evidence_source = Slot(
-    uri=COMMUNITYMECH.evidence_source,
-    name="evidenceItem__evidence_source",
-    curie=COMMUNITYMECH.curie("evidence_source"),
-    model_uri=COMMUNITYMECH.evidenceItem__evidence_source,
-    domain=None,
-    range=Union[str, "EvidenceSourceEnum"],
-)
-
-slots.evidenceItem__snippet = Slot(
-    uri=COMMUNITYMECH.snippet,
-    name="evidenceItem__snippet",
-    curie=COMMUNITYMECH.curie("snippet"),
-    model_uri=COMMUNITYMECH.evidenceItem__snippet,
-    domain=None,
-    range=str,
-)
-
-slots.evidenceItem__explanation = Slot(
-    uri=COMMUNITYMECH.explanation,
-    name="evidenceItem__explanation",
-    curie=COMMUNITYMECH.curie("explanation"),
-    model_uri=COMMUNITYMECH.evidenceItem__explanation,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.evidenceItem__confidence_score = Slot(
-    uri=COMMUNITYMECH.confidence_score,
-    name="evidenceItem__confidence_score",
-    curie=COMMUNITYMECH.curie("confidence_score"),
-    model_uri=COMMUNITYMECH.evidenceItem__confidence_score,
-    domain=None,
-    range=Optional[float],
-)
-
-slots.taxonDescriptor__preferred_term = Slot(
-    uri=COMMUNITYMECH.preferred_term,
-    name="taxonDescriptor__preferred_term",
-    curie=COMMUNITYMECH.curie("preferred_term"),
-    model_uri=COMMUNITYMECH.taxonDescriptor__preferred_term,
-    domain=None,
-    range=str,
-)
-
-slots.taxonDescriptor__term = Slot(
-    uri=COMMUNITYMECH.term,
-    name="taxonDescriptor__term",
-    curie=COMMUNITYMECH.curie("term"),
-    model_uri=COMMUNITYMECH.taxonDescriptor__term,
-    domain=None,
-    range=Union[dict, Term],
-)
-
-slots.taxonDescriptor__notes = Slot(
-    uri=COMMUNITYMECH.notes,
-    name="taxonDescriptor__notes",
-    curie=COMMUNITYMECH.curie("notes"),
-    model_uri=COMMUNITYMECH.taxonDescriptor__notes,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.metaboliteDescriptor__preferred_term = Slot(
-    uri=COMMUNITYMECH.preferred_term,
-    name="metaboliteDescriptor__preferred_term",
-    curie=COMMUNITYMECH.curie("preferred_term"),
-    model_uri=COMMUNITYMECH.metaboliteDescriptor__preferred_term,
-    domain=None,
-    range=str,
-)
-
-slots.metaboliteDescriptor__term = Slot(
-    uri=COMMUNITYMECH.term,
-    name="metaboliteDescriptor__term",
-    curie=COMMUNITYMECH.curie("term"),
-    model_uri=COMMUNITYMECH.metaboliteDescriptor__term,
-    domain=None,
-    range=Union[dict, Term],
-)
-
-slots.metaboliteDescriptor__concentration = Slot(
-    uri=COMMUNITYMECH.concentration,
-    name="metaboliteDescriptor__concentration",
-    curie=COMMUNITYMECH.curie("concentration"),
-    model_uri=COMMUNITYMECH.metaboliteDescriptor__concentration,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.metaboliteDescriptor__notes = Slot(
-    uri=COMMUNITYMECH.notes,
-    name="metaboliteDescriptor__notes",
-    curie=COMMUNITYMECH.curie("notes"),
-    model_uri=COMMUNITYMECH.metaboliteDescriptor__notes,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.biologicalProcessDescriptor__preferred_term = Slot(
-    uri=COMMUNITYMECH.preferred_term,
-    name="biologicalProcessDescriptor__preferred_term",
-    curie=COMMUNITYMECH.curie("preferred_term"),
-    model_uri=COMMUNITYMECH.biologicalProcessDescriptor__preferred_term,
-    domain=None,
-    range=str,
-)
-
-slots.biologicalProcessDescriptor__term = Slot(
-    uri=COMMUNITYMECH.term,
-    name="biologicalProcessDescriptor__term",
-    curie=COMMUNITYMECH.curie("term"),
-    model_uri=COMMUNITYMECH.biologicalProcessDescriptor__term,
-    domain=None,
-    range=Union[dict, Term],
-)
-
-slots.biologicalProcessDescriptor__notes = Slot(
-    uri=COMMUNITYMECH.notes,
-    name="biologicalProcessDescriptor__notes",
-    curie=COMMUNITYMECH.curie("notes"),
-    model_uri=COMMUNITYMECH.biologicalProcessDescriptor__notes,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.environmentDescriptor__preferred_term = Slot(
-    uri=COMMUNITYMECH.preferred_term,
-    name="environmentDescriptor__preferred_term",
-    curie=COMMUNITYMECH.curie("preferred_term"),
-    model_uri=COMMUNITYMECH.environmentDescriptor__preferred_term,
-    domain=None,
-    range=str,
-)
-
-slots.environmentDescriptor__term = Slot(
-    uri=COMMUNITYMECH.term,
-    name="environmentDescriptor__term",
-    curie=COMMUNITYMECH.curie("term"),
-    model_uri=COMMUNITYMECH.environmentDescriptor__term,
-    domain=None,
-    range=Union[dict, Term],
-)
-
-slots.environmentDescriptor__notes = Slot(
-    uri=COMMUNITYMECH.notes,
-    name="environmentDescriptor__notes",
-    curie=COMMUNITYMECH.curie("notes"),
-    model_uri=COMMUNITYMECH.environmentDescriptor__notes,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.cultureCollectionID__collection = Slot(
-    uri=COMMUNITYMECH.collection,
-    name="cultureCollectionID__collection",
-    curie=COMMUNITYMECH.curie("collection"),
-    model_uri=COMMUNITYMECH.cultureCollectionID__collection,
-    domain=None,
-    range=Union[str, "CultureCollectionEnum"],
-)
-
-slots.cultureCollectionID__accession = Slot(
-    uri=COMMUNITYMECH.accession,
-    name="cultureCollectionID__accession",
-    curie=COMMUNITYMECH.curie("accession"),
-    model_uri=COMMUNITYMECH.cultureCollectionID__accession,
-    domain=None,
-    range=str,
-)
-
-slots.cultureCollectionID__url = Slot(
-    uri=COMMUNITYMECH.url,
-    name="cultureCollectionID__url",
-    curie=COMMUNITYMECH.curie("url"),
-    model_uri=COMMUNITYMECH.cultureCollectionID__url,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.cultureCollectionID__notes = Slot(
-    uri=COMMUNITYMECH.notes,
-    name="cultureCollectionID__notes",
-    curie=COMMUNITYMECH.curie("notes"),
-    model_uri=COMMUNITYMECH.cultureCollectionID__notes,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.strainDesignation__strain_name = Slot(
-    uri=COMMUNITYMECH.strain_name,
-    name="strainDesignation__strain_name",
-    curie=COMMUNITYMECH.curie("strain_name"),
-    model_uri=COMMUNITYMECH.strainDesignation__strain_name,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.strainDesignation__culture_collections = Slot(
-    uri=COMMUNITYMECH.culture_collections,
-    name="strainDesignation__culture_collections",
-    curie=COMMUNITYMECH.curie("culture_collections"),
-    model_uri=COMMUNITYMECH.strainDesignation__culture_collections,
-    domain=None,
-    range=Optional[Union[Union[dict, CultureCollectionID], list[Union[dict, CultureCollectionID]]]],
-)
-
-slots.strainDesignation__type_strain = Slot(
-    uri=COMMUNITYMECH.type_strain,
-    name="strainDesignation__type_strain",
-    curie=COMMUNITYMECH.curie("type_strain"),
-    model_uri=COMMUNITYMECH.strainDesignation__type_strain,
-    domain=None,
-    range=Optional[Union[bool, Bool]],
-)
-
-slots.strainDesignation__genome_accession = Slot(
-    uri=COMMUNITYMECH.genome_accession,
-    name="strainDesignation__genome_accession",
-    curie=COMMUNITYMECH.curie("genome_accession"),
-    model_uri=COMMUNITYMECH.strainDesignation__genome_accession,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.strainDesignation__genome_url = Slot(
-    uri=COMMUNITYMECH.genome_url,
-    name="strainDesignation__genome_url",
-    curie=COMMUNITYMECH.curie("genome_url"),
-    model_uri=COMMUNITYMECH.strainDesignation__genome_url,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.strainDesignation__genetic_modification = Slot(
-    uri=COMMUNITYMECH.genetic_modification,
-    name="strainDesignation__genetic_modification",
-    curie=COMMUNITYMECH.curie("genetic_modification"),
-    model_uri=COMMUNITYMECH.strainDesignation__genetic_modification,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.strainDesignation__isolation_source = Slot(
-    uri=COMMUNITYMECH.isolation_source,
-    name="strainDesignation__isolation_source",
-    curie=COMMUNITYMECH.curie("isolation_source"),
-    model_uri=COMMUNITYMECH.strainDesignation__isolation_source,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.strainDesignation__notes = Slot(
-    uri=COMMUNITYMECH.notes,
-    name="strainDesignation__notes",
-    curie=COMMUNITYMECH.curie("notes"),
-    model_uri=COMMUNITYMECH.strainDesignation__notes,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.taxonomicComposition__taxon_term = Slot(
-    uri=COMMUNITYMECH.taxon_term,
-    name="taxonomicComposition__taxon_term",
-    curie=COMMUNITYMECH.curie("taxon_term"),
-    model_uri=COMMUNITYMECH.taxonomicComposition__taxon_term,
-    domain=None,
-    range=Union[dict, TaxonDescriptor],
-)
-
-slots.taxonomicComposition__strain_designation = Slot(
-    uri=COMMUNITYMECH.strain_designation,
-    name="taxonomicComposition__strain_designation",
-    curie=COMMUNITYMECH.curie("strain_designation"),
-    model_uri=COMMUNITYMECH.taxonomicComposition__strain_designation,
-    domain=None,
-    range=Optional[Union[dict, StrainDesignation]],
-)
-
-slots.taxonomicComposition__abundance_level = Slot(
-    uri=COMMUNITYMECH.abundance_level,
-    name="taxonomicComposition__abundance_level",
-    curie=COMMUNITYMECH.curie("abundance_level"),
-    model_uri=COMMUNITYMECH.taxonomicComposition__abundance_level,
-    domain=None,
-    range=Optional[Union[str, "AbundanceEnum"]],
-)
-
-slots.taxonomicComposition__abundance_value = Slot(
-    uri=COMMUNITYMECH.abundance_value,
-    name="taxonomicComposition__abundance_value",
-    curie=COMMUNITYMECH.curie("abundance_value"),
-    model_uri=COMMUNITYMECH.taxonomicComposition__abundance_value,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.taxonomicComposition__functional_role = Slot(
-    uri=COMMUNITYMECH.functional_role,
-    name="taxonomicComposition__functional_role",
-    curie=COMMUNITYMECH.curie("functional_role"),
-    model_uri=COMMUNITYMECH.taxonomicComposition__functional_role,
-    domain=None,
-    range=Optional[Union[Union[str, "FunctionalRoleEnum"], list[Union[str, "FunctionalRoleEnum"]]]],
-)
-
-slots.taxonomicComposition__evidence = Slot(
-    uri=COMMUNITYMECH.evidence,
-    name="taxonomicComposition__evidence",
-    curie=COMMUNITYMECH.curie("evidence"),
-    model_uri=COMMUNITYMECH.taxonomicComposition__evidence,
-    domain=None,
-    range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
-)
-
-slots.interactionDownstream__target = Slot(
-    uri=COMMUNITYMECH.target,
-    name="interactionDownstream__target",
-    curie=COMMUNITYMECH.curie("target"),
-    model_uri=COMMUNITYMECH.interactionDownstream__target,
-    domain=None,
-    range=str,
-)
-
-slots.interactionDownstream__description = Slot(
-    uri=COMMUNITYMECH.description,
-    name="interactionDownstream__description",
-    curie=COMMUNITYMECH.curie("description"),
-    model_uri=COMMUNITYMECH.interactionDownstream__description,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.ecologicalInteraction__name = Slot(
-    uri=COMMUNITYMECH.name,
-    name="ecologicalInteraction__name",
-    curie=COMMUNITYMECH.curie("name"),
-    model_uri=COMMUNITYMECH.ecologicalInteraction__name,
-    domain=None,
-    range=str,
-)
-
-slots.ecologicalInteraction__description = Slot(
-    uri=COMMUNITYMECH.description,
-    name="ecologicalInteraction__description",
-    curie=COMMUNITYMECH.curie("description"),
-    model_uri=COMMUNITYMECH.ecologicalInteraction__description,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.ecologicalInteraction__interaction_type = Slot(
-    uri=COMMUNITYMECH.interaction_type,
-    name="ecologicalInteraction__interaction_type",
-    curie=COMMUNITYMECH.curie("interaction_type"),
-    model_uri=COMMUNITYMECH.ecologicalInteraction__interaction_type,
-    domain=None,
-    range=Optional[Union[str, "InteractionTypeEnum"]],
-)
-
-slots.ecologicalInteraction__scope = Slot(
-    uri=COMMUNITYMECH.scope,
-    name="ecologicalInteraction__scope",
-    curie=COMMUNITYMECH.curie("scope"),
-    model_uri=COMMUNITYMECH.ecologicalInteraction__scope,
-    domain=None,
-    range=Optional[Union[str, "InteractionScopeEnum"]],
-)
-
-slots.ecologicalInteraction__source_taxon = Slot(
-    uri=COMMUNITYMECH.source_taxon,
-    name="ecologicalInteraction__source_taxon",
-    curie=COMMUNITYMECH.curie("source_taxon"),
-    model_uri=COMMUNITYMECH.ecologicalInteraction__source_taxon,
-    domain=None,
-    range=Optional[Union[dict, TaxonDescriptor]],
-)
-
-slots.ecologicalInteraction__target_taxon = Slot(
-    uri=COMMUNITYMECH.target_taxon,
-    name="ecologicalInteraction__target_taxon",
-    curie=COMMUNITYMECH.curie("target_taxon"),
-    model_uri=COMMUNITYMECH.ecologicalInteraction__target_taxon,
-    domain=None,
-    range=Optional[Union[dict, TaxonDescriptor]],
-)
-
-slots.ecologicalInteraction__metabolites = Slot(
-    uri=COMMUNITYMECH.metabolites,
-    name="ecologicalInteraction__metabolites",
-    curie=COMMUNITYMECH.curie("metabolites"),
-    model_uri=COMMUNITYMECH.ecologicalInteraction__metabolites,
-    domain=None,
-    range=Optional[
-        Union[Union[dict, MetaboliteDescriptor], list[Union[dict, MetaboliteDescriptor]]]
-    ],
-)
-
-slots.ecologicalInteraction__biological_processes = Slot(
-    uri=COMMUNITYMECH.biological_processes,
-    name="ecologicalInteraction__biological_processes",
-    curie=COMMUNITYMECH.curie("biological_processes"),
-    model_uri=COMMUNITYMECH.ecologicalInteraction__biological_processes,
-    domain=None,
-    range=Optional[
-        Union[
-            Union[dict, BiologicalProcessDescriptor], list[Union[dict, BiologicalProcessDescriptor]]
-        ]
-    ],
-)
-
-slots.ecologicalInteraction__downstream = Slot(
-    uri=COMMUNITYMECH.downstream,
-    name="ecologicalInteraction__downstream",
-    curie=COMMUNITYMECH.curie("downstream"),
-    model_uri=COMMUNITYMECH.ecologicalInteraction__downstream,
-    domain=None,
-    range=Optional[
-        Union[Union[dict, InteractionDownstream], list[Union[dict, InteractionDownstream]]]
-    ],
-)
-
-slots.ecologicalInteraction__evidence = Slot(
-    uri=COMMUNITYMECH.evidence,
-    name="ecologicalInteraction__evidence",
-    curie=COMMUNITYMECH.curie("evidence"),
-    model_uri=COMMUNITYMECH.ecologicalInteraction__evidence,
-    domain=None,
-    range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
-)
-
-slots.environmentalFactor__name = Slot(
-    uri=COMMUNITYMECH.name,
-    name="environmentalFactor__name",
-    curie=COMMUNITYMECH.curie("name"),
-    model_uri=COMMUNITYMECH.environmentalFactor__name,
-    domain=None,
-    range=str,
-)
-
-slots.environmentalFactor__value = Slot(
-    uri=COMMUNITYMECH.value,
-    name="environmentalFactor__value",
-    curie=COMMUNITYMECH.curie("value"),
-    model_uri=COMMUNITYMECH.environmentalFactor__value,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.environmentalFactor__unit = Slot(
-    uri=COMMUNITYMECH.unit,
-    name="environmentalFactor__unit",
-    curie=COMMUNITYMECH.curie("unit"),
-    model_uri=COMMUNITYMECH.environmentalFactor__unit,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.environmentalFactor__description = Slot(
-    uri=COMMUNITYMECH.description,
-    name="environmentalFactor__description",
-    curie=COMMUNITYMECH.curie("description"),
-    model_uri=COMMUNITYMECH.environmentalFactor__description,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.environmentalFactor__evidence = Slot(
-    uri=COMMUNITYMECH.evidence,
-    name="environmentalFactor__evidence",
-    curie=COMMUNITYMECH.curie("evidence"),
-    model_uri=COMMUNITYMECH.environmentalFactor__evidence,
-    domain=None,
-    range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
-)
-
-slots.growthMediaComponent__name = Slot(
-    uri=COMMUNITYMECH.name,
-    name="growthMediaComponent__name",
-    curie=COMMUNITYMECH.curie("name"),
-    model_uri=COMMUNITYMECH.growthMediaComponent__name,
-    domain=None,
-    range=str,
-)
-
-slots.growthMediaComponent__media_ingredient_mech_id = Slot(
-    uri=COMMUNITYMECH.media_ingredient_mech_id,
-    name="growthMediaComponent__media_ingredient_mech_id",
-    curie=COMMUNITYMECH.curie("media_ingredient_mech_id"),
-    model_uri=COMMUNITYMECH.growthMediaComponent__media_ingredient_mech_id,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMediaComponent__media_ingredient_mech_url = Slot(
-    uri=COMMUNITYMECH.media_ingredient_mech_url,
-    name="growthMediaComponent__media_ingredient_mech_url",
-    curie=COMMUNITYMECH.curie("media_ingredient_mech_url"),
-    model_uri=COMMUNITYMECH.growthMediaComponent__media_ingredient_mech_url,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMediaComponent__concentration = Slot(
-    uri=COMMUNITYMECH.concentration,
-    name="growthMediaComponent__concentration",
-    curie=COMMUNITYMECH.curie("concentration"),
-    model_uri=COMMUNITYMECH.growthMediaComponent__concentration,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMediaComponent__unit = Slot(
-    uri=COMMUNITYMECH.unit,
-    name="growthMediaComponent__unit",
-    curie=COMMUNITYMECH.curie("unit"),
-    model_uri=COMMUNITYMECH.growthMediaComponent__unit,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMediaComponent__chebi_term = Slot(
-    uri=COMMUNITYMECH.chebi_term,
-    name="growthMediaComponent__chebi_term",
-    curie=COMMUNITYMECH.curie("chebi_term"),
-    model_uri=COMMUNITYMECH.growthMediaComponent__chebi_term,
-    domain=None,
-    range=Optional[Union[dict, MetaboliteDescriptor]],
-)
-
-slots.growthMediaComponent__from_source = Slot(
-    uri=COMMUNITYMECH.from_source,
-    name="growthMediaComponent__from_source",
-    curie=COMMUNITYMECH.curie("from_source"),
-    model_uri=COMMUNITYMECH.growthMediaComponent__from_source,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__name = Slot(
-    uri=COMMUNITYMECH.name,
-    name="growthMedia__name",
-    curie=COMMUNITYMECH.curie("name"),
-    model_uri=COMMUNITYMECH.growthMedia__name,
-    domain=None,
-    range=str,
-)
-
-slots.growthMedia__culturemech_id = Slot(
-    uri=COMMUNITYMECH.culturemech_id,
-    name="growthMedia__culturemech_id",
-    curie=COMMUNITYMECH.curie("culturemech_id"),
-    model_uri=COMMUNITYMECH.growthMedia__culturemech_id,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__culturemech_url = Slot(
-    uri=COMMUNITYMECH.culturemech_url,
-    name="growthMedia__culturemech_url",
-    curie=COMMUNITYMECH.curie("culturemech_url"),
-    model_uri=COMMUNITYMECH.growthMedia__culturemech_url,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__composition = Slot(
-    uri=COMMUNITYMECH.composition,
-    name="growthMedia__composition",
-    curie=COMMUNITYMECH.curie("composition"),
-    model_uri=COMMUNITYMECH.growthMedia__composition,
-    domain=None,
-    range=Optional[
-        Union[Union[dict, GrowthMediaComponent], list[Union[dict, GrowthMediaComponent]]]
-    ],
-)
-
-slots.growthMedia__ph = Slot(
-    uri=COMMUNITYMECH.ph,
-    name="growthMedia__ph",
-    curie=COMMUNITYMECH.curie("ph"),
-    model_uri=COMMUNITYMECH.growthMedia__ph,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__ph_range = Slot(
-    uri=COMMUNITYMECH.ph_range,
-    name="growthMedia__ph_range",
-    curie=COMMUNITYMECH.curie("ph_range"),
-    model_uri=COMMUNITYMECH.growthMedia__ph_range,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__temperature = Slot(
-    uri=COMMUNITYMECH.temperature,
-    name="growthMedia__temperature",
-    curie=COMMUNITYMECH.curie("temperature"),
-    model_uri=COMMUNITYMECH.growthMedia__temperature,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__temperature_unit = Slot(
-    uri=COMMUNITYMECH.temperature_unit,
-    name="growthMedia__temperature_unit",
-    curie=COMMUNITYMECH.curie("temperature_unit"),
-    model_uri=COMMUNITYMECH.growthMedia__temperature_unit,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__temperature_range = Slot(
-    uri=COMMUNITYMECH.temperature_range,
-    name="growthMedia__temperature_range",
-    curie=COMMUNITYMECH.curie("temperature_range"),
-    model_uri=COMMUNITYMECH.growthMedia__temperature_range,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__atmosphere = Slot(
-    uri=COMMUNITYMECH.atmosphere,
-    name="growthMedia__atmosphere",
-    curie=COMMUNITYMECH.curie("atmosphere"),
-    model_uri=COMMUNITYMECH.growthMedia__atmosphere,
-    domain=None,
-    range=Optional[Union[str, "AtmosphereEnum"]],
-)
-
-slots.growthMedia__headspace_gas = Slot(
-    uri=COMMUNITYMECH.headspace_gas,
-    name="growthMedia__headspace_gas",
-    curie=COMMUNITYMECH.curie("headspace_gas"),
-    model_uri=COMMUNITYMECH.growthMedia__headspace_gas,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__salinity = Slot(
-    uri=COMMUNITYMECH.salinity,
-    name="growthMedia__salinity",
-    curie=COMMUNITYMECH.curie("salinity"),
-    model_uri=COMMUNITYMECH.growthMedia__salinity,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__salinity_unit = Slot(
-    uri=COMMUNITYMECH.salinity_unit,
-    name="growthMedia__salinity_unit",
-    curie=COMMUNITYMECH.curie("salinity_unit"),
-    model_uri=COMMUNITYMECH.growthMedia__salinity_unit,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__pressure = Slot(
-    uri=COMMUNITYMECH.pressure,
-    name="growthMedia__pressure",
-    curie=COMMUNITYMECH.curie("pressure"),
-    model_uri=COMMUNITYMECH.growthMedia__pressure,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__pressure_unit = Slot(
-    uri=COMMUNITYMECH.pressure_unit,
-    name="growthMedia__pressure_unit",
-    curie=COMMUNITYMECH.curie("pressure_unit"),
-    model_uri=COMMUNITYMECH.growthMedia__pressure_unit,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__light_regime = Slot(
-    uri=COMMUNITYMECH.light_regime,
-    name="growthMedia__light_regime",
-    curie=COMMUNITYMECH.curie("light_regime"),
-    model_uri=COMMUNITYMECH.growthMedia__light_regime,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__light_intensity = Slot(
-    uri=COMMUNITYMECH.light_intensity,
-    name="growthMedia__light_intensity",
-    curie=COMMUNITYMECH.curie("light_intensity"),
-    model_uri=COMMUNITYMECH.growthMedia__light_intensity,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__light_intensity_unit = Slot(
-    uri=COMMUNITYMECH.light_intensity_unit,
-    name="growthMedia__light_intensity_unit",
-    curie=COMMUNITYMECH.curie("light_intensity_unit"),
-    model_uri=COMMUNITYMECH.growthMedia__light_intensity_unit,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__redox_potential = Slot(
-    uri=COMMUNITYMECH.redox_potential,
-    name="growthMedia__redox_potential",
-    curie=COMMUNITYMECH.curie("redox_potential"),
-    model_uri=COMMUNITYMECH.growthMedia__redox_potential,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__redox_potential_unit = Slot(
-    uri=COMMUNITYMECH.redox_potential_unit,
-    name="growthMedia__redox_potential_unit",
-    curie=COMMUNITYMECH.curie("redox_potential_unit"),
-    model_uri=COMMUNITYMECH.growthMedia__redox_potential_unit,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__inoculum_source = Slot(
-    uri=COMMUNITYMECH.inoculum_source,
-    name="growthMedia__inoculum_source",
-    curie=COMMUNITYMECH.curie("inoculum_source"),
-    model_uri=COMMUNITYMECH.growthMedia__inoculum_source,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__inoculum_size = Slot(
-    uri=COMMUNITYMECH.inoculum_size,
-    name="growthMedia__inoculum_size",
-    curie=COMMUNITYMECH.curie("inoculum_size"),
-    model_uri=COMMUNITYMECH.growthMedia__inoculum_size,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__inoculum_unit = Slot(
-    uri=COMMUNITYMECH.inoculum_unit,
-    name="growthMedia__inoculum_unit",
-    curie=COMMUNITYMECH.curie("inoculum_unit"),
-    model_uri=COMMUNITYMECH.growthMedia__inoculum_unit,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__incubation_time = Slot(
-    uri=COMMUNITYMECH.incubation_time,
-    name="growthMedia__incubation_time",
-    curie=COMMUNITYMECH.curie("incubation_time"),
-    model_uri=COMMUNITYMECH.growthMedia__incubation_time,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__incubation_time_unit = Slot(
-    uri=COMMUNITYMECH.incubation_time_unit,
-    name="growthMedia__incubation_time_unit",
-    curie=COMMUNITYMECH.curie("incubation_time_unit"),
-    model_uri=COMMUNITYMECH.growthMedia__incubation_time_unit,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__shaking_speed = Slot(
-    uri=COMMUNITYMECH.shaking_speed,
-    name="growthMedia__shaking_speed",
-    curie=COMMUNITYMECH.curie("shaking_speed"),
-    model_uri=COMMUNITYMECH.growthMedia__shaking_speed,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__shaking_speed_unit = Slot(
-    uri=COMMUNITYMECH.shaking_speed_unit,
-    name="growthMedia__shaking_speed_unit",
-    curie=COMMUNITYMECH.curie("shaking_speed_unit"),
-    model_uri=COMMUNITYMECH.growthMedia__shaking_speed_unit,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__vessel_type = Slot(
-    uri=COMMUNITYMECH.vessel_type,
-    name="growthMedia__vessel_type",
-    curie=COMMUNITYMECH.curie("vessel_type"),
-    model_uri=COMMUNITYMECH.growthMedia__vessel_type,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__preparation_notes = Slot(
-    uri=COMMUNITYMECH.preparation_notes,
-    name="growthMedia__preparation_notes",
-    curie=COMMUNITYMECH.curie("preparation_notes"),
-    model_uri=COMMUNITYMECH.growthMedia__preparation_notes,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__protocol_url = Slot(
-    uri=COMMUNITYMECH.protocol_url,
-    name="growthMedia__protocol_url",
-    curie=COMMUNITYMECH.curie("protocol_url"),
-    model_uri=COMMUNITYMECH.growthMedia__protocol_url,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.growthMedia__evidence = Slot(
-    uri=COMMUNITYMECH.evidence,
-    name="growthMedia__evidence",
-    curie=COMMUNITYMECH.curie("evidence"),
-    model_uri=COMMUNITYMECH.growthMedia__evidence,
-    domain=None,
-    range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
-)
-
-slots.relatedMedia__preferred_term = Slot(
-    uri=COMMUNITYMECH.preferred_term,
-    name="relatedMedia__preferred_term",
-    curie=COMMUNITYMECH.curie("preferred_term"),
-    model_uri=COMMUNITYMECH.relatedMedia__preferred_term,
-    domain=None,
-    range=str,
-)
-
-slots.relatedMedia__culturemech_id = Slot(
-    uri=COMMUNITYMECH.culturemech_id,
-    name="relatedMedia__culturemech_id",
-    curie=COMMUNITYMECH.curie("culturemech_id"),
-    model_uri=COMMUNITYMECH.relatedMedia__culturemech_id,
-    domain=None,
-    range=Optional[str],
-    pattern=re.compile(r"^CultureMech:\d{6}$"),
-)
-
-slots.relatedMedia__relationship_type = Slot(
-    uri=COMMUNITYMECH.relationship_type,
-    name="relatedMedia__relationship_type",
-    curie=COMMUNITYMECH.curie("relationship_type"),
-    model_uri=COMMUNITYMECH.relatedMedia__relationship_type,
-    domain=None,
-    range=Optional[Union[str, "MediaRelationshipEnum"]],
-)
-
-slots.relatedMedia__shared_environment_term = Slot(
-    uri=COMMUNITYMECH.shared_environment_term,
-    name="relatedMedia__shared_environment_term",
-    curie=COMMUNITYMECH.curie("shared_environment_term"),
-    model_uri=COMMUNITYMECH.relatedMedia__shared_environment_term,
-    domain=None,
-    range=Optional[Union[dict, Term]],
-)
-
-slots.relatedMedia__relevance_notes = Slot(
-    uri=COMMUNITYMECH.relevance_notes,
-    name="relatedMedia__relevance_notes",
-    curie=COMMUNITYMECH.curie("relevance_notes"),
-    model_uri=COMMUNITYMECH.relatedMedia__relevance_notes,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.relatedMedia__evidence = Slot(
-    uri=COMMUNITYMECH.evidence,
-    name="relatedMedia__evidence",
-    curie=COMMUNITYMECH.curie("evidence"),
-    model_uri=COMMUNITYMECH.relatedMedia__evidence,
-    domain=None,
-    range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
-)
-
-slots.relatedIngredient__preferred_term = Slot(
-    uri=COMMUNITYMECH.preferred_term,
-    name="relatedIngredient__preferred_term",
-    curie=COMMUNITYMECH.curie("preferred_term"),
-    model_uri=COMMUNITYMECH.relatedIngredient__preferred_term,
-    domain=None,
-    range=str,
-)
-
-slots.relatedIngredient__mediaingredientmech_id = Slot(
-    uri=COMMUNITYMECH.mediaingredientmech_id,
-    name="relatedIngredient__mediaingredientmech_id",
-    curie=COMMUNITYMECH.curie("mediaingredientmech_id"),
-    model_uri=COMMUNITYMECH.relatedIngredient__mediaingredientmech_id,
-    domain=None,
-    range=Optional[str],
-    pattern=re.compile(r"^MediaIngredientMech:\d{6}$"),
-)
-
-slots.relatedIngredient__chebi_term = Slot(
-    uri=COMMUNITYMECH.chebi_term,
-    name="relatedIngredient__chebi_term",
-    curie=COMMUNITYMECH.curie("chebi_term"),
-    model_uri=COMMUNITYMECH.relatedIngredient__chebi_term,
-    domain=None,
-    range=Optional[Union[dict, Term]],
-)
-
-slots.relatedIngredient__relevance = Slot(
-    uri=COMMUNITYMECH.relevance,
-    name="relatedIngredient__relevance",
-    curie=COMMUNITYMECH.curie("relevance"),
-    model_uri=COMMUNITYMECH.relatedIngredient__relevance,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.relatedIngredient__evidence = Slot(
-    uri=COMMUNITYMECH.evidence,
-    name="relatedIngredient__evidence",
-    curie=COMMUNITYMECH.curie("evidence"),
-    model_uri=COMMUNITYMECH.relatedIngredient__evidence,
-    domain=None,
-    range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
-)
-
-slots.associatedDataset__name = Slot(
-    uri=COMMUNITYMECH.name,
-    name="associatedDataset__name",
-    curie=COMMUNITYMECH.curie("name"),
-    model_uri=COMMUNITYMECH.associatedDataset__name,
-    domain=None,
-    range=str,
-)
-
-slots.associatedDataset__dataset_type = Slot(
-    uri=COMMUNITYMECH.dataset_type,
-    name="associatedDataset__dataset_type",
-    curie=COMMUNITYMECH.curie("dataset_type"),
-    model_uri=COMMUNITYMECH.associatedDataset__dataset_type,
-    domain=None,
-    range=Union[str, "DatasetTypeEnum"],
-)
-
-slots.associatedDataset__repository = Slot(
-    uri=COMMUNITYMECH.repository,
-    name="associatedDataset__repository",
-    curie=COMMUNITYMECH.curie("repository"),
-    model_uri=COMMUNITYMECH.associatedDataset__repository,
-    domain=None,
-    range=Optional[Union[str, "DatasetRepositoryEnum"]],
-)
-
-slots.associatedDataset__accession = Slot(
-    uri=COMMUNITYMECH.accession,
-    name="associatedDataset__accession",
-    curie=COMMUNITYMECH.curie("accession"),
-    model_uri=COMMUNITYMECH.associatedDataset__accession,
-    domain=None,
-    range=str,
-)
-
-slots.associatedDataset__url = Slot(
-    uri=COMMUNITYMECH.url,
-    name="associatedDataset__url",
-    curie=COMMUNITYMECH.curie("url"),
-    model_uri=COMMUNITYMECH.associatedDataset__url,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.associatedDataset__description = Slot(
-    uri=COMMUNITYMECH.description,
-    name="associatedDataset__description",
-    curie=COMMUNITYMECH.curie("description"),
-    model_uri=COMMUNITYMECH.associatedDataset__description,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.associatedDataset__evidence = Slot(
-    uri=COMMUNITYMECH.evidence,
-    name="associatedDataset__evidence",
-    curie=COMMUNITYMECH.curie("evidence"),
-    model_uri=COMMUNITYMECH.associatedDataset__evidence,
-    domain=None,
-    range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
-)
-
-slots.externalResource__name = Slot(
-    uri=COMMUNITYMECH.name,
-    name="externalResource__name",
-    curie=COMMUNITYMECH.curie("name"),
-    model_uri=COMMUNITYMECH.externalResource__name,
-    domain=None,
-    range=str,
-)
-
-slots.externalResource__repository = Slot(
-    uri=COMMUNITYMECH.repository,
-    name="externalResource__repository",
-    curie=COMMUNITYMECH.curie("repository"),
-    model_uri=COMMUNITYMECH.externalResource__repository,
-    domain=None,
-    range=Union[str, "ExternalResourceRepositoryEnum"],
-)
-
-slots.externalResource__resource_id = Slot(
-    uri=COMMUNITYMECH.resource_id,
-    name="externalResource__resource_id",
-    curie=COMMUNITYMECH.curie("resource_id"),
-    model_uri=COMMUNITYMECH.externalResource__resource_id,
-    domain=None,
-    range=str,
-)
-
-slots.externalResource__url = Slot(
-    uri=COMMUNITYMECH.url,
-    name="externalResource__url",
-    curie=COMMUNITYMECH.curie("url"),
-    model_uri=COMMUNITYMECH.externalResource__url,
-    domain=None,
-    range=str,
-)
-
-slots.externalResource__description = Slot(
-    uri=COMMUNITYMECH.description,
-    name="externalResource__description",
-    curie=COMMUNITYMECH.curie("description"),
-    model_uri=COMMUNITYMECH.externalResource__description,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.externalResource__evidence = Slot(
-    uri=COMMUNITYMECH.evidence,
-    name="externalResource__evidence",
-    curie=COMMUNITYMECH.curie("evidence"),
-    model_uri=COMMUNITYMECH.externalResource__evidence,
-    domain=None,
-    range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
-)
-
-slots.communityEngineeringDesign__objective = Slot(
-    uri=COMMUNITYMECH.objective,
-    name="communityEngineeringDesign__objective",
-    curie=COMMUNITYMECH.curie("objective"),
-    model_uri=COMMUNITYMECH.communityEngineeringDesign__objective,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.communityEngineeringDesign__assembly_strategy = Slot(
-    uri=COMMUNITYMECH.assembly_strategy,
-    name="communityEngineeringDesign__assembly_strategy",
-    curie=COMMUNITYMECH.curie("assembly_strategy"),
-    model_uri=COMMUNITYMECH.communityEngineeringDesign__assembly_strategy,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.communityEngineeringDesign__inoculation_strategy = Slot(
-    uri=COMMUNITYMECH.inoculation_strategy,
-    name="communityEngineeringDesign__inoculation_strategy",
-    curie=COMMUNITYMECH.curie("inoculation_strategy"),
-    model_uri=COMMUNITYMECH.communityEngineeringDesign__inoculation_strategy,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.communityEngineeringDesign__passaging_regimen = Slot(
-    uri=COMMUNITYMECH.passaging_regimen,
-    name="communityEngineeringDesign__passaging_regimen",
-    curie=COMMUNITYMECH.curie("passaging_regimen"),
-    model_uri=COMMUNITYMECH.communityEngineeringDesign__passaging_regimen,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.communityEngineeringDesign__perturbation_design = Slot(
-    uri=COMMUNITYMECH.perturbation_design,
-    name="communityEngineeringDesign__perturbation_design",
-    curie=COMMUNITYMECH.curie("perturbation_design"),
-    model_uri=COMMUNITYMECH.communityEngineeringDesign__perturbation_design,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.communityEngineeringDesign__measurement_endpoints = Slot(
-    uri=COMMUNITYMECH.measurement_endpoints,
-    name="communityEngineeringDesign__measurement_endpoints",
-    curie=COMMUNITYMECH.curie("measurement_endpoints"),
-    model_uri=COMMUNITYMECH.communityEngineeringDesign__measurement_endpoints,
-    domain=None,
-    range=Optional[Union[str, list[str]]],
-)
-
-slots.communityEngineeringDesign__protocol_url = Slot(
-    uri=COMMUNITYMECH.protocol_url,
-    name="communityEngineeringDesign__protocol_url",
-    curie=COMMUNITYMECH.curie("protocol_url"),
-    model_uri=COMMUNITYMECH.communityEngineeringDesign__protocol_url,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.communityEngineeringDesign__notes = Slot(
-    uri=COMMUNITYMECH.notes,
-    name="communityEngineeringDesign__notes",
-    curie=COMMUNITYMECH.curie("notes"),
-    model_uri=COMMUNITYMECH.communityEngineeringDesign__notes,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.communityEngineeringDesign__evidence = Slot(
-    uri=COMMUNITYMECH.evidence,
-    name="communityEngineeringDesign__evidence",
-    curie=COMMUNITYMECH.curie("evidence"),
-    model_uri=COMMUNITYMECH.communityEngineeringDesign__evidence,
-    domain=None,
-    range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
-)
-
-slots.microbialCommunity__id = Slot(
-    uri=COMMUNITYMECH.id,
-    name="microbialCommunity__id",
-    curie=COMMUNITYMECH.curie("id"),
-    model_uri=COMMUNITYMECH.microbialCommunity__id,
-    domain=None,
-    range=URIRef,
-    pattern=re.compile(r"^CommunityMech:\d{6}$"),
-)
-
-slots.microbialCommunity__name = Slot(
-    uri=COMMUNITYMECH.name,
-    name="microbialCommunity__name",
-    curie=COMMUNITYMECH.curie("name"),
-    model_uri=COMMUNITYMECH.microbialCommunity__name,
-    domain=None,
-    range=str,
-)
-
-slots.microbialCommunity__description = Slot(
-    uri=COMMUNITYMECH.description,
-    name="microbialCommunity__description",
-    curie=COMMUNITYMECH.curie("description"),
-    model_uri=COMMUNITYMECH.microbialCommunity__description,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.microbialCommunity__ecological_state = Slot(
-    uri=COMMUNITYMECH.ecological_state,
-    name="microbialCommunity__ecological_state",
-    curie=COMMUNITYMECH.curie("ecological_state"),
-    model_uri=COMMUNITYMECH.microbialCommunity__ecological_state,
-    domain=None,
-    range=Optional[Union[str, "EcologicalStateEnum"]],
-)
-
-slots.microbialCommunity__community_origin = Slot(
-    uri=COMMUNITYMECH.community_origin,
-    name="microbialCommunity__community_origin",
-    curie=COMMUNITYMECH.curie("community_origin"),
-    model_uri=COMMUNITYMECH.microbialCommunity__community_origin,
-    domain=None,
-    range=Optional[Union[str, "CommunityOriginEnum"]],
-)
-
-slots.microbialCommunity__community_category = Slot(
-    uri=COMMUNITYMECH.community_category,
-    name="microbialCommunity__community_category",
-    curie=COMMUNITYMECH.curie("community_category"),
-    model_uri=COMMUNITYMECH.microbialCommunity__community_category,
-    domain=None,
-    range=Optional[Union[str, "CommunityCategoryEnum"]],
-)
-
-slots.microbialCommunity__engineering_design = Slot(
-    uri=COMMUNITYMECH.engineering_design,
-    name="microbialCommunity__engineering_design",
-    curie=COMMUNITYMECH.curie("engineering_design"),
-    model_uri=COMMUNITYMECH.microbialCommunity__engineering_design,
-    domain=None,
-    range=Optional[Union[dict, CommunityEngineeringDesign]],
-)
-
-slots.microbialCommunity__environment_term = Slot(
-    uri=COMMUNITYMECH.environment_term,
-    name="microbialCommunity__environment_term",
-    curie=COMMUNITYMECH.curie("environment_term"),
-    model_uri=COMMUNITYMECH.microbialCommunity__environment_term,
-    domain=None,
-    range=Optional[Union[dict, EnvironmentDescriptor]],
-)
-
-slots.microbialCommunity__taxonomy = Slot(
-    uri=COMMUNITYMECH.taxonomy,
-    name="microbialCommunity__taxonomy",
-    curie=COMMUNITYMECH.curie("taxonomy"),
-    model_uri=COMMUNITYMECH.microbialCommunity__taxonomy,
-    domain=None,
-    range=Optional[
-        Union[Union[dict, TaxonomicComposition], list[Union[dict, TaxonomicComposition]]]
-    ],
-)
-
-slots.microbialCommunity__ecological_interactions = Slot(
-    uri=COMMUNITYMECH.ecological_interactions,
-    name="microbialCommunity__ecological_interactions",
-    curie=COMMUNITYMECH.curie("ecological_interactions"),
-    model_uri=COMMUNITYMECH.microbialCommunity__ecological_interactions,
-    domain=None,
-    range=Optional[
-        Union[Union[dict, EcologicalInteraction], list[Union[dict, EcologicalInteraction]]]
-    ],
-)
-
-slots.microbialCommunity__environmental_factors = Slot(
-    uri=COMMUNITYMECH.environmental_factors,
-    name="microbialCommunity__environmental_factors",
-    curie=COMMUNITYMECH.curie("environmental_factors"),
-    model_uri=COMMUNITYMECH.microbialCommunity__environmental_factors,
-    domain=None,
-    range=Optional[Union[Union[dict, EnvironmentalFactor], list[Union[dict, EnvironmentalFactor]]]],
-)
-
-slots.microbialCommunity__growth_media = Slot(
-    uri=COMMUNITYMECH.growth_media,
-    name="microbialCommunity__growth_media",
-    curie=COMMUNITYMECH.curie("growth_media"),
-    model_uri=COMMUNITYMECH.microbialCommunity__growth_media,
-    domain=None,
-    range=Optional[Union[Union[dict, GrowthMedia], list[Union[dict, GrowthMedia]]]],
-)
-
-slots.microbialCommunity__related_media = Slot(
-    uri=COMMUNITYMECH.related_media,
-    name="microbialCommunity__related_media",
-    curie=COMMUNITYMECH.curie("related_media"),
-    model_uri=COMMUNITYMECH.microbialCommunity__related_media,
-    domain=None,
-    range=Optional[Union[Union[dict, RelatedMedia], list[Union[dict, RelatedMedia]]]],
-)
-
-slots.microbialCommunity__related_ingredients = Slot(
-    uri=COMMUNITYMECH.related_ingredients,
-    name="microbialCommunity__related_ingredients",
-    curie=COMMUNITYMECH.curie("related_ingredients"),
-    model_uri=COMMUNITYMECH.microbialCommunity__related_ingredients,
-    domain=None,
-    range=Optional[Union[Union[dict, RelatedIngredient], list[Union[dict, RelatedIngredient]]]],
-)
-
-slots.microbialCommunity__associated_datasets = Slot(
-    uri=COMMUNITYMECH.associated_datasets,
-    name="microbialCommunity__associated_datasets",
-    curie=COMMUNITYMECH.curie("associated_datasets"),
-    model_uri=COMMUNITYMECH.microbialCommunity__associated_datasets,
-    domain=None,
-    range=Optional[Union[Union[dict, AssociatedDataset], list[Union[dict, AssociatedDataset]]]],
-)
-
-slots.microbialCommunity__external_resources = Slot(
-    uri=COMMUNITYMECH.external_resources,
-    name="microbialCommunity__external_resources",
-    curie=COMMUNITYMECH.curie("external_resources"),
-    model_uri=COMMUNITYMECH.microbialCommunity__external_resources,
-    domain=None,
-    range=Optional[Union[Union[dict, ExternalResource], list[Union[dict, ExternalResource]]]],
-)
-
-slots.microbialCommunity__metals_present = Slot(
-    uri=COMMUNITYMECH.metals_present,
-    name="microbialCommunity__metals_present",
-    curie=COMMUNITYMECH.curie("metals_present"),
-    model_uri=COMMUNITYMECH.microbialCommunity__metals_present,
-    domain=None,
-    range=Optional[Union[Union[str, "MetalElementEnum"], list[Union[str, "MetalElementEnum"]]]],
-)
-
-slots.microbialCommunity__rare_earth_elements_present = Slot(
-    uri=COMMUNITYMECH.rare_earth_elements_present,
-    name="microbialCommunity__rare_earth_elements_present",
-    curie=COMMUNITYMECH.curie("rare_earth_elements_present"),
-    model_uri=COMMUNITYMECH.microbialCommunity__rare_earth_elements_present,
-    domain=None,
-    range=Optional[
-        Union[Union[str, "RareEarthElementEnum"], list[Union[str, "RareEarthElementEnum"]]]
-    ],
-)
-
-slots.microbialCommunity__metal_relevance = Slot(
-    uri=COMMUNITYMECH.metal_relevance,
-    name="microbialCommunity__metal_relevance",
-    curie=COMMUNITYMECH.curie("metal_relevance"),
-    model_uri=COMMUNITYMECH.microbialCommunity__metal_relevance,
-    domain=None,
-    range=Optional[Union[str, "MetalRelevanceEnum"]],
-)
-
-slots.microbialCommunity__metal_notes = Slot(
-    uri=COMMUNITYMECH.metal_notes,
-    name="microbialCommunity__metal_notes",
-    curie=COMMUNITYMECH.curie("metal_notes"),
-    model_uri=COMMUNITYMECH.microbialCommunity__metal_notes,
-    domain=None,
-    range=Optional[str],
-)
+slots.term__label = Slot(uri=COMMUNITYMECH.label, name="term__label", curie=COMMUNITYMECH.curie('label'),
+                   model_uri=COMMUNITYMECH.term__label, domain=None, range=str)
+
+slots.evidenceItem__reference = Slot(uri=COMMUNITYMECH.reference, name="evidenceItem__reference", curie=COMMUNITYMECH.curie('reference'),
+                   model_uri=COMMUNITYMECH.evidenceItem__reference, domain=None, range=str,
+                   pattern=re.compile(r'^(PMID:|doi:|bioproject:).*'))
+
+slots.evidenceItem__supports = Slot(uri=COMMUNITYMECH.supports, name="evidenceItem__supports", curie=COMMUNITYMECH.curie('supports'),
+                   model_uri=COMMUNITYMECH.evidenceItem__supports, domain=None, range=Union[str, "EvidenceItemSupportEnum"])
+
+slots.evidenceItem__evidence_source = Slot(uri=COMMUNITYMECH.evidence_source, name="evidenceItem__evidence_source", curie=COMMUNITYMECH.curie('evidence_source'),
+                   model_uri=COMMUNITYMECH.evidenceItem__evidence_source, domain=None, range=Union[str, "EvidenceSourceEnum"])
+
+slots.evidenceItem__snippet = Slot(uri=COMMUNITYMECH.snippet, name="evidenceItem__snippet", curie=COMMUNITYMECH.curie('snippet'),
+                   model_uri=COMMUNITYMECH.evidenceItem__snippet, domain=None, range=str)
+
+slots.evidenceItem__explanation = Slot(uri=COMMUNITYMECH.explanation, name="evidenceItem__explanation", curie=COMMUNITYMECH.curie('explanation'),
+                   model_uri=COMMUNITYMECH.evidenceItem__explanation, domain=None, range=Optional[str])
+
+slots.evidenceItem__confidence_score = Slot(uri=COMMUNITYMECH.confidence_score, name="evidenceItem__confidence_score", curie=COMMUNITYMECH.curie('confidence_score'),
+                   model_uri=COMMUNITYMECH.evidenceItem__confidence_score, domain=None, range=Optional[float])
+
+slots.taxonDescriptor__preferred_term = Slot(uri=COMMUNITYMECH.preferred_term, name="taxonDescriptor__preferred_term", curie=COMMUNITYMECH.curie('preferred_term'),
+                   model_uri=COMMUNITYMECH.taxonDescriptor__preferred_term, domain=None, range=str)
+
+slots.taxonDescriptor__term = Slot(uri=COMMUNITYMECH.term, name="taxonDescriptor__term", curie=COMMUNITYMECH.curie('term'),
+                   model_uri=COMMUNITYMECH.taxonDescriptor__term, domain=None, range=Union[dict, Term])
+
+slots.taxonDescriptor__notes = Slot(uri=COMMUNITYMECH.notes, name="taxonDescriptor__notes", curie=COMMUNITYMECH.curie('notes'),
+                   model_uri=COMMUNITYMECH.taxonDescriptor__notes, domain=None, range=Optional[str])
+
+slots.metaboliteDescriptor__preferred_term = Slot(uri=COMMUNITYMECH.preferred_term, name="metaboliteDescriptor__preferred_term", curie=COMMUNITYMECH.curie('preferred_term'),
+                   model_uri=COMMUNITYMECH.metaboliteDescriptor__preferred_term, domain=None, range=str)
+
+slots.metaboliteDescriptor__term = Slot(uri=COMMUNITYMECH.term, name="metaboliteDescriptor__term", curie=COMMUNITYMECH.curie('term'),
+                   model_uri=COMMUNITYMECH.metaboliteDescriptor__term, domain=None, range=Union[dict, Term])
+
+slots.metaboliteDescriptor__concentration = Slot(uri=COMMUNITYMECH.concentration, name="metaboliteDescriptor__concentration", curie=COMMUNITYMECH.curie('concentration'),
+                   model_uri=COMMUNITYMECH.metaboliteDescriptor__concentration, domain=None, range=Optional[str])
+
+slots.metaboliteDescriptor__notes = Slot(uri=COMMUNITYMECH.notes, name="metaboliteDescriptor__notes", curie=COMMUNITYMECH.curie('notes'),
+                   model_uri=COMMUNITYMECH.metaboliteDescriptor__notes, domain=None, range=Optional[str])
+
+slots.biologicalProcessDescriptor__preferred_term = Slot(uri=COMMUNITYMECH.preferred_term, name="biologicalProcessDescriptor__preferred_term", curie=COMMUNITYMECH.curie('preferred_term'),
+                   model_uri=COMMUNITYMECH.biologicalProcessDescriptor__preferred_term, domain=None, range=str)
+
+slots.biologicalProcessDescriptor__term = Slot(uri=COMMUNITYMECH.term, name="biologicalProcessDescriptor__term", curie=COMMUNITYMECH.curie('term'),
+                   model_uri=COMMUNITYMECH.biologicalProcessDescriptor__term, domain=None, range=Union[dict, Term])
+
+slots.biologicalProcessDescriptor__notes = Slot(uri=COMMUNITYMECH.notes, name="biologicalProcessDescriptor__notes", curie=COMMUNITYMECH.curie('notes'),
+                   model_uri=COMMUNITYMECH.biologicalProcessDescriptor__notes, domain=None, range=Optional[str])
+
+slots.environmentDescriptor__preferred_term = Slot(uri=COMMUNITYMECH.preferred_term, name="environmentDescriptor__preferred_term", curie=COMMUNITYMECH.curie('preferred_term'),
+                   model_uri=COMMUNITYMECH.environmentDescriptor__preferred_term, domain=None, range=str)
+
+slots.environmentDescriptor__term = Slot(uri=COMMUNITYMECH.term, name="environmentDescriptor__term", curie=COMMUNITYMECH.curie('term'),
+                   model_uri=COMMUNITYMECH.environmentDescriptor__term, domain=None, range=Union[dict, Term])
+
+slots.environmentDescriptor__notes = Slot(uri=COMMUNITYMECH.notes, name="environmentDescriptor__notes", curie=COMMUNITYMECH.curie('notes'),
+                   model_uri=COMMUNITYMECH.environmentDescriptor__notes, domain=None, range=Optional[str])
+
+slots.cultureCollectionID__collection = Slot(uri=COMMUNITYMECH.collection, name="cultureCollectionID__collection", curie=COMMUNITYMECH.curie('collection'),
+                   model_uri=COMMUNITYMECH.cultureCollectionID__collection, domain=None, range=Union[str, "CultureCollectionEnum"])
+
+slots.cultureCollectionID__accession = Slot(uri=COMMUNITYMECH.accession, name="cultureCollectionID__accession", curie=COMMUNITYMECH.curie('accession'),
+                   model_uri=COMMUNITYMECH.cultureCollectionID__accession, domain=None, range=str)
+
+slots.cultureCollectionID__url = Slot(uri=COMMUNITYMECH.url, name="cultureCollectionID__url", curie=COMMUNITYMECH.curie('url'),
+                   model_uri=COMMUNITYMECH.cultureCollectionID__url, domain=None, range=Optional[str])
+
+slots.cultureCollectionID__notes = Slot(uri=COMMUNITYMECH.notes, name="cultureCollectionID__notes", curie=COMMUNITYMECH.curie('notes'),
+                   model_uri=COMMUNITYMECH.cultureCollectionID__notes, domain=None, range=Optional[str])
+
+slots.strainDesignation__strain_name = Slot(uri=COMMUNITYMECH.strain_name, name="strainDesignation__strain_name", curie=COMMUNITYMECH.curie('strain_name'),
+                   model_uri=COMMUNITYMECH.strainDesignation__strain_name, domain=None, range=Optional[str])
+
+slots.strainDesignation__culture_collections = Slot(uri=COMMUNITYMECH.culture_collections, name="strainDesignation__culture_collections", curie=COMMUNITYMECH.curie('culture_collections'),
+                   model_uri=COMMUNITYMECH.strainDesignation__culture_collections, domain=None, range=Optional[Union[Union[dict, CultureCollectionID], list[Union[dict, CultureCollectionID]]]])
+
+slots.strainDesignation__type_strain = Slot(uri=COMMUNITYMECH.type_strain, name="strainDesignation__type_strain", curie=COMMUNITYMECH.curie('type_strain'),
+                   model_uri=COMMUNITYMECH.strainDesignation__type_strain, domain=None, range=Optional[Union[bool, Bool]])
+
+slots.strainDesignation__genome_accession = Slot(uri=COMMUNITYMECH.genome_accession, name="strainDesignation__genome_accession", curie=COMMUNITYMECH.curie('genome_accession'),
+                   model_uri=COMMUNITYMECH.strainDesignation__genome_accession, domain=None, range=Optional[str])
+
+slots.strainDesignation__genome_url = Slot(uri=COMMUNITYMECH.genome_url, name="strainDesignation__genome_url", curie=COMMUNITYMECH.curie('genome_url'),
+                   model_uri=COMMUNITYMECH.strainDesignation__genome_url, domain=None, range=Optional[str])
+
+slots.strainDesignation__genetic_modification = Slot(uri=COMMUNITYMECH.genetic_modification, name="strainDesignation__genetic_modification", curie=COMMUNITYMECH.curie('genetic_modification'),
+                   model_uri=COMMUNITYMECH.strainDesignation__genetic_modification, domain=None, range=Optional[str])
+
+slots.strainDesignation__isolation_source = Slot(uri=COMMUNITYMECH.isolation_source, name="strainDesignation__isolation_source", curie=COMMUNITYMECH.curie('isolation_source'),
+                   model_uri=COMMUNITYMECH.strainDesignation__isolation_source, domain=None, range=Optional[str])
+
+slots.strainDesignation__notes = Slot(uri=COMMUNITYMECH.notes, name="strainDesignation__notes", curie=COMMUNITYMECH.curie('notes'),
+                   model_uri=COMMUNITYMECH.strainDesignation__notes, domain=None, range=Optional[str])
+
+slots.taxonomicComposition__taxon_term = Slot(uri=COMMUNITYMECH.taxon_term, name="taxonomicComposition__taxon_term", curie=COMMUNITYMECH.curie('taxon_term'),
+                   model_uri=COMMUNITYMECH.taxonomicComposition__taxon_term, domain=None, range=Union[dict, TaxonDescriptor])
+
+slots.taxonomicComposition__strain_designation = Slot(uri=COMMUNITYMECH.strain_designation, name="taxonomicComposition__strain_designation", curie=COMMUNITYMECH.curie('strain_designation'),
+                   model_uri=COMMUNITYMECH.taxonomicComposition__strain_designation, domain=None, range=Optional[Union[dict, StrainDesignation]])
+
+slots.taxonomicComposition__abundance_level = Slot(uri=COMMUNITYMECH.abundance_level, name="taxonomicComposition__abundance_level", curie=COMMUNITYMECH.curie('abundance_level'),
+                   model_uri=COMMUNITYMECH.taxonomicComposition__abundance_level, domain=None, range=Optional[Union[str, "AbundanceEnum"]])
+
+slots.taxonomicComposition__abundance_value = Slot(uri=COMMUNITYMECH.abundance_value, name="taxonomicComposition__abundance_value", curie=COMMUNITYMECH.curie('abundance_value'),
+                   model_uri=COMMUNITYMECH.taxonomicComposition__abundance_value, domain=None, range=Optional[str])
+
+slots.taxonomicComposition__functional_role = Slot(uri=COMMUNITYMECH.functional_role, name="taxonomicComposition__functional_role", curie=COMMUNITYMECH.curie('functional_role'),
+                   model_uri=COMMUNITYMECH.taxonomicComposition__functional_role, domain=None, range=Optional[Union[Union[str, "FunctionalRoleEnum"], list[Union[str, "FunctionalRoleEnum"]]]])
+
+slots.taxonomicComposition__evidence = Slot(uri=COMMUNITYMECH.evidence, name="taxonomicComposition__evidence", curie=COMMUNITYMECH.curie('evidence'),
+                   model_uri=COMMUNITYMECH.taxonomicComposition__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+
+slots.interactionDownstream__target = Slot(uri=COMMUNITYMECH.target, name="interactionDownstream__target", curie=COMMUNITYMECH.curie('target'),
+                   model_uri=COMMUNITYMECH.interactionDownstream__target, domain=None, range=str)
+
+slots.interactionDownstream__description = Slot(uri=COMMUNITYMECH.description, name="interactionDownstream__description", curie=COMMUNITYMECH.curie('description'),
+                   model_uri=COMMUNITYMECH.interactionDownstream__description, domain=None, range=Optional[str])
+
+slots.ecologicalInteraction__name = Slot(uri=COMMUNITYMECH.name, name="ecologicalInteraction__name", curie=COMMUNITYMECH.curie('name'),
+                   model_uri=COMMUNITYMECH.ecologicalInteraction__name, domain=None, range=str)
+
+slots.ecologicalInteraction__description = Slot(uri=COMMUNITYMECH.description, name="ecologicalInteraction__description", curie=COMMUNITYMECH.curie('description'),
+                   model_uri=COMMUNITYMECH.ecologicalInteraction__description, domain=None, range=Optional[str])
+
+slots.ecologicalInteraction__interaction_type = Slot(uri=COMMUNITYMECH.interaction_type, name="ecologicalInteraction__interaction_type", curie=COMMUNITYMECH.curie('interaction_type'),
+                   model_uri=COMMUNITYMECH.ecologicalInteraction__interaction_type, domain=None, range=Optional[Union[str, "InteractionTypeEnum"]])
+
+slots.ecologicalInteraction__scope = Slot(uri=COMMUNITYMECH.scope, name="ecologicalInteraction__scope", curie=COMMUNITYMECH.curie('scope'),
+                   model_uri=COMMUNITYMECH.ecologicalInteraction__scope, domain=None, range=Optional[Union[str, "InteractionScopeEnum"]])
+
+slots.ecologicalInteraction__source_taxon = Slot(uri=COMMUNITYMECH.source_taxon, name="ecologicalInteraction__source_taxon", curie=COMMUNITYMECH.curie('source_taxon'),
+                   model_uri=COMMUNITYMECH.ecologicalInteraction__source_taxon, domain=None, range=Optional[Union[dict, TaxonDescriptor]])
+
+slots.ecologicalInteraction__target_taxon = Slot(uri=COMMUNITYMECH.target_taxon, name="ecologicalInteraction__target_taxon", curie=COMMUNITYMECH.curie('target_taxon'),
+                   model_uri=COMMUNITYMECH.ecologicalInteraction__target_taxon, domain=None, range=Optional[Union[dict, TaxonDescriptor]])
+
+slots.ecologicalInteraction__metabolites = Slot(uri=COMMUNITYMECH.metabolites, name="ecologicalInteraction__metabolites", curie=COMMUNITYMECH.curie('metabolites'),
+                   model_uri=COMMUNITYMECH.ecologicalInteraction__metabolites, domain=None, range=Optional[Union[Union[dict, MetaboliteDescriptor], list[Union[dict, MetaboliteDescriptor]]]])
+
+slots.ecologicalInteraction__biological_processes = Slot(uri=COMMUNITYMECH.biological_processes, name="ecologicalInteraction__biological_processes", curie=COMMUNITYMECH.curie('biological_processes'),
+                   model_uri=COMMUNITYMECH.ecologicalInteraction__biological_processes, domain=None, range=Optional[Union[Union[dict, BiologicalProcessDescriptor], list[Union[dict, BiologicalProcessDescriptor]]]])
+
+slots.ecologicalInteraction__downstream = Slot(uri=COMMUNITYMECH.downstream, name="ecologicalInteraction__downstream", curie=COMMUNITYMECH.curie('downstream'),
+                   model_uri=COMMUNITYMECH.ecologicalInteraction__downstream, domain=None, range=Optional[Union[Union[dict, InteractionDownstream], list[Union[dict, InteractionDownstream]]]])
+
+slots.ecologicalInteraction__evidence = Slot(uri=COMMUNITYMECH.evidence, name="ecologicalInteraction__evidence", curie=COMMUNITYMECH.curie('evidence'),
+                   model_uri=COMMUNITYMECH.ecologicalInteraction__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+
+slots.environmentalFactor__name = Slot(uri=COMMUNITYMECH.name, name="environmentalFactor__name", curie=COMMUNITYMECH.curie('name'),
+                   model_uri=COMMUNITYMECH.environmentalFactor__name, domain=None, range=str)
+
+slots.environmentalFactor__value = Slot(uri=COMMUNITYMECH.value, name="environmentalFactor__value", curie=COMMUNITYMECH.curie('value'),
+                   model_uri=COMMUNITYMECH.environmentalFactor__value, domain=None, range=Optional[str])
+
+slots.environmentalFactor__unit = Slot(uri=COMMUNITYMECH.unit, name="environmentalFactor__unit", curie=COMMUNITYMECH.curie('unit'),
+                   model_uri=COMMUNITYMECH.environmentalFactor__unit, domain=None, range=Optional[str])
+
+slots.environmentalFactor__description = Slot(uri=COMMUNITYMECH.description, name="environmentalFactor__description", curie=COMMUNITYMECH.curie('description'),
+                   model_uri=COMMUNITYMECH.environmentalFactor__description, domain=None, range=Optional[str])
+
+slots.environmentalFactor__evidence = Slot(uri=COMMUNITYMECH.evidence, name="environmentalFactor__evidence", curie=COMMUNITYMECH.curie('evidence'),
+                   model_uri=COMMUNITYMECH.environmentalFactor__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+
+slots.growthMediaComponent__name = Slot(uri=COMMUNITYMECH.name, name="growthMediaComponent__name", curie=COMMUNITYMECH.curie('name'),
+                   model_uri=COMMUNITYMECH.growthMediaComponent__name, domain=None, range=str)
+
+slots.growthMediaComponent__media_ingredient_mech_id = Slot(uri=COMMUNITYMECH.media_ingredient_mech_id, name="growthMediaComponent__media_ingredient_mech_id", curie=COMMUNITYMECH.curie('media_ingredient_mech_id'),
+                   model_uri=COMMUNITYMECH.growthMediaComponent__media_ingredient_mech_id, domain=None, range=Optional[str])
+
+slots.growthMediaComponent__media_ingredient_mech_url = Slot(uri=COMMUNITYMECH.media_ingredient_mech_url, name="growthMediaComponent__media_ingredient_mech_url", curie=COMMUNITYMECH.curie('media_ingredient_mech_url'),
+                   model_uri=COMMUNITYMECH.growthMediaComponent__media_ingredient_mech_url, domain=None, range=Optional[str])
+
+slots.growthMediaComponent__concentration = Slot(uri=COMMUNITYMECH.concentration, name="growthMediaComponent__concentration", curie=COMMUNITYMECH.curie('concentration'),
+                   model_uri=COMMUNITYMECH.growthMediaComponent__concentration, domain=None, range=Optional[str])
+
+slots.growthMediaComponent__unit = Slot(uri=COMMUNITYMECH.unit, name="growthMediaComponent__unit", curie=COMMUNITYMECH.curie('unit'),
+                   model_uri=COMMUNITYMECH.growthMediaComponent__unit, domain=None, range=Optional[str])
+
+slots.growthMediaComponent__chebi_term = Slot(uri=COMMUNITYMECH.chebi_term, name="growthMediaComponent__chebi_term", curie=COMMUNITYMECH.curie('chebi_term'),
+                   model_uri=COMMUNITYMECH.growthMediaComponent__chebi_term, domain=None, range=Optional[Union[dict, MetaboliteDescriptor]])
+
+slots.growthMediaComponent__from_source = Slot(uri=COMMUNITYMECH.from_source, name="growthMediaComponent__from_source", curie=COMMUNITYMECH.curie('from_source'),
+                   model_uri=COMMUNITYMECH.growthMediaComponent__from_source, domain=None, range=Optional[str])
+
+slots.growthMedia__name = Slot(uri=COMMUNITYMECH.name, name="growthMedia__name", curie=COMMUNITYMECH.curie('name'),
+                   model_uri=COMMUNITYMECH.growthMedia__name, domain=None, range=str)
+
+slots.growthMedia__culturemech_id = Slot(uri=COMMUNITYMECH.culturemech_id, name="growthMedia__culturemech_id", curie=COMMUNITYMECH.curie('culturemech_id'),
+                   model_uri=COMMUNITYMECH.growthMedia__culturemech_id, domain=None, range=Optional[str])
+
+slots.growthMedia__culturemech_url = Slot(uri=COMMUNITYMECH.culturemech_url, name="growthMedia__culturemech_url", curie=COMMUNITYMECH.curie('culturemech_url'),
+                   model_uri=COMMUNITYMECH.growthMedia__culturemech_url, domain=None, range=Optional[str])
+
+slots.growthMedia__composition = Slot(uri=COMMUNITYMECH.composition, name="growthMedia__composition", curie=COMMUNITYMECH.curie('composition'),
+                   model_uri=COMMUNITYMECH.growthMedia__composition, domain=None, range=Optional[Union[Union[dict, GrowthMediaComponent], list[Union[dict, GrowthMediaComponent]]]])
+
+slots.growthMedia__ph = Slot(uri=COMMUNITYMECH.ph, name="growthMedia__ph", curie=COMMUNITYMECH.curie('ph'),
+                   model_uri=COMMUNITYMECH.growthMedia__ph, domain=None, range=Optional[str])
+
+slots.growthMedia__ph_range = Slot(uri=COMMUNITYMECH.ph_range, name="growthMedia__ph_range", curie=COMMUNITYMECH.curie('ph_range'),
+                   model_uri=COMMUNITYMECH.growthMedia__ph_range, domain=None, range=Optional[str])
+
+slots.growthMedia__temperature = Slot(uri=COMMUNITYMECH.temperature, name="growthMedia__temperature", curie=COMMUNITYMECH.curie('temperature'),
+                   model_uri=COMMUNITYMECH.growthMedia__temperature, domain=None, range=Optional[str])
+
+slots.growthMedia__temperature_unit = Slot(uri=COMMUNITYMECH.temperature_unit, name="growthMedia__temperature_unit", curie=COMMUNITYMECH.curie('temperature_unit'),
+                   model_uri=COMMUNITYMECH.growthMedia__temperature_unit, domain=None, range=Optional[str])
+
+slots.growthMedia__temperature_range = Slot(uri=COMMUNITYMECH.temperature_range, name="growthMedia__temperature_range", curie=COMMUNITYMECH.curie('temperature_range'),
+                   model_uri=COMMUNITYMECH.growthMedia__temperature_range, domain=None, range=Optional[str])
+
+slots.growthMedia__atmosphere = Slot(uri=COMMUNITYMECH.atmosphere, name="growthMedia__atmosphere", curie=COMMUNITYMECH.curie('atmosphere'),
+                   model_uri=COMMUNITYMECH.growthMedia__atmosphere, domain=None, range=Optional[Union[str, "AtmosphereEnum"]])
+
+slots.growthMedia__headspace_gas = Slot(uri=COMMUNITYMECH.headspace_gas, name="growthMedia__headspace_gas", curie=COMMUNITYMECH.curie('headspace_gas'),
+                   model_uri=COMMUNITYMECH.growthMedia__headspace_gas, domain=None, range=Optional[str])
+
+slots.growthMedia__salinity = Slot(uri=COMMUNITYMECH.salinity, name="growthMedia__salinity", curie=COMMUNITYMECH.curie('salinity'),
+                   model_uri=COMMUNITYMECH.growthMedia__salinity, domain=None, range=Optional[str])
+
+slots.growthMedia__salinity_unit = Slot(uri=COMMUNITYMECH.salinity_unit, name="growthMedia__salinity_unit", curie=COMMUNITYMECH.curie('salinity_unit'),
+                   model_uri=COMMUNITYMECH.growthMedia__salinity_unit, domain=None, range=Optional[str])
+
+slots.growthMedia__pressure = Slot(uri=COMMUNITYMECH.pressure, name="growthMedia__pressure", curie=COMMUNITYMECH.curie('pressure'),
+                   model_uri=COMMUNITYMECH.growthMedia__pressure, domain=None, range=Optional[str])
+
+slots.growthMedia__pressure_unit = Slot(uri=COMMUNITYMECH.pressure_unit, name="growthMedia__pressure_unit", curie=COMMUNITYMECH.curie('pressure_unit'),
+                   model_uri=COMMUNITYMECH.growthMedia__pressure_unit, domain=None, range=Optional[str])
+
+slots.growthMedia__light_regime = Slot(uri=COMMUNITYMECH.light_regime, name="growthMedia__light_regime", curie=COMMUNITYMECH.curie('light_regime'),
+                   model_uri=COMMUNITYMECH.growthMedia__light_regime, domain=None, range=Optional[str])
+
+slots.growthMedia__light_intensity = Slot(uri=COMMUNITYMECH.light_intensity, name="growthMedia__light_intensity", curie=COMMUNITYMECH.curie('light_intensity'),
+                   model_uri=COMMUNITYMECH.growthMedia__light_intensity, domain=None, range=Optional[str])
+
+slots.growthMedia__light_intensity_unit = Slot(uri=COMMUNITYMECH.light_intensity_unit, name="growthMedia__light_intensity_unit", curie=COMMUNITYMECH.curie('light_intensity_unit'),
+                   model_uri=COMMUNITYMECH.growthMedia__light_intensity_unit, domain=None, range=Optional[str])
+
+slots.growthMedia__redox_potential = Slot(uri=COMMUNITYMECH.redox_potential, name="growthMedia__redox_potential", curie=COMMUNITYMECH.curie('redox_potential'),
+                   model_uri=COMMUNITYMECH.growthMedia__redox_potential, domain=None, range=Optional[str])
+
+slots.growthMedia__redox_potential_unit = Slot(uri=COMMUNITYMECH.redox_potential_unit, name="growthMedia__redox_potential_unit", curie=COMMUNITYMECH.curie('redox_potential_unit'),
+                   model_uri=COMMUNITYMECH.growthMedia__redox_potential_unit, domain=None, range=Optional[str])
+
+slots.growthMedia__inoculum_source = Slot(uri=COMMUNITYMECH.inoculum_source, name="growthMedia__inoculum_source", curie=COMMUNITYMECH.curie('inoculum_source'),
+                   model_uri=COMMUNITYMECH.growthMedia__inoculum_source, domain=None, range=Optional[str])
+
+slots.growthMedia__inoculum_size = Slot(uri=COMMUNITYMECH.inoculum_size, name="growthMedia__inoculum_size", curie=COMMUNITYMECH.curie('inoculum_size'),
+                   model_uri=COMMUNITYMECH.growthMedia__inoculum_size, domain=None, range=Optional[str])
+
+slots.growthMedia__inoculum_unit = Slot(uri=COMMUNITYMECH.inoculum_unit, name="growthMedia__inoculum_unit", curie=COMMUNITYMECH.curie('inoculum_unit'),
+                   model_uri=COMMUNITYMECH.growthMedia__inoculum_unit, domain=None, range=Optional[str])
+
+slots.growthMedia__incubation_time = Slot(uri=COMMUNITYMECH.incubation_time, name="growthMedia__incubation_time", curie=COMMUNITYMECH.curie('incubation_time'),
+                   model_uri=COMMUNITYMECH.growthMedia__incubation_time, domain=None, range=Optional[str])
+
+slots.growthMedia__incubation_time_unit = Slot(uri=COMMUNITYMECH.incubation_time_unit, name="growthMedia__incubation_time_unit", curie=COMMUNITYMECH.curie('incubation_time_unit'),
+                   model_uri=COMMUNITYMECH.growthMedia__incubation_time_unit, domain=None, range=Optional[str])
+
+slots.growthMedia__shaking_speed = Slot(uri=COMMUNITYMECH.shaking_speed, name="growthMedia__shaking_speed", curie=COMMUNITYMECH.curie('shaking_speed'),
+                   model_uri=COMMUNITYMECH.growthMedia__shaking_speed, domain=None, range=Optional[str])
+
+slots.growthMedia__shaking_speed_unit = Slot(uri=COMMUNITYMECH.shaking_speed_unit, name="growthMedia__shaking_speed_unit", curie=COMMUNITYMECH.curie('shaking_speed_unit'),
+                   model_uri=COMMUNITYMECH.growthMedia__shaking_speed_unit, domain=None, range=Optional[str])
+
+slots.growthMedia__vessel_type = Slot(uri=COMMUNITYMECH.vessel_type, name="growthMedia__vessel_type", curie=COMMUNITYMECH.curie('vessel_type'),
+                   model_uri=COMMUNITYMECH.growthMedia__vessel_type, domain=None, range=Optional[str])
+
+slots.growthMedia__preparation_notes = Slot(uri=COMMUNITYMECH.preparation_notes, name="growthMedia__preparation_notes", curie=COMMUNITYMECH.curie('preparation_notes'),
+                   model_uri=COMMUNITYMECH.growthMedia__preparation_notes, domain=None, range=Optional[str])
+
+slots.growthMedia__protocol_url = Slot(uri=COMMUNITYMECH.protocol_url, name="growthMedia__protocol_url", curie=COMMUNITYMECH.curie('protocol_url'),
+                   model_uri=COMMUNITYMECH.growthMedia__protocol_url, domain=None, range=Optional[str])
+
+slots.growthMedia__evidence = Slot(uri=COMMUNITYMECH.evidence, name="growthMedia__evidence", curie=COMMUNITYMECH.curie('evidence'),
+                   model_uri=COMMUNITYMECH.growthMedia__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+
+slots.relatedMedia__preferred_term = Slot(uri=COMMUNITYMECH.preferred_term, name="relatedMedia__preferred_term", curie=COMMUNITYMECH.curie('preferred_term'),
+                   model_uri=COMMUNITYMECH.relatedMedia__preferred_term, domain=None, range=str)
+
+slots.relatedMedia__culturemech_id = Slot(uri=COMMUNITYMECH.culturemech_id, name="relatedMedia__culturemech_id", curie=COMMUNITYMECH.curie('culturemech_id'),
+                   model_uri=COMMUNITYMECH.relatedMedia__culturemech_id, domain=None, range=Optional[str],
+                   pattern=re.compile(r'^CultureMech:\d{6}$'))
+
+slots.relatedMedia__relationship_type = Slot(uri=COMMUNITYMECH.relationship_type, name="relatedMedia__relationship_type", curie=COMMUNITYMECH.curie('relationship_type'),
+                   model_uri=COMMUNITYMECH.relatedMedia__relationship_type, domain=None, range=Optional[Union[str, "MediaRelationshipEnum"]])
+
+slots.relatedMedia__shared_environment_term = Slot(uri=COMMUNITYMECH.shared_environment_term, name="relatedMedia__shared_environment_term", curie=COMMUNITYMECH.curie('shared_environment_term'),
+                   model_uri=COMMUNITYMECH.relatedMedia__shared_environment_term, domain=None, range=Optional[Union[dict, Term]])
+
+slots.relatedMedia__relevance_notes = Slot(uri=COMMUNITYMECH.relevance_notes, name="relatedMedia__relevance_notes", curie=COMMUNITYMECH.curie('relevance_notes'),
+                   model_uri=COMMUNITYMECH.relatedMedia__relevance_notes, domain=None, range=Optional[str])
+
+slots.relatedMedia__evidence = Slot(uri=COMMUNITYMECH.evidence, name="relatedMedia__evidence", curie=COMMUNITYMECH.curie('evidence'),
+                   model_uri=COMMUNITYMECH.relatedMedia__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+
+slots.relatedIngredient__preferred_term = Slot(uri=COMMUNITYMECH.preferred_term, name="relatedIngredient__preferred_term", curie=COMMUNITYMECH.curie('preferred_term'),
+                   model_uri=COMMUNITYMECH.relatedIngredient__preferred_term, domain=None, range=str)
+
+slots.relatedIngredient__mediaingredientmech_id = Slot(uri=COMMUNITYMECH.mediaingredientmech_id, name="relatedIngredient__mediaingredientmech_id", curie=COMMUNITYMECH.curie('mediaingredientmech_id'),
+                   model_uri=COMMUNITYMECH.relatedIngredient__mediaingredientmech_id, domain=None, range=Optional[str],
+                   pattern=re.compile(r'^MediaIngredientMech:\d{6}$'))
+
+slots.relatedIngredient__chebi_term = Slot(uri=COMMUNITYMECH.chebi_term, name="relatedIngredient__chebi_term", curie=COMMUNITYMECH.curie('chebi_term'),
+                   model_uri=COMMUNITYMECH.relatedIngredient__chebi_term, domain=None, range=Optional[Union[dict, Term]])
+
+slots.relatedIngredient__relevance = Slot(uri=COMMUNITYMECH.relevance, name="relatedIngredient__relevance", curie=COMMUNITYMECH.curie('relevance'),
+                   model_uri=COMMUNITYMECH.relatedIngredient__relevance, domain=None, range=Optional[str])
+
+slots.relatedIngredient__evidence = Slot(uri=COMMUNITYMECH.evidence, name="relatedIngredient__evidence", curie=COMMUNITYMECH.curie('evidence'),
+                   model_uri=COMMUNITYMECH.relatedIngredient__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+
+slots.associatedDataset__name = Slot(uri=COMMUNITYMECH.name, name="associatedDataset__name", curie=COMMUNITYMECH.curie('name'),
+                   model_uri=COMMUNITYMECH.associatedDataset__name, domain=None, range=str)
+
+slots.associatedDataset__dataset_type = Slot(uri=COMMUNITYMECH.dataset_type, name="associatedDataset__dataset_type", curie=COMMUNITYMECH.curie('dataset_type'),
+                   model_uri=COMMUNITYMECH.associatedDataset__dataset_type, domain=None, range=Union[str, "DatasetTypeEnum"])
+
+slots.associatedDataset__repository = Slot(uri=COMMUNITYMECH.repository, name="associatedDataset__repository", curie=COMMUNITYMECH.curie('repository'),
+                   model_uri=COMMUNITYMECH.associatedDataset__repository, domain=None, range=Optional[Union[str, "DatasetRepositoryEnum"]])
+
+slots.associatedDataset__accession = Slot(uri=COMMUNITYMECH.accession, name="associatedDataset__accession", curie=COMMUNITYMECH.curie('accession'),
+                   model_uri=COMMUNITYMECH.associatedDataset__accession, domain=None, range=str)
+
+slots.associatedDataset__url = Slot(uri=COMMUNITYMECH.url, name="associatedDataset__url", curie=COMMUNITYMECH.curie('url'),
+                   model_uri=COMMUNITYMECH.associatedDataset__url, domain=None, range=Optional[str])
+
+slots.associatedDataset__description = Slot(uri=COMMUNITYMECH.description, name="associatedDataset__description", curie=COMMUNITYMECH.curie('description'),
+                   model_uri=COMMUNITYMECH.associatedDataset__description, domain=None, range=Optional[str])
+
+slots.associatedDataset__evidence = Slot(uri=COMMUNITYMECH.evidence, name="associatedDataset__evidence", curie=COMMUNITYMECH.curie('evidence'),
+                   model_uri=COMMUNITYMECH.associatedDataset__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+
+slots.externalResource__name = Slot(uri=COMMUNITYMECH.name, name="externalResource__name", curie=COMMUNITYMECH.curie('name'),
+                   model_uri=COMMUNITYMECH.externalResource__name, domain=None, range=str)
+
+slots.externalResource__repository = Slot(uri=COMMUNITYMECH.repository, name="externalResource__repository", curie=COMMUNITYMECH.curie('repository'),
+                   model_uri=COMMUNITYMECH.externalResource__repository, domain=None, range=Union[str, "ExternalResourceRepositoryEnum"])
+
+slots.externalResource__resource_id = Slot(uri=COMMUNITYMECH.resource_id, name="externalResource__resource_id", curie=COMMUNITYMECH.curie('resource_id'),
+                   model_uri=COMMUNITYMECH.externalResource__resource_id, domain=None, range=str)
+
+slots.externalResource__url = Slot(uri=COMMUNITYMECH.url, name="externalResource__url", curie=COMMUNITYMECH.curie('url'),
+                   model_uri=COMMUNITYMECH.externalResource__url, domain=None, range=str)
+
+slots.externalResource__description = Slot(uri=COMMUNITYMECH.description, name="externalResource__description", curie=COMMUNITYMECH.curie('description'),
+                   model_uri=COMMUNITYMECH.externalResource__description, domain=None, range=Optional[str])
+
+slots.externalResource__evidence = Slot(uri=COMMUNITYMECH.evidence, name="externalResource__evidence", curie=COMMUNITYMECH.curie('evidence'),
+                   model_uri=COMMUNITYMECH.externalResource__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+
+slots.communityEngineeringDesign__objective = Slot(uri=COMMUNITYMECH.objective, name="communityEngineeringDesign__objective", curie=COMMUNITYMECH.curie('objective'),
+                   model_uri=COMMUNITYMECH.communityEngineeringDesign__objective, domain=None, range=Optional[str])
+
+slots.communityEngineeringDesign__assembly_strategy = Slot(uri=COMMUNITYMECH.assembly_strategy, name="communityEngineeringDesign__assembly_strategy", curie=COMMUNITYMECH.curie('assembly_strategy'),
+                   model_uri=COMMUNITYMECH.communityEngineeringDesign__assembly_strategy, domain=None, range=Optional[str])
+
+slots.communityEngineeringDesign__inoculation_strategy = Slot(uri=COMMUNITYMECH.inoculation_strategy, name="communityEngineeringDesign__inoculation_strategy", curie=COMMUNITYMECH.curie('inoculation_strategy'),
+                   model_uri=COMMUNITYMECH.communityEngineeringDesign__inoculation_strategy, domain=None, range=Optional[str])
+
+slots.communityEngineeringDesign__passaging_regimen = Slot(uri=COMMUNITYMECH.passaging_regimen, name="communityEngineeringDesign__passaging_regimen", curie=COMMUNITYMECH.curie('passaging_regimen'),
+                   model_uri=COMMUNITYMECH.communityEngineeringDesign__passaging_regimen, domain=None, range=Optional[str])
+
+slots.communityEngineeringDesign__perturbation_design = Slot(uri=COMMUNITYMECH.perturbation_design, name="communityEngineeringDesign__perturbation_design", curie=COMMUNITYMECH.curie('perturbation_design'),
+                   model_uri=COMMUNITYMECH.communityEngineeringDesign__perturbation_design, domain=None, range=Optional[str])
+
+slots.communityEngineeringDesign__measurement_endpoints = Slot(uri=COMMUNITYMECH.measurement_endpoints, name="communityEngineeringDesign__measurement_endpoints", curie=COMMUNITYMECH.curie('measurement_endpoints'),
+                   model_uri=COMMUNITYMECH.communityEngineeringDesign__measurement_endpoints, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.communityEngineeringDesign__protocol_url = Slot(uri=COMMUNITYMECH.protocol_url, name="communityEngineeringDesign__protocol_url", curie=COMMUNITYMECH.curie('protocol_url'),
+                   model_uri=COMMUNITYMECH.communityEngineeringDesign__protocol_url, domain=None, range=Optional[str])
+
+slots.communityEngineeringDesign__notes = Slot(uri=COMMUNITYMECH.notes, name="communityEngineeringDesign__notes", curie=COMMUNITYMECH.curie('notes'),
+                   model_uri=COMMUNITYMECH.communityEngineeringDesign__notes, domain=None, range=Optional[str])
+
+slots.communityEngineeringDesign__evidence = Slot(uri=COMMUNITYMECH.evidence, name="communityEngineeringDesign__evidence", curie=COMMUNITYMECH.curie('evidence'),
+                   model_uri=COMMUNITYMECH.communityEngineeringDesign__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+
+slots.microbialCommunity__id = Slot(uri=COMMUNITYMECH.id, name="microbialCommunity__id", curie=COMMUNITYMECH.curie('id'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__id, domain=None, range=URIRef,
+                   pattern=re.compile(r'^CommunityMech:\d{6}$'))
+
+slots.microbialCommunity__name = Slot(uri=COMMUNITYMECH.name, name="microbialCommunity__name", curie=COMMUNITYMECH.curie('name'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__name, domain=None, range=str)
+
+slots.microbialCommunity__description = Slot(uri=COMMUNITYMECH.description, name="microbialCommunity__description", curie=COMMUNITYMECH.curie('description'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__description, domain=None, range=Optional[str])
+
+slots.microbialCommunity__ecological_state = Slot(uri=COMMUNITYMECH.ecological_state, name="microbialCommunity__ecological_state", curie=COMMUNITYMECH.curie('ecological_state'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__ecological_state, domain=None, range=Optional[Union[str, "EcologicalStateEnum"]])
+
+slots.microbialCommunity__community_origin = Slot(uri=COMMUNITYMECH.community_origin, name="microbialCommunity__community_origin", curie=COMMUNITYMECH.curie('community_origin'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__community_origin, domain=None, range=Optional[Union[str, "CommunityOriginEnum"]])
+
+slots.microbialCommunity__community_category = Slot(uri=COMMUNITYMECH.community_category, name="microbialCommunity__community_category", curie=COMMUNITYMECH.curie('community_category'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__community_category, domain=None, range=Optional[Union[str, "CommunityCategoryEnum"]])
+
+slots.microbialCommunity__engineering_design = Slot(uri=COMMUNITYMECH.engineering_design, name="microbialCommunity__engineering_design", curie=COMMUNITYMECH.curie('engineering_design'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__engineering_design, domain=None, range=Optional[Union[dict, CommunityEngineeringDesign]])
+
+slots.microbialCommunity__environment_term = Slot(uri=COMMUNITYMECH.environment_term, name="microbialCommunity__environment_term", curie=COMMUNITYMECH.curie('environment_term'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__environment_term, domain=None, range=Optional[Union[dict, EnvironmentDescriptor]])
+
+slots.microbialCommunity__taxonomy = Slot(uri=COMMUNITYMECH.taxonomy, name="microbialCommunity__taxonomy", curie=COMMUNITYMECH.curie('taxonomy'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__taxonomy, domain=None, range=Optional[Union[Union[dict, TaxonomicComposition], list[Union[dict, TaxonomicComposition]]]])
+
+slots.microbialCommunity__ecological_interactions = Slot(uri=COMMUNITYMECH.ecological_interactions, name="microbialCommunity__ecological_interactions", curie=COMMUNITYMECH.curie('ecological_interactions'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__ecological_interactions, domain=None, range=Optional[Union[Union[dict, EcologicalInteraction], list[Union[dict, EcologicalInteraction]]]])
+
+slots.microbialCommunity__environmental_factors = Slot(uri=COMMUNITYMECH.environmental_factors, name="microbialCommunity__environmental_factors", curie=COMMUNITYMECH.curie('environmental_factors'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__environmental_factors, domain=None, range=Optional[Union[Union[dict, EnvironmentalFactor], list[Union[dict, EnvironmentalFactor]]]])
+
+slots.microbialCommunity__growth_media = Slot(uri=COMMUNITYMECH.growth_media, name="microbialCommunity__growth_media", curie=COMMUNITYMECH.curie('growth_media'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__growth_media, domain=None, range=Optional[Union[Union[dict, GrowthMedia], list[Union[dict, GrowthMedia]]]])
+
+slots.microbialCommunity__related_media = Slot(uri=COMMUNITYMECH.related_media, name="microbialCommunity__related_media", curie=COMMUNITYMECH.curie('related_media'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__related_media, domain=None, range=Optional[Union[Union[dict, RelatedMedia], list[Union[dict, RelatedMedia]]]])
+
+slots.microbialCommunity__related_ingredients = Slot(uri=COMMUNITYMECH.related_ingredients, name="microbialCommunity__related_ingredients", curie=COMMUNITYMECH.curie('related_ingredients'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__related_ingredients, domain=None, range=Optional[Union[Union[dict, RelatedIngredient], list[Union[dict, RelatedIngredient]]]])
+
+slots.microbialCommunity__associated_datasets = Slot(uri=COMMUNITYMECH.associated_datasets, name="microbialCommunity__associated_datasets", curie=COMMUNITYMECH.curie('associated_datasets'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__associated_datasets, domain=None, range=Optional[Union[Union[dict, AssociatedDataset], list[Union[dict, AssociatedDataset]]]])
+
+slots.microbialCommunity__external_resources = Slot(uri=COMMUNITYMECH.external_resources, name="microbialCommunity__external_resources", curie=COMMUNITYMECH.curie('external_resources'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__external_resources, domain=None, range=Optional[Union[Union[dict, ExternalResource], list[Union[dict, ExternalResource]]]])
+
+slots.microbialCommunity__metals_present = Slot(uri=COMMUNITYMECH.metals_present, name="microbialCommunity__metals_present", curie=COMMUNITYMECH.curie('metals_present'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__metals_present, domain=None, range=Optional[Union[Union[str, "MetalElementEnum"], list[Union[str, "MetalElementEnum"]]]])
+
+slots.microbialCommunity__rare_earth_elements_present = Slot(uri=COMMUNITYMECH.rare_earth_elements_present, name="microbialCommunity__rare_earth_elements_present", curie=COMMUNITYMECH.curie('rare_earth_elements_present'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__rare_earth_elements_present, domain=None, range=Optional[Union[Union[str, "RareEarthElementEnum"], list[Union[str, "RareEarthElementEnum"]]]])
+
+slots.microbialCommunity__metal_relevance = Slot(uri=COMMUNITYMECH.metal_relevance, name="microbialCommunity__metal_relevance", curie=COMMUNITYMECH.curie('metal_relevance'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__metal_relevance, domain=None, range=Optional[Union[str, "MetalRelevanceEnum"]])
+
+slots.microbialCommunity__metal_notes = Slot(uri=COMMUNITYMECH.metal_notes, name="microbialCommunity__metal_notes", curie=COMMUNITYMECH.curie('metal_notes'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__metal_notes, domain=None, range=Optional[str])
+
+slots.microbialCommunity__curation_history = Slot(uri=COMMUNITYMECH.curation_history, name="microbialCommunity__curation_history", curie=COMMUNITYMECH.curie('curation_history'),
+                   model_uri=COMMUNITYMECH.microbialCommunity__curation_history, domain=None, range=Optional[Union[Union[dict, CurationEvent], list[Union[dict, CurationEvent]]]])
+
+slots.curationEvent__timestamp = Slot(uri=COMMUNITYMECH.timestamp, name="curationEvent__timestamp", curie=COMMUNITYMECH.curie('timestamp'),
+                   model_uri=COMMUNITYMECH.curationEvent__timestamp, domain=None, range=Union[str, XSDDateTime])
+
+slots.curationEvent__curator = Slot(uri=COMMUNITYMECH.curator, name="curationEvent__curator", curie=COMMUNITYMECH.curie('curator'),
+                   model_uri=COMMUNITYMECH.curationEvent__curator, domain=None, range=str)
+
+slots.curationEvent__action = Slot(uri=COMMUNITYMECH.action, name="curationEvent__action", curie=COMMUNITYMECH.curie('action'),
+                   model_uri=COMMUNITYMECH.curationEvent__action, domain=None, range=str,
+                   pattern=re.compile(r'^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'))
+
+slots.curationEvent__changes = Slot(uri=COMMUNITYMECH.changes, name="curationEvent__changes", curie=COMMUNITYMECH.curie('changes'),
+                   model_uri=COMMUNITYMECH.curationEvent__changes, domain=None, range=Optional[str])
+
+slots.curationEvent__llm_assisted = Slot(uri=COMMUNITYMECH.llm_assisted, name="curationEvent__llm_assisted", curie=COMMUNITYMECH.curie('llm_assisted'),
+                   model_uri=COMMUNITYMECH.curationEvent__llm_assisted, domain=None, range=Optional[Union[bool, Bool]])
+

--- a/src/communitymech/network/llm_repair.py
+++ b/src/communitymech/network/llm_repair.py
@@ -7,10 +7,15 @@ from typing import Any
 
 import yaml
 
+from communitymech.curate.curation_event import record_curation_event
 from communitymech.llm.anthropic_client import AnthropicClient
 from communitymech.network.auditor import NetworkIntegrityAuditor
 from communitymech.network.repair_strategies import StrategySelector
 from communitymech.network.validators import SuggestionValidator
+from communitymech.validation.write_validated import (
+    ValidationFailedError,
+    write_validated_community,
+)
 
 
 class LLMNetworkRepairer:
@@ -234,12 +239,26 @@ class LLMNetworkRepairer:
 
             community_data["ecological_interactions"].extend(suggested_interactions)
 
-            # Write back
-            with open(yaml_path, "w") as f:
-                yaml.dump(
-                    community_data, f, default_flow_style=False, sort_keys=False, allow_unicode=True
-                )
+            # Record curation event for the LLM-driven change
+            record_curation_event(
+                community_data,
+                curator="llm_repair",
+                action="LLM_REPAIR_APPLIED",
+                changes=(
+                    f"Accepted {len(suggested_interactions)} LLM-suggested "
+                    f"ecological interaction(s) for network repair"
+                ),
+                llm_assisted=True,
+            )
 
+            # Write back via validated writer (closed-schema gate)
+            write_validated_community(community_data, yaml_path)
+
+        except ValidationFailedError as e:
+            # Restore from backup on validation failure
+            if backup_path.exists():
+                shutil.copy(backup_path, yaml_path)
+            raise RuntimeError(f"Failed to apply suggestion: {e}") from e
         except Exception as e:
             # Restore from backup on failure
             if backup_path.exists():

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -1006,3 +1006,38 @@ classes:
       metal_notes:
         description: Additional context on metal/REE processing mechanisms or significance
         range: string
+      curation_history:
+        description: >-
+          Append-only audit trail of curation actions that modified this
+          community record. Populated by ``record_curation_event()`` from
+          ``communitymech.curate.curation_event``.
+        range: CurationEvent
+        multivalued: true
+        inlined_as_list: true
+
+  CurationEvent:
+    description: >-
+      A timestamped curator action on a MicrobialCommunity. Mirrors the
+      shape used by sibling Mech repos (CultureMech, MediaIngredientMech,
+      TraitMech) so cross-repo tooling can read curation events uniformly.
+    attributes:
+      timestamp:
+        range: datetime
+        required: true
+        description: When this action occurred (ISO-8601 UTC).
+      curator:
+        required: true
+        description: Who performed this action (script name or human identifier).
+      action:
+        range: string
+        required: true
+        pattern: "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"
+        description: >-
+          SCREAMING_SNAKE_CASE action label minted by the curation tool
+          that produced this event (e.g. ``"ADD_COMMUNITY_IDS"``,
+          ``"FIX_NETWORK_INTEGRITY"``).
+      changes:
+        description: Description of what changed.
+      llm_assisted:
+        range: boolean
+        description: Whether LLM assistance was used.

--- a/src/communitymech/validation/__init__.py
+++ b/src/communitymech/validation/__init__.py
@@ -1,0 +1,1 @@
+"""Validation helpers for CommunityMech."""

--- a/src/communitymech/validation/write_validated.py
+++ b/src/communitymech/validation/write_validated.py
@@ -1,0 +1,129 @@
+"""Write-time validation: dump a MicrobialCommunity to YAML *only if* it
+passes closed-schema LinkML validation.
+
+This is the write-time gate that pairs the in-memory mutation step with
+a schema check at the same call site, so a script can't accidentally
+write a doc that drifted into an invalid shape between the mutation and
+the disk write. The check is on the in-memory object (not a re-load of
+the emitted YAML), which is the right granularity for catching missing
+required fields, unknown fields, enum / pattern violations, etc. — the
+failure modes the audit cares about.
+
+Use::
+
+    from communitymech.validation.write_validated import (
+        write_validated_community,
+        ValidationFailedError,
+    )
+
+    try:
+        write_validated_community(doc, path)
+    except ValidationFailedError as exc:
+        # Bad doc refused; print categorized errors and abort.
+        print(exc.summary())
+        raise
+
+The validator is shared across calls (LinkML schema parse + JSON-schema
+emit is the slow part), so calling this in a tight migration loop is
+cheap.
+
+Ported from CultureMech's ``src/culturemech/validation/write_validated.py``
+(by way of MediaIngredientMech / TraitMech). CommunityMech has a single
+``tree_root: true`` class (``MicrobialCommunity``), so ``target_class``
+is a constant.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+import yaml
+from linkml.validator import Validator
+from linkml.validator.plugins import JsonschemaValidationPlugin
+from linkml.validator.report import Severity, ValidationResult
+
+DEFAULT_SCHEMA_PATH = Path(__file__).resolve().parents[1] / "schema" / "communitymech.yaml"
+DEFAULT_TARGET_CLASS = "MicrobialCommunity"
+
+_VALIDATORS: dict[Path, Validator] = {}
+_VALIDATOR_LOCK = Lock()
+
+
+class ValidationFailedError(Exception):
+    """Raised when a MicrobialCommunity fails closed-schema validation before write."""
+
+    def __init__(self, path: Path | None, errors: list[ValidationResult]):
+        self.path = path
+        self.errors = errors
+        super().__init__(self.summary())
+
+    def summary(self) -> str:
+        lines = [
+            f"validation failed: {len(self.errors)} error(s)"
+            + (f" for {self.path}" if self.path else "")
+        ]
+        for err in self.errors[:10]:
+            lines.append(f"  - {err.message[:200]}")
+        if len(self.errors) > 10:
+            lines.append(f"  ... + {len(self.errors) - 10} more")
+        return "\n".join(lines)
+
+
+def _get_validator(schema_path: Path) -> Validator:
+    """Cache validators keyed by resolved schema path so callers can mix
+    schemas in the same process without silently reusing a stale instance."""
+    key = Path(schema_path).resolve()
+    with _VALIDATOR_LOCK:
+        if key not in _VALIDATORS:
+            _VALIDATORS[key] = Validator(
+                schema=str(key),
+                validation_plugins=[JsonschemaValidationPlugin(closed=True)],
+            )
+        return _VALIDATORS[key]
+
+
+def validate_community(
+    doc: dict[str, Any],
+    *,
+    target_class: str = DEFAULT_TARGET_CLASS,
+    schema_path: Path = DEFAULT_SCHEMA_PATH,
+) -> list[ValidationResult]:
+    """Return the list of ERROR-severity validation results (empty when clean)."""
+    validator = _get_validator(schema_path)
+    report = validator.validate(doc, target_class=target_class)
+    return [r for r in report.results if r.severity == Severity.ERROR]
+
+
+def write_validated_community(
+    doc: dict[str, Any],
+    path: Path,
+    *,
+    target_class: str = DEFAULT_TARGET_CLASS,
+    schema_path: Path = DEFAULT_SCHEMA_PATH,
+    yaml_kwargs: dict[str, Any] | None = None,
+) -> None:
+    """Write ``doc`` to ``path`` as YAML, but only if validation passes.
+
+    Raises :class:`ValidationFailedError` (without writing) when closed-schema
+    validation finds any error. Use in place of
+    ``yaml.dump(doc, fh, default_flow_style=False, ...)`` inside mutating
+    scripts.
+    """
+    errors = validate_community(doc, target_class=target_class, schema_path=schema_path)
+    if errors:
+        raise ValidationFailedError(path, errors)
+    # Match the existing repo convention so re-running the helper over an
+    # existing file produces a byte-identical diff.
+    opts = {
+        "default_flow_style": False,
+        "sort_keys": False,
+        "allow_unicode": True,
+        "width": 120,
+        "indent": 2,
+        **(yaml_kwargs or {}),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(doc, f, **opts)


### PR DESCRIPTION
## Summary

Brings CommunityMech to parity with the audit-machinery ports recently landed in CultureMech (source), [MediaIngredientMech #32](https://github.com/CultureBotAI/MediaIngredientMech/pull/32), and [TraitMech #76](https://github.com/CultureBotAI/TraitMech/pull/76). CommunityMech is the last sibling; the lift is larger than the others because the schema did not yet define `CurationEvent` or `curation_history`.

## Schema additions (additive — no migration needed)

- New **`CurationEvent`** class with `timestamp` / `curator` / `action` / `changes` / `llm_assisted` attributes. Mirrors the shape used by sibling Mech repos so cross-repo tooling reads curation events uniformly.
- New **`curation_history`** slot on `MicrobialCommunity` — multivalued, inlined, optional. Existing community YAMLs continue to validate without modification.
- `src/communitymech/datamodel/communitymech.py` regenerated via `just gen-python`.

## New helpers

- **`src/communitymech/validation/write_validated.py`** — `write_validated_community(doc, path)` refuses to dump a `MicrobialCommunity` that fails closed-schema LinkML validation; raises `ValidationFailedError`. Single-root-class schema so no `target_class` routing needed. Default yaml opts match the existing emission convention (`default_flow_style=False, sort_keys=False, allow_unicode=True, width=120, indent=2`) so existing files roundtrip byte-identically.
- **`src/communitymech/curate/curation_event.py`** — `record_curation_event()` is the standard helper for appending a `CurationEvent` to `doc['curation_history']`. Schema-aligned signature; whole-second + Z suffix timestamps; `skip_if_recent` support for idempotent re-runs.

## New scripts

- **`scripts/validate_strict.py`** — strict closed-schema parallel walk of `kb/communities/` (with `backups/` + `snapshots/` excluded). Emits `reports/instance_validation_failures.tsv` categorized by error class, exits non-zero on ERROR. Strictly stronger than the per-file `linkml-validate` loop in `just validate-all` (open-mode, swallows exit codes).
- **`scripts/audit_writers.py`** — inventory of every YAML-writing module under `scripts/` + `src/communitymech/`, flags whether each script validates before writing and appends a `curation_history` event.

## Writer conversions (5 of ~15)

| Script | Action label |
|---|---|
| `scripts/add_community_ids.py` | `ASSIGN_COMMUNITY_ID` (also gained a `--dry-run` safeguard it lacked) |
| `scripts/apply_pmc_conversions.py` | `CONVERT_PMC_TO_PMID` |
| `scripts/fix_network_integrity.py` | `FIX_NETWORK_INTEGRITY` |
| `scripts/link_growth_media.py` | `LINK_GROWTH_MEDIA` |
| `src/communitymech/network/llm_repair.py` | `LLM_REPAIR_APPLIED` (`llm_assisted=True`) |

Each was wrapped in `try/except ValidationFailedError` on the write call so one bad record can't kill a batch run. Existing CLI surfaces preserved.

## Future work (the other ~10 writers in the audit TSV)

These 10 mutating writers were not converted in this PR to keep it focused. They appear in `reports/pipeline_writers_audit.tsv` as `appends_curation_history=no` and follow the same conversion pattern as the 5 above:

`apply_strain_designations.py`, `apply_suggested_fixes.py`, `apply_suggested_snippets.py`, `apply_taxonomy_corrections.py`, `backfill_metals.py`, `batch_snippet_fixer.py`, `clean_metals_inplace.py`, `curate_evidence_with_pdfs.py`, `enhance_strain_data.py`, `fix_invalid_snippets.py`, `fix_reference_formats.py`, `intelligent_snippet_fixer.py`, plus a handful of smaller writers.

## Justfile

- New `validate-strict` + `audit-writers` recipes.
- `qc` composite extended to include `validate-strict`.

## Baseline (committed in `reports/`)

| Check | Result |
|---|---|
| `just validate-strict` | 265 files, **0 ERROR rows** (clean) |
| `just audit-writers` | 15 writers; **5 now validate before write + append curation_history**; the rest are documented as follow-up above |
| `pytest tests/` | 136 passed, 9 skipped |

## Test plan

- [x] All edited files pass `uv run ruff check`.
- [x] `uv run python -c "from communitymech.validation.write_validated import write_validated_community; from communitymech.curate.curation_event import record_curation_event"` — imports resolve.
- [x] `uv run python scripts/validate_strict.py` — 0 errors / 265 files (clean baseline).
- [x] `uv run python scripts/audit_writers.py` — 5/15 writers validate; the others documented as future work.
- [x] `pytest tests/` — 136 passed.
- [ ] (Manual, post-merge) Run one of the converted writers against real data with `--apply` to confirm the new gate doesn't regress an active workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)