### PR TITLE
Close audit-writers blind-spot for text-templated writers + lock in growth_media id patterns

### DIFF
--- a/reports/pipeline_writers_audit.tsv
+++ b/reports/pipeline_writers_audit.tsv
@@ -5,6 +5,7 @@ scripts/apply_pmc_conversions.py	yes	yes	yes	yes	no
 scripts/apply_strain_designations.py	yes	no	no	no	no
 scripts/apply_taxonomy_corrections.py	yes	no	no	no	no
 scripts/backfill_metals.py	yes	no	yes	no	no
+scripts/clean_metals_inplace.py	yes	no	yes	no	no
 scripts/enhance_strain_data.py	yes	no	no	no	no
 scripts/fix_network_integrity.py	yes	yes	yes	yes	no
 scripts/fix_reference_formats.py	yes	no	yes	no	no

--- a/scripts/audit_writers.py
+++ b/scripts/audit_writers.py
@@ -38,6 +38,12 @@ SEARCH_DIRS = [
 
 # Patterns
 _WRITE_TEXT_OF_YAML = re.compile(r"\.write_text\s*\(\s*yaml\.(?:safe_)?dump")
+# Match the path literal "kb/communities" appearing in source — used to
+# anchor the in-place-mutation heuristic below to scripts that actually
+# operate on community YAMLs.
+_COMMUNITIES_PATH_LITERAL = re.compile(r"kb/communities")
+_READ_TEXT_VAR = re.compile(r"(\w+)\.read_text\s*\(")
+_WRITE_TEXT_VAR = re.compile(r"(\w+)\.write_text\s*\(")
 _CURATION_APPEND = re.compile(
     r"curation_history.*?(append|\+=|\.insert)"
     r"|['\"]curator['\"]\s*:"
@@ -73,7 +79,20 @@ def looks_like_yaml_writer(text: str) -> bool:
         return True
     # write_validated_community is the closed-schema-gated wrapper that
     # callers route through instead of yaml.dump directly.
-    return "write_validated_community(" in text
+    if "write_validated_community(" in text:
+        return True
+    # Text-templated in-place writers: scripts that round-trip the same
+    # path variable through .read_text() and .write_text(...) AND
+    # reference the kb/communities directory are mutating community
+    # YAMLs via raw text surgery (e.g. clean_metals_inplace.py uses
+    # regex/line edits + path.write_text(string)). They bypass yaml.dump
+    # but are still community-YAML writers and must be audited.
+    if _COMMUNITIES_PATH_LITERAL.search(text):
+        read_vars = set(_READ_TEXT_VAR.findall(text))
+        write_vars = set(_WRITE_TEXT_VAR.findall(text))
+        if read_vars & write_vars:
+            return True
+    return False
 
 
 def audit(path: Path, justfile_text: str) -> dict | None:

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-25T01:44:55
+# Generation date: 2026-05-25T18:12:41
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech
@@ -1949,7 +1949,8 @@ slots.growthMediaComponent__name = Slot(uri=COMMUNITYMECH.name, name="growthMedi
                    model_uri=COMMUNITYMECH.growthMediaComponent__name, domain=None, range=str)
 
 slots.growthMediaComponent__media_ingredient_mech_id = Slot(uri=COMMUNITYMECH.media_ingredient_mech_id, name="growthMediaComponent__media_ingredient_mech_id", curie=COMMUNITYMECH.curie('media_ingredient_mech_id'),
-                   model_uri=COMMUNITYMECH.growthMediaComponent__media_ingredient_mech_id, domain=None, range=Optional[str])
+                   model_uri=COMMUNITYMECH.growthMediaComponent__media_ingredient_mech_id, domain=None, range=Optional[str],
+                   pattern=re.compile(r'^MediaIngredientMech:\d{6}$'))
 
 slots.growthMediaComponent__media_ingredient_mech_url = Slot(uri=COMMUNITYMECH.media_ingredient_mech_url, name="growthMediaComponent__media_ingredient_mech_url", curie=COMMUNITYMECH.curie('media_ingredient_mech_url'),
                    model_uri=COMMUNITYMECH.growthMediaComponent__media_ingredient_mech_url, domain=None, range=Optional[str])
@@ -1970,7 +1971,8 @@ slots.growthMedia__name = Slot(uri=COMMUNITYMECH.name, name="growthMedia__name",
                    model_uri=COMMUNITYMECH.growthMedia__name, domain=None, range=str)
 
 slots.growthMedia__culturemech_id = Slot(uri=COMMUNITYMECH.culturemech_id, name="growthMedia__culturemech_id", curie=COMMUNITYMECH.curie('culturemech_id'),
-                   model_uri=COMMUNITYMECH.growthMedia__culturemech_id, domain=None, range=Optional[str])
+                   model_uri=COMMUNITYMECH.growthMedia__culturemech_id, domain=None, range=Optional[str],
+                   pattern=re.compile(r'^CultureMech:\d{6}$'))
 
 slots.growthMedia__culturemech_url = Slot(uri=COMMUNITYMECH.culturemech_url, name="growthMedia__culturemech_url", curie=COMMUNITYMECH.curie('culturemech_url'),
                    model_uri=COMMUNITYMECH.growthMedia__culturemech_url, domain=None, range=Optional[str])

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -699,6 +699,7 @@ classes:
         required: true
       media_ingredient_mech_id:
         description: Identifier in MediaIngredientMech database (e.g., MediaIngredientMech:000001)
+        pattern: "^MediaIngredientMech:\\d{6}$"
       media_ingredient_mech_url:
         description: URL to MediaIngredientMech ingredient entry
       concentration:
@@ -719,6 +720,7 @@ classes:
         required: true
       culturemech_id:
         description: Identifier in CultureMech media database (e.g., CultureMech:000001)
+        pattern: "^CultureMech:\\d{6}$"
       culturemech_url:
         description: URL to CultureMech media entry
       composition:


### PR DESCRIPTION
## Summary

Two small follow-ups to the schema-gap audit landed in #84:

- **F7 (high)** — `scripts/audit_writers.py` was blind to `scripts/clean_metals_inplace.py`, which mutates 149 community YAMLs via regex/line-edit substitutions + `path.write_text(string)`. The auditor's `_WRITE_TEXT_OF_YAML` regex only matched `path.write_text(yaml.dump(...))`, so a high-risk writer with no validation, no curation trail, and no `yaml`-roundtrip safety was invisible. Broaden the heuristic so it now surfaces. (Does **not** convert the script — that's a separate, larger change.)
- **Fix #5 (low)** — `GrowthMedia.culturemech_id` and `GrowthMediaComponent.media_ingredient_mech_id` had no `pattern:` declared, while the sibling `RelatedMedia.culturemech_id` / `RelatedIngredient.mediaingredientmech_id` slots do. Live data already conforms to the standard `^CultureMech:\d{6}$` / `^MediaIngredientMech:\d{6}$` — just lock it in.

## What changed

### 1. `scripts/audit_writers.py` — extended `looks_like_yaml_writer`

New branch in the detector:

> A script that references the `kb/communities` path literal **and** round-trips the same path variable through `.read_text()` **and** `.write_text(...)` is a community-YAML writer (text-templated in-place mutation).

Calibration:
- Across all `scripts/` + `src/communitymech/` only **one** new script matches: `clean_metals_inplace.py`.
- `src/communitymech/visualization/umap_generator.py` and `src/communitymech/render_community_pages.py` reference `kb/communities` and call `.write_text(...)` but write **HTML output** to a different `out_path` — no same-variable round-trip, so they don't match.
- `src/communitymech/literature.py` and `src/communitymech/utils/media_linker.py` have same-variable `read_text` / `write_text` round-trips but operate on cache files (no `kb/communities` reference) — they don't match either.
- `audit_writers.py` itself round-trips `path` and references `kb/communities` in its regex source, but is already self-excluded via `path.resolve() == Path(__file__).resolve()`.

After-state audit row for the now-surfaced writer:

```
scripts/clean_metals_inplace.py  yes  no  yes  no  no
```

(`writes_yaml=yes`, `appends_curation_history=no`, `has_write_safeguard=yes` — it does have `--dry-run`, `validates_before_write=no`, `wired_into_just=no`.)

### 2. `src/communitymech/schema/communitymech.yaml` — patterns added

```yaml
GrowthMediaComponent:
  attributes:
    media_ingredient_mech_id:
      ...
      pattern: "^MediaIngredientMech:\\d{6}$"

GrowthMedia:
  attributes:
    culturemech_id:
      ...
      pattern: "^CultureMech:\\d{6}$"
```

Schema regenerated via `just gen-python`; the four compiled regexes are now in `src/communitymech/datamodel/communitymech.py` (two new lines for the GrowthMedia* slots, in addition to the two already present for RelatedMedia/RelatedIngredient).

### 3. `reports/pipeline_writers_audit.tsv` — refreshed

Now 16 rows (was 15). The added row is `clean_metals_inplace.py`.

## Before/after

| check | before | after |
|---|---|---|
| audit_writers TSV rows | 15 | 16 |
| `clean_metals_inplace.py` surfaced | no | yes |
| `validate_strict` ERROR rows | 0 / 265 | 0 / 265 |
| `pytest tests/` | 136 pass / 9 skip | 136 pass / 9 skip |
| `ruff check scripts/audit_writers.py` | clean | clean |

## Deferred

Converting `scripts/clean_metals_inplace.py` itself to a `yaml.safe_load` → mutate-dict → `write_validated_community` flow is **not** in this PR. That change is more invasive (149-file regex surgery to load/dump round-trip, with quoting / float-rendering / comment-preservation pitfalls). Now that the audit surfaces it, it's tracked in the standard backlog. From the audit's remaining un-gated writers, the next priority candidates are:

- `intelligent_snippet_fixer.py` (no safeguard, no validation, no curation)
- `enhance_strain_data.py` (no safeguard, no validation, no curation)
- `add_evidence_source.py` (safeguarded but no validation, no curation)
- `clean_metals_inplace.py` (this PR's new finding — `--dry-run` already in place)

## Test plan

- [x] `uv run python scripts/audit_writers.py | grep clean_metals_inplace` returns a row
- [x] No new false-positives surfaced in the audit TSV (rows = 15 + 1 = 16; the new row is the target)
- [x] `uv run python scripts/validate_strict.py --quiet` → 0 ERROR rows / 265 files
- [x] `uv run pytest tests/ -q --no-cov` → 136 passed, 9 skipped
- [x] `uv run ruff check scripts/audit_writers.py` → clean
- [x] Regenerated `datamodel/communitymech.py` contains four `^CultureMech:\d{6}$` / `^MediaIngredientMech:\d{6}$` compiled patterns