### PR TITLE
#30 backfill: re-fetch stub abstracts; unblock Thalassiosira_Ruegeria (+4)

### DIFF
--- a/kb/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.yaml
+++ b/kb/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.yaml
@@ -225,6 +225,63 @@ growth_media:
     evidence_source: IN_VITRO
     snippet: bacteria pre-grown in YTSS medium were washed five times in sterile L1 medium and inoculated into three replicate diatom cultures
     explanation: Supports bacterial preparation and coculture inoculation conditions.
+related_ingredients:
+- preferred_term: dimethylsulfoniopropionate
+  chebi_term:
+    id: CHEBI:16457
+    label: S,S-dimethyl-beta-propiothetin
+  relevance: DMSP is a phytoplankton-derived organic sulfur compound taken up by the
+    heterotrophic bacterial partner, a central currency of diatom-to-roseobacter
+    metabolite transfer in this phycosphere coculture.
+  evidence:
+  - reference: PMID:33097854
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: compounds (including dihydroxypropanesulfonate and dimethysulfoniopropionate)
+    explanation: Names dimethylsulfoniopropionate (DMSP, CHEBI:16457) among the organic
+      sulfur exometabolites with evidence of bacterial uptake in the diatom coculture.
+- preferred_term: N-acetyl-D-glucosamine
+  chebi_term:
+    id: CHEBI:506227
+    label: N-acetyl-D-glucosamine
+  relevance: A diatom-derived polysaccharide component (chitin monomer) predicted to
+    be used by all three co-cultured bacteria, marking it as a central shared
+    substrate exchanged in the phycosphere.
+  evidence:
+  - reference: PMID:33097854
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: N-acetyl-D-glucosamine were predicted to be used by all three
+    explanation: Names N-acetyl-D-glucosamine as one of the metabolites predicted to
+      be used by all three diatom-associated bacteria, anchoring this compound.
+- preferred_term: proline
+  chebi_term:
+    id: CHEBI:26271
+    label: proline
+  relevance: Proline is a diatom-derived amino acid predicted to be used by all three
+    co-cultured bacteria, a central nitrogen-containing exometabolite of the
+    phycosphere exchange.
+  evidence:
+  - reference: PMID:33097854
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: only guanosine, proline, and
+    explanation: Names proline among the metabolites predicted to be used by all three
+      bacterial partners co-cultured with the diatom.
+- preferred_term: guanosine
+  chebi_term:
+    id: CHEBI:16750
+    label: guanosine
+  relevance: Guanosine is a diatom-derived nucleoside predicted to be used by all three
+    co-cultured bacteria, a central nitrogen-rich exometabolite shared across the
+    phycosphere community.
+  evidence:
+  - reference: PMID:33097854
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: only guanosine, proline, and
+    explanation: Names guanosine among the metabolites predicted to be used by all
+      three bacterial partners co-cultured with the diatom.
 associated_datasets:
 - name: Exact-composition publication - Thalassiosira-Ruegeria recognition cascade
   dataset_type: PHENOTYPE

--- a/references_cache/PMID_33097854.md
+++ b/references_cache/PMID_33097854.md
@@ -12,6 +12,10 @@ Identifiers:
 Cached source notes:
 - Follow-up pairwise coculture source including Thalassiosira pseudonana as the sole substrate source for Ruegeria pomeroyi DSS-3.
 - Used for exact-composition publication listing, medium and inoculation conditions, RNA-seq BioProject, and MetaboLights metabolomics accessions.
+- Full abstract backfilled below from PubMed (replaces earlier snippet-only stub).
+
+Abstract:
+The communities of bacteria that assemble around marine microphytoplankton are predictably dominated by Rhodobacterales, Flavobacteriales, and families within the Gammaproteobacteria. Yet whether this consistent ecological pattern reflects the result of resource-based niche partitioning or resource competition requires better knowledge of the metabolites linking microbial autotrophs and heterotrophs in the surface ocean. We characterized molecules targeted for uptake by three heterotrophic bacteria individually co-cultured with a marine diatom using two strategies that vetted the exometabolite pool for biological relevance by means of bacterial activity assays: expression of diagnostic genes and net drawdown of exometabolites, the latter detected with mass spectrometry and nuclear magnetic resonance using novel sample preparation approaches. Of the more than 36 organic molecules with evidence of bacterial uptake, 53% contained nitrogen (including nucleosides and amino acids), 11% were organic sulfur compounds (including dihydroxypropanesulfonate and dimethysulfoniopropionate), and 28% were components of polysaccharides (including chrysolaminarin, chitin, and alginate). Overlap in phytoplankton-derived metabolite use by bacteria in the absence of competition was low, and only guanosine, proline, and N-acetyl-D-glucosamine were predicted to be used by all three. Exometabolite uptake pattern points to a key role for ecological resource partitioning in the assembly marine bacterial communities transforming recent photosynthate.
 
 Key snippets used in curated records:
 - "Pairwise co-culture systems were established with the diatom Thalassiosira pseudonana as the sole source of substrates for Ruegeria pomeroyi DSS-3"

--- a/references_cache/pmid_24723722.txt
+++ b/references_cache/pmid_24723722.txt
@@ -1,0 +1,18 @@
+1. Genome Announc. 2014 Apr 10;2(2):e00287-14. doi: 10.1128/genomeA.00287-14.
+
+Draft genome sequences of the altered schaedler flora, a defined bacterial 
+community from gnotobiotic mice.
+
+Wannemuehler MJ(1), Overstreet AM, Ward DV, Phillips GJ.
+
+Author information:
+(1)Department of Veterinary Microbiology and Preventive Medicine, College of 
+Veterinary Medicine, Iowa State University, Ames, Iowa, USA.
+
+The altered Schaedler flora (ASF) is a bacterial community that supports normal 
+growth and development of gnotobiotic mice. We report here the draft genome 
+sequences of the 8 bacteria that comprise the ASF.
+
+DOI: 10.1128/genomeA.00287-14
+PMCID: PMC3983311
+PMID: 24723722

--- a/references_cache/pmid_26323627.txt
+++ b/references_cache/pmid_26323627.txt
@@ -1,0 +1,61 @@
+1. ILAR J. 2015;56(2):169-78. doi: 10.1093/ilar/ilv012.
+
+The Altered Schaedler Flora: Continued Applications of a Defined Murine 
+Microbial Community.
+
+Wymore Brand M(1), Wannemuehler MJ(1), Phillips GJ(1), Proctor A(1), Overstreet 
+AM(1), Jergens AE(1), Orcutt RP(1), Fox JG(1).
+
+Author information:
+(1)Meghan Wymore Brand, DVM, is a graduate student in the Department of 
+Veterinary Microbiology and Preventive Medicine at the College of Veterinary 
+Medicine at Iowa State University in Ames, Iowa. Michael J. Wannemuehler, MS, 
+PhD, is Professor and Chair in the Department of Veterinary Microbiology and 
+Preventive Medicine at the College of Veterinary Medicine at Iowa State 
+University in Ames, Iowa. Gregory J. Phillips, MA, PhD, is a professor in the 
+Department of Veterinary Microbiology and Preventive Medicine at the College of 
+Veterinary Medicine at Iowa State University in Ames, Iowa. Alexandra Proctor is 
+a graduate student in the Department of Veterinary Microbiology and Preventive 
+Medicine at the College of Veterinary Medicine at Iowa State University in Ames, 
+Iowa. Anne-Marie Overstreet, PhD, is a postdoctoral fellow in the Department of 
+Microbiology and Immunology at Indiana University School of Medicine-South Bend 
+in South Bend, Indiana. Albert E. Jergens, DVM, MS, PhD, is Professor and 
+Associate Chair for Research and Graduate Studies in the Department of 
+Veterinary Clinical Sciences at the College of Veterinary Medicine at Iowa State 
+University in Ames, Iowa. Roger P. Orcutt, PhD, is a consultant at Biomedical 
+Research Associates in Dunkirk, New York. James G. Fox, MS, DVM, is Director of 
+the Division of Comparative Medicine and Professor in the Department of 
+Biological Engineering at Massachusetts Institute of Technology in Cambridge, 
+Massachusetts.
+
+The gastrointestinal (GI) microbiota forms a mutualistic relationship with the 
+host through complex and dynamic interactions. Because of the complexity and 
+interindividual variation of the GI microbiota, investigating how members of the 
+microbiota interact with each other, as well as with the host, is daunting. The 
+altered Schaedler flora (ASF) is a model community of eight microorganisms that 
+was developed by R.P. Orcutt and has been in use since the late 1970s. The eight 
+microorganisms composing the ASF were all derived from mice, can be cultured in 
+vitro, and are stably passed through multiple generations (at least 15 years or 
+more by the authors) in gnotobiotic mice continually bred in isolator 
+facilities. With the limitations associated with conventional, mono- or 
+biassociated, and germfree mice, use of mice colonized with a consortium of 
+known bacteria that naturally inhabit the murine gut offers a powerful system to 
+investigate mechanisms governing host-microbiota relationships, and how members 
+of the GI microbiota interact with one another. The ASF community offers 
+significant advantages to study homeostatic as well as disease-related 
+interactions by taking advantage of a well-defined, limited community of 
+microorganisms. For example, quantification and spatial distribution of 
+individual members, microbial genetic manipulation, genomic-scale analysis, and 
+identification of microorganism-specific host immune responses are all 
+achievable using the ASF model. This review compiles highlights associated with 
+the 37-year history of the ASF, including descriptions of its continued use in 
+biomedical research to elucidate the complexities of host-microbiome 
+interactions in health and disease.
+
+© The Author 2015. Published by Oxford University Press on behalf of the 
+Institute for Laboratory Animal Research. All rights reserved. For permissions, 
+please email: journals.permissions@oup.com.
+
+DOI: 10.1093/ilar/ilv012
+PMCID: PMC4554250
+PMID: 26323627 [Indexed for MEDLINE]

--- a/references_cache/pmid_27869789.txt
+++ b/references_cache/pmid_27869789.txt
@@ -1,0 +1,56 @@
+1. Nat Microbiol. 2016 Nov 21;2:16215. doi: 10.1038/nmicrobiol.2016.215.
+
+Genome-guided design of a defined mouse microbiota that confers colonization 
+resistance against Salmonella enterica serovar Typhimurium.
+
+Brugiroux S(1), Beutler M(1), Pfann C(2), Garzetti D(1)(3), Ruscheweyh HJ(4), 
+Ring D(1), Diehl M(1), Herp S(1), Lötscher Y(5), Hussain S(1), Bunk B(6), Pukall 
+R(6), Huson DH(4), Münch PC(1)(7), McHardy AC(7)(8), McCoy KD(9), Macpherson 
+AJ(9), Loy A(2), Clavel T(10), Berry D(2), Stecher B(1)(3).
+
+Author information:
+(1)Max von Pettenkofer Institute of Hygiene and Medical Microbiology, 
+Ludwig-Maximilians-University of Munich, 80336 Munich, Germany.
+(2)Division of Microbial Ecology, Department of Microbiology and Ecosystem 
+Science, Research Network Chemistry meets Microbiology, University of Vienna, 
+A-1090 Vienna, Austria.
+(3)German Center for Infection Research (DZIF); Partner Site Munich.
+(4)Center for Bioinformatics, University of Tübingen, 72076 Tübingen, Germany.
+(5)Institute of Microbiology, ETH Zürich, 8093 Zürich, Switzerland.
+(6)DSMZ - German Collection of Microorganisms and Cell Cultures, 38124 
+Braunschweig, Germany.
+(7)Computational Biology of Infection Research, Helmholtz Centre for Infection 
+Research, 38124 Braunschweig, Germany.
+(8)Department of Algorithmic Bioinformatics, Heinrich Heine University 
+Düsseldorf, 40225 Düsseldorf, Germany.
+(9)Maurice Müller Laboratories, Department of Clinical Research (DKF), UVCM, 
+University Hospital, 3010 Bern, Switzerland.
+(10)ZIEL Institute for Food and Health, Technische Universität München, 85354 
+Freising, Germany.
+
+Protection against enteric infections, also termed colonization resistance, 
+results from mutualistic interactions of the host and its indigenous microbes. 
+The gut microbiota of humans and mice is highly diverse and it is therefore 
+challenging to assign specific properties to its individual members. Here, we 
+have used a collection of murine bacterial strains and a modular design approach 
+to create a minimal bacterial community that, once established in germ-free 
+mice, provided colonization resistance against the human enteric pathogen 
+Salmonella enterica serovar Typhimurium (S. Tm). Initially, a community of 12 
+strains, termed Oligo-Mouse-Microbiota (Oligo-MM12), representing members of the 
+major bacterial phyla in the murine gut, was selected. This community was stable 
+over consecutive mouse generations and provided colonization resistance against 
+S. Tm infection, albeit not to the degree of a conventional complex microbiota. 
+Comparative (meta)genome analyses identified functions represented in a 
+conventional microbiome but absent from the Oligo-MM12. By genome-informed 
+design, we created an improved version of the Oligo-MM community harbouring 
+three facultative anaerobic bacteria from the mouse intestinal bacterial 
+collection (miBC) that provided conventional-like colonization resistance. In 
+conclusion, we have established a highly versatile experimental system that 
+showed efficacy in an enteric infection model. Thus, in combination with 
+exhaustive bacterial strain collections and systems-based approaches, 
+genome-guided design can be used to generate insights into microbe-microbe and 
+microbe-host interactions for the investigation of ecological and 
+disease-relevant mechanisms in the intestine.
+
+DOI: 10.1038/nmicrobiol.2016.215
+PMID: 27869789 [Indexed for MEDLINE]

--- a/references_cache/pmid_28087529.txt
+++ b/references_cache/pmid_28087529.txt
@@ -1,0 +1,54 @@
+1. Appl Environ Microbiol. 2017 Mar 2;83(6):e03033-16. doi: 10.1128/AEM.03033-16.
+ Print 2017 Mar 15.
+
+Resilience, Dynamics, and Interactions within a Model Multispecies 
+Exoelectrogenic-Biofilm Community.
+
+Prokhorova A(1), Sturm-Richter K(1), Doetsch A(2), Gescher J(3)(4).
+
+Author information:
+(1)Institute for Applied Biosciences, Department of Applied Biology, Karlsruhe 
+Institute of Technology, Karlsruhe, Germany.
+(2)Institute of Functional Interfaces, Department of Interface Microbiology, 
+Karlsruhe Institute of Technology, Eggenstein-Leopoldshafen, Germany.
+(3)Institute for Applied Biosciences, Department of Applied Biology, Karlsruhe 
+Institute of Technology, Karlsruhe, Germany johannes.gescher@kit.edu.
+(4)Institute for Biological Interfaces, Karlsruhe Institute of Technology (KIT), 
+Eggenstein-Leopoldshafen, Germany.
+
+Anode-associated multispecies exoelectrogenic biofilms are essential for the 
+function of bioelectrochemical systems (BESs). The individual activities of 
+anode-associated organisms and physiological responses resulting from 
+coculturing are often hard to assess due to the high microbial diversity in 
+these systems. Therefore, we developed a model multispecies biofilm comprising 
+three exoelectrogenic proteobacteria, Shewanella oneidensis, Geobacter 
+sulfurreducens, and Geobacter metallireducens, with the aim to study in detail 
+the biofilm formation dynamics, the interactions between the organisms, and the 
+overall activity of an exoelectrogenic biofilm as a consequence of the applied 
+anode potential. The experiments revealed that the organisms build a stable 
+biofilm on an electrode surface that is rather resilient to changes in the redox 
+potential of the anode. The community operated at maximum electron transfer 
+rates at electrode potentials that were higher than 0.04 V versus a normal 
+hydrogen electrode. Current densities decreased gradually with lower potentials 
+and reached half-maximal values at -0.08 V. Transcriptomic results point toward 
+a positive interaction among the individual strains. S. oneidensis and G. 
+sulfurreducens upregulated their central metabolisms as a response to 
+cultivation under mixed-species conditions. G. sulfurreducens was detected in 
+the planktonic phase of the bioelectrochemical reactors in mixed-culture 
+experiments but not when it was grown in the absence of the other two 
+organisms.IMPORTANCE In many cases, multispecies communities can convert organic 
+substrates into electric power more efficiently than axenic cultures, a 
+phenomenon that remains unresolved. In this study, we aimed to elucidate the 
+potential mutual effects of multispecies communities in bioelectrochemical 
+systems to understand how microbes interact in the coculture anodic network and 
+to improve the community's conversion efficiency for organic substrates into 
+electrical energy. The results reveal positive interactions that might lead to 
+accelerated electron transfer in mixed-species anode communities. The 
+observations made within this model biofilm might be applicable to a variety of 
+nonaxenic systems in the field.
+
+Copyright © 2017 American Society for Microbiology.
+
+DOI: 10.1128/AEM.03033-16
+PMCID: PMC5335525
+PMID: 28087529 [Indexed for MEDLINE]

--- a/references_cache/pmid_28631440.txt
+++ b/references_cache/pmid_28631440.txt
@@ -1,0 +1,40 @@
+1. Environ Microbiol. 2017 Sep;19(9):3500-3513. doi: 10.1111/1462-2920.13834.
+Epub  2017 Jul 21.
+
+Recognition cascade and metabolite transfer in a marine bacteria-phytoplankton 
+model system.
+
+Durham BP(1), Dearth SP(2), Sharma S(3), Amin SA(4), Smith CB(3), Campagna 
+SR(2), Armbrust EV(4), Moran MA(3).
+
+Author information:
+(1)Department of Microbiology, University of Georgia, Athens, GA, USA.
+(2)Department of Chemistry, University of Tennessee, Knoxville, TN, USA.
+(3)Department of Marine Sciences, University of Georgia, Athens, GA, USA.
+(4)School of Oceanography, University of Washington, Seattle, WA, USA.
+
+The trophic linkage between marine bacteria and phytoplankton in the surface 
+ocean is a key step in the global carbon cycle, with almost half of marine 
+primary production transformed by heterotrophic bacterioplankton within hours to 
+weeks of fixation. Early studies conceptualized this link as the passive 
+addition and removal of organic compounds from a shared seawater reservoir. 
+Here, we analysed transcript and intracellular metabolite patterns in a 
+two-member model system and found that the presence of a heterotrophic bacterium 
+induced a potential recognition cascade in a marine phytoplankton species that 
+parallels better-understood vascular plant response systems. Bacterium Ruegeria 
+pomeroyi DSS-3 triggered differential expression of >80 genes in diatom 
+Thalassiosira pseudonana CCMP1335 that are homologs to those used by plants to 
+recognize external stimuli, including proteins putatively involved in 
+leucine-rich repeat recognition activity, second messenger production and 
+protein kinase cascades. Co-cultured diatoms also downregulated lipid 
+biosynthesis genes and upregulated chitin metabolism genes. From differential 
+expression of bacterial transporter systems, we hypothesize that nine diatom 
+metabolites supported the majority of bacterial growth, among them sulfonates, 
+sugar derivatives and organic nitrogen compounds. Similar recognition responses 
+and metabolic linkages as observed in this model system may influence carbon 
+transformations by ocean plankton.
+
+© 2017 Society for Applied Microbiology and John Wiley & Sons Ltd.
+
+DOI: 10.1111/1462-2920.13834
+PMID: 28631440 [Indexed for MEDLINE]

--- a/references_cache/pmid_29051233.txt
+++ b/references_cache/pmid_29051233.txt
@@ -1,0 +1,32 @@
+1. Genome Announc. 2017 Oct 19;5(42):e00758-17. doi: 10.1128/genomeA.00758-17.
+
+High-Quality Whole-Genome Sequences of the Oligo-Mouse-Microbiota Bacterial 
+Community.
+
+Garzetti D(1)(2), Brugiroux S(3), Bunk B(4), Pukall R(4), McCoy KD(5), 
+Macpherson AJ(5), Stecher B(3)(2).
+
+Author information:
+(1)Max von Pettenkofer Institute of Hygiene and Medical Microbiology, 
+Ludwig-Maximilians-University of Munich, Munich, Germany 
+garzetti@mvp.uni-muenchen.de.
+(2)German Center for Infection Research (DZIF), Partner Site Munich, Munich, 
+Germany.
+(3)Max von Pettenkofer Institute of Hygiene and Medical Microbiology, 
+Ludwig-Maximilians-University of Munich, Munich, Germany.
+(4)Leibniz Institute DSMZ-German Collection of Microorganisms and Cell Cultures, 
+Braunschweig, Germany.
+(5)Maurice Müller Laboratories, Department of Clinical Research (DKF), UVCM, 
+University Hospital, Bern, Switzerland.
+
+The Oligo-Mouse-Microbiota (Oligo-MM12) is a community of 12 mouse intestinal 
+bacteria to be used for microbiome research in gnotobiotic mice. We present here 
+the high-quality whole genome sequences of the Oligo-MM12 strains, which were 
+obtained by combining the accuracy of the Illumina platforms with the long reads 
+of the PacBio technology.
+
+Copyright © 2017 Garzetti et al.
+
+DOI: 10.1128/genomeA.00758-17
+PMCID: PMC5646386
+PMID: 29051233

--- a/references_cache/pmid_31998276.txt
+++ b/references_cache/pmid_31998276.txt
@@ -1,0 +1,50 @@
+1. Front Microbiol. 2020 Jan 10;10:2999. doi: 10.3389/fmicb.2019.02999.
+eCollection  2019.
+
+Reproducible Colonization of Germ-Free Mice With the Oligo-Mouse-Microbiota in 
+Different Animal Facilities.
+
+Eberl C(1), Ring D(1)(2), Münch PC(1)(3), Beutler M(1), Basic M(4), Slack EC(5), 
+Schwarzer M(6), Srutkova D(6), Lange A(7)(8), Frick JS(7)(8), Bleich A(4), 
+Stecher B(1)(2).
+
+Author information:
+(1)Max von Pettenkofer-Institute, LMU Munich, Munich, Germany.
+(2)German Center for Infection Research (DZIF), LMU Munich, Munich, Germany.
+(3)Department for Computational Biology of Infection Research, Helmholtz Center 
+for Infection Research, Brunswick, Germany.
+(4)Institute for Laboratory Animal Science and Central Animal Facility, Hannover 
+Medical School, Hanover, Germany.
+(5)Institute of Food, Nutrition and Health, ETH Zürich, Zurich, Switzerland.
+(6)Institute of Microbiology of the Czech Academy of Sciences, Nový Hrádek, 
+Czechia.
+(7)Institute of Medical Microbiology and Hygiene, University of Tübingen, 
+Tübingen, Germany.
+(8)German Center for Infection Research (DZIF), Tübingen, Germany.
+
+The Oligo-Mouse-Microbiota (OMM12) is a recently developed synthetic bacterial 
+community for functional microbiome research in mouse models (Brugiroux et al., 
+2016). To date, the OMM12 model has been established in several germ-free mouse 
+facilities world-wide and is employed to address a growing variety of research 
+questions related to infection biology, mucosal immunology, microbial ecology 
+and host-microbiome metabolic cross-talk. The OMM12 consists of 12 sequenced and 
+publically available strains isolated from mice, representing five bacterial 
+phyla that are naturally abundant in the murine gastrointestinal tract 
+(Lagkouvardos et al., 2016). Under germ-free conditions, the OMM12 colonizes 
+mice stably over multiple generations. Here, we investigated whether stably 
+colonized OMM12 mouse lines could be reproducibly established in different 
+animal facilities. Germ-free C57Bl/6J mice were inoculated with a frozen mixture 
+of the OMM12 strains. Within 2 weeks after application, the OMM12 community 
+reached the same stable composition in all facilities, as determined by fecal 
+microbiome analysis. We show that a second application of the OMM12 strains 
+after 72 h leads to a more stable community composition than a single 
+application. The availability of such protocols for reliable de novo generation 
+of gnotobiotic rodents will certainly contribute to increasing experimental 
+reproducibility in biomedical research.
+
+Copyright © 2020 Eberl, Ring, Münch, Beutler, Basic, Slack, Schwarzer, Srutkova, 
+Lange, Frick, Bleich and Stecher.
+
+DOI: 10.3389/fmicb.2019.02999
+PMCID: PMC6965490
+PMID: 31998276

--- a/references_cache/pmid_33097854.txt
+++ b/references_cache/pmid_33097854.txt
@@ -1,0 +1,46 @@
+1. ISME J. 2021 Mar;15(3):762-773. doi: 10.1038/s41396-020-00811-y. Epub 2020 Oct
+ 23.
+
+Resource partitioning of phytoplankton metabolites that support bacterial 
+heterotrophy.
+
+Ferrer-González FX(#)(1), Widner B(#)(2), Holderman NR(#)(3), Glushka J(3), 
+Edison AS(3), Kujawinski EB(2), Moran MA(4).
+
+Author information:
+(1)Department of Marine Sciences, University of Georgia, Athens, GA, 30602, USA.
+(2)Department of Marine Chemistry and Geochemistry, Woods Hole Oceanographic 
+Institution, Woods Hole, MA, 02543, USA.
+(3)Department of Biochemistry and Complex Carbohydrate Research Center, 
+University of Georgia, Athens, GA, 30602, USA.
+(4)Department of Marine Sciences, University of Georgia, Athens, GA, 30602, USA. 
+mmoran@uga.edu.
+(#)Contributed equally
+
+The communities of bacteria that assemble around marine microphytoplankton are 
+predictably dominated by Rhodobacterales, Flavobacteriales, and families within 
+the Gammaproteobacteria. Yet whether this consistent ecological pattern reflects 
+the result of resource-based niche partitioning or resource competition requires 
+better knowledge of the metabolites linking microbial autotrophs and 
+heterotrophs in the surface ocean. We characterized molecules targeted for 
+uptake by three heterotrophic bacteria individually co-cultured with a marine 
+diatom using two strategies that vetted the exometabolite pool for biological 
+relevance by means of bacterial activity assays: expression of diagnostic genes 
+and net drawdown of exometabolites, the latter detected with mass spectrometry 
+and nuclear magnetic resonance using novel sample preparation approaches. Of the 
+more than 36 organic molecules with evidence of bacterial uptake, 53% contained 
+nitrogen (including nucleosides and amino acids), 11% were organic sulfur 
+compounds (including dihydroxypropanesulfonate and dimethysulfoniopropionate), 
+and 28% were components of polysaccharides (including chrysolaminarin, chitin, 
+and alginate). Overlap in phytoplankton-derived metabolite use by bacteria in 
+the absence of competition was low, and only guanosine, proline, and 
+N-acetyl-D-glucosamine were predicted to be used by all three. Exometabolite 
+uptake pattern points to a key role for ecological resource partitioning in the 
+assembly marine bacterial communities transforming recent photosynthate.
+
+DOI: 10.1038/s41396-020-00811-y
+PMCID: PMC8027193
+PMID: 33097854 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare that they have no conflict 
+of interest.


### PR DESCRIPTION
Re-fetched full PubMed abstracts (via `communitymech.literature`) for the 9 references behind the 6 files that the *stub* caches had blocked, caching them as full `pmid_<id>.txt` (reproducibility + future curation).

`related_ingredients` adoption: **86/265 → 87/265**.

## Result
Only **Thalassiosira_Ruegeria_Phycosphere_Coculture** had nameable substrate chemistry in its full abstract — added 4 ingredients (OAK-verified, verbatim from PMID:33097854): **dimethylsulfoniopropionate** (CHEBI:16457), **N-acetyl-D-glucosamine** (506227), **proline** (26271), **guanosine** (16750). The `PMID_33097854.md` stub was backfilled with the full abstract (pre-existing snippet lines preserved).

The other 4 stay at **0 ingredients — confirmed NOT a cache artifact**: OMM12, hCom2, Altered_Schaedler_Flora, and Shewanella_Geobacter cite only genome-design / colonization-resistance / methods papers whose *full* abstracts name no specific metabolite (only generic "organic substrates" / "host-microbiome metabolic cross-talk"). Backfilling them needs a different, metabolism-focused reference cited + cached. (Pseudonitzschia_Sulfitobacter is the same case — its IAA/tryptophan story is in an uncited paper.)

## Test plan
- `just test` → 136 passed, 9 skipped
- Thalassiosira file validates clean (schema + references + terms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)