### PR TITLE
#30 backfill: syntrophy/methanogenesis cohort batch 1 (10 communities)

### DIFF
--- a/kb/communities/Desulfovibrio_Methanococcus_Syntrophy.yaml
+++ b/kb/communities/Desulfovibrio_Methanococcus_Syntrophy.yaml
@@ -237,6 +237,37 @@ environmental_factors:
       energy generation pathways and imply that to understand microbial processes that sustain nutrient
       cycling, lifestyles not captured in pure culture must be considered.
     explanation: Quantifies growth conditions for the syntrophic consortium
+related_ingredients:
+- preferred_term: lactate
+  chebi_term:
+    id: CHEBI:24996
+    label: lactate
+  relevance: Central carbon and electron-donor substrate of the syntrophy; D. vulgaris oxidizes
+    lactate to acetate, H2, and CO2 in the absence of sulfate, and lactate transport/oxidation genes
+    are upregulated during syntrophic growth.
+  evidence:
+  - reference: PMID:19581361
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: During syntrophic growth on lactate with a hydrogenotrophic methanogen, numerous genes involved
+      in electron transfer and energy generation were upregulated in D
+    explanation: Names lactate as the substrate consumed during syntrophic growth, anchoring it as the
+      central substrate compound of the consortium.
+- preferred_term: dihydrogen
+  chebi_term:
+    id: CHEBI:18276
+    label: dihydrogen
+  relevance: Key interspecies electron-carrier intermediate; H2 produced by D. vulgaris lactate oxidation
+    is consumed by the hydrogenotrophic methanogen, and low H2 partial pressure makes the otherwise
+    thermodynamically unfavorable oxidation feasible.
+  evidence:
+  - reference: PMID:19581361
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Interspecies hydrogen transfer between organisms producing and consuming hydrogen promotes
+      the decomposition of organic matter in most anoxic environments
+    explanation: Identifies hydrogen as the transferred intermediate between producer and consumer,
+      anchoring dihydrogen as the central interspecies electron carrier.
 metals_present:
 - IRON
 metal_relevance: SIGNIFICANT

--- a/kb/communities/Desulfovibrio_Methanosarcina_Lactate_Syntrophy.yaml
+++ b/kb/communities/Desulfovibrio_Methanosarcina_Lactate_Syntrophy.yaml
@@ -192,6 +192,55 @@ growth_media:
     evidence_source: IN_VITRO
     snippet: rumen fluid-vitamin-based medium
     explanation: Supports the medium used for Methanosarcina methanogenic activity.
+related_ingredients:
+- preferred_term: lactate
+  chebi_term:
+    id: CHEBI:24996
+    label: lactate
+  relevance: Primary substrate added to the sulfate-free coculture; its degradation by D. desulfuricans
+    drives the entire syntrophic system, fueling methanogenesis by M. barkeri.
+  evidence:
+  - reference: PMID:16345708
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: degraded lactate, with the production of acetate and CH(4)
+    explanation: Names lactate as the degraded substrate yielding acetate and methane in the coculture.
+- preferred_term: acetate
+  chebi_term:
+    id: CHEBI:30089
+    label: acetate
+  relevance: Central intermediate produced during early lactate degradation and later consumed by
+    M. barkeri for acetoclastic methanogenesis, linking lactate oxidation to methane formation.
+  evidence:
+  - reference: PMID:16345708
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: stoichiometric production of acetate and CH(4)
+    explanation: Anchors acetate as a stoichiometric product of lactate degradation in the coculture.
+- preferred_term: dihydrogen
+  chebi_term:
+    id: CHEBI:18276
+    label: dihydrogen
+  relevance: Interspecies electron carrier produced by Desulfovibrio during lactate growth; its
+    accumulation regulates carbon flow by inhibiting acetate degradation by M. barkeri.
+  evidence:
+  - reference: PMID:16345708
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: H(2) produced by the Desulfovibrio species during
+    explanation: Anchors hydrogen (H2) as a Desulfovibrio-derived intermediate central to the syntrophy.
+- preferred_term: methane
+  chebi_term:
+    id: CHEBI:16183
+    label: methane
+  relevance: Terminal product of the coupled syntrophy, formed by M. barkeri from both the
+    H2-CO2 and acetate methanogenic routes.
+  evidence:
+  - reference: PMID:16345708
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Later, acetate was degraded to CH(4) and presumably to CO(2)
+    explanation: Anchors methane (CH4) as the terminal product formed by M. barkeri from acetate.
 associated_datasets:
 - name: Desulfovibrio-Methanosarcina lactate syntrophy publication
   dataset_type: PHENOTYPE

--- a/kb/communities/Geobacter_Methanosaeta_DIET.yaml
+++ b/kb/communities/Geobacter_Methanosaeta_DIET.yaml
@@ -293,6 +293,47 @@ growth_media:
       specialized medium
   culturemech_id: CultureMech:015435
   culturemech_url: https://github.com/CultureBotAI/CultureMech/tree/main/kb/media/CultureMech:015435
+related_ingredients:
+- preferred_term: ethanol
+  chebi_term:
+    id: CHEBI:16236
+    label: ethanol
+  relevance: Central electron-donor substrate oxidized by G. metallireducens to drive
+    DIET; stoichiometrically converted to methane in the coculture.
+  evidence:
+  - reference: doi:10.1039/C3EE42189A
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: defined co-cultures of Geobacter metallireducens and Methanosaeta harundinacea
+      which stoichiometrically converted ethanol to methane
+    explanation: Names ethanol as the substrate consumed by the DIET coculture, anchoring
+      it as the central electron-donor compound.
+- preferred_term: carbon dioxide
+  chebi_term:
+    id: CHEBI:16526
+    label: carbon dioxide
+  relevance: Terminal electron acceptor reduced to methane by M. harundinacea using
+    electrons received directly from G. metallireducens via DIET.
+  evidence:
+  - reference: doi:10.1039/C3EE42189A
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: M. harundinacea accepted electrons via DIET for the reduction of carbon
+      dioxide to methane
+    explanation: Anchors carbon dioxide as the compound reduced to methane during DIET-driven
+      methanogenesis.
+- preferred_term: methane
+  chebi_term:
+    id: CHEBI:16183
+    label: methane
+  relevance: Terminal product of the DIET coculture, formed by CO2 reduction in M.
+    harundinacea and representing stoichiometric conversion of the ethanol substrate.
+  evidence:
+  - reference: doi:10.1039/C3EE42189A
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: stoichiometrically converted ethanol to methane
+    explanation: Anchors methane as the end product of the coculture's electron flow.
 metals_present: []
 metal_relevance: SIGNIFICANT
 metal_notes: Metal/REE detected via environmental factor measurements; Metal/REE detected

--- a/kb/communities/Geobacter_Methanosarcina_DIET.yaml
+++ b/kb/communities/Geobacter_Methanosarcina_DIET.yaml
@@ -336,6 +336,61 @@ growth_media:
     explanation: Confirms ethanol as electron donor and DIET mechanism in coculture
   culturemech_id: CultureMech:015434
   culturemech_url: https://github.com/CultureBotAI/CultureMech/tree/main/kb/media/CultureMech:015434
+related_ingredients:
+- preferred_term: ethanol
+  chebi_term:
+    id: CHEBI:16236
+    label: ethanol
+  relevance: Sole electron-donor substrate of the coculture; oxidized by G. metallireducens,
+    with the electrons transferred via DIET to drive methanogenesis.
+  evidence:
+  - reference: PMID:24837373
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: shared electrons via DIET during the stoichiometric conversion of ethanol
+      to methane
+    explanation: Names ethanol as the substrate stoichiometrically converted via DIET,
+      anchoring it as the central electron-donating compound.
+- preferred_term: acetate
+  chebi_term:
+    id: CHEBI:30089
+    label: acetate
+  relevance: Intermediate of ethanol oxidation; its metabolism distinguishes DIET-based
+    syntrophy from H2-mediated transfer in M. barkeri cocultures.
+  evidence:
+  - reference: PMID:24837373
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: metabolized little of the acetate that P.carbinolicus produced
+    explanation: Explicitly names acetate as a metabolic intermediate handled by M.
+      barkeri, anchoring the compound in the consortium's metabolism.
+- preferred_term: methane
+  chebi_term:
+    id: CHEBI:16183
+    label: methane
+  relevance: Terminal product of the consortium; M. barkeri reduces CO2 to methane
+    using DIET-derived electrons.
+  evidence:
+  - reference: PMID:24837373
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: shared electrons via DIET during the stoichiometric conversion of ethanol
+      to methane
+    explanation: Names methane as the stoichiometric end product of the DIET coculture,
+      anchoring it as the central output compound.
+- preferred_term: carbon dioxide
+  chebi_term:
+    id: CHEBI:16526
+    label: carbon dioxide
+  relevance: Terminal electron acceptor reduced to methane by M. barkeri using electrons
+    received via DIET.
+  evidence:
+  - reference: PMID:24837373
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: using either H2 or electrons derived from DIET for CO2 reduction
+    explanation: States that DIET-derived electrons drive CO2 reduction, anchoring
+      carbon dioxide as the electron-accepting substrate for methanogenesis.
 metals_present: []
 metal_relevance: SIGNIFICANT
 metal_notes: Metal/REE detected via environmental factor measurements; Metal/REE detected

--- a/kb/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.yaml
+++ b/kb/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.yaml
@@ -342,6 +342,60 @@ external_resources:
   resource_id: NCBITaxon:1175444
   url: https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1175444
   description: NCBI Taxonomy record for Methanocella conradii.
+related_ingredients:
+- preferred_term: propionate
+  chebi_term:
+    id: CHEBI:17272
+    label: propionate
+  relevance: >
+    Propionate is the central catabolic substrate oxidized by
+    P. thermopropionicum, defining the syntrophic propionate-oxidizing
+    methanogenic system.
+  evidence:
+  - reference: PMID:30038609
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: propionate-oxidizing
+    explanation: Anchors propionate as the substrate oxidized by the bacterial syntroph.
+- preferred_term: formate
+  chebi_term:
+    id: CHEBI:15740
+    label: formate
+  relevance: >
+    Formate is produced and consumed across the partners as an interspecies
+    electron carrier supporting syntrophic electron transfer.
+  evidence:
+  - reference: PMID:30038609
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: employing formate as an alternate electron carrier
+    explanation: Anchors formate as an interspecies electron carrier in the coculture.
+- preferred_term: dihydrogen
+  chebi_term:
+    id: CHEBI:18276
+    label: dihydrogen
+  relevance: >
+    Hydrogen (H2/CO2) is an interspecies electron-transfer intermediate
+    feeding the hydrogenotrophic methanogenic partner.
+  evidence:
+  - reference: PMID:30038609
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: but not H2/CO2
+    explanation: Anchors H2/CO2 as an interspecies transfer intermediate tested during syntrophy.
+- preferred_term: methane
+  chebi_term:
+    id: CHEBI:16183
+    label: methane
+  relevance: >
+    Methane is the terminal product of hydrogenotrophic methanogenesis by
+    M. conradii in this coculture.
+  evidence:
+  - reference: PMID:30038609
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: methanogenesis in M. conradii
+    explanation: Anchors methane as the product of methanogenesis by the methanogenic partner.
 metals_present: []
 rare_earth_elements_present: []
 metal_relevance: NOT_APPLICABLE

--- a/kb/communities/Pelotomaculum_Methanothermobacter_Syntrophy.yaml
+++ b/kb/communities/Pelotomaculum_Methanothermobacter_Syntrophy.yaml
@@ -252,6 +252,27 @@ environmental_factors:
       was characterized
     explanation: Establishes syntrophic nature of the organism requiring close association with methanogenic
       partner
+related_ingredients:
+- preferred_term: propionate
+  chebi_term:
+    id: CHEBI:17272
+    label: propionate
+  relevance: Propionate is the defining growth substrate of this syntrophy. Pelotomaculum
+    thermopropionicum oxidizes propionate to acetate, CO2, and H2, but only in coculture
+    with the hydrogenotrophic methanogen Methanothermobacter thermautotrophicus, which
+    removes H2 and keeps the reaction thermodynamically feasible. Propionate is therefore
+    the central electron/carbon input that the entire two-member consortium is organized
+    around.
+  evidence:
+  - reference: PMID:12361280
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The strain grew on propionate, ethanol, lactate, 1-butanol, 1-pentanol,
+      1,3-propanediol, 1-propanol and ethylene glycol in co-culture with the hydrogenotrophic
+      methanogen Methanothermobacter thermautotrophicus strain deltaH(T)
+    explanation: Names propionate explicitly as the growth substrate consumed only in
+      syntrophic co-culture with the H2-using methanogen, anchoring it as the central
+      substrate of this consortium.
 metals_present:
 - IRON
 - TITANIUM

--- a/kb/communities/Syntrophobacter_Methanobacterium_Syntrophy.yaml
+++ b/kb/communities/Syntrophobacter_Methanobacterium_Syntrophy.yaml
@@ -225,6 +225,51 @@ environmental_factors:
     snippet: A syntrophic propionate-oxidizing bacterium, strain MPOBT, was isolated from a culture enriched
       from anaerobic granular sludge
     explanation: Establishes ecological origin and relevance to anaerobic waste treatment processes
+related_ingredients:
+- preferred_term: propionate
+  chebi_term:
+    id: CHEBI:17272
+    label: propionate
+  relevance: Propionate is the central growth substrate of this consortium. Syntrophobacter
+    fumaroxidans oxidizes propionate to acetate, a reaction that proceeds only when a
+    H2/formate-utilizing partner keeps electron-carrier concentrations low.
+  evidence:
+  - reference: doi:10.1099/00207713-48-4-1383
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: A syntrophic propionate-oxidizing bacterium, strain MPOBT, was isolated from
+      a
+    explanation: Identifies propionate as the substrate oxidized by S. fumaroxidans, the
+      defining metabolic activity of this syntrophy.
+- preferred_term: formate
+  chebi_term:
+    id: CHEBI:15740
+    label: formate
+  relevance: Formate is a key interspecies electron carrier transferred from S. fumaroxidans
+    to M. formicicum. Proteomic evidence indicates S. fumaroxidans mainly uses formate
+    for electron release during syntrophic growth.
+  evidence:
+  - reference: PMID:29611893
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: S. fumaroxidans mainly used formate for electron release
+    explanation: Anchors formate as the dominant electron-release carrier in syntrophic
+      propionate oxidation.
+- preferred_term: dihydrogen
+  chebi_term:
+    id: CHEBI:18276
+    label: dihydrogen
+  relevance: Hydrogen (dihydrogen) is the second interspecies electron carrier in this
+    consortium. The partner methanogen consumes the hydrogen released by S. fumaroxidans,
+    making propionate oxidation thermodynamically feasible.
+  evidence:
+  - reference: doi:10.1099/00207713-48-4-1383
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: It oxidized propionate syntrophically in co-culture with the hydrogen- and
+      formate-utilizing
+    explanation: Establishes hydrogen as an interspecies electron carrier consumed by the
+      syntrophic methanogenic partner.
 metals_present:
 - IRON
 metal_relevance: SIGNIFICANT

--- a/kb/communities/Syntrophobacter_Methanospirillum_Syntrophy.yaml
+++ b/kb/communities/Syntrophobacter_Methanospirillum_Syntrophy.yaml
@@ -225,6 +225,50 @@ environmental_factors:
     snippet: A syntrophic propionate-oxidizing bacterium, strain MPOBT, was isolated from a culture enriched
       from anaerobic granular sludge
     explanation: Establishes ecological origin and relevance to anaerobic waste treatment processes
+related_ingredients:
+- preferred_term: propionate
+  chebi_term:
+    id: CHEBI:17272
+    label: propionate
+  relevance: Central growth substrate of the consortium; Syntrophobacter fumaroxidans
+    oxidizes propionate to acetate via the methylmalonyl-CoA pathway, a reaction that
+    is thermodynamically feasible only when its H2/formate products are consumed by
+    the methanogenic partner.
+  evidence:
+  - reference: PMID:9828440
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: A syntrophic propionate-oxidizing bacterium, strain MPOBT, was isolated from a
+    explanation: Identifies propionate as the defining oxidizable substrate of strain
+      MPOBT (S. fumaroxidans), the primary degrader of the consortium.
+- preferred_term: dihydrogen
+  chebi_term:
+    id: CHEBI:18276
+    label: dihydrogen
+  relevance: One of the two interspecies electron-transfer carriers produced by S.
+    fumaroxidans during propionate oxidation and consumed by the hydrogen-utilizing
+    methanogen M. hungatei; its low partial pressure is essential for syntrophy.
+  evidence:
+  - reference: PMID:29611893
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Special attention was put on the role of hydrogen and formate in
+    explanation: Anchors hydrogen (dihydrogen) as a focal electron carrier in interspecies
+      electron transfer during syntrophic propionate degradation.
+- preferred_term: formate
+  chebi_term:
+    id: CHEBI:15740
+    label: formate
+  relevance: The preferential interspecies electron carrier produced by S. fumaroxidans
+    and consumed by M. hungatei; formate transfer relieves the thermodynamic constraint
+    on propionate oxidation alongside H2.
+  evidence:
+  - reference: PMID:29611893
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: formate for electron release and that different confurcating mechanisms were
+    explanation: Identifies formate as the main electron-release carrier used by S.
+      fumaroxidans, central to interspecies electron transfer.
 metals_present:
 - IRON
 metal_relevance: SIGNIFICANT

--- a/kb/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.yaml
+++ b/kb/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.yaml
@@ -302,6 +302,51 @@ external_resources:
   resource_id: NCBITaxon:39152
   url: https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=39152
   description: NCBI Taxonomy record for Methanococcus maripaludis.
+related_ingredients:
+- preferred_term: butyrate
+  chebi_term:
+    id: CHEBI:17968
+    label: butyrate
+  relevance: >
+    Butyrate is the central growth substrate of the coculture; its syntrophic
+    beta-oxidation by S. wolfei drives the entire system.
+  evidence:
+  - reference: PMID:34603271
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: butyrate-oxidizing bacteria and methanogens
+    explanation: Anchors butyrate as the substrate oxidized by the bacterial partner.
+  - reference: doi:10.1038/s41598-018-30745-7
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: syntrophic oxidation of butyrate
+    explanation: Anchors butyrate as the substrate oxidized in the defined coculture.
+- preferred_term: dihydrogen
+  chebi_term:
+    id: CHEBI:18276
+    label: dihydrogen
+  relevance: >
+    Hydrogen is the interspecies electron-carrier intermediate transferred from
+    the butyrate-oxidizing syntroph to the hydrogenotrophic methanogen.
+  evidence:
+  - reference: PMID:34603271
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: hydrogenotrophic methanogens
+    explanation: Anchors dihydrogen as the electron donor consumed by the hydrogenotrophic methanogenic partner.
+- preferred_term: methane
+  chebi_term:
+    id: CHEBI:16183
+    label: methane
+  relevance: >
+    Methane is the terminal product of the coculture, produced by the
+    hydrogenotrophic methanogen during syntrophic butyrate conversion.
+  evidence:
+  - reference: doi:10.1038/s41598-018-30745-7
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: CH4production was significantly accelerated by carbon nanotubes
+    explanation: Anchors methane (CH4) as the gaseous product of syntrophic butyrate oxidation.
 associated_datasets: []
 metals_present: []
 rare_earth_elements_present: []

--- a/kb/communities/Syntrophomonas_Methanospirillum_Syntrophy.yaml
+++ b/kb/communities/Syntrophomonas_Methanospirillum_Syntrophy.yaml
@@ -195,6 +195,48 @@ environmental_factors:
     evidence_source: IN_VITRO
     snippet: The most rapid generation time obtained by cocultures of S
     explanation: Quantifies growth rate of the syntrophic consortium
+related_ingredients:
+- preferred_term: butyrate
+  chebi_term:
+    id: CHEBI:17968
+    label: butyrate
+  relevance: Central growth substrate. Syntrophomonas wolfei β-oxidizes butyrate to acetate,
+    using protons as the electron acceptor and releasing H2; this is the entry-point substrate
+    that drives the entire syntrophic consortium.
+  evidence:
+  - reference: PMID:16345745
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: (butyrate through octanoate) to acetate or acetate and propionate using protons
+    explanation: Snippet names butyrate explicitly as the saturated fatty acid substrate β-oxidized
+      by S. wolfei, anchoring it as the central substrate of the consortium.
+- preferred_term: acetate
+  chebi_term:
+    id: CHEBI:30089
+    label: acetate
+  relevance: Primary oxidation product. Acetate is produced from butyrate β-oxidation by S. wolfei
+    and is the major reduced-carbon end product released by the fatty-acid-oxidizing partner.
+  evidence:
+  - reference: PMID:16345745
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: (butyrate through octanoate) to acetate or acetate and propionate using protons
+    explanation: Snippet names acetate as the direct product of fatty-acid β-oxidation, anchoring it
+      as a central intermediate/product of the consortium.
+- preferred_term: dihydrogen
+  chebi_term:
+    id: CHEBI:18276
+    label: dihydrogen
+  relevance: Interspecies electron carrier. H2 is the electron sink product of S. wolfei butyrate
+    oxidation and the substrate consumed by M. hungatei; its removal via interspecies hydrogen transfer
+    is thermodynamically essential to the syntrophy.
+  evidence:
+  - reference: PMID:16345745
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: as the electron acceptor (H(2) as electron sink product)
+    explanation: Snippet names H2 as the electron sink product of S. wolfei metabolism, anchoring
+      dihydrogen as the central interspecies electron carrier.
 metals_present:
 - IRON
 metal_relevance: SIGNIFICANT


### PR DESCRIPTION
Starts the **syntrophy/methanogenesis** arm of the #30 `related_ingredients` backfill. This cohort backfilled **richly** — all entries are specific named compounds (no broad-class fallbacks).

Every CHEBI id **verified live against the ChEBI sqlite db via OAK**; snippets copied **verbatim** from cached PMID/DOI abstracts.

`related_ingredients` adoption: **46/265 → 56/265**.

## Communities (10)

| Community | Ingredients (CHEBI-verified) |
|---|---|
| Syntrophobacter_Methanobacterium_Syntrophy | propionate, formate, dihydrogen |
| Syntrophobacter_Methanospirillum_Syntrophy | propionate, dihydrogen, formate |
| Syntrophomonas_Methanospirillum_Syntrophy | butyrate, acetate, dihydrogen |
| Syntrophomonas_Methanococcus_Butyrate_Coculture | butyrate, dihydrogen, methane |
| Pelotomaculum_Methanothermobacter_Syntrophy | propionate |
| Pelotomaculum_Methanocella_Propionate_RNASeq | propionate, formate, dihydrogen, methane |
| Desulfovibrio_Methanococcus_Syntrophy | lactate, dihydrogen |
| Desulfovibrio_Methanosarcina_Lactate_Syntrophy | lactate, acetate, dihydrogen, methane |
| Geobacter_Methanosaeta_DIET | ethanol, carbon dioxide, methane |
| Geobacter_Methanosarcina_DIET | ethanol, acetate, methane, carbon dioxide |

Compounds were **dropped (not invented)** where the cited+cached abstract had no verbatim mention.

## ⚠️ Pre-existing CHEBI bugs flagged (out of scope, `growth_media` this time)
`Syntrophomonas_Methanospirillum` (`CHEBI:88613` sodium butyrate → a PI lipid; `CHEBI:87157` sodium sulfide → a morpholine; `CHEBI:32447` L-cysteine HCl → L-cysteinyl group; `CHEBI:48953` resazurin → cyclohexenones) and both Geobacter DIET files (`CHEBI:35235` L-cysteine → zwitterion; `CHEBI:85357` sodium sulfide → unrelated). Added to the running cleanup list.

## Test plan
- `just test` → 136 passed, 9 skipped
- All 10 files validate clean (`linkml-validate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)