### PR TITLE
Add validate-strict CI workflow

### DIFF
--- a/.github/workflows/validate-strict.yaml
+++ b/.github/workflows/validate-strict.yaml
@@ -2,16 +2,19 @@ name: validate-strict
 
 on:
   pull_request:
-    paths:
+    paths: &trigger_paths
       - "kb/communities/**"
       - "src/communitymech/schema/**"
-      - "src/communitymech/**.py"
-      - "scripts/**.py"
+      - "src/communitymech/**/*.py"
+      - "scripts/**/*.py"
+      - "tests/**/*.py"
       - "justfile"
       - "pyproject.toml"
+      - "uv.lock"
       - ".github/workflows/validate-strict.yaml"
   push:
     branches: [main]
+    paths: *trigger_paths
   workflow_dispatch:
 
 permissions:
@@ -37,7 +40,11 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        # --frozen fails the workflow if uv.lock is stale (don't silently
+        # re-resolve in CI). --all-extras keeps parity with the existing
+        # network-quality.yml workflow and ensures pytest + optional deps
+        # are available for the test step below.
+        run: uv sync --frozen --all-extras
 
       - name: Run validate-strict (closed-schema LinkML validation)
         run: just validate-strict

--- a/.github/workflows/validate-strict.yaml
+++ b/.github/workflows/validate-strict.yaml
@@ -1,0 +1,59 @@
+name: validate-strict
+
+on:
+  pull_request:
+    paths:
+      - "kb/communities/**"
+      - "src/communitymech/schema/**"
+      - "src/communitymech/**.py"
+      - "scripts/**.py"
+      - "justfile"
+      - "pyproject.toml"
+      - ".github/workflows/validate-strict.yaml"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-strict:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: extractions/setup-just@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validate-strict (closed-schema LinkML validation)
+        run: just validate-strict
+
+      - name: Run audit-writers
+        run: just audit-writers
+
+      - name: Run tests
+        run: uv run pytest tests/ -q --no-cov
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: validate-strict-reports-${{ github.run_id }}
+          path: |
+            reports/instance_validation_failures.tsv
+            reports/pipeline_writers_audit.tsv
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary

Locks in the 0-error closed-schema baseline established across [PRs #84-#88](https://github.com/CultureBotAI/CommunityMech/pulls?q=is%3Apr+is%3Aclosed) so it can't silently regress on future merges. Mirrors the qc.yaml workflow shipped to [TraitMech #77](https://github.com/CultureBotAI/TraitMech/pull/77) and matches the CommunityMech runner conventions (Python 3.10, \`uv sync --all-extras\`).

Runs three checks on every PR touching schema/data/source/scripts:

- \`just validate-strict\` — closed-schema LinkML walk over kb/communities/
- \`just audit-writers\` — writer-script inventory + safety-flag matrix
- \`pytest tests/ -q --no-cov\` — unit-test suite

Uploads \`reports/instance_validation_failures.tsv\` + \`reports/pipeline_writers_audit.tsv\` as artifacts.

## Scope

Narrower than \`just qc\` — the existing \`network-quality.yml\` already covers the network-integrity audit. The new workflow specifically gates the fast closed-schema + writer-audit + unit-test loop, which can run on every PR without becoming a bottleneck.

## Test plan

- [x] Workflow yaml is valid.
- [ ] (Verified post-merge) Workflow runs and passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)