### PR TITLE
#30 backfill: gut/rhizosphere cohort batch 2 (5 communities)

### DIFF
--- a/kb/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.yaml
+++ b/kb/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.yaml
@@ -222,6 +222,33 @@ growth_media:
     evidence_source: IN_VITRO
     snippet: All bacteria were maintained on MMRS medium at 30
     explanation: Supports modified MRS and incubation temperature for bacterial propagation.
+related_ingredients:
+- preferred_term: glucose
+  chebi_term:
+    id: CHEBI:17234
+    label: glucose
+  relevance: Host glucose is a central nutritional readout of this five-species community; the
+    yeast-glucose diet supplies glucose and colonization by any of the five bacterial taxa lowers
+    host glucose content relative to axenic flies.
+  evidence:
+  - reference: PMID:24242251
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: The low glucose content of conventional flies was recapitulated in gnotobiotic Drosophila flies colonized with any of the 5 bacterial taxa tested.
+    explanation: The snippet names glucose as the host metabolite directly modulated by colonization with members of this defined community.
+- preferred_term: triglyceride
+  chebi_term:
+    id: CHEBI:17855
+    label: triglyceride
+  relevance: Host triglyceride content is a key nutrient-allocation phenotype of this community; only
+    flies carrying both Acetobacter and Lactobacillus members restore triglyceride to conventional
+    levels, making triglyceride central to the Acetobacter-Lactobacillus interaction.
+  evidence:
+  - reference: PMID:24242251
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Only flies with both Acetobacter and Lactobacillus had triglyceride contents restored to the level in conventional flies.
+    explanation: The snippet anchors triglyceride as the host lipid metabolite whose level depends on the combined bacterial members of this community.
 associated_datasets:
 - name: Exact-composition publication - Drosophila five-species gnotobiotic microbiota
   dataset_type: PHENOTYPE

--- a/kb/communities/Honeybee_Core20_Defined_Microbiota.yaml
+++ b/kb/communities/Honeybee_Core20_Defined_Microbiota.yaml
@@ -57,3 +57,34 @@ environmental_factors:
     inhibition.
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: carbohydrate
+  chebi_term:
+    id: CHEBI:16646
+    label: carbohydrate
+  relevance: Carbohydrate utilization is a defining functional capacity of the Core-20 community,
+    enriched in the genomic analysis of the defined microbiota and likely central to its colonization
+    and immune-priming activity in the honeybee gut.
+  evidence:
+  - reference: PMID:36532452
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Functions related to carbohydrate utilization and the phosphoenolpyruvate-dependent sugar
+      phosphotransferase system (PTS systems) are represented in genomic analysis of the defined community
+    explanation: The abstract names carbohydrate utilization as a represented function of the Core-20
+      community, anchoring carbohydrate as a central substrate class.
+- preferred_term: phosphoenolpyruvate
+  chebi_term:
+    id: CHEBI:18021
+    label: phosphoenolpyruvate
+  relevance: The phosphoenolpyruvate-dependent sugar phosphotransferase system (PTS) is represented in
+    the Core-20 genomes, implicating phosphoenolpyruvate as the central phosphoryl donor driving sugar
+    uptake in this gut community.
+  evidence:
+  - reference: PMID:36532452
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: the phosphoenolpyruvate-dependent sugar phosphotransferase system (PTS systems) are represented
+      in genomic analysis of the defined community
+    explanation: The abstract explicitly names the phosphoenolpyruvate-dependent PTS as a represented
+      function, anchoring phosphoenolpyruvate as a key metabolite in sugar transport.

--- a/kb/communities/Medicago_Nodule_Biofertilizer_SynCom.yaml
+++ b/kb/communities/Medicago_Nodule_Biofertilizer_SynCom.yaml
@@ -64,3 +64,20 @@ environmental_factors:
   description: Metal contamination, salinity, drought, and high temperature in estuarine soils.
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: dinitrogen
+  chebi_term:
+    id: CHEBI:17997
+    label: dinitrogen
+  relevance: Atmospheric dinitrogen (N2) is the substrate fixed by the Ensifer (rhizobial)
+    members of this Medicago nodule SynCom. Inoculation increased plant nitrogen content up
+    to 4-fold under metal stress, the central nutritional benefit of this nodule biofertilizer.
+  evidence:
+  - reference: PMID:37299063
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: nodulation (from 1.5- to 3-fold increase in nodules number), photosynthesis and
+      nitrogen content (up to 4-fold under metal stress) under all the controlled conditions
+      tested
+    explanation: The increase in nodulation and plant nitrogen content reflects symbiotic
+      dinitrogen fixation by the nodule-forming rhizobial members of the SynCom.

--- a/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
+++ b/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
@@ -445,6 +445,26 @@ environmental_factors:
     dependence on synthetic nitrogen fertilizers
 
     '
+related_ingredients:
+- preferred_term: N-acyl-L-homoserine lactone
+  chebi_term:
+    id: CHEBI:55474
+    label: N-acyl-L-homoserine lactone
+  relevance: Acyl homoserine lactones (AHLs) are the central signaling metabolites
+    produced by the two Pantoea helper strains in this sfSynCom. They drive the quorum
+    sensing interaction that significantly enhances colonization and infection of
+    soybean roots by the core symbiont Bradyrhizobium elkanii BXYD3, which is the
+    mechanistic basis for the community's improved nodulation and nitrogen fixation.
+  evidence:
+  - reference: PMID:40052412
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Two of these helper strains assigned to the Pantoea taxon produce acyl
+      homoserine lactones, which significantly enhanced the colonization and infection
+      of soybean by BXYD3
+    explanation: The snippet names acyl homoserine lactones as the compound produced
+      by the Pantoea helper strains, directly anchoring N-acyl-L-homoserine lactone
+      as the key signaling metabolite of this community.
 metals_present: []
 metal_relevance: INCIDENTAL
 metal_notes: Metal/REE detected via environmental factor measurements

--- a/kb/communities/Tomato_Oxylipin_SynCom3.yaml
+++ b/kb/communities/Tomato_Oxylipin_SynCom3.yaml
@@ -73,3 +73,49 @@ environmental_factors:
   description: Botrytis cinerea foliar infection and tomato oxylipin pathway perturbation.
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: oxylipin
+  chebi_term:
+    id: CHEBI:61121
+    label: oxylipin
+  relevance: Oxylipins are the central class of plant defense signaling lipids that this
+    SynCom is designed to steer; the simplified community significantly intensified oxylipin
+    pathway activation in phytopathogen-infected leaves.
+  evidence:
+  - reference: PMID:37549573
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the activation of oxylipin pathways in the phytopathogen-infected leaves was
+      significantly intensified by the simplified community
+    explanation: Directly names oxylipin pathways as the defense response intensified by
+      this community.
+- preferred_term: colneleic acid
+  chebi_term:
+    id: CHEBI:60956
+    label: colneleic acid
+  relevance: Colneleic acid is one of the antimicrobial divinyl ethers whose biosynthesis
+    is required for the community-induced disease resistance; blocking its production
+    abolished protection against Botrytis cinerea.
+  evidence:
+  - reference: PMID:37549573
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the inhibited biosynthesis of antimicrobial divinyl ethers, including colneleic
+      and colnelenic acid, fully abolished the community-induced plant disease resistance
+    explanation: Names colneleic acid as an antimicrobial divinyl ether essential to the
+      community's disease resistance.
+- preferred_term: colnelenic acid
+  chebi_term:
+    id: CHEBI:60959
+    label: colnelenic acid
+  relevance: Colnelenic acid is the second antimicrobial divinyl ether downstream of the
+    oxylipin pathway whose loss abolishes community-induced resistance, marking it a key
+    protective metabolite of this SynCom.
+  evidence:
+  - reference: PMID:37549573
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the inhibited biosynthesis of antimicrobial divinyl ethers, including colneleic
+      and colnelenic acid, fully abolished the community-induced plant disease resistance
+    explanation: Names colnelenic acid as an antimicrobial divinyl ether essential to the
+      community's disease resistance.


### PR DESCRIPTION
Continues the **gut/rhizosphere** arm of the #30 `related_ingredients` backfill (follows #91).

Every entry uses a CHEBI term **verified live against the ChEBI sqlite db via OAK**, with snippets copied **verbatim** from cached PMID/DOI abstracts.

`related_ingredients` adoption: **41/265 → 46/265**.

## Communities (5)

| Community | Ingredients (CHEBI-verified) |
|---|---|
| Tomato_Oxylipin_SynCom3 | oxylipin, colneleic acid, colnelenic acid |
| Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota | glucose, triglyceride |
| Honeybee_Core20_Defined_Microbiota | carbohydrate, phosphoenolpyruvate |
| Soybean_N_Fixation_sfSynCom | N-acyl-L-homoserine lactone |
| Medicago_Nodule_Biofertilizer_SynCom | dinitrogen |

## Curation note
Batch B also screened **OMM12**, **hCom2**, and **Altered_Schaedler_Flora**, but their only cached references are *stubs* (title + previously-used snippets, no abstract body), so no verbatim-supportable ingredient exists — left unchanged rather than inventing. They need full abstracts re-fetched into `references_cache/` first.

## ⚠️ Pre-existing CHEBI bug flagged (out of scope)
`Soybean_N_Fixation_sfSynCom` `metabolites` use `CHEBI:48850` for "N-acyl-L-homoserine lactone", but that id is *alkyloxynaphthalene*; correct id is `CHEBI:55474` (used in the new block). Adds to the running CHEBI-cleanup list.

## Test plan
- `just test` → 136 passed, 9 skipped
- All 5 files validate clean (`linkml-validate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)