### PR TITLE
Fix broken literature_enhanced imports in two writer scripts

### DIFF
--- a/scripts/add_evidence_source.py
+++ b/scripts/add_evidence_source.py
@@ -26,7 +26,7 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from communitymech.literature_enhanced import EnhancedLiteratureFetcher
+from communitymech.literature import LiteratureFetcher
 
 from communitymech.curate.curation_event import record_curation_event
 from communitymech.validation.write_validated import (
@@ -39,10 +39,13 @@ class EvidenceSourceAdder:
     """Add evidence_source to evidence items"""
 
     def __init__(self):
-        self.fetcher = EnhancedLiteratureFetcher(
-            cache_dir=".literature_cache",
-            use_fallback_pdf=False
-        )
+        # Previously imported a sibling EnhancedLiteratureFetcher class that
+        # was never committed to the repo; the LiteratureFetcher in
+        # communitymech.literature exposes the same fetch_pubmed_abstract +
+        # fetch_paper surface (plus a richer DOI fallback chain through
+        # CrossRef / PMC / OpenAlex / Semantic Scholar / Europe PMC) which
+        # is what these scripts actually need.
+        self.fetcher = LiteratureFetcher(cache_dir=".literature_cache")
         self.stats = {
             'total_evidence': 0,
             'already_has_source': 0,
@@ -148,12 +151,14 @@ class EvidenceSourceAdder:
 
                     # Try to fetch abstract for better classification
                     abstract = None
-                    title = None
+                    title = None  # LiteratureFetcher.fetch_paper returns
+                                  # (abstract, pdf_url); the title is embedded
+                                  # in PubMed abstracts and can be pulled from
+                                  # CrossRef metadata via fetch_doi_metadata()
+                                  # if richer classification is needed later.
                     try:
-                        paper = self.fetcher.fetch_paper(reference, download_pdf=False)
-                        abstract = paper.get('abstract')
-                        title = paper.get('title')
-                    except:
+                        abstract, _ = self.fetcher.fetch_paper(reference)
+                    except Exception:
                         pass
 
                     # Guess evidence source
@@ -221,12 +226,14 @@ class EvidenceSourceAdder:
                     reference = ev.get('reference', '')
 
                     abstract = None
-                    title = None
+                    title = None  # LiteratureFetcher.fetch_paper returns
+                                  # (abstract, pdf_url); the title is embedded
+                                  # in PubMed abstracts and can be pulled from
+                                  # CrossRef metadata via fetch_doi_metadata()
+                                  # if richer classification is needed later.
                     try:
-                        paper = self.fetcher.fetch_paper(reference, download_pdf=False)
-                        abstract = paper.get('abstract')
-                        title = paper.get('title')
-                    except:
+                        abstract, _ = self.fetcher.fetch_paper(reference)
+                    except Exception:
                         pass
 
                     guessed_source = self.guess_evidence_source(

--- a/scripts/add_evidence_source.py
+++ b/scripts/add_evidence_source.py
@@ -81,13 +81,12 @@ class EvidenceSourceAdder:
         self,
         snippet: str,
         abstract: str = None,
-        title: str = None,
         community_origin: str = None
     ) -> Optional[str]:
         """Guess evidence source using heuristics"""
 
         # Combine text for keyword matching
-        text = ' '.join(filter(None, [snippet, abstract, title])).lower()
+        text = ' '.join(filter(None, [snippet, abstract])).lower()
 
         # Check for review first (highest specificity)
         if any(kw in text for kw in self.review_keywords):
@@ -150,12 +149,11 @@ class EvidenceSourceAdder:
                     reference = ev.get('reference', '')
 
                     # Try to fetch abstract for better classification
+                    # Title is not threaded into the classifier — PubMed
+                    # abstracts already embed the title, and CrossRef
+                    # titles for DOIs are available via fetch_doi_metadata()
+                    # if richer classification is wanted later.
                     abstract = None
-                    title = None  # LiteratureFetcher.fetch_paper returns
-                                  # (abstract, pdf_url); the title is embedded
-                                  # in PubMed abstracts and can be pulled from
-                                  # CrossRef metadata via fetch_doi_metadata()
-                                  # if richer classification is needed later.
                     try:
                         abstract, _ = self.fetcher.fetch_paper(reference)
                     except Exception:
@@ -163,7 +161,7 @@ class EvidenceSourceAdder:
 
                     # Guess evidence source
                     guessed_source = self.guess_evidence_source(
-                        snippet, abstract, title, community_origin
+                        snippet, abstract, community_origin
                     )
 
                     if auto_mode and guessed_source:
@@ -225,19 +223,18 @@ class EvidenceSourceAdder:
                     snippet = ev.get('snippet', '')
                     reference = ev.get('reference', '')
 
+                    # Title is not threaded into the classifier — PubMed
+                    # abstracts already embed the title, and CrossRef
+                    # titles for DOIs are available via fetch_doi_metadata()
+                    # if richer classification is wanted later.
                     abstract = None
-                    title = None  # LiteratureFetcher.fetch_paper returns
-                                  # (abstract, pdf_url); the title is embedded
-                                  # in PubMed abstracts and can be pulled from
-                                  # CrossRef metadata via fetch_doi_metadata()
-                                  # if richer classification is needed later.
                     try:
                         abstract, _ = self.fetcher.fetch_paper(reference)
                     except Exception:
                         pass
 
                     guessed_source = self.guess_evidence_source(
-                        snippet, abstract, title, community_origin
+                        snippet, abstract, community_origin
                     )
 
                     if auto_mode and guessed_source:

--- a/scripts/intelligent_snippet_fixer.py
+++ b/scripts/intelligent_snippet_fixer.py
@@ -25,7 +25,7 @@ import yaml
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from communitymech.curate.curation_event import record_curation_event
-from communitymech.literature_enhanced import EnhancedLiteratureFetcher
+from communitymech.literature import LiteratureFetcher
 from communitymech.validation.write_validated import (
     ValidationFailedError,
     write_validated_community,
@@ -59,7 +59,12 @@ class IntelligentSnippetFixer:
     """Intelligent snippet fixer with context-aware abstract analysis."""
 
     def __init__(self, verbose: bool = False):
-        self.fetcher = EnhancedLiteratureFetcher()
+        # Previously imported a sibling EnhancedLiteratureFetcher class
+        # that was never committed; LiteratureFetcher exposes the same
+        # fetch_pubmed_abstract + fetch_paper surface plus a richer DOI
+        # fallback chain (CrossRef / PMC / OpenAlex / Semantic Scholar /
+        # Europe PMC) which subsumes what fetch_abstract_for_doi did.
+        self.fetcher = LiteratureFetcher()
         self.verbose = verbose
 
     def extract_relevant_sentences(
@@ -210,12 +215,13 @@ class IntelligentSnippetFixer:
         if reference.upper().startswith("PMID:"):
             pmid = reference.replace("PMID:", "").replace("pmid:", "").strip()
             abstract = self.fetcher.fetch_pubmed_abstract(pmid)
-        elif "doi" in reference.lower() or reference.startswith("10."):
-            doi = reference.replace("doi:", "").replace("https://doi.org/", "").strip()
-            abstract = self.fetcher.fetch_abstract_for_doi(doi)
         else:
-            paper = self.fetcher.fetch_paper(reference, download_pdf=False)
-            abstract = paper.get("abstract")
+            # fetch_paper auto-detects PMID vs DOI and runs the full
+            # DOI fallback chain (CrossRef → PMID via DOI lookup → PMC
+            # full-text → OpenAlex → Semantic Scholar → Europe PMC →
+            # publisher meta-tag scrape). Returns (abstract, pdf_url);
+            # we don't need the pdf here.
+            abstract, _ = self.fetcher.fetch_paper(reference)
 
         if not abstract:
             if self.verbose:


### PR DESCRIPTION
## Summary

Fix a pre-existing import bug surfaced as a heads-up by [PR #87](https://github.com/CultureBotAI/CommunityMech/pull/87).

**`scripts/add_evidence_source.py`** and **`scripts/intelligent_snippet_fixer.py`** both import `EnhancedLiteratureFetcher` from `communitymech.literature_enhanced` — a module that **was never committed to git** (only a stale `.pyc` in `__pycache__/` was shadowing the missing source locally). Both scripts raise `ModuleNotFoundError` on import for anyone running them today.

Swap to `LiteratureFetcher` from `communitymech.literature`, which exists in the repo, is well-tested, and exposes the same `fetch_pubmed_abstract` + `fetch_paper` surface plus a richer DOI fallback chain (CrossRef → PubMed-via-DOI → PMC full-text → OpenAlex → Semantic Scholar → Europe PMC → publisher meta-tag scrape) that subsumes what the missing `fetch_abstract_for_doi` did.

## API differences

| Difference | Impact |
|---|---|
| `fetch_paper()` returns `(abstract, pdf_url)` not a dict | Tuple-unpack at call sites |
| `fetch_paper()` has no `download_pdf` kwarg | The flag was effectively a no-op in `LiteratureFetcher`'s pipeline (the PDF URL is just returned alongside the abstract) |
| Title field unavailable separately | `add_evidence_source.guess_evidence_source` `filter(None, …)`-merged title with snippet + abstract; losing it degrades classification marginally. PubMed abstracts include the title in the abstract text, so PMID references are unaffected. If DOI title is needed later, `fetch_doi_metadata()` returns CrossRef metadata with a title field. |
| Constructor: no `use_fallback_pdf` arg | Drop it; was a no-op |

## After-state

- Both scripts now import + run their initialization paths cleanly (verified via `importlib.util.spec_from_file_location` + `exec_module`).
- `pytest tests/`: 136 passed, 9 skipped (unchanged).
- `ruff check`: pre-existing F541 warnings on lines this PR didn't touch are left alone.

## Test plan

- [x] Both scripts pass `ast.parse`.
- [x] Both scripts now import without `ModuleNotFoundError`.
- [x] Existing tests pass.
- [ ] (Manual, post-merge) Run one of the converted writers against real data with `--apply` to confirm end-to-end behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)