### PR TITLE
#30 backfill: agri/SynCom chemistry-rich subset (10 communities)

### DIFF
--- a/kb/communities/Aerobic_Denitrification_QQ_SynCom.yaml
+++ b/kb/communities/Aerobic_Denitrification_QQ_SynCom.yaml
@@ -65,6 +65,58 @@ ecological_interactions:
   scope: COMMUNITY_LEVEL
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: nitrate
+  chebi_term:
+    id: CHEBI:17632
+    label: nitrate
+  relevance: Primary electron acceptor and target pollutant; the SMC achieves 97% nitrate
+    reduction, making nitrate the central substrate of the aerobic denitrification process.
+  evidence:
+  - reference: PMID:38277828
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The nitrate (NO3--N) reduction efficiency of the SMC reached 97 % with little
+      nitrite (NO2--N) accumulation
+    explanation: Names nitrate (NO3--N) as the reduced substrate quantifying denitrification efficiency.
+- preferred_term: nitrite
+  chebi_term:
+    id: CHEBI:16301
+    label: nitrite
+  relevance: Denitrification intermediate; PA exerts nitrite reduction and low nitrite accumulation
+    indicates efficient stepwise N-cycle processing within the community.
+  evidence:
+  - reference: PMID:38277828
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: while PA exerted NO2--N reduction
+    explanation: Names nitrite (NO2--N) as the reduction step performed by Pseudomonas aeruginosa (PA).
+- preferred_term: N-(3-oxododecanoyl)-L-homoserine lactone
+  chebi_term:
+    id: CHEBI:44534
+    label: N-(3-oxododecanoyl)-L-homoserine lactone
+  relevance: AHL quorum signal whose decline via quorum quenching by AH triggers pyocyanin excretion
+    and downstream electron transfer for nitrite reduction.
+  evidence:
+  - reference: PMID:38277828
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The declined N-(3-oxododecanoyl)-L-homoserine lactone (3OC12-HSL), resulting from
+      quorum quenching (QQ) by AH, stimulated the excretion of pyocyanin
+    explanation: Names 3OC12-HSL verbatim as the quorum-quenched AHL signal central to the mechanism.
+- preferred_term: pyocyanine
+  chebi_term:
+    id: CHEBI:8653
+    label: pyocyanine
+  relevance: Redox-active phenazine excreted following quorum quenching that improves electron transfer
+    from complex III to downstream denitrifying enzymes for nitrite reduction.
+  evidence:
+  - reference: PMID:38277828
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: stimulated the excretion of pyocyanin, which could improve the electron transfer from
+      complex III to downstream denitrifying enzymes for NO2--N reduction
+    explanation: Names pyocyanin verbatim as the excreted redox mediator driving nitrite reduction.
 environmental_factors:
 - name: defined synthetic community design
   value: Acinetobacter baumannii N1, Pseudomonas aeruginosa N2, and Aeromonas hydrophila were assembled

--- a/kb/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.yaml
+++ b/kb/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.yaml
@@ -57,6 +57,62 @@ ecological_interactions:
   scope: COMMUNITY_LEVEL
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: lignocellulose
+  chebi_term:
+    id: CHEBI:180683
+    label: lignocellulose
+  relevance: Maize straw is the lignocellulosic substrate the SynCom degrades and humifies;
+    its turnover into soil organic carbon is the central function of this community.
+  evidence:
+  - reference: PMID:41264879
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: thereby promote maize straw humification
+    explanation: Identifies maize straw, the lignocellulosic biomass, as the substrate the
+      SynCom acts on to drive humification.
+- preferred_term: cellulose
+  chebi_term:
+    id: CHEBI:18246
+    label: (1->4)-beta-D-glucan
+  relevance: Cellulose is the major polysaccharide fraction of maize straw; the SynCom raises
+    carboxymethyl cellulase activity to depolymerize it during humification.
+  evidence:
+  - reference: PMID:41264879
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: increase the activities of key enzymes (carboxymethyl cellulase, xylanase, lignin
+      peroxidase, and nitrogenase)
+    explanation: Carboxymethyl cellulase named in the snippet acts on cellulose, anchoring the
+      cellulose (beta-1,4-glucan) substrate degraded by the community.
+- preferred_term: lignin
+  chebi_term:
+    id: CHEBI:6457
+    label: lignin
+  relevance: Lignin is the recalcitrant aromatic fraction of straw whose oxidation by SynCom
+    lignin peroxidase contributes carbon to the humic pool.
+  evidence:
+  - reference: PMID:41264879
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: increase the activities of key enzymes (carboxymethyl cellulase, xylanase, lignin
+      peroxidase, and nitrogenase)
+    explanation: Lignin peroxidase named in the snippet acts on lignin, anchoring lignin as a
+      central straw substrate transformed during humification.
+- preferred_term: xylan
+  chebi_term:
+    id: CHEBI:37166
+    label: xylan
+  relevance: Xylan is the dominant hemicellulose of maize straw; SynCom xylanase activity
+    hydrolyzes it as part of lignocellulose breakdown and humification.
+  evidence:
+  - reference: PMID:41264879
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: increase the activities of key enzymes (carboxymethyl cellulase, xylanase, lignin
+      peroxidase, and nitrogenase)
+    explanation: Xylanase named in the snippet acts on xylan, anchoring xylan as the
+      hemicellulose substrate the community degrades.
 environmental_factors:
 - name: defined synthetic community design
   value: Keystone taxa from dilution microcosms were assembled as Bacillus siamensis B and Bradyrhizobium

--- a/kb/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.yaml
+++ b/kb/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.yaml
@@ -388,6 +388,64 @@ external_resources:
   resource_id: doi:10.1093/femsec/fiz186
   url: https://archive.jgi.doe.gov/publication/defining-the-eco-enzymological-role-of-the-fungal-strain-coniochaeta-sp-2t2-1-in-a-tripartite-lignocellulolytic-microbial-consortium/
   description: DOE JGI publication page for the FEMS Microbiology Ecology exact-system paper.
+related_ingredients:
+- preferred_term: lignocellulose
+  chebi_term:
+    id: CHEBI:180683
+    label: lignocellulose
+  relevance: Wheat straw lignocellulose is the central substrate driving this
+    consortium; Coniochaeta sp. 2T2.1 is a versatile ascomycete deconstructing
+    lignocellulose and the whole community is defined by its lignocellulolytic
+    activity.
+  evidence:
+  - reference: PMID:31769802
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: deconstruct lignocellulose
+    explanation: Anchors lignocellulose as the bulk plant-biomass substrate the
+      Coniochaeta-led consortium deconstructs.
+- preferred_term: cellulose
+  chebi_term:
+    id: CHEBI:18246
+    label: (1->4)-beta-D-glucan
+  relevance: Cellulose is a core polysaccharide fraction of wheat straw; Coniochaeta
+    sp. 2T2.1 is strongly involved in cellulose degradation at early stages, making
+    this glucan a central degradation target for the consortium.
+  evidence:
+  - reference: PMID:36991472
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: cellulose and xylan
+    explanation: Anchors cellulose (a (1->4)-beta-D-glucan) as a central substrate
+      Coniochaeta sp. 2T2.1 was held to degrade.
+- preferred_term: xylan
+  chebi_term:
+    id: CHEBI:37166
+    label: xylan
+  relevance: Xylan is the major hemicellulose backbone in wheat straw and a central
+    degradation target partitioned between the fungal and bacterial members of the
+    consortium.
+  evidence:
+  - reference: PMID:36991472
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: cellulose and xylan
+    explanation: Anchors xylan as a central polysaccharide substrate degraded by
+      consortium members.
+- preferred_term: hemicellulose
+  chebi_term:
+    id: CHEBI:61266
+    label: hemicellulose
+  relevance: Hemicellulose is a central wheat-straw fraction whose degradation is
+    a key division-of-labor axis, with Sphingobacterium paramultivorum w15 mainly
+    involved in its degradation.
+  evidence:
+  - reference: PMID:36991472
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: degradation of mainly hemicellulose
+    explanation: Anchors hemicellulose as a central substrate fraction degraded
+      chiefly by the w15 bacterial member.
 metals_present: []
 rare_earth_elements_present: []
 metal_relevance: NOT_APPLICABLE

--- a/kb/communities/ENIGMA_Denitrifying_SynCom.yaml
+++ b/kb/communities/ENIGMA_Denitrifying_SynCom.yaml
@@ -177,6 +177,59 @@ environmental_factors:
     snippet: The altered growth characteristics of community members drives accumulation of toxic NO2-,
       which disrupts denitrification causing N2O off gassing
     explanation: Defines mechanistic link between NO2- accumulation and N2O emission
+related_ingredients:
+- preferred_term: nitrate
+  chebi_term:
+    id: CHEBI:17632
+    label: nitrate
+  relevance: Nitrate (NO3-) is the initial electron acceptor and entry substrate of the partitioned
+    denitrification pathway; it is also the dominant site contaminant and, at high concentrations,
+    the perturbation that destabilizes community cooperativity.
+  evidence:
+  - reference: PMID:40349173
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: heavily nitrate (NO3-)
+    explanation: Anchors nitrate (NO3-) as the contaminating substrate the consortium reduces during
+      denitrification.
+- preferred_term: nitrite
+  chebi_term:
+    id: CHEBI:16301
+    label: nitrite
+  relevance: Nitrite (NO2-) is the central exchanged intermediate handed off between partners; its
+    toxic accumulation under high nitrate disrupts denitrification and drives N2O off-gassing.
+  evidence:
+  - reference: PMID:40349173
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: accumulation of toxic NO2-
+    explanation: Anchors nitrite (NO2-) as the toxic intermediate whose accumulation disrupts cooperative
+      denitrification.
+- preferred_term: nitric oxide
+  chebi_term:
+    id: CHEBI:16480
+    label: nitric oxide
+  relevance: Nitric oxide (NO) is the second metabolite exchanged between the two isolates to complete
+    the partitioned denitrification pathway.
+  evidence:
+  - reference: PMID:40349173
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: and nitric oxide (NO)
+    explanation: Anchors nitric oxide (NO) as the exchanged intermediate completing partitioned denitrification.
+- preferred_term: dinitrogen oxide
+  chebi_term:
+    id: CHEBI:17045
+    label: dinitrogen oxide
+  relevance: Nitrous oxide (N2O) is the climate-relevant end product whose emission emerges when cooperative
+    denitrification is disrupted, motivating study of this community.
+  evidence:
+  - reference: PMID:40349173
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: nitrous oxide (N2O), a potent greenhouse gas and an ozone depleting substance
+    explanation: Anchors dinitrogen oxide (nitrous oxide, N2O) as the potent greenhouse-gas product of
+      denitrification central to the study.
 associated_datasets:
 - name: SynCom transcriptome sequencing
   dataset_type: METATRANSCRIPTOME

--- a/kb/communities/Methane_Oxidation_CrVI_Reduction_SynCom.yaml
+++ b/kb/communities/Methane_Oxidation_CrVI_Reduction_SynCom.yaml
@@ -72,6 +72,33 @@ environmental_factors:
   description: Methane concentration, chromium load, and methane oxidation inhibition.
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: methane
+  chebi_term:
+    id: CHEBI:16183
+    label: methane
+  relevance: Methane is the electron-donating substrate oxidized by the methanotroph-led
+    consortium; its oxidation is mechanistically coupled to Cr(VI) reduction.
+  evidence:
+  - reference: PMID:41932525
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: methane oxidation coupled to Cr(VI) reduction has been widely investigated
+    explanation: Anchors methane as the oxidized substrate driving the coupled Cr(VI)-reduction
+      process central to this community.
+- preferred_term: Cr(VI)
+  chebi_term:
+    id: CHEBI:35404
+    label: chromate(2-)
+  relevance: Hexavalent chromium (chromate, Cr(VI)) is the terminal electron acceptor
+    reduced by the community, the central pollutant the SynCom is engineered to remediate.
+  evidence:
+  - reference: PMID:41932525
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The maximum Cr(VI) removal load of this system reached 20.63 mg/L/d.
+    explanation: Quantifies Cr(VI) removal, anchoring hexavalent chromium (chromate)
+      as the central acceptor reduced by the community.
 metals_present:
 - CHROMIUM
 metal_relevance: PRIMARY

--- a/kb/communities/Multiomics_Corn_Straw_Degradation_SynCom.yaml
+++ b/kb/communities/Multiomics_Corn_Straw_Degradation_SynCom.yaml
@@ -55,3 +55,48 @@ environmental_factors:
     time.
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: lignocellulose
+  chebi_term:
+    id: CHEBI:180683
+    label: lignocellulose
+  relevance: Lignocellulose is the central corn-straw substrate the SynCom was constructed to degrade.
+  evidence:
+  - reference: PMID:37774801
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The efficient degradation of lignocellulose is a bottleneck for its integrated
+    explanation: Names lignocellulose as the central substrate whose degradation motivates the community.
+- preferred_term: cellulose
+  chebi_term:
+    id: CHEBI:18246
+    label: (1->4)-beta-D-glucan
+  relevance: Cellulose is a primary lignocellulose fraction the community enzymatically degrades.
+  evidence:
+  - reference: PMID:37774801
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the degradation rates of cellulose, hemicellulose, and lignin were 34.91%,
+    explanation: Reports a measured cellulose degradation rate, anchoring cellulose as a degraded substrate.
+- preferred_term: hemicellulose
+  chebi_term:
+    id: CHEBI:61266
+    label: hemicellulose
+  relevance: Hemicellulose is a primary lignocellulose fraction targeted by the SynCom's xylanases.
+  evidence:
+  - reference: PMID:37774801
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the degradation rates of cellulose, hemicellulose, and lignin were 34.91%,
+    explanation: Reports a measured hemicellulose degradation rate, anchoring hemicellulose as a degraded substrate.
+- preferred_term: lignin
+  chebi_term:
+    id: CHEBI:6457
+    label: lignin
+  relevance: Lignin is the recalcitrant lignocellulose fraction the community degrades.
+  evidence:
+  - reference: PMID:37774801
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: 'Proteomic analysis revealed that lignin'
+    explanation: Names lignin in the proteomic degradation context of this lignocellulose-degrading community.

--- a/kb/communities/Rice_P_Uptake_Intercropping_SynCom4.yaml
+++ b/kb/communities/Rice_P_Uptake_Intercropping_SynCom4.yaml
@@ -83,3 +83,46 @@ environmental_factors:
   description: Pot experiments testing rice growth and phosphorus uptake after SynCom inoculation.
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: phosphorus
+  chebi_term:
+    id: CHEBI:28659
+    label: phosphorus atom
+  relevance: Phosphorus is the central nutrient whose uptake efficiency the rice intercropping
+    SynCom is designed to improve.
+  evidence:
+  - reference: PMID:39684532
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Changes in root traits and rhizosphere microbiome are important ways to optimize
+      plant phosphorus (P) efficiency and promote multifunctionality in intercropping.
+    explanation: Snippet names phosphorus (P) as the nutrient whose plant uptake efficiency
+      is the focus of the SynCom system.
+- preferred_term: phosphate
+  chebi_term:
+    id: CHEBI:26020
+    label: phosphate
+  relevance: Soil available phosphate is the plant-accessible inorganic P pool that the
+    SynCom directly activates to enhance rice P acquisition.
+  evidence:
+  - reference: PMID:39684532
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: including the direct activation of soil available P, increased root surface area
+      and root tip number
+    explanation: Snippet refers to direct activation of soil available P (phosphate), the
+      plant-accessible inorganic phosphate pool mobilized by the SynCom.
+- preferred_term: phosphate ion
+  chebi_term:
+    id: CHEBI:35780
+    label: phosphate ion
+  relevance: Inorganic phosphate (Pi) is the form transported into roots and translocated
+    to shoots via Pi transporters up-regulated by the SynCom.
+  evidence:
+  - reference: PMID:39684532
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: promotion of root-to-shoot P translocation through up-regulation of Pi transporter
+      genes (OsPht1;1, OsPht1;2, OsPht1;4, OsPht1;6)
+    explanation: Snippet anchors inorganic phosphate (Pi) as the transported ion via Pi
+      transporter genes up-regulated by the SynCom.

--- a/kb/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.yaml
+++ b/kb/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.yaml
@@ -75,3 +75,42 @@ environmental_factors:
   description: Optimization of glucose, sulfate, and inoculum density under anaerobic conditions.
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: 2,4,6-tribromophenol
+  chebi_term:
+    id: CHEBI:47696
+    label: 2,4,6-tribromophenol
+  relevance: The target halogenated aromatic pollutant that the synthetic community anaerobically
+    mineralizes to CO2 via reductive debromination.
+  evidence:
+  - reference: PMID:25461007
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Anaerobic mineralization of 2,4,6-tribromophenol (2,4,6-TBP) was achieved by a synthetic
+      anaerobe community
+    explanation: Names 2,4,6-tribromophenol as the substrate mineralized by the synthetic community.
+- preferred_term: phenol
+  chebi_term:
+    id: CHEBI:15882
+    label: phenol
+  relevance: The central debromination intermediate produced from 2,4,6-TBP by Ma13 and FTH1
+    before mineralization to CO2 by strain DS.
+  evidence:
+  - reference: PMID:25461007
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: 2,4,6-TBP was debrominated to phenol by the combined action of Ma13 and FTH1, then
+      mineralized into CO2 by sequential introduction of DS
+    explanation: Identifies phenol as the debromination intermediate channeled through the community.
+- preferred_term: glucose
+  chebi_term:
+    id: CHEBI:17234
+    label: glucose
+  relevance: The fermentation substrate supplied to Clostridium strain Ma13, which acts as the
+    hydrogen supplier (electron donor) driving reductive debromination.
+  evidence:
+  - reference: PMID:25461007
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Clostridium sp. strain Ma13 acting as a hydrogen supplier via glucose fermentation
+    explanation: Anchors glucose as the electron-donor source fermented to hydrogen for debromination.

--- a/kb/communities/Urine_Nitrification_SynCom.yaml
+++ b/kb/communities/Urine_Nitrification_SynCom.yaml
@@ -90,3 +90,47 @@ environmental_factors:
   description: Salt adaptation and urine feeding in nitrification reactors.
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: urea
+  chebi_term:
+    id: CHEBI:16199
+    label: urea
+  relevance: Primary nitrogen source in urine; hydrolyzed by the ureolytic heterotrophs to release
+    ammonium that feeds the nitrifiers, initiating the community N-cycle conversion.
+  evidence:
+  - reference: PMID:31623889
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: In reactor 2, the nitrifiers and ureolytic heterotrophs were fed with urine and achieved
+      a 15±6mg NO3--NL-1d-1 production rate for 1% and 10% synthetic and fresh real urine, respectively.
+    explanation: Urine feeding requires ureolysis of urea by the ureolytic heterotrophs, anchoring
+      urea as the upstream nitrogen substrate of the community.
+- preferred_term: ammonium
+  chebi_term:
+    id: CHEBI:28938
+    label: ammonium
+  relevance: Central intermediate released by ureolysis and oxidized by the AOB Nitrosomonas europaea;
+    ammonium removal is a primary measured endpoint of the community.
+  evidence:
+  - reference: PMID:31623889
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: In reactor 1, salt adaptation of the ammonium-fed AOB and NOB co-culture was possible
+      up to 45mScm-1, which resembled undiluted nitrified urine, while maintaining a 44±10mgNH4+-NL-1d-1
+      removal rate.
+    explanation: Explicitly names the ammonium-fed nitrifier co-culture and an NH4+ removal rate,
+      anchoring ammonium as the oxidized intermediate.
+- preferred_term: nitrate
+  chebi_term:
+    id: CHEBI:17632
+    label: nitrate
+  relevance: Terminal product of the nitrification cascade and the target fertilizer output of the
+    engineered community.
+  evidence:
+  - reference: PMID:31623889
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Astronauts' urine can, for instance, be nitrified by micro-organisms into a liquid nitrate
+      fertilizer for plant growth in space.
+    explanation: Names nitrate as the fertilizer end-product produced by nitrification, anchoring it
+      as the community's terminal N-cycle compound.

--- a/kb/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.yaml
+++ b/kb/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.yaml
@@ -85,3 +85,43 @@ environmental_factors:
   description: Synthetic microbial community enzyme pretreatment compared with commercial enzyme pretreatments.
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: lignocellulose
+  chebi_term:
+    id: CHEBI:180683
+    label: lignocellulose
+  relevance: Lignocellulose is the primary wheat-straw substrate the synthetic community is designed
+    to degrade, with degradation efficiency being the crucial factor for enhanced biogas production.
+  evidence:
+  - reference: PMID:38748977
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: with the improvement in lignocellulose degradation efficiency being
+    explanation: Names lignocellulose as the substrate whose degradation efficiency drives the pretreatment
+      and biogas-production goal of this community.
+- preferred_term: cellulose
+  chebi_term:
+    id: CHEBI:18246
+    label: (1->4)-beta-D-glucan
+  relevance: Cellulose is one of the wheat-straw polymers degraded by the community's enzymes during
+    pretreatment, a measured degradation endpoint.
+  evidence:
+  - reference: PMID:38748977
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: yielding cellulose, hemicellulose, and lignin degradation rates of 39.85, 36.99,
+    explanation: Reports a measured cellulose degradation rate, anchoring cellulose as a central substrate
+      of the pretreatment.
+- preferred_term: hemicellulose
+  chebi_term:
+    id: CHEBI:61266
+    label: hemicellulose
+  relevance: Hemicellulose is a second wheat-straw polymer degraded by the community's enzymes, with
+    a measured degradation rate during pretreatment.
+  evidence:
+  - reference: PMID:38748977
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: yielding cellulose, hemicellulose, and lignin degradation rates of 39.85, 36.99,
+    explanation: Reports a measured hemicellulose degradation rate, anchoring hemicellulose as a central
+      substrate of the pretreatment.


### PR DESCRIPTION
Backfills the substrate-chemistry-bearing subset of the agricultural/SynCom files (denitrification, nitrification, bioremediation, P-uptake, methane–Cr coupling, straw/lignocellulose degradation). CHEBI ids **verified live via OAK**; snippets **verbatim** from cached abstracts.

`related_ingredients` adoption: **87/265 → 97/265**.

| Community | Ingredients (CHEBI-verified) |
|---|---|
| Aerobic_Denitrification_QQ_SynCom | nitrate, nitrite, N-(3-oxododecanoyl)-L-homoserine lactone, pyocyanine |
| ENIGMA_Denitrifying_SynCom | nitrate, nitrite, nitric oxide, dinitrogen oxide |
| Urine_Nitrification_SynCom | urea, ammonium, nitrate |
| Rice_P_Uptake_Intercropping_SynCom4 | phosphorus atom, phosphate, phosphate ion |
| Tribromophenol_Anaerobic_Bioremediation_SynCom | 2,4,6-tribromophenol, phenol, glucose |
| Methane_Oxidation_CrVI_Reduction_SynCom | methane, chromate(2-) |
| Multiomics_Corn_Straw_Degradation_SynCom | lignocellulose, cellulose, hemicellulose, lignin |
| Coniochaeta_…_Wheat_Straw_Consortium | lignocellulose, cellulose, xylan, hemicellulose |
| Wheat_Straw_Biogas_Pretreatment_SynCom | lignocellulose, cellulose, hemicellulose |
| Bacillus_Bradyrhizobium_Straw_Humification_SynCom | lignocellulose, cellulose, lignin, xylan |

**2 of 12 attempted yielded 0** (abstracts too generic): Aerobic_Denitrification_Disturbance and Phylogenetically_Diverse_Denitrifying name no N-cycle compound verbatim. The remaining ~38 agri/biocontrol SynComs (Banana/Pepper/Watermelon/nematode, etc.) are expected to be similarly thin and were not attempted.

Pre-existing CHEBI bugs in Coniochaeta (`CHEBI:37686` "xylan"=*alpha-D-allose*; `CHEBI:18246` label "cellulose") are already fixed in the cleanup PR #98.

## Test plan
- `just test` → 136 passed, 9 skipped
- All 10 files validate clean (`linkml-validate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)