### PR TITLE
#30 backfill: metals stragglers (6 communities)

### DIFF
--- a/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
+++ b/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
@@ -360,6 +360,72 @@ associated_datasets:
 
       '
     explanation: Documents the metagenome sequencing and MAG reconstruction from EFPC sediment
+related_ingredients:
+- preferred_term: inorganic mercury Hg(II)
+  chebi_term:
+    id: CHEBI:16793
+    label: mercury(2+)
+  relevance: 'Inorganic divalent mercury Hg(II) is the substrate that hgcAB+ community
+    members methylate to methylmercury. Chronic Hg contamination of EFPC sediment selects
+    for this mercury-cycling community, making Hg(II) the central inorganic species
+    driving its metabolism.
+
+    '
+  evidence:
+  - reference: PMID:29636434
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: ranged from 2 to >50% of the added Hg(II)
+    explanation: Names Hg(II) (inorganic divalent mercury) verbatim as the substrate converted
+      to MeHg by hgcAB+ methanogens
+- preferred_term: methylmercury
+  chebi_term:
+    id: CHEBI:49747
+    label: methylmercury(1+)
+  relevance: 'Methylmercury (MeHg) is the toxic, bioaccumulating product of hgcAB-mediated
+    mercury methylation by this community. Its production is the central environmental
+    concern of the EFPC mercury-cycling system.
+
+    '
+  evidence:
+  - reference: PMID:29636434
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: where methylmercury production incurs risk
+    explanation: Names methylmercury verbatim as the product of methanogen-driven Hg methylation
+      posing ecological risk
+- preferred_term: sulfide
+  chebi_term:
+    id: CHEBI:26822
+    label: sulfide
+  relevance: 'Sulfide is a central biogeochemical control on mercury methylation in
+    this anoxic sediment community: it precipitates mercuric sulfides that reduce Hg(II)
+    bioavailability and inhibits MeHg production by hgcAB+ organisms.
+
+    '
+  evidence:
+  - reference: PMID:29636434
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: sulfide inhibited MeHg production
+    explanation: Names sulfide verbatim as an inhibitor of methylmercury production, anchoring
+      its role in mercury bioavailability
+- preferred_term: secondary alcohol
+  chebi_term:
+    id: CHEBI:35681
+    label: secondary alcohol
+  relevance: 'Secondary alcohols serve as electron donors for CO2 reduction by hgcAB+
+    methanogens such as Methanocorpusculum bavaricum, a mercury-methylating member of
+    this community, linking electron-donor metabolism to Hg methylation.
+
+    '
+  evidence:
+  - reference: PMID:29636434
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: it can utilize secondary alcohols as electron donors to reduce CO2
+    explanation: Names secondary alcohols verbatim as electron donors used by an hgcAB+ methanogen
+      in this community
 metals_present: []
 metal_relevance: SIGNIFICANT
 metal_notes: Metal/REE detected via environmental factor measurements

--- a/kb/communities/Mixed_Gallium_LED_Recovery_Consortium.yaml
+++ b/kb/communities/Mixed_Gallium_LED_Recovery_Consortium.yaml
@@ -493,6 +493,23 @@ environmental_factors:
     snippet: Results showed the significant promotion by bioelectricity on ammonium and total nitrogen
       by 7.80-8.14 %
     explanation: Documents recent publication and research advancement
+related_ingredients:
+- preferred_term: gallium(3+)
+  chebi_term:
+    id: CHEBI:84043
+    label: gallium(3+)
+  relevance: Gallium is the central target metal of this consortium; the engineered acidophilic
+    community produces biogenic lixiviants specifically to solubilize gallium (as Ga3+) from
+    GaN-based waste LED materials, the defining objective of the system.
+  evidence:
+  - reference: doi:10.1016/j.jece.2025.120403
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: gallium recovery from waste LEDs via biogenic lixiviants produced by mixed microbial
+      community
+    explanation: The cited title names gallium recovery from waste LEDs via biogenic lixiviants
+      produced by a mixed microbial community, directly anchoring gallium as the central compound
+      this consortium targets.
 metals_present:
 - COPPER
 - GALLIUM

--- a/kb/communities/Ngawha_Geothermal_Mercury_Cycling_Community.yaml
+++ b/kb/communities/Ngawha_Geothermal_Mercury_Cycling_Community.yaml
@@ -134,6 +134,61 @@ environmental_factors:
     snippet: acidic warm springs in the Ngawha Geothermal Field
     explanation: Supports the spring chemistry.
 growth_media: []
+related_ingredients:
+- preferred_term: mercury(2+)
+  chebi_term:
+    id: CHEBI:16793
+    label: mercury(2+)
+  relevance: Divalent inorganic mercury, Hg(II), is the substrate the community
+    reduces to volatile elemental mercury and is central to the curated mercury
+    cycle.
+  evidence:
+  - reference: PMID:32414793
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Hg(II) reduction to volatile Hg(0)
+    explanation: Names Hg(II) (mercury(2+)) as the reduced substrate in the
+      community's mercury cycle.
+- preferred_term: mercury(0)
+  chebi_term:
+    id: CHEBI:16170
+    label: mercury(0)
+  relevance: Volatile elemental mercury, Hg(0), is the product of microbial
+    Hg(II) reduction and the form emitted from these geothermal springs.
+  evidence:
+  - reference: PMID:32414793
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Hg(II) reduction to volatile Hg(0)
+    explanation: Names volatile Hg(0) (mercury(0)) as the product of microbial
+      mercury reduction.
+- preferred_term: methylmercury(1+)
+  chebi_term:
+    id: CHEBI:49747
+    label: methylmercury(1+)
+  relevance: Methylated mercury is produced and demethylated by the community and
+    reaches among the highest concentrations reported from natural sources.
+  evidence:
+  - reference: PMID:32414793
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: methylated mercury concentrations in two adjacent springs
+    explanation: Anchors methylated mercury (methylmercury) as a central measured
+      mercury species in the springs.
+- preferred_term: sulfur atom
+  chebi_term:
+    id: CHEBI:26833
+    label: sulfur atom
+  relevance: Sulfur biogeochemistry is coupled to mercury cycling in the springs,
+    with sulfur-cycling bacteria dominating and sulfur cycles interconnected with
+    mercury.
+  evidence:
+  - reference: PMID:32414793
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: community dynamics and sulfur and iron
+    explanation: Anchors sulfur as a central element whose cycling couples to
+      geothermal mercury cycling.
 external_resources:
 - name: Primary publication for the Ngawha Hg-cycling community
   repository: OTHER

--- a/kb/communities/Polaromonas_Vanadium_Reduction_Community.yaml
+++ b/kb/communities/Polaromonas_Vanadium_Reduction_Community.yaml
@@ -598,6 +598,35 @@ environmental_factors:
     snippet: Further, VV-reducing enrichments indicated that bacteria associated with Polaromonas, a genus
       belonging to the family Burkholderiaceae, were potentially responsible for VV reduction
     explanation: Quantifies sulfate availability for sulfate reduction
+related_ingredients:
+- preferred_term: vanadate
+  chebi_term:
+    id: CHEBI:46442
+    label: vanadate(3-)
+  relevance: Vanadate [V(V)] is the central soluble, toxic electron acceptor that this
+    community reduces; its dissimilatory reduction to V(IV) is the defining metabolic
+    process and the basis for vanadium detoxification and immobilization.
+  evidence:
+  - reference: PMID:33125214
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Microorganisms can reduce the more toxic and mobile VV
+    explanation: Identifies V(V)/vanadate as the toxic, mobile vanadium species reduced
+      by the community, anchoring vanadate as the central electron acceptor.
+- preferred_term: vanadyl cation
+  chebi_term:
+    id: CHEBI:30046
+    label: oxidovanadium(2+)
+  relevance: Vanadyl [V(IV), VO2+] is the central reduction product of microbial V(V)
+    reduction; its low solubility immobilizes vanadium, making it the key end-product
+    of the community's detoxification mechanism.
+  evidence:
+  - reference: PMID:33125214
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the less toxic and immobile VIV
+    explanation: Identifies V(IV)/vanadyl as the less toxic, immobile product of reduction,
+      anchoring oxidovanadium(2+) as the central reduction end-product.
 metals_present:
 - CHROMIUM
 - IRON

--- a/kb/communities/Salar_Atacama_Lithium_Brine_Community.yaml
+++ b/kb/communities/Salar_Atacama_Lithium_Brine_Community.yaml
@@ -504,6 +504,77 @@ environmental_factors:
     evidence_source: IN_VIVO
     snippet: dominated by microorganisms; however, little is known about the microbes present in the brines associated with this economically important mining process
     explanation: Documents salar size and status as largest lithium reserve
+related_ingredients:
+- preferred_term: lithium chloride
+  chebi_term:
+    id: CHEBI:48607
+    label: lithium chloride
+  relevance: LiCl is the dominant solute defining this community's environment; the concentrated
+    brines are among the most saline environments known and are dominated by LiCl, reaching 11.7 M
+    in the industrial brine. Lithium chloride is the central chaotropic stressor that shapes community
+    composition and selects for the resident halophilic archaea and bacteria.
+  evidence:
+  - reference: doi:10.1029/2018JG004621
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: The concentrated lithium brines of the Salar de Atacama represent one of the most saline
+      environments described to date (dominated by LiCl)
+    explanation: Names LiCl verbatim as the dominant solute of the concentrated Atacama brines.
+  - reference: PMID:31354691
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: one of the most hypersaline lithium-dominated man-made environments (total salinity 556
+      g/L; 11.7 M LiCl) reported to date
+    explanation: Quantifies LiCl concentration (11.7 M) verbatim, anchoring lithium chloride as the
+      defining brine solute.
+- preferred_term: lithium(1+)
+  chebi_term:
+    id: CHEBI:49713
+    label: lithium(1+)
+  relevance: Lithium ion is the key environmental modulator of this community, acting as a selective
+    pressure that increases bacterial diversity and decreases archaeal diversity as its concentration
+    rises during industrial processing. The natural brine carries one of the highest natural lithium
+    concentrations on Earth (1,500 ppm).
+  evidence:
+  - reference: doi:10.1029/2018JG004621
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Here we study lithium as a modulator of microbial richness and diversity in brines
+    explanation: Anchors lithium itself verbatim as the modulator of community richness and diversity.
+- preferred_term: sodium chloride
+  chebi_term:
+    id: CHEBI:26710
+    label: sodium chloride
+  relevance: NaCl is the baseline hypersaline solute against which this community is contrasted; the
+    resident taxa are phylogenetically differentiated from organisms adapted to high-NaCl environments,
+    highlighting that Atacama brine life copes with salts extending beyond NaCl.
+  evidence:
+  - reference: doi:10.1029/2018JG004621
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: extremely high concentrations of salts that extend beyond that of NaCl, a far more commonly
+      studied salt
+    explanation: Names NaCl verbatim as the reference salt contrasted with the LiCl-dominated brine.
+  - reference: PMID:31354691
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: phylogenetically differentiated from those Bacillus associated with high NaCl concentration
+      environments
+    explanation: Anchors NaCl verbatim, distinguishing Atacama isolates from typical high-NaCl halophiles.
+- preferred_term: magnesium dichloride
+  chebi_term:
+    id: CHEBI:6636
+    label: magnesium dichloride
+  relevance: MgCl2 is the previously recognized chaotropic salt that defined the upper limit of the
+    "window of life"; this community extends that window beyond MgCl2 to LiCl, making MgCl2 a key
+    comparator for the chaotropic-stress biology of the Atacama brine.
+  evidence:
+  - reference: PMID:31354691
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: our work extends the window of life beyond high concentrations of MgCl2, as previously
+      reported, to LiCl
+    explanation: Names MgCl2 verbatim as the prior chaotropic limit of life, contextualizing the brine's solutes.
 metals_present:
 - IRON
 - LITHIUM

--- a/kb/communities/Thermophilic_Pyrite_QS_Consortium.yaml
+++ b/kb/communities/Thermophilic_Pyrite_QS_Consortium.yaml
@@ -846,6 +846,70 @@ environmental_factors:
       termed diffusible signal factors (DSF), reduced pyrite and chalcopyrite dissolution via an inhibitory
       effect on iron oxidation and mineral colonization by the mixed culture
     explanation: Documents aerobic cultivation with continuous agitation
+related_ingredients:
+- preferred_term: pyrite
+  chebi_term:
+    id: CHEBI:86471
+    label: pyrite
+  relevance: Pyrite (FeS2) is the primary sulfide mineral substrate and energy source for the consortium;
+    its dissolution is the central readout for quorum sensing effects and the substrate on which DSF
+    signaling is produced.
+  evidence:
+  - reference: doi:10.3389/fmicb.2025.1592588
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: reduced pyrite and chalcopyrite dissolution via an inhibitory effect on iron oxidation and
+      mineral colonization by the mixed culture
+    explanation: Names pyrite as the mineral substrate whose dissolution is modulated by QS compounds
+  - reference: doi:10.1038/s41598-021-95324-9
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: produces (Z)-11-methyl-2-dodecenoic acid when grown with pyrite as energy source
+    explanation: Anchors pyrite as the energy source enabling DSF quorum sensing signal production
+- preferred_term: chalcopyrite
+  chebi_term:
+    id: CHEBI:86202
+    label: chalcopyrite
+  relevance: Chalcopyrite (CuFeS2) is the second target mineral substrate; QS-mediated changes in iron
+    oxidation and colonization decrease its bioleaching, the practical endpoint of interest.
+  evidence:
+  - reference: doi:10.3389/fmicb.2025.1592588
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: reduced pyrite and chalcopyrite dissolution via an inhibitory effect on iron oxidation and
+      mineral colonization by the mixed culture
+    explanation: Names chalcopyrite as the mineral substrate whose dissolution is reduced by DSF treatment
+- preferred_term: iron(2+)
+  chebi_term:
+    id: CHEBI:29033
+    label: iron(2+)
+  relevance: Ferrous iron [Fe(II)] released from sulfide mineral dissolution is the central electron
+    donor oxidized by L. ferriphilum and S. thermosulfidooxidans; QS inhibition of iron oxidation is
+    the mechanism reducing leaching.
+  evidence:
+  - reference: doi:10.1038/s41598-021-95324-9
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: oxidation of iron(II)-ions and inorganic sulfur compounds
+    explanation: Identifies iron(II) as the substrate whose oxidation drives metal sulfide dissolution
+  - reference: doi:10.1038/s41598-021-95324-9
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: effective primary mineral colonizers and oxidize iron(II)-ions efficiently
+    explanation: Anchors iron(II) as the energy substrate central to Leptospirillum mineral colonization
+- preferred_term: cis-11-Methyl-2-dodecenoic acid
+  chebi_term:
+    id: CHEBI:81585
+    label: cis-11-Methyl-2-dodecenoic acid
+  relevance: (Z)-11-methyl-2-dodecenoic acid is the diffusible signal factor (DSF) quorum sensing molecule
+    produced by Leptospirillum on pyrite; it is the central signal coordinating consortium behavior and
+    modulating bioleaching.
+  evidence:
+  - reference: doi:10.1038/s41598-021-95324-9
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: produces (Z)-11-methyl-2-dodecenoic acid when grown with pyrite as energy source
+    explanation: Names the DSF compound produced by the iron-oxidizing member as the QS signal of the system
 metals_present:
 - COPPER
 - IRON


### PR DESCRIPTION
Closes the metals-cohort tail (gallium / vanadium / lithium / pyrite-QS / mercury×2). CHEBI ids **verified live via OAK**; snippets **verbatim** from cached abstracts.

`related_ingredients` adoption: **80/265 → 86/265**.

| Community | Ingredients (CHEBI-verified) |
|---|---|
| Mixed_Gallium_LED_Recovery_Consortium | gallium(3+) |
| Polaromonas_Vanadium_Reduction_Community | vanadate(3-), oxidovanadium(2+) |
| Salar_Atacama_Lithium_Brine_Community | lithium chloride, lithium(1+), sodium chloride, magnesium dichloride |
| Thermophilic_Pyrite_QS_Consortium | pyrite, chalcopyrite, iron(2+), cis-11-Methyl-2-dodecenoic acid (DSF) |
| Mercury_SFA_EFPC_Sediment_Community | mercury(2+), methylmercury(1+), sulfide, secondary alcohol |
| Ngawha_Geothermal_Mercury_Cycling_Community | mercury(2+), mercury(0), methylmercury(1+), sulfur atom |

`Mixed_Gallium` got only 1 ingredient — its sole reference has no cached abstract body (title only). It also has pre-existing **fabricated snippets** unrelated to gallium (constructed wetlands / PFOA / denitrification text) — flagged for a separate evidence-repair pass.

## Notes
Pre-existing CHEBI bugs flagged by the agents in these files' `metabolites` blocks overlap with fixes already in the CHEBI-cleanup PR (#98) and will be corrected when that merges. **New finding:** vanadyl cation `CHEBI:30320` (left unmapped in #98) has a valid id `CHEBI:30046` (oxidovanadium(2+)) — worth folding into a CHEBI-cleanup follow-up.

## Test plan
- `just test` → 136 passed, 9 skipped
- All 6 files validate clean (`linkml-validate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)