### PR TITLE
#30 backfill: gut/rhizosphere cohort batch 1 (8 communities)

### DIFF
--- a/kb/communities/Arabidopsis_Coumarin_Root_SynCom.yaml
+++ b/kb/communities/Arabidopsis_Coumarin_Root_SynCom.yaml
@@ -52,3 +52,34 @@ environmental_factors:
   description: Plant mutants deficient in secreted phytoalexins, flavonoids, and coumarins.
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: coumarin
+  chebi_term:
+    id: CHEBI:28794
+    label: coumarin
+  relevance: Coumarins are the central class of root-exuded specialized metabolites
+    studied in this SynCom; loss of coumarin biosynthesis in the f6'h1 mutant drives
+    the iron-dependent shift in root-associated bacterial community composition.
+  evidence:
+  - reference: PMID:31152139
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: lack of coumarin biosynthesis in f6'h1 mutant plant lines causes a shift
+      in the root microbial community specifically under iron deficiency
+    explanation: Names coumarin biosynthesis as the perturbation that reshapes the
+      synthetic root microbiome, anchoring coumarin as central to this community.
+- preferred_term: iron(3+)
+  chebi_term:
+    id: CHEBI:29034
+    label: iron(3+)
+  relevance: Iron availability gates the community effect; the coumarins exuded by
+    Arabidopsis act as iron-mobilizing molecules that sculpt the bacterial community
+    under iron-limited conditions, making ferric iron a defining environmental driver.
+  evidence:
+  - reference: PMID:31152139
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: iron-mobilizing coumarins in sculpting the A. thaliana root bacterial
+      community
+    explanation: Links iron mobilization by coumarins to community structuring, anchoring
+      ferric iron as a central species in this iron-deficiency-dependent system.

--- a/kb/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.yaml
+++ b/kb/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.yaml
@@ -194,6 +194,22 @@ environmental_factors:
       plant growth
     explanation: Supports the time-course sampling design.
 growth_media: []
+related_ingredients:
+- preferred_term: 13CO2 (plant-fixed carbon source)
+  chebi_term:
+    id: CHEBI:16526
+    label: carbon dioxide
+  relevance: 13CO2 is the labeled substrate at the center of this community's SIP
+    design; Avena fatua fixed 13CO2 photosynthetically and routed the labeled
+    carbon into root exudates and the rhizosphere food web, allowing 13C-enriched
+    bacteria, microeukaryotes, and phage to be tracked.
+  evidence:
+  - reference: PMID:34468166
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: carbon from Avena fatua grown in a 13CO2 atmosphere
+    explanation: Anchors carbon dioxide as the 13C-labeled atmospheric substrate
+      whose fixed carbon is traced into the rhizosphere community.
 external_resources:
 - name: Primary publication for the Avena rhizosphere cross-kingdom SIP community
   repository: OTHER

--- a/kb/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.yaml
+++ b/kb/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.yaml
@@ -182,6 +182,63 @@ environmental_factors:
     evidence_source: IN_VIVO
     snippet: fermentation of dietary fructans to acetate
     explanation: Supports dietary fructans as a substrate shaping the interaction.
+related_ingredients:
+- preferred_term: formate
+  chebi_term:
+    id: CHEBI:15740
+    label: formate
+  relevance: Formate produced by Bacteroides thetaiotaomicron is the key cross-fed substrate
+    transferred to Methanobrevibacter smithii, which consumes it for methanogenesis. This
+    interspecies transfer is the metabolic basis of the gnotobiotic mutualism.
+  evidence:
+  - reference: PMID:16782812
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: B. thetaiotaomicron-derived formate is used by M. smithii for methanogenesis
+    explanation: Snippet names formate explicitly as the B. thetaiotaomicron-derived substrate
+      feeding M. smithii methanogenesis.
+- preferred_term: methane
+  chebi_term:
+    id: CHEBI:16183
+    label: methane
+  relevance: Methane is the terminal product of M. smithii methanogenesis fueled by
+    B. thetaiotaomicron-derived formate, representing the metabolic sink that drives the
+    syntrophic interaction in the mouse gut.
+  evidence:
+  - reference: PMID:16782812
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: B. thetaiotaomicron-derived formate is used by M. smithii for methanogenesis
+    explanation: Snippet anchors methanogenesis, the methane-producing process for which
+      methane is the defining product.
+- preferred_term: acetate
+  chebi_term:
+    id: CHEBI:30089
+    label: acetate
+  relevance: Acetate is the major fermentation product that M. smithii directs B. thetaiotaomicron
+    to produce from dietary fructans, marking the methanogen-specific shift in bacterial
+    metabolic output.
+  evidence:
+  - reference: PMID:16782812
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: M. smithii directs B. thetaiotaomicron to focus on fermentation of dietary fructans to acetate
+    explanation: Snippet names acetate as the end product of the methanogen-directed fructan
+      fermentation.
+- preferred_term: fructan
+  chebi_term:
+    id: CHEBI:28796
+    label: fructan
+  relevance: Dietary fructans are the central polysaccharide substrate whose fermentation by
+    B. thetaiotaomicron is redirected by M. smithii, linking dietary carbohydrate input to the
+    acetate-formate-methane syntrophy.
+  evidence:
+  - reference: PMID:16782812
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: fermentation of dietary fructans to acetate
+    explanation: Snippet names dietary fructans as the substrate whose fermentation underlies
+      the interaction.
 associated_datasets:
 - name: Methanobrevibacter smithii gene sequences
   dataset_type: GENOME

--- a/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
+++ b/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
@@ -258,6 +258,53 @@ ecological_interactions:
       microbiota of infants.
     explanation: Supports that Bacteroides species contribute to authentic infant gut microbiota characteristics
       including HMO degradation.
+related_ingredients:
+- preferred_term: human milk oligosaccharide
+  chebi_term:
+    id: CHEBI:50699
+    label: oligosaccharide
+  relevance: Human milk oligosaccharides are the defining growth substrate of BIG-Syc.
+    They are degraded by the primary Bifidobacterium and Bacteroides degraders, and the
+    specific four- versus five-HMO mix determines whether B. infantis or B. bifidum
+    dominates the community.
+  evidence:
+  - reference: doi:10.1093/ismejo/wrae209
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: human milk oligosaccharides prompt resource-sharing for their complete degradation
+      while leading to a different compositional and functional profile in the community
+    explanation: Anchors human milk oligosaccharides (oligosaccharides) as the central
+      substrate driving resource-sharing and community structure.
+- preferred_term: organic acid
+  chebi_term:
+    id: CHEBI:64709
+    label: organic acid
+  relevance: Organic acids are the cross-fed metabolites released by HMO degraders and
+    consumed by the cross-feeding members of BIG-Syc, central to the syntrophic teamwork
+    that achieves complete HMO degradation.
+  evidence:
+  - reference: doi:10.1093/ismejo/wrae209
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: BIG-Syc demonstrated teamwork as cross-feeders utilized simpler carbohydrates,
+      organic acids, and gases released from human milk oligosaccharide degraders.
+    explanation: Anchors organic acids as cross-fed products that cross-feeders consume
+      from the HMO degraders.
+- preferred_term: carbohydrate
+  chebi_term:
+    id: CHEBI:16646
+    label: carbohydrate
+  relevance: Simpler carbohydrates liberated from HMO breakdown are a key shared resource
+    in BIG-Syc, taken up by cross-feeders that cannot degrade intact human milk
+    oligosaccharides themselves.
+  evidence:
+  - reference: doi:10.1093/ismejo/wrae209
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: BIG-Syc demonstrated teamwork as cross-feeders utilized simpler carbohydrates,
+      organic acids, and gases released from human milk oligosaccharide degraders.
+    explanation: Anchors simpler carbohydrates as the HMO-derived shared resource utilized
+      by cross-feeders.
 associated_datasets:
 - name: BioModels model archive
   dataset_type: OTHER

--- a/kb/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.yaml
+++ b/kb/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.yaml
@@ -218,4 +218,20 @@ associated_datasets:
     evidence_source: IN_VITRO
     snippet: strain-specific quantitative PCR
     explanation: Supports the publication as the source of strain-resolved consortium measurements.
+related_ingredients:
+- preferred_term: amino acid
+  chebi_term:
+    id: CHEBI:33709
+    label: amino acid
+  relevance: Amino acids are the central exchanged substrate of this engineered consortium.
+    Each of the four strains was made auxotrophic for three amino acids while overproducing one,
+    so reciprocal amino acid exchange is the designed mechanism driving cross-feeding and the
+    observed increase in population evenness.
+  evidence:
+  - reference: doi:10.1128/mSystems.00352-19
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Each strain is auxotrophic for three amino acids and overproduces one
+    explanation: Anchors amino acids as the auxotrophy-complementing, overproduced compounds exchanged
+      between strains in the engineered consortium.
 metal_relevance: NOT_APPLICABLE

--- a/kb/communities/GLBRC_Exometabolite_Transwell_SynCom.yaml
+++ b/kb/communities/GLBRC_Exometabolite_Transwell_SynCom.yaml
@@ -47,6 +47,22 @@ ecological_interactions:
   scope: COMMUNITY_LEVEL
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: antibiotics
+  chebi_term:
+    id: CHEBI:33282
+    label: antibacterial agent
+  relevance: Antibiotics are one of the explicitly named classes of exometabolites assayed
+    from the shared reservoir in this Transwell synthetic community, representing chemically
+    mediated antagonistic interactions among physically separated community members.
+  evidence:
+  - reference: PMID:29152587
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: antibiotics, are assayed from the reservoir using sensitive mass spectrometry.
+    explanation: The snippet names antibiotics as one of the exometabolite classes assayed
+      from the shared reservoir, anchoring the antibacterial agent compound class as a central
+      exchanged exometabolite in this community.
 environmental_factors:
 - name: defined synthetic community design
   value: Synthetic community members are cultured in a filter plate system that separates cells while

--- a/kb/communities/Maize_Benzoxazinoid_Metabolizing_SynComs.yaml
+++ b/kb/communities/Maize_Benzoxazinoid_Metabolizing_SynComs.yaml
@@ -53,3 +53,20 @@ environmental_factors:
   description: In vitro exposure to MBOA, a maize benzoxazinoid breakdown product.
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: MBOA (6-methoxybenzoxazolin-2(3H)-one)
+  chebi_term:
+    id: CHEBI:195240
+    label: 6-methoxy-2-benzoxazolinone
+  relevance: MBOA is the maize benzoxazinoid breakdown product the SynComs were exposed
+    to in vitro; the benzoxazinoid-metabolizing community redirects MBOA degradation
+    toward an acetamide and can use MBOA as a sole carbon source, making it the central
+    compound shaping community composition and function.
+  evidence:
+  - reference: PMID:40853002
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: We exposed both communities to the benzoxazinoid MBOA (6-methoxybenzoxazolin-2(3H)-one)
+      in vitro
+    explanation: Names MBOA explicitly with its full chemical name (6-methoxybenzoxazolin-2(3H)-one),
+      anchoring it as the benzoxazinoid the SynComs metabolize.

--- a/kb/communities/SIHUMIx_Human_Intestinal_Model_Community.yaml
+++ b/kb/communities/SIHUMIx_Human_Intestinal_Model_Community.yaml
@@ -306,6 +306,66 @@ growth_media:
     evidence_source: IN_VITRO
     snippet: the eight bacterial species were cultivated individually for 72 h before inoculation
     explanation: Supports the preparation of individual strains before community inoculation.
+related_ingredients:
+- preferred_term: acetate
+  chebi_term:
+    id: CHEBI:30089
+    label: acetate
+  relevance: Acetate is a central short-chain fatty acid in SIHUMIx community metabolism;
+    metabolic modelling of the eight-species community predicts acetate as a cross-fed
+    product exchanged between Blautia producta and other members under complex intestinal
+    medium conditions.
+  evidence:
+  - reference: PMID:33622394
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: production of the short-chain fatty acid acetate
+    explanation: Names acetate explicitly as a short-chain fatty acid produced within
+      the SIHUMIx community metabolism.
+- preferred_term: butyrate
+  chebi_term:
+    id: CHEBI:17968
+    label: butyrate
+  relevance: Butyrate is a key short-chain fatty acid output of SIHUMIx, produced by
+    its butyrogenic members; its concentration is a primary functional readout that
+    shifts when colonic transit time is altered in bioreactor cultivation.
+  evidence:
+  - reference: doi:10.3390/microorganisms7120641
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: a reduction in butyrate, methyl butyrate, isobutyrate, valerate, and isovalerate
+      concentrations
+    explanation: Identifies butyrate as a measured short-chain fatty acid output of
+      the SIHUMIx community that responds to transit-time perturbation.
+- preferred_term: carbohydrate
+  chebi_term:
+    id: CHEBI:16646
+    label: carbohydrate
+  relevance: Carbohydrates are the principal dietary substrates fermented by SIHUMIx;
+    carbohydrate metabolism is a core community function that decreases as colonic
+    transit time is shortened in the in vitro model.
+  evidence:
+  - reference: doi:10.3390/microorganisms7120641
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: a slight decrease in glycan biosynthesis, carbohydrate, and amino acid
+      metabolism
+    explanation: Anchors carbohydrate metabolism as a central, measurable substrate-utilization
+      function of the SIHUMIx community.
+- preferred_term: choline
+  chebi_term:
+    id: CHEBI:15354
+    label: choline
+  relevance: Choline is an exchanged metabolite in SIHUMIx community metabolism; community
+    modelling predicts increased choline uptake by Blautia producta coupled to betaine
+    production, illustrating substrate cross-feeding within the eight-species model.
+  evidence:
+  - reference: PMID:33622394
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the uptake of choline along with the production of betaine was increased
+    explanation: Names choline as a substrate taken up by a SIHUMIx member during predicted
+      community metabolic exchange.
 associated_datasets:
 - name: SIHUMIx metaproteomics and metatranscriptomics study
   dataset_type: METAPROTEOME


### PR DESCRIPTION
Starts the **gut/rhizosphere** arm of the #30 `related_ingredients` backfill to broaden ENVO/substrate coverage (continues #90 and the metals cohort #79/#80/#81/#83).

Every entry uses a CHEBI term **verified live against the ChEBI sqlite db via OAK**, with snippets copied **verbatim** from cached PMID/DOI abstracts.

`related_ingredients` adoption: **33/265 → 41/265**.

## Communities (8)

| Community | Ingredients (CHEBI-verified) |
|---|---|
| Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism | formate, methane, acetate, fructan |
| SIHUMIx_Human_Intestinal_Model_Community | acetate, butyrate, carbohydrate, choline |
| Arabidopsis_Coumarin_Root_SynCom | coumarin, iron(3+) |
| Maize_Benzoxazinoid_Metabolizing_SynComs | 6-methoxy-2-benzoxazolinone (MBOA) |
| Infant_Gut_HMO_SynCom | oligosaccharide (HMO), organic acid, carbohydrate |
| Engineered_Gut_Amino_Acid_CrossFeeding_Consortium | amino acid |
| Avena_Rhizosphere_CrossKingdom_SIP_Community | carbon dioxide (¹³C SIP substrate) |
| GLBRC_Exometabolite_Transwell_SynCom | antibacterial agent (exometabolite class) |

## Curation note
Several gut/rhizosphere abstracts name few specific compounds, so some entries fall back to broad CHEBI classes (carbohydrate, amino acid, organic acid, antibacterial agent) rather than invent specific-compound snippets. These are honest, evidence-backed, and improvable when richer references are cached. The agents OAK-verified every id and refused to fabricate specifics (DIMBOA, scopoletin, specific HMOs/SCFAs were dropped when not named verbatim in the cited abstract).

## Test plan
- `just test` → 136 passed, 9 skipped
- All 8 files validate clean (`linkml-validate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)