### PR TITLE
#30 backfill: electroactive/MFC peripheral set (4 communities)

### DIFF
--- a/kb/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.yaml
+++ b/kb/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.yaml
@@ -285,6 +285,55 @@ growth_media:
     evidence_source: IN_VITRO
     snippet: from 1 g/L carboxymethyl cellulose
     explanation: Supports the CMC concentration included in the medium summary.
+related_ingredients:
+- preferred_term: cellulose
+  chebi_term:
+    id: CHEBI:18246
+    label: (1->4)-beta-D-glucan
+  relevance: Central insoluble substrate of the coculture; C. cellulolyticum hydrolyzes and
+    ferments cellulose, providing the electron donor that ultimately drives anode respiration.
+  evidence:
+  - reference: PMID:17695929
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the conversion of cellulosic biomass to electricity requires a
+    explanation: Anchors cellulose as the central cellulosic substrate converted by the coculture.
+- preferred_term: acetate
+  chebi_term:
+    id: CHEBI:30089
+    label: acetate
+  relevance: Major fermentation product of C. cellulolyticum cellulose metabolism and a
+    cross-fed electron-donor substrate for G. sulfurreducens anode respiration.
+  evidence:
+  - reference: PMID:17695929
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Hydrogen, acetate, and ethanol were the main residual metabolites
+    explanation: Lists acetate among the main residual fermentation metabolites of the binary culture.
+- preferred_term: ethanol
+  chebi_term:
+    id: CHEBI:16236
+    label: ethanol
+  relevance: Fermentation product of cellulose metabolism by C. cellulolyticum, present as a
+    residual intermediate in the cellulose-fed coculture.
+  evidence:
+  - reference: PMID:17695929
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Hydrogen, acetate, and ethanol were the main residual metabolites
+    explanation: Lists ethanol among the main residual fermentation metabolites of the binary culture.
+- preferred_term: dihydrogen
+  chebi_term:
+    id: CHEBI:18276
+    label: dihydrogen
+  relevance: Hydrogen is a primary fermentation product of cellulose catabolism by C.
+    cellulolyticum and a cross-fed reductant in the coculture's metabolic exchange.
+  evidence:
+  - reference: PMID:17695929
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Hydrogen, acetate, and ethanol were the main residual metabolites
+    explanation: The abstract names hydrogen (dihydrogen) as a main residual fermentation metabolite.
 external_resources:
 - name: Exact-system primary publication - cellulose-to-electricity binary MFC coculture
   repository: OTHER

--- a/kb/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.yaml
+++ b/kb/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.yaml
@@ -365,6 +365,45 @@ external_resources:
   resource_id: doi:10.25345/C5H85T
   url: https://doi.org/10.25345/C5H85T
   description: Dataset DOI for raw metaproteomics mass spectra.
+related_ingredients:
+- preferred_term: lignocellulose
+  chebi_term:
+    id: CHEBI:180683
+    label: lignocellulose
+  relevance: Switchgrass lignocellulose is the central substrate the microbiome
+    deconstructs and utilizes at increasing high-solids loadings.
+  evidence:
+  - reference: PMID:35790765
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: lignocellulose at high solids
+    explanation: Names lignocellulose as the substrate the microbiome deconstructs and
+      utilizes at high solids, anchoring it as the central feedstock.
+- preferred_term: dihydrogen
+  chebi_term:
+    id: CHEBI:18276
+    label: dihydrogen
+  relevance: Hydrogen is the key fermentation-derived intermediate consumed by the
+    hydrogenotrophic methanogenesis pathway that dominates at high solids.
+  evidence:
+  - reference: PMID:35790765
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: all hydrogenotrophic methanogenesis pathway enzymes
+    explanation: Detection of all hydrogenotrophic methanogenesis pathway enzymes anchors
+      H2 as the central electron-donor intermediate for archaeal methane formation.
+- preferred_term: methane
+  chebi_term:
+    id: CHEBI:16183
+    label: methane
+  relevance: Methane is the main steady-state product of this methanogenic microbiome.
+  evidence:
+  - reference: PMID:35790765
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The main products observed were methane
+    explanation: Identifies methane as a main observed reactor product, anchoring it as the
+      central end-product of the community.
 metals_present: []
 rare_earth_elements_present: []
 metal_relevance: NOT_APPLICABLE

--- a/kb/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.yaml
+++ b/kb/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.yaml
@@ -267,6 +267,46 @@ external_resources:
     evidence_source: IN_VITRO
     snippet: M. marinum S8 excreted acetate
     explanation: Supports the primary article as the source for this curated community.
+related_ingredients:
+- preferred_term: methane
+  chebi_term:
+    id: CHEBI:16183
+    label: methane
+  relevance: Methane is the sole carbon and energy input oxidized by the methanotroph M.
+    marinum S8, driving the entire cross-feeding system.
+  evidence:
+  - reference: doi:10.1093/bbb/zbab150
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Methane-oxidizing bacteria (methanotrophs) often coexist with methylotrophs that
+      utilize methanol excreted by methanotrophs
+    explanation: Anchors methane as the substrate oxidized by methanotrophs such as M. marinum
+      S8.
+- preferred_term: acetate
+  chebi_term:
+    id: CHEBI:30089
+    label: acetate
+  relevance: Acetate is the methane-derived intermediate excreted by M. marinum S8 and the
+    likely cross-fed carbon source supporting the non-methylotrophic partner.
+  evidence:
+  - reference: doi:10.1093/bbb/zbab150
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: M. marinum S8 excreted acetate during the exponential growth phase
+    explanation: Anchors acetate as the compound excreted by M. marinum S8 during growth.
+- preferred_term: methanol
+  chebi_term:
+    id: CHEBI:17790
+    label: methanol
+  relevance: Methanol is the classical methanotroph-excreted intermediate against which this
+    system contrasts a methanol-independent, acetate-based cross-feeding route.
+  evidence:
+  - reference: doi:10.1093/bbb/zbab150
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: possibly utilizes acetate rather than methanol
+    explanation: Anchors methanol as the alternative intermediate distinguished from acetate
+      in this cross-feeding system.
 metals_present: []
 rare_earth_elements_present: []
 metal_relevance: NOT_APPLICABLE

--- a/kb/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.yaml
+++ b/kb/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.yaml
@@ -328,6 +328,52 @@ external_resources:
     evidence_source: OTHER
     snippet: Iron acts as both a source and sink of electrons for microorganisms in the environment
     explanation: Supports the primary publication context linked by this DOE highlight.
+related_ingredients:
+- preferred_term: magnetite
+  chebi_term:
+    id: CHEBI:46726
+    label: magnetite
+  relevance: >
+    Magnetite (Fe3O4) nanoparticles are the central shared mineral substrate that
+    acts as a recyclable electron donor and acceptor, allowing electron exchange
+    between the phototrophic Fe(II)-oxidizer and the anaerobic Fe(III)-reducer.
+  evidence:
+  - reference: PMID:25814583
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: oxidizes magnetite (Fe3O4) nanoparticles using light energy
+    explanation: Names magnetite (Fe3O4) nanoparticles as the mineral substrate being redox-cycled.
+  - reference: PMID:25814583
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: effectively rendering magnetite a naturally occurring battery
+    explanation: Anchors magnetite as the central electron-storage compound of the coculture.
+- preferred_term: iron(2+)
+  chebi_term:
+    id: CHEBI:29033
+    label: iron(2+)
+  relevance: >
+    Fe(II) is the reduced iron pool in magnetite that R. palustris TIE-1 oxidizes
+    phototrophically, serving as the electron-donor side of the shared mineral redox cycle.
+  evidence:
+  - reference: doi:10.1126/science.aaa4834
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: phototrophic bacteria can use reduced Fe(II) as an electron donor
+    explanation: Anchors Fe(II) as the reduced iron pool used as an electron donor by the phototroph.
+- preferred_term: iron(3+)
+  chebi_term:
+    id: CHEBI:29034
+    label: iron(3+)
+  relevance: >
+    Fe(III) is the oxidized iron pool in magnetite that G. sulfurreducens reduces
+    anaerobically, serving as the electron-acceptor side of the shared mineral redox cycle.
+  evidence:
+  - reference: doi:10.1126/science.aaa4834
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Some anaerobic bacteria use oxidized Fe(III) as an electron acceptor
+    explanation: Anchors Fe(III) as the oxidized iron pool used as an electron acceptor by the iron-reducer.
 metals_present:
 - IRON
 rare_earth_elements_present: []


### PR DESCRIPTION
Closes the electroactive/MFC tail of the syntrophy/methanogenesis work (follows #94/#95). CHEBI ids **verified live via OAK**; snippets **verbatim** from cached abstracts.

`related_ingredients` adoption: **65/265 → 69/265**.

| Community | Ingredients (CHEBI-verified) |
|---|---|
| Rhodopseudomonas_Geobacter_Magnetite_Redox | magnetite, iron(2+), iron(3+) |
| Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC | cellulose [(1->4)-beta-D-glucan], acetate, ethanol, dihydrogen |
| Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding | methane, acetate, methanol |
| High_Solids_Switchgrass_Methanogenic_Microbiome | lignocellulose, dihydrogen, methane |

`Shewanella_Geobacter_Exoelectrogenic_Biofilm` left unchanged — its one cached reference names only generic "organic substrates", nothing verbatim-supportable.

## ⚠️ Pre-existing CHEBI label issues flagged (out of scope)
`CHEBI:18246` is labeled "cellulose" in several files but its canonical label is "(1->4)-beta-D-glucan"; `CHEBI:37686` "xylan" is *alpha-D-allose*; `CHEBI:50821` "iron(II,III) oxide" canonical label is "ferrosoferric oxide". Added to the running cleanup list.

## Test plan
- `just test` → 136 passed, 9 skipped
- All 4 files validate clean (`linkml-validate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)