### PR TITLE
ENVO term cleanup: fix 24 wrong id/label pairs (146 occurrences)

### DIFF
--- a/kb/communities/AMD_Acidophile_Heterotroph_Network.yaml
+++ b/kb/communities/AMD_Acidophile_Heterotroph_Network.yaml
@@ -24,7 +24,7 @@ community_category: AMD
 environment_term:
   preferred_term: acid mine drainage
   term:
-    id: ENVO:00002186
+    id: ENVO:00001997
     label: acid mine drainage
   notes: 'Moderately acidic (pH 2-4) mine drainage waters and biofilms where heterotrophic acidophiles
     thrive. Unlike the extreme acidity (pH 0.5-1.0) dominated by autotrophic iron oxidizers, this pH range

--- a/kb/communities/AMD_Nitrososphaerota_Archaeal.yaml
+++ b/kb/communities/AMD_Nitrososphaerota_Archaeal.yaml
@@ -26,7 +26,7 @@ community_category: AMD
 environment_term:
   preferred_term: acid mine drainage
   term:
-    id: ENVO:00002186
+    id: ENVO:00001997
     label: acid mine drainage
   notes: 'Acidic (pH 2.5-4.5) aquatic and sediment environments impacted by acid mine drainage from sulfide
     mineral oxidation. High concentrations of ammonium (up to 380 mg/L NH4+-N) result from microbial degradation

--- a/kb/communities/Aalborg_East_Full_Scale_EBPR_Community.yaml
+++ b/kb/communities/Aalborg_East_Full_Scale_EBPR_Community.yaml
@@ -31,7 +31,7 @@ environment_term:
   preferred_term: full-scale enhanced biological phosphorus removal activated sludge
   term:
     id: ENVO:00002046
-    label: sludge
+    label: activated sludge
   notes: Activated sludge was sampled from the aeration tank of the Aalborg East wastewater treatment plant.
 taxonomy:
 - taxon_term:

--- a/kb/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.yaml
+++ b/kb/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.yaml
@@ -39,7 +39,7 @@ environment_term:
   preferred_term: anaerobic laboratory bioreactor with in situ electrolysis
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled anaerobic laboratory bioreactor or culture system supplied with CO2/H2, including
     an All-in-One electrode condition for in situ water electrolysis.
 taxonomy:

--- a/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
+++ b/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
@@ -39,7 +39,7 @@ environment_term:
   preferred_term: contaminated groundwater enrichment culture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Stable laboratory enrichment from TCE/PCE-contaminated groundwater fed
     with C2H2 as sole electron donor and carbon source.
 taxonomy:

--- a/kb/communities/Aerobic_Denitrification_Disturbance_SynCom.yaml
+++ b/kb/communities/Aerobic_Denitrification_Disturbance_SynCom.yaml
@@ -29,7 +29,7 @@ environment_term:
   preferred_term: laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Aerobic denitrification synthetic microbial community under pollutant disturbances.
 taxonomy:
 - taxon_term:

--- a/kb/communities/Aerobic_Denitrification_QQ_SynCom.yaml
+++ b/kb/communities/Aerobic_Denitrification_QQ_SynCom.yaml
@@ -28,7 +28,7 @@ environment_term:
   preferred_term: laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Aerobic denitrification synthetic microbial community for nitrate wastewater removal.
 taxonomy:
 - taxon_term:

--- a/kb/communities/Alaska_Tundra_Permafrost_Iron_Redox_Community.yaml
+++ b/kb/communities/Alaska_Tundra_Permafrost_Iron_Redox_Community.yaml
@@ -19,7 +19,7 @@ community_category: METAL_REDUCTION
 environment_term:
   preferred_term: wet sedge tundra permafrost soil
   term:
-    id: ENVO:00002179
+    id: ENVO:00000134
     label: permafrost
   notes: Organic soils from active-layer (0-50 cm), transition-zone (50-70 cm),
     and permafrost (70+ cm) depths of wet sedge tundra in northern Alaska,

--- a/kb/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.yaml
+++ b/kb/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.yaml
@@ -26,8 +26,8 @@ engineering_design:
 environment_term:
   preferred_term: gnotobiotic mouse gastrointestinal tract
   term:
-    id: ENVO:0001998
-    label: human gut environment
+    id: ENVO:2100002
+    label: intestine environment
   notes: ENVO human gut environment is used as the closest validated gut-environment term in this schema;
     the curated system is a murine gnotobiotic gastrointestinal community.
 taxonomy:

--- a/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
+++ b/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
@@ -39,7 +39,7 @@ environment_term:
   preferred_term: laboratory anammox bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Laboratory-scale anammox bioreactor treating reactive nitrogen,
     followed by metagenomics through destabilization and recovery.
 taxonomy:

--- a/kb/communities/Anammox_Granule_Metabolic_Interaction_Community.yaml
+++ b/kb/communities/Anammox_Granule_Metabolic_Interaction_Community.yaml
@@ -29,7 +29,7 @@ engineering_design:
 environment_term:
   preferred_term: anammox granular sludge bioreactor
   term:
-    id: ENVO:00002001
+    id: ENVO:00002043
     label: wastewater treatment plant
   notes: Engineered laboratory bioreactor granular sludge used as a wastewater treatment model; ENVO wastewater
     treatment plant is the closest validated built-environment term used in this schema.

--- a/kb/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.yaml
+++ b/kb/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.yaml
@@ -17,8 +17,8 @@ community_category: METHANOGENESIS
 environment_term:
   preferred_term: wetland soil
   term:
-    id: ENVO:00000044
-    label: wetland
+    id: ENVO:00000043
+    label: wetland area
   notes: Wetland soil ecosystem with anaerobic and microaerobic microsites
     supporting Asgard archaeal lineages and methanogens.
 taxonomy:

--- a/kb/communities/Australian_Lead_Zinc_Polymetallic.yaml
+++ b/kb/communities/Australian_Lead_Zinc_Polymetallic.yaml
@@ -28,7 +28,7 @@ community_category: BIOREMEDIATION
 environment_term:
   preferred_term: mine tailing
   term:
-    id: ENVO:00000072
+    id: ENVO:00000003
     label: mine tailing
   notes: 'Abandoned sulfidic mine tailings from a volcanogenic massive sulfide (VMS) deposit in arid Western
     Australia containing polymetallic mineralization (Pb-Zn-Cu-Fe). The tailings exhibit vertical stratification

--- a/kb/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.yaml
+++ b/kb/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.yaml
@@ -20,7 +20,7 @@ community_category: RHIZOSPHERE
 environment_term:
   preferred_term: Avena fatua root rhizosphere
   term:
-    id: ENVO:00002233
+    id: ENVO:00005801
     label: rhizosphere
   notes: Rhizosphere and nonrhizosphere soils collected at 6 and 9 weeks from
     Avena fatua grown in a 13CO2 atmosphere for genome-resolved SIP.

--- a/kb/communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.yaml
+++ b/kb/communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.yaml
@@ -20,7 +20,7 @@ community_category: RHIZOSPHERE
 environment_term:
   preferred_term: Avena fatua rhizosphere and detritusphere
   term:
-    id: ENVO:00002233
+    id: ENVO:00005801
     label: rhizosphere
   notes: Time-resolved metatranscriptomes of Avena fatua rhizosphere,
     detritusphere, and combined habitats sampled to compare functional

--- a/kb/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.yaml
+++ b/kb/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.yaml
@@ -32,8 +32,8 @@ engineering_design:
 environment_term:
   preferred_term: gnotobiotic mouse gut environment
   term:
-    id: ENVO:0001998
-    label: human gut environment
+    id: ENVO:2100002
+    label: intestine environment
   notes: The organisms are human gut-derived strains tested in the distal gut of gnotobiotic mice as a
     controlled model of human gut microbial interactions.
 taxonomy:

--- a/kb/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.yaml
+++ b/kb/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.yaml
@@ -29,8 +29,8 @@ engineering_design:
 environment_term:
   preferred_term: gnotobiotic mouse gut environment
   term:
-    id: ENVO:0001998
-    label: human gut environment
+    id: ENVO:2100002
+    label: intestine environment
   notes: The source organisms are human gut-associated, and the interaction was tested in the distal gut
     of gnotobiotic mice as a humanized model.
 taxonomy:

--- a/kb/communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.yaml
+++ b/kb/communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.yaml
@@ -15,7 +15,7 @@ community_category: OTHER
 environment_term:
   preferred_term: municipal wastewater sewage
   term:
-    id: ENVO:00002047
+    id: ENVO:00002001
     label: waste water
   notes: Municipal sewage from utility districts in the San Francisco Bay
     Area collected for direct RNA sequencing.

--- a/kb/communities/Bayan_Obo_REE_Tailings_Consortium.yaml
+++ b/kb/communities/Bayan_Obo_REE_Tailings_Consortium.yaml
@@ -40,7 +40,7 @@ engineering_design:
 environment_term:
   preferred_term: mine tailing
   term:
-    id: ENVO:00000072
+    id: ENVO:00000003
     label: mine tailing
   notes: 'Rare-earth-rich tailings (RERT) from Bayan Obo mine, Inner Mongolia, China, the world''s largest
     REE deposit. Tailings are iron extraction residues obtained from 15 million tons of medium-poor oxidized

--- a/kb/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.yaml
+++ b/kb/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.yaml
@@ -43,8 +43,8 @@ engineering_design:
 environment_term:
   preferred_term: infant gut HMO cultivation
   term:
-    id: ENVO:00002009
-    label: feces environment
+    id: ENVO:00002003
+    label: fecal material
   notes: In vitro cultivation of infant gut microbial communities from three
     infant fecal inocula in HMO-supplemented media.
 taxonomy:

--- a/kb/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.yaml
+++ b/kb/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.yaml
@@ -18,7 +18,7 @@ community_category: RHIZOSPHERE
 environment_term:
   preferred_term: young Brachypodium primary-root rhizosphere
   term:
-    id: ENVO:00002233
+    id: ENVO:00005801
     label: rhizosphere
   notes: Rhizosphere community sampled at root tip and root base of young
     Brachypodium distachyon plants grown in natural soil in EcoFABs and

--- a/kb/communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.yaml
+++ b/kb/communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.yaml
@@ -41,7 +41,7 @@ environment_term:
   preferred_term: aerobic cellulose-fed laboratory coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled thermophilic coculture experiments on cellulose under oxidative and anaerobic
     laboratory conditions.
 taxonomy:

--- a/kb/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.yaml
+++ b/kb/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.yaml
@@ -44,7 +44,7 @@ environment_term:
   preferred_term: thermophilic anaerobic continuous-flow laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled CSTR coculture operated under anaerobic thermophilic conditions for biohydrogen production.
 taxonomy:
 - taxon_term:

--- a/kb/communities/Candida_Parapsilosis_Hospitalized_Infant_Microbiome.yaml
+++ b/kb/communities/Candida_Parapsilosis_Hospitalized_Infant_Microbiome.yaml
@@ -15,8 +15,8 @@ community_category: OTHER
 environment_term:
   preferred_term: hospitalized infant gut microbiome
   term:
-    id: ENVO:00002009
-    label: feces environment
+    id: ENVO:00002003
+    label: fecal material
   notes: In situ infant gut samples from hospitalized infants, profiled with
     genomics, transcriptomics, and proteomics to characterize C. parapsilosis
     behavior within the resident microbiome.

--- a/kb/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.yaml
+++ b/kb/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.yaml
@@ -43,7 +43,7 @@ environment_term:
   preferred_term: anaerobic illuminated laboratory coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: >
     Laboratory anaerobic coculture for cellulose-dependent photohydrogen
     production; the broad ENVO laboratory bioreactor term is used for a

--- a/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
+++ b/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
@@ -30,7 +30,7 @@ environment_term:
   preferred_term: laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Anaerobic cellulose-degrading laboratory quad-culture with sulfate perturbation.
 taxonomy:
 - taxon_term:

--- a/kb/communities/Chlorella_Azospirillum_Synthetic_Mutualism.yaml
+++ b/kb/communities/Chlorella_Azospirillum_Synthetic_Mutualism.yaml
@@ -45,7 +45,7 @@ environment_term:
   preferred_term: algal-bacterial laboratory culture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: >
     The curated community is a controlled laboratory coculture rather than a
     sampled natural community; publications use alginate bead and related

--- a/kb/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.yaml
+++ b/kb/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.yaml
@@ -44,7 +44,7 @@ environment_term:
   preferred_term: mixotrophic algal-bacterial airlift reactor coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: >
     Laboratory airlift reactor system used to study algal-bacterial coculture
     effects on biofuel-precursor production.

--- a/kb/communities/Chlorella_Rhizobium_Bioflocculation.yaml
+++ b/kb/communities/Chlorella_Rhizobium_Bioflocculation.yaml
@@ -32,7 +32,7 @@ engineering_design:
 environment_term:
   preferred_term: wastewater treatment plant
   term:
-    id: ENVO:00002001
+    id: ENVO:00002043
     label: wastewater treatment plant
   notes: 'Co-culture system grown in synthetic wastewater for optimization of algal harvesting through
     bioflocculation. Process variables include inoculation ratio, glucose concentration, and co-culture

--- a/kb/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml
+++ b/kb/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml
@@ -11,7 +11,7 @@ community_category: SYNTROPHY
 environment_term:
   preferred_term: anoxic sulfide-containing freshwater lake sediment
   term:
-    id: ENVO:01001242
+    id: ENVO:01000306
     label: freshwater environment
   notes: The consortium was originally enriched from freshwater lake sediment and maintained under anoxic,
     sulfide-reduced conditions.

--- a/kb/communities/Chromium_Sulfur_Reduction_Enrichment.yaml
+++ b/kb/communities/Chromium_Sulfur_Reduction_Enrichment.yaml
@@ -44,8 +44,8 @@ engineering_design:
 environment_term:
   preferred_term: mine tailings
   term:
-    id: ENVO:01000650
-    label: mine tailings
+    id: ENVO:00000003
+    label: mine tailing
   notes: 'Chromium-contaminated mine tailings from chromite ore processing operations, enriched under
     laboratory conditions for coupled Cr(VI) reduction and sulfur oxidation. Original environmental samples
     derived from mining-impacted sites with extreme chromium contamination (500-2000 mg/kg total Cr, 50-200

--- a/kb/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.yaml
+++ b/kb/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.yaml
@@ -40,7 +40,7 @@ environment_term:
   preferred_term: anaerobic syngas-fed laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled anaerobic laboratory cultivation with CO or syngas as gas substrate; later model
     publications evaluate the same species pair in a syngas fermentation context.
 taxonomy:

--- a/kb/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.yaml
+++ b/kb/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.yaml
@@ -40,7 +40,7 @@ environment_term:
   preferred_term: thermophilic anaerobic laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled anaerobic laboratory culture system used to evaluate defined medium for thermophilic
     cellulolytic bacteria and their coculture.
 taxonomy:

--- a/kb/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.yaml
+++ b/kb/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.yaml
@@ -45,7 +45,7 @@ environment_term:
   preferred_term: anaerobic CO-fed laboratory stirred-tank bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: >
     Controlled anaerobic stirred-tank bioreactor system with continuous carbon
     monoxide/carbon dioxide gassing for synthetic clostridial cocultivation.

--- a/kb/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.yaml
+++ b/kb/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.yaml
@@ -44,7 +44,7 @@ environment_term:
   preferred_term: cellulose-fed microbial fuel cell anode chamber
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled two-chamber laboratory microbial fuel cell with an anode as the extracellular electron
     acceptor and cellulose or carboxymethyl cellulose as the supplied electron donor.
 taxonomy:

--- a/kb/communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.yaml
+++ b/kb/communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.yaml
@@ -41,7 +41,7 @@ environment_term:
   preferred_term: anaerobic cellulose-fed laboratory serum bottle culture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled anaerobic 160-mL serum-bottle cultures in DCB-1 medium with cellulose and a
     CO2/N2 headspace.
 taxonomy:

--- a/kb/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.yaml
+++ b/kb/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.yaml
@@ -47,7 +47,7 @@ environment_term:
   preferred_term: anaerobic illuminated laboratory serum-bottle culture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: >
     Defined laboratory serum-bottle cocultures were grown anaerobically with
     cellulose, light, and argon headspace to support integrated dark and photo

--- a/kb/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.yaml
+++ b/kb/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.yaml
@@ -44,7 +44,7 @@ environment_term:
   preferred_term: anaerobic syngas-fed laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled continuous syngas-fed laboratory bioreactor for microbial gas
     fermentation and chain elongation.
 taxonomy:

--- a/kb/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.yaml
+++ b/kb/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.yaml
@@ -50,7 +50,7 @@ environment_term:
   preferred_term: laboratory cellobiose biofilm consortium
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled laboratory planktonic and colony-biofilm culture system grown in modified GS-2
     medium for cellulosic-sugar bioprocessing experiments.
 taxonomy:

--- a/kb/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.yaml
@@ -43,7 +43,7 @@ environment_term:
   preferred_term: oxygen-controlled cellulose-fed laboratory bioreactor coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled laboratory cellulose fermentation with diffusive low-level oxygen
     transfer through neoprene tubing in shake cultures and 500 mL bioreactors.
 taxonomy:

--- a/kb/communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.yaml
@@ -37,7 +37,7 @@ environment_term:
   preferred_term: anaerobic laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled anaerobic batch and semicontinuous cyclic fed-batch fermentor system for cellulose-to-ethanol
     conversion.
 taxonomy:

--- a/kb/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.yaml
+++ b/kb/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.yaml
@@ -42,7 +42,7 @@ environment_term:
   preferred_term: anaerobic cellulose-fed laboratory coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Laboratory coculture system for cellulose, cellobiose, and glucose conversion by defined
     thermophilic anaerobes.
 taxonomy:

--- a/kb/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.yaml
@@ -38,7 +38,7 @@ environment_term:
   preferred_term: cellulose-fed laboratory coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled laboratory coculture using Avicel crystalline cellulose and staged incubation for
     cellulolysis followed by butanol production.
 taxonomy:

--- a/kb/communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.yaml
+++ b/kb/communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.yaml
@@ -21,8 +21,8 @@ community_category: METHANOGENESIS
 environment_term:
   preferred_term: coastal forested freshwater wetland soil
   term:
-    id: ENVO:00000044
-    label: wetland
+    id: ENVO:00000043
+    label: wetland area
   notes: Restored coastal forested freshwater wetland soil represented by
     laboratory microcosms that simulate seawater intrusion and sulfate exposure.
 taxonomy:

--- a/kb/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.yaml
+++ b/kb/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.yaml
@@ -44,7 +44,7 @@ environment_term:
   preferred_term: wheat-straw laboratory culture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled laboratory wheat-straw culture system used for fungal transcriptomics and
     bacterial-fungal consortium metatranscriptomics.
 taxonomy:

--- a/kb/communities/Copper_Biomining_Heap_Leach.yaml
+++ b/kb/communities/Copper_Biomining_Heap_Leach.yaml
@@ -40,7 +40,7 @@ engineering_design:
 environment_term:
   preferred_term: mine tailing
   term:
-    id: ENVO:00000072
+    id: ENVO:00000003
     label: mine tailing
   notes: 'Industrial copper sulfide ore heap leach operation. Crushed low-grade ore is piled in heaps
     and irrigated with acidic solution (pH 1.5-2.5) containing the microbial consortium. The heaps provide

--- a/kb/communities/Coscinodiscus_Synthetic_Community.yaml
+++ b/kb/communities/Coscinodiscus_Synthetic_Community.yaml
@@ -33,7 +33,7 @@ engineering_design:
 environment_term:
   preferred_term: marine environment
   term:
-    id: ENVO:00002149
+    id: ENVO:01000320
     label: marine environment
   notes: 'Synthetic community assembled in laboratory culture to model diatom-bacteria interactions in
     marine phytoplankton. Members were isolated from marine environments and maintained under controlled

--- a/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
+++ b/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
@@ -48,7 +48,7 @@ environment_term:
   preferred_term: copper bioleaching column laboratory enrichment
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Acidophilic enrichments on chalcopyrite or chalcocite ores under
     bioleaching conditions, characterized by genome-resolved metagenomics at 4
     and 8 weeks.

--- a/kb/communities/DVM_Triculture.yaml
+++ b/kb/communities/DVM_Triculture.yaml
@@ -19,7 +19,7 @@ environment_term:
   preferred_term: laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: 'Laboratory synthetic community designed to study the impact of sulfate gradients on syntrophic
     lactate degradation and methanogenesis. The system demonstrates how geochemical conditions (sulfate
     availability) regulate interspecies interactions and community productivity. All three species can

--- a/kb/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.yaml
+++ b/kb/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.yaml
@@ -12,7 +12,7 @@ community_category: BIOREMEDIATION
 environment_term:
   preferred_term: deep marine hydrocarbon plume
   term:
-    id: ENVO:00002149
+    id: ENVO:01000320
     label: marine environment
   notes: Deep Gulf of Mexico water-column plume formed by the Deepwater Horizon blowout; the broader ENVO
     marine environment term is used with plume-specific context in notes.

--- a/kb/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.yaml
+++ b/kb/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.yaml
@@ -42,7 +42,7 @@ environment_term:
   preferred_term: anaerobic chlorinated-ethene laboratory coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled anaerobic defined coculture used to model chlorinated-solvent
     groundwater bioremediation under laboratory conditions.
 taxonomy:

--- a/kb/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.yaml
+++ b/kb/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.yaml
@@ -44,7 +44,7 @@ environment_term:
   preferred_term: anaerobic chlorinated-ethene laboratory triculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled defined anaerobic triculture used to model nutrient and cofactor
     exchange in chlorinated-solvent dechlorinating microbial communities.
 taxonomy:

--- a/kb/communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.yaml
@@ -40,7 +40,7 @@ environment_term:
   preferred_term: chlorinated-ethene laboratory coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Defined laboratory coculture for testing corrinoid-mediated support of Dehalococcoides
     chlorinated-ethene reductive dechlorination.
 taxonomy:

--- a/kb/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml
@@ -45,7 +45,7 @@ environment_term:
   preferred_term: anaerobic chlorinated-solvent laboratory coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled anaerobic coculture model for TCE bioremediation under acetylene exposure.
 taxonomy:
 - taxon_term:

--- a/kb/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.yaml
@@ -51,7 +51,7 @@ environment_term:
   preferred_term: anaerobic chlorinated-ethene laboratory coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled serum-bottle coculture used as a laboratory model for chlorinated-solvent bioremediation.
 taxonomy:
 - taxon_term:

--- a/kb/communities/Desulfovibrio_Methanococcus_Syntrophy.yaml
+++ b/kb/communities/Desulfovibrio_Methanococcus_Syntrophy.yaml
@@ -18,7 +18,7 @@ environment_term:
   preferred_term: sulfate-free anaerobic environment
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: 'Grown in continuous culture on lactate without sulfate under strict anaerobic conditions. In
     the absence of sulfate, D. vulgaris cannot use its typical respiratory pathway and must rely on syntrophic
     partnership with a H2-consuming organism. The system demonstrates obligate dependence on interspecies

--- a/kb/communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.yaml
+++ b/kb/communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.yaml
@@ -17,7 +17,7 @@ community_category: RHIZOSPHERE
 environment_term:
   preferred_term: drought-stressed root rhizosphere
   term:
-    id: ENVO:00002233
+    id: ENVO:00005801
     label: rhizosphere
   notes: Plant root rhizosphere under imposed drought stress, with
     phytosiderophore-transporter mutants and exogenous iron amendments used

--- a/kb/communities/ENIGMA_Denitrifying_SynCom.yaml
+++ b/kb/communities/ENIGMA_Denitrifying_SynCom.yaml
@@ -11,7 +11,7 @@ community_category: BIOREMEDIATION
 environment_term:
   preferred_term: contaminated soil
   term:
-    id: ENVO:00002874
+    id: ENVO:00002116
     label: contaminated soil
   notes: Community members were isolated from a heavily nitrate-contaminated superfund site groundwater
     system associated with ENIGMA research.

--- a/kb/communities/EcoFAB_Ring_Trial_SynCom17.yaml
+++ b/kb/communities/EcoFAB_Ring_Trial_SynCom17.yaml
@@ -41,7 +41,7 @@ environment_term:
   preferred_term: EcoFAB 2.0 hydroponic device
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: 'Fabricated ecosystem (EcoFAB 2.0) devices for standardized hydroponic plant growth. Plants grown
     in 0.5x Murashige-Skoog medium with NH4NO3 nitrogen source under controlled light conditions (16h/8h
     light/dark cycle). Protocol available at https://dx.doi.org/10.17504/protocols.io.kxygxyydkl8j/v1.

--- a/kb/communities/Emiliania_Phaeobacter_Dynamic_Interaction.yaml
+++ b/kb/communities/Emiliania_Phaeobacter_Dynamic_Interaction.yaml
@@ -30,7 +30,7 @@ engineering_design:
 environment_term:
   preferred_term: marine coccolithophore-bacterium co-culture
   term:
-    id: ENVO:00002149
+    id: ENVO:01000320
     label: marine environment
   notes: Laboratory marine co-culture representing an interaction relevant to E. huxleyi blooms and
     Roseobacter-group bacteria.

--- a/kb/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.yaml
+++ b/kb/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.yaml
@@ -33,8 +33,8 @@ engineering_design:
 environment_term:
   preferred_term: gnotobiotic mouse gut environment
   term:
-    id: ENVO:0001998
-    label: human gut environment
+    id: ENVO:2100002
+    label: intestine environment
   notes: The engineered organisms are mammalian gut-associated and were tested both in anaerobic laboratory
     medium and in gnotobiotic mouse gut conditions.
 taxonomy:

--- a/kb/communities/Ewaste_Bioleaching_Consortium.yaml
+++ b/kb/communities/Ewaste_Bioleaching_Consortium.yaml
@@ -40,7 +40,7 @@ engineering_design:
 environment_term:
   preferred_term: contaminated soil
   term:
-    id: ENVO:00002874
+    id: ENVO:00002116
     label: contaminated soil
   notes: 'Bioreactor environment for e-waste recycling using acidophilic microorganisms. Printed circuit
     boards (PCBs) from discarded electronics are crushed and added to acidic bioleaching solution containing

--- a/kb/communities/Ferroplasma_Leptospirillum_Syntrophy.yaml
+++ b/kb/communities/Ferroplasma_Leptospirillum_Syntrophy.yaml
@@ -24,7 +24,7 @@ community_category: AMD
 environment_term:
   preferred_term: acid mine drainage
   term:
-    id: ENVO:00002186
+    id: ENVO:00001997
     label: acid mine drainage
   notes: 'Extremely acidic (pH <2), metal-rich environments including natural acid mine drainage and industrial
     biomining operations. The consortium thrives on pyrite (FeS₂) and chalcopyrite (CuFeS₂) surfaces where

--- a/kb/communities/GLBRC_Exometabolite_Transwell_SynCom.yaml
+++ b/kb/communities/GLBRC_Exometabolite_Transwell_SynCom.yaml
@@ -27,7 +27,7 @@ environment_term:
   preferred_term: laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Filter plate Transwell synthetic community system for exometabolite-mediated microbial interactions.
 taxonomy:
 - taxon_term:

--- a/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
+++ b/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
@@ -45,7 +45,7 @@ environment_term:
   preferred_term: Anaerobic bioreactor (35C, pH 5.5, 6-day retention time)
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: 'Anaerobic continuous stirred-tank reactor fed ultra-filtered milk permeate (UFMP) at 0.5 L/day.
     Operated at 35 degrees C, pH controlled at 5.5, with a 6-day hydraulic retention time. Total operation
     period was 282 days.

--- a/kb/communities/GOM_Oil_Degrading_Consortium.yaml
+++ b/kb/communities/GOM_Oil_Degrading_Consortium.yaml
@@ -14,7 +14,7 @@ community_category: BIOREMEDIATION
 environment_term:
   preferred_term: marine environment
   term:
-    id: ENVO:00002149
+    id: ENVO:01000320
     label: marine environment
 taxonomy:
 - taxon_term:

--- a/kb/communities/Geobacter_Clostridium_DIET.yaml
+++ b/kb/communities/Geobacter_Clostridium_DIET.yaml
@@ -23,7 +23,7 @@ environment_term:
   preferred_term: laboratory culture
   term:
     id: ENVO:01001405
-    label: laboratory culture
+    label: laboratory environment
   notes: 'Laboratory synthetic coculture developed to optimize glycerol fermentation
     toward 1,3-propanediol production. Cultured under strict anaerobic conditions
     using Hungate techniques at 35°C with N2 gas phase. DIET occurs through physical

--- a/kb/communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.yaml
+++ b/kb/communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.yaml
@@ -46,7 +46,7 @@ environment_term:
   preferred_term: electroactive laboratory coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled laboratory coculture in restricted medium used to study
     extracellular and interspecies electron transfer.
 taxonomy:

--- a/kb/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.yaml
+++ b/kb/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.yaml
@@ -43,7 +43,7 @@ environment_term:
   preferred_term: thermophilic anaerobic laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Semi-continuously fed thermophilic enrichment reactor operated on switchgrass solids under
     anaerobic methanogenic conditions.
 taxonomy:

--- a/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
+++ b/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
@@ -25,7 +25,7 @@ community_category: AMD
 environment_term:
   preferred_term: acid mine drainage
   term:
-    id: ENVO:00002186
+    id: ENVO:00001997
     label: acid mine drainage
   notes: 'Permanently stratified (meromictic) acidic pit lake from the Iberian Pyrite Belt, southwestern
     Spain (Cueva de la Mora and similar systems). The lake exhibits three distinct layers: upper oxic

--- a/kb/communities/Industrial_Bioreactor_Consortium.yaml
+++ b/kb/communities/Industrial_Bioreactor_Consortium.yaml
@@ -43,7 +43,7 @@ engineering_design:
 environment_term:
   preferred_term: bioreactor
   term:
-    id: ENVO:01000605
+    id: ENVO:00002123
     label: bioreactor
   notes: 'Industrial-scale continuous and batch bioreactor system for chalcopyrite and sulfide ore bioleaching.
     Reactors operate at controlled moderate thermophilic temperatures (40-50°C) with pH maintained at

--- a/kb/communities/Infant_Gut_DNA_Phage_Succession_Community.yaml
+++ b/kb/communities/Infant_Gut_DNA_Phage_Succession_Community.yaml
@@ -19,8 +19,8 @@ community_category: OTHER
 environment_term:
   preferred_term: infant gut microbiome
   term:
-    id: ENVO:00002009
-    label: feces environment
+    id: ENVO:00002003
+    label: fecal material
   notes: Infant fecal samples collected longitudinally from full-term and
     preterm infants and their mothers across the first 3 years of life.
 taxonomy:

--- a/kb/communities/Infant_Gut_Strain_Persistence_Maternal_Community.yaml
+++ b/kb/communities/Infant_Gut_Strain_Persistence_Maternal_Community.yaml
@@ -16,8 +16,8 @@ community_category: OTHER
 environment_term:
   preferred_term: infant gut microbiome
   term:
-    id: ENVO:00002009
-    label: feces environment
+    id: ENVO:00002003
+    label: fecal material
   notes: Longitudinal fecal metagenome series from full-term and preterm
     infants and 17 mother-infant pairs across the first year of life.
 taxonomy:

--- a/kb/communities/Ion_Adsorption_REE_Indigenous_Community.yaml
+++ b/kb/communities/Ion_Adsorption_REE_Indigenous_Community.yaml
@@ -25,7 +25,7 @@ community_category: BIOTECHNOLOGY
 environment_term:
   preferred_term: weathering crust
   term:
-    id: ENVO:00002230
+    id: ENVO:01000747
     label: regolith
   notes: 'Weathering profile (regolith-hosted deposit) extending to 40 meters depth in granitic bedrock,
     representing the classic ion-adsorption REE deposit type of South China. The profile shows vertical

--- a/kb/communities/KBase_ORT_Workflow_Community_Model.yaml
+++ b/kb/communities/KBase_ORT_Workflow_Community_Model.yaml
@@ -30,8 +30,8 @@ engineering_design:
 environment_term:
   preferred_term: river sediment
   term:
-    id: ENVO:00002359
-    label: river sediment
+    id: ENVO:00002127
+    label: stream sediment
   notes: Columbia River sediment samples used for metagenomic assembly and metabolic modeling.
 associated_datasets:
 - name: Primary publication

--- a/kb/communities/Lac_Pavin_Stratified_Lake_Community.yaml
+++ b/kb/communities/Lac_Pavin_Stratified_Lake_Community.yaml
@@ -18,7 +18,7 @@ community_category: METHANOGENESIS
 environment_term:
   preferred_term: permanently stratified freshwater lake
   term:
-    id: ENVO:00000035
+    id: ENVO:00000020
     label: lake
   notes: Deep, permanently stratified Lac Pavin in central France, sampled
     across the oxygen gradient from the oxic interface through the anoxic

--- a/kb/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.yaml
+++ b/kb/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.yaml
@@ -19,8 +19,8 @@ community_category: METHANOGENESIS
 environment_term:
   preferred_term: terrestrial freshwater wetland
   term:
-    id: ENVO:00000044
-    label: wetland
+    id: ENVO:00000043
+    label: wetland area
   notes: Multi-site freshwater wetland synthesis spanning marsh, swamp, fen, and
     bog systems represented in the MUCC v2.0.0 database.
 taxonomy:

--- a/kb/communities/Methane_Oxidation_CrVI_Reduction_SynCom.yaml
+++ b/kb/communities/Methane_Oxidation_CrVI_Reduction_SynCom.yaml
@@ -27,7 +27,7 @@ environment_term:
   preferred_term: laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Hypoxic methane-fed synthetic microbial community for chromium reduction.
 taxonomy:
 - taxon_term:

--- a/kb/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.yaml
+++ b/kb/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.yaml
@@ -39,7 +39,7 @@ environment_term:
   preferred_term: thermoacidophilic methane-fed photobioreactor coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Laboratory methane-fed photobioreactor system assembled from thermoacidophilic strains
     originally associated with geothermal environments.
 taxonomy:

--- a/kb/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.yaml
+++ b/kb/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.yaml
@@ -39,7 +39,7 @@ environment_term:
   preferred_term: methane-fed aerobic laboratory coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled vial coculture experiment with methane and oxygen headspace, curated as a laboratory
     bioreactor-like methane-fed culture system.
 taxonomy:

--- a/kb/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.yaml
+++ b/kb/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.yaml
@@ -36,7 +36,7 @@ environment_term:
   preferred_term: methane-fed laboratory coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled NMS-SP bottle coculture under methane/air headspace using strains originally isolated
     from marine sediment near Kagoshima Bay, Japan.
 taxonomy:

--- a/kb/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.yaml
+++ b/kb/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.yaml
@@ -34,7 +34,7 @@ environment_term:
   preferred_term: methane-fed laboratory bioreactor coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled laboratory coculture with methane, oxygen or air headspace, mineral
     salt medium, and volatile fatty acid cosubstrates.
 taxonomy:

--- a/kb/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.yaml
+++ b/kb/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.yaml
@@ -45,7 +45,7 @@ environment_term:
   preferred_term: saline methane-fed laboratory coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: >
     Controlled laboratory coculture in saline medium and enclosed methane-fed
     serum bottles; the record represents the experimental system rather than a

--- a/kb/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.yaml
+++ b/kb/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.yaml
@@ -39,7 +39,7 @@ environment_term:
   preferred_term: illuminated gas-fed laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled batch and continuous gas-fed laboratory coculture under illumination.
 taxonomy:
 - taxon_term:

--- a/kb/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.yaml
+++ b/kb/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.yaml
@@ -28,7 +28,7 @@ engineering_design:
 environment_term:
   preferred_term: contaminated soil
   term:
-    id: ENVO:00002874
+    id: ENVO:00002116
     label: contaminated soil
   notes: Ionic rare earth mine tailing soil with high ammonia nitrogen.
 taxonomy:

--- a/kb/communities/Mixed_Gallium_LED_Recovery_Consortium.yaml
+++ b/kb/communities/Mixed_Gallium_LED_Recovery_Consortium.yaml
@@ -42,7 +42,7 @@ engineering_design:
 environment_term:
   preferred_term: contaminated soil
   term:
-    id: ENVO:00002874
+    id: ENVO:00002116
     label: contaminated soil
   notes: 'Engineered two-stage bioleaching system for gallium recovery from waste LEDs. The non-contact
     process consists of: (1) a bioreactor where the acidophilic consortium generates sulfuric acid and

--- a/kb/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.yaml
+++ b/kb/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.yaml
@@ -46,7 +46,7 @@ environment_term:
   preferred_term: laboratory cyanobacteria-heterotroph coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Replicated in vitro consortia maintained as stable cyanobacteria-heterotroph
     cocultures derived from three freshwater inocula and five model cyanobacterial
     hosts.

--- a/kb/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.yaml
+++ b/kb/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.yaml
@@ -42,7 +42,7 @@ environment_term:
   preferred_term: defined model lignocellulose laboratory culture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: The community was studied in reproducible laboratory coculture experiments using a defined
     Model Lignocellulose growth medium.
 taxonomy:

--- a/kb/communities/Multiomics_Corn_Straw_Degradation_SynCom.yaml
+++ b/kb/communities/Multiomics_Corn_Straw_Degradation_SynCom.yaml
@@ -27,7 +27,7 @@ environment_term:
   preferred_term: laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Solid-state corn straw fermentation with an eight-strain lignocellulose-degrading SynCom.
 taxonomy:
 - taxon_term:

--- a/kb/communities/NCycle_Bioflocculation_Model_Consortium.yaml
+++ b/kb/communities/NCycle_Bioflocculation_Model_Consortium.yaml
@@ -28,7 +28,7 @@ environment_term:
   preferred_term: activated sludge floc model
   term:
     id: ENVO:00002046
-    label: sludge
+    label: activated sludge
   notes: Model consortium designed to emulate aggregation in biological wastewater treatment.
 taxonomy:
 - taxon_term:

--- a/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
+++ b/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
@@ -23,8 +23,8 @@ community_category: EXTREME_ENVIRONMENT
 environment_term:
   preferred_term: deep subsurface environment
   term:
-    id: ENVO:01000017
-    label: subsurface environment
+    id: ENVO:01000942
+    label: continental subsurface zone
   notes: 'Deep subsurface hydrothermal aquifer system at 700-760 m depth in the Naica Mine, Chihuahua,
     Mexico, feeding the Cave of Crystals (Cueva de los Cristales) with giant gypsum selenite crystals
     up to 11 m long. The aquifer contains low-salinity hydrothermal water at 54-60°C originating from

--- a/kb/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.yaml
+++ b/kb/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.yaml
@@ -44,7 +44,7 @@ environment_term:
   preferred_term: anaerobic continuous-flow laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: The source describes an anaerobic continuous-culture laboratory system rather than an
     environmental field sample.
 taxonomy:

--- a/kb/communities/PGM_Spent_Catalyst_Bioleaching.yaml
+++ b/kb/communities/PGM_Spent_Catalyst_Bioleaching.yaml
@@ -44,7 +44,7 @@ engineering_design:
 environment_term:
   preferred_term: contaminated soil
   term:
-    id: ENVO:00002874
+    id: ENVO:00002116
     label: contaminated soil
   notes: 'Column bioreactor environment for PGM recovery from spent catalysts using acidophilic bioleaching
     consortium. Spent automotive three-way catalysts (TWC) and petroleum refinery hydroprocessing catalysts

--- a/kb/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.yaml
+++ b/kb/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.yaml
@@ -50,7 +50,7 @@ engineering_design:
 environment_term:
   preferred_term: PSY transgenic rice paddy rhizosphere
   term:
-    id: ENVO:00002233
+    id: ENVO:00005801
     label: rhizosphere
   notes: Rhizosphere soil surrounding PSY1 and PSY2 transgenic rice genotypes in
     rice paddy growth conditions.

--- a/kb/communities/Panzhihua_Vanadium_Titanium_Tailings.yaml
+++ b/kb/communities/Panzhihua_Vanadium_Titanium_Tailings.yaml
@@ -26,8 +26,8 @@ community_category: BIOREMEDIATION
 environment_term:
   preferred_term: mine tailings
   term:
-    id: ENVO:01000650
-    label: mine tailings
+    id: ENVO:00000003
+    label: mine tailing
   notes: 'Vanadium-titanium magnetite mine tailings from Panzhihua, Sichuan Province, China, located by
     the Jinsha River in the southern Panxi rift valley. Panzhihua hosts the world''s largest vanadium-titanium
     magnetite deposit with approximately 570 million tons of accumulated tailings from V-Ti magnetite

--- a/kb/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.yaml
+++ b/kb/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.yaml
@@ -45,7 +45,7 @@ environment_term:
   preferred_term: anaerobic methanogenic laboratory coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: >
     Controlled anaerobic laboratory coculture used to study syntrophic
     propionate oxidation coupled to hydrogenotrophic methanogenesis.

--- a/kb/communities/Pelotomaculum_Methanothermobacter_Syntrophy.yaml
+++ b/kb/communities/Pelotomaculum_Methanothermobacter_Syntrophy.yaml
@@ -18,7 +18,7 @@ environment_term:
   preferred_term: thermophilic anaerobic digester
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: 'Enriched from thermophilic anaerobic digesters. Grown as syntrophic coculture under strict anaerobic
     conditions at 55°C and pH 7.0. The organism requires coaggregation with hydrogenotrophic methanogens
     and demonstrates obligate dependence on interspecies hydrogen transfer. Optimal growth temperature

--- a/kb/communities/Phylogenetically_Diverse_Denitrifying_SynCom.yaml
+++ b/kb/communities/Phylogenetically_Diverse_Denitrifying_SynCom.yaml
@@ -28,7 +28,7 @@ environment_term:
   preferred_term: laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Synthetic denitrifying communities experimentally evolved under laboratory conditions.
 taxonomy:
 - taxon_term:

--- a/kb/communities/Polaromonas_Vanadium_Reduction_Community.yaml
+++ b/kb/communities/Polaromonas_Vanadium_Reduction_Community.yaml
@@ -25,8 +25,8 @@ community_category: OTHER
 environment_term:
   preferred_term: mine tailings
   term:
-    id: ENVO:01000650
-    label: mine tailings
+    id: ENVO:00000003
+    label: mine tailing
   notes: 'Vanadium mine tailings from northern China (Chengde region) containing extremely high concentrations
     of vanadium (10,500 mg/kg total V) and co-contaminating metals including arsenic, chromium, and manganese.
     The tailings are derived from vanadium titanomagnetite ore processing and steel production waste.

--- a/kb/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.yaml
+++ b/kb/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.yaml
@@ -17,8 +17,8 @@ community_category: METHANOGENESIS
 environment_term:
   preferred_term: Prairie Pothole wetland sediment
   term:
-    id: ENVO:00000044
-    label: wetland
+    id: ENVO:00000043
+    label: wetland area
   notes: Prairie Pothole Region wetland sediments with high dissolved organic
     carbon, sulfur species, methane fluxes, and sulfate reduction rates.
 taxonomy:

--- a/kb/communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.yaml
+++ b/kb/communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.yaml
@@ -20,8 +20,8 @@ community_category: OTHER
 environment_term:
   preferred_term: premature infant gut microbiome
   term:
-    id: ENVO:00002009
-    label: feces environment
+    id: ENVO:00002003
+    label: fecal material
   notes: Twenty fecal samples (4-6 time points each) from four premature
     infants; two infants later developed necrotizing enterocolitis.
 taxonomy:

--- a/kb/communities/Prochlorococcus_Alteromonas_Helper_Coculture.yaml
+++ b/kb/communities/Prochlorococcus_Alteromonas_Helper_Coculture.yaml
@@ -30,7 +30,7 @@ engineering_design:
 environment_term:
   preferred_term: marine environment
   term:
-    id: ENVO:00002149
+    id: ENVO:01000320
     label: marine environment
   notes: Ocean-surface phototroph-heterotroph interaction represented in controlled laboratory coculture.
 taxonomy:

--- a/kb/communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.yaml
+++ b/kb/communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.yaml
@@ -60,7 +60,7 @@ environment_term:
   preferred_term: aerobic propane-amended chlorinated-ethene enrichment culture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Serum-bottle laboratory enrichment cultures derived from KBS-LTER
     agricultural soils and West Coast Naval Station impacted-site sediment,
     amended with propane and individual chlorinated ethenes.

--- a/kb/communities/Pseudomonas_Rhodococcus_Chloronitrobenzene_Coculture.yaml
+++ b/kb/communities/Pseudomonas_Rhodococcus_Chloronitrobenzene_Coculture.yaml
@@ -43,7 +43,7 @@ environment_term:
   preferred_term: chloronitrobenzene-fed laboratory coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled laboratory coculture assay for degradation of chloronitrobenzene pollutants.
 taxonomy:
 - taxon_term:

--- a/kb/communities/Pseudonitzschia_Sulfitobacter_Association.yaml
+++ b/kb/communities/Pseudonitzschia_Sulfitobacter_Association.yaml
@@ -13,7 +13,7 @@ community_category: PHYTOPLANKTON
 environment_term:
   preferred_term: marine environment
   term:
-    id: ENVO:00002149
+    id: ENVO:01000320
     label: marine environment
 taxonomy:
 - taxon_term:

--- a/kb/communities/Rammelsberg_Cobalt_Nickel_Tailings.yaml
+++ b/kb/communities/Rammelsberg_Cobalt_Nickel_Tailings.yaml
@@ -42,7 +42,7 @@ engineering_design:
 environment_term:
   preferred_term: mine tailing
   term:
-    id: ENVO:00000072
+    id: ENVO:00000003
     label: mine tailing
   notes: 'Sulfidic mine tailings from the Rammelsberg polymetallic massive sulfide deposit in the Harz
     Mountains, Germany. The tailings contain low-grade cobalt (0.02% in bulk tailings, 0.06% in flotation

--- a/kb/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.yaml
+++ b/kb/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.yaml
@@ -28,7 +28,7 @@ environment_term:
   preferred_term: laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Engineered and evolved two-member cross-feeding coculture.
 taxonomy:
 - taxon_term:

--- a/kb/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.yaml
+++ b/kb/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.yaml
@@ -44,7 +44,7 @@ environment_term:
   preferred_term: magnetite-amended laboratory coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: >
     Controlled laboratory coculture used to test microbe-mineral electron
     transfer through magnetite under changing redox and light conditions.

--- a/kb/communities/Rice_Acid_Soil_Bioinoculant_SynCom.yaml
+++ b/kb/communities/Rice_Acid_Soil_Bioinoculant_SynCom.yaml
@@ -27,7 +27,7 @@ engineering_design:
 environment_term:
   preferred_term: contaminated soil
   term:
-    id: ENVO:00002874
+    id: ENVO:00002116
     label: contaminated soil
   notes: Acid soil with aluminum toxicity constraints for rice production.
 taxonomy:

--- a/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
+++ b/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
@@ -24,7 +24,7 @@ community_category: AMD
 environment_term:
   preferred_term: acid mine drainage
   term:
-    id: ENVO:00002186
+    id: ENVO:00001997
     label: acid mine drainage
   notes: 'Extremely acidic (pH 0.5-1.0) subaerial biofilm formed at the air-solution
     interface of underground AMD streams and pools within the Richmond Mine. The mine

--- a/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
+++ b/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
@@ -41,7 +41,7 @@ environment_term:
   preferred_term: microbial electrochemical cell anode biofilm
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Acetate-fed microbial electrochemical cells inoculated with Rifle, CO
     aquifer material; anodes poised at iron-oxide-like redox potentials.
 taxonomy:

--- a/kb/communities/Rifle_Uranium_Reducing_Community.yaml
+++ b/kb/communities/Rifle_Uranium_Reducing_Community.yaml
@@ -22,7 +22,7 @@ community_category: BIOREMEDIATION
 environment_term:
   preferred_term: contaminated soil
   term:
-    id: ENVO:00002874
+    id: ENVO:00002116
     label: contaminated soil
   notes: 'Uranium-contaminated alluvial aquifer sediment at the Old Rifle UMTRA (Uranium Mill Tailings
     Remedial Action) site in Rifle, Colorado. Groundwater contamination resulted from historic uranium

--- a/kb/communities/SIHUMIx_Human_Intestinal_Model_Community.yaml
+++ b/kb/communities/SIHUMIx_Human_Intestinal_Model_Community.yaml
@@ -32,8 +32,8 @@ engineering_design:
 environment_term:
   preferred_term: human gut environment
   term:
-    id: ENVO:0001998
-    label: human gut environment
+    id: ENVO:2100002
+    label: intestine environment
   notes: SIHUMIx is an in vitro model of the human intestinal microbiota.
 taxonomy:
 - taxon_term:

--- a/kb/communities/SPRUCE_Peatland_Methane_Cycling_Community.yaml
+++ b/kb/communities/SPRUCE_Peatland_Methane_Cycling_Community.yaml
@@ -13,7 +13,7 @@ environment_term:
   preferred_term: bog
   term:
     id: ENVO:00000044
-    label: bog
+    label: peatland
   notes: SPRUCE is located in the acidic, ombrotrophic S1 Bog of the Marcell Experimental Forest in northern
     Minnesota.
 taxonomy:

--- a/kb/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.yaml
+++ b/kb/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.yaml
@@ -12,7 +12,7 @@ community_category: EXTREME_ENVIRONMENT
 environment_term:
   preferred_term: seasonally anoxic marine fjord water column
   term:
-    id: ENVO:00002149
+    id: ENVO:01000320
     label: marine environment
   notes: Saanich Inlet is a seasonally anoxic fjord and model oxygen minimum zone; this record captures
     the water-column redox-gradient microbial community.

--- a/kb/communities/Salar_Atacama_Lithium_Brine_Community.yaml
+++ b/kb/communities/Salar_Atacama_Lithium_Brine_Community.yaml
@@ -21,7 +21,7 @@ community_category: EXTREME_ENVIRONMENT
 environment_term:
   preferred_term: hypersaline brine
   term:
-    id: ENVO:00002019
+    id: ENVO:00002012
     label: hypersaline water
   notes: 'Extremely hypersaline lithium-rich brine environment in the Salar de Atacama, located at 2,300
     m above sea level in the Atacama Desert. The salar covers 3,000 km² and represents the world''s largest

--- a/kb/communities/Shewanella_Denitrifying_Richness_SynComs.yaml
+++ b/kb/communities/Shewanella_Denitrifying_Richness_SynComs.yaml
@@ -27,7 +27,7 @@ environment_term:
   preferred_term: laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Synthetic denitrifying communities with Shewanella richness gradient.
 taxonomy:
 - taxon_term:

--- a/kb/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.yaml
+++ b/kb/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.yaml
@@ -40,7 +40,7 @@ environment_term:
   preferred_term: anode-associated bioelectrochemical reactor biofilm
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled laboratory bioelectrochemical system with a defined anode-associated multispecies
     biofilm.
 taxonomy:

--- a/kb/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.yaml
+++ b/kb/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.yaml
@@ -42,7 +42,7 @@ environment_term:
   preferred_term: starch-fed laboratory microbial fuel cell
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled laboratory microbial fuel cell operated with starch-derived
     fermentation products supporting exoelectrogenic current generation.
 taxonomy:

--- a/kb/communities/Sphingobium_Rhodococcus_Lignin_Dimer_Valorization_Coculture.yaml
+++ b/kb/communities/Sphingobium_Rhodococcus_Lignin_Dimer_Valorization_Coculture.yaml
@@ -43,7 +43,7 @@ environment_term:
   preferred_term: laboratory lignin-dimer bioconversion culture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: >
     Controlled laboratory coculture system for bioconversion of lignin-derived
     aromatic dimers. The broad laboratory bioreactor term is used for the

--- a/kb/communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.yaml
+++ b/kb/communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.yaml
@@ -18,7 +18,7 @@ environment_term:
   preferred_term: thawing permafrost peatland
   term:
     id: ENVO:00000044
-    label: bog
+    label: peatland
   notes: Stordalen Mire is represented as a thawing permafrost peatland mosaic
     with palsa, bog, and fen habitats; ENVO bog is used as the closest validated
     wetland habitat term already used in this repository for peat methanogenesis

--- a/kb/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.yaml
+++ b/kb/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.yaml
@@ -20,8 +20,8 @@ community_category: EXTREME_ENVIRONMENT
 environment_term:
   preferred_term: sulfide-rich spring biofilm
   term:
-    id: ENVO:01001063
-    label: sulfide-rich spring
+    id: ENVO:00000126
+    label: sulfur spring
   notes: Biofilms in sulfide-rich springs sustained by deeply sourced groundwater.
 taxonomy:
 - taxon_term:

--- a/kb/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.yaml
+++ b/kb/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.yaml
@@ -39,7 +39,7 @@ environment_term:
   preferred_term: illuminated laboratory photobioreactor coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled synthetic illuminated coculture for photosynthetic sucrose transfer, nitrogen fixation,
     and PHB production.
 taxonomy:

--- a/kb/communities/Synechococcus_Ecoli_SPC.yaml
+++ b/kb/communities/Synechococcus_Ecoli_SPC.yaml
@@ -32,7 +32,7 @@ environment_term:
   preferred_term: laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: 'Grown in liquid culture under continuous illumination with osmotic pressure (NaCl) and IPTG
     induction for sucrose secretion.
 

--- a/kb/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.yaml
+++ b/kb/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.yaml
@@ -40,7 +40,7 @@ environment_term:
   preferred_term: illuminated laboratory photobioreactor coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled synthetic light-driven coculture for photosynthetic sucrose transfer and PHB production.
 taxonomy:
 - taxon_term:

--- a/kb/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.yaml
+++ b/kb/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.yaml
@@ -44,7 +44,7 @@ environment_term:
   preferred_term: illuminated laboratory photobioreactor coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: BG-11-derived laboratory coculture and photobioreactor system under illumination, salt stress,
     IPTG induction, and controlled or semi-controlled CO2/light conditions.
 taxonomy:

--- a/kb/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.yaml
+++ b/kb/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.yaml
@@ -45,7 +45,7 @@ environment_term:
   preferred_term: biophotovoltaic laboratory electrochemical coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled light-driven laboratory bioelectrochemical device with separated cyanobacterial
     and anode-associated Shewanella functions.
 taxonomy:

--- a/kb/communities/Synthetic_Periphyton_Freshwater_Biofilm.yaml
+++ b/kb/communities/Synthetic_Periphyton_Freshwater_Biofilm.yaml
@@ -28,7 +28,7 @@ engineering_design:
 environment_term:
   preferred_term: freshwater periphyton biofilm
   term:
-    id: ENVO:01001242
+    id: ENVO:01000306
     label: freshwater environment
   notes: Synthetic periphytic biofilm grown on glass slides under controlled conditions.
 taxonomy:

--- a/kb/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.yaml
+++ b/kb/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.yaml
@@ -45,7 +45,7 @@ environment_term:
   preferred_term: anaerobic methanogenic laboratory coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: >
     Controlled laboratory coculture used as a model for syntrophic butyrate
     oxidation and methanogenesis in anoxic environments.

--- a/kb/communities/Syntrophomonas_Methanospirillum_Syntrophy.yaml
+++ b/kb/communities/Syntrophomonas_Methanospirillum_Syntrophy.yaml
@@ -16,7 +16,7 @@ environment_term:
   preferred_term: anaerobic digester
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: 'Enriched from anaerobic digesters. Grown as syntrophic coculture under strict anaerobic conditions.
     The addition of H2 gas inhibits growth and butyrate degradation, demonstrating obligate dependence
     on interspecies hydrogen transfer.

--- a/kb/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.yaml
+++ b/kb/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.yaml
@@ -39,7 +39,7 @@ environment_term:
   preferred_term: anaerobic methanogenic laboratory coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled anaerobic laboratory coculture assay used to study methanogenic benzoate degradation.
 taxonomy:
 - taxon_term:

--- a/kb/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.yaml
+++ b/kb/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.yaml
@@ -44,7 +44,7 @@ environment_term:
   preferred_term: thermophilic anaerobic laboratory coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled thermophilic anaerobic serum-bottle or coculture assays used to study acetate
     oxidation coupled to methanogenesis.
 taxonomy:

--- a/kb/communities/Thermophilic_Pyrite_QS_Consortium.yaml
+++ b/kb/communities/Thermophilic_Pyrite_QS_Consortium.yaml
@@ -41,7 +41,7 @@ engineering_design:
 environment_term:
   preferred_term: mine tailing
   term:
-    id: ENVO:00000072
+    id: ENVO:00000003
     label: mine tailing
   notes: 'Laboratory-scale moderately thermophilic bioleaching system using pyrite (FeS₂) and chalcopyrite
     (CuFeS₂) minerals as substrates. Cultures were grown in acidic media (pH 2.0-2.5) at 40°C with constant

--- a/kb/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.yaml
+++ b/kb/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.yaml
@@ -45,7 +45,7 @@ environment_term:
   preferred_term: hyperthermophilic anaerobic laboratory coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled anaerobic high-temperature coculture model for hydrogen transfer and methanogenesis.
 taxonomy:
 - taxon_term:

--- a/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
+++ b/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
@@ -45,7 +45,7 @@ environment_term:
   preferred_term: thiocyanate-fed laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Laboratory bioreactor cultivations of SCN- degrading consortia over
     790 days with molasses-amended and molasses-free reactors.
 taxonomy:

--- a/kb/communities/Tinto_River_Iron_Cycling_Community.yaml
+++ b/kb/communities/Tinto_River_Iron_Cycling_Community.yaml
@@ -23,7 +23,7 @@ community_category: AMD
 environment_term:
   preferred_term: acid mine drainage
   term:
-    id: ENVO:00002186
+    id: ENVO:00001997
     label: acid mine drainage
   notes: 'Natural acid mine drainage from the Rio Tinto River, southwestern Spain (Huelva province), flowing
     100 km through the Iberian Pyrite Belt with massive sulfide ore deposits. The river exhibits constant

--- a/kb/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.yaml
+++ b/kb/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.yaml
@@ -31,7 +31,7 @@ environment_term:
   preferred_term: laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Anaerobic laboratory consortium for halogenated aromatic mineralization.
 taxonomy:
 - taxon_term:

--- a/kb/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.yaml
+++ b/kb/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.yaml
@@ -40,7 +40,7 @@ environment_term:
   preferred_term: anaerobic wastewater bioreactor model coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: >
     The exact coculture was assembled and assayed in the laboratory as a model
     for syntrophic fatty acid oxidation in anoxic sediments, soils, and

--- a/kb/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.yaml
+++ b/kb/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.yaml
@@ -39,7 +39,7 @@ environment_term:
   preferred_term: cellulosic biomass laboratory bioprocess
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled laboratory fungal-bacterial consortium culture for cellulosic biomass
     hydrolysis and isobutanol fermentation.
 taxonomy:

--- a/kb/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.yaml
+++ b/kb/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.yaml
@@ -44,7 +44,7 @@ environment_term:
   preferred_term: cellulose-fed filamentous laboratory coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: >
     Controlled laboratory coculture designed for studying tunable filamentous
     population dynamics and cellulose-supported cross-feeding.

--- a/kb/communities/Trichodesmium_Alteromonas_Marine_Consortium.yaml
+++ b/kb/communities/Trichodesmium_Alteromonas_Marine_Consortium.yaml
@@ -13,7 +13,7 @@ community_category: PHYTOPLANKTON
 environment_term:
   preferred_term: warm oligotrophic marine water column
   term:
-    id: ENVO:00002149
+    id: ENVO:01000320
     label: marine environment
   notes: Trichodesmium colonies are described from warm oligotrophic oceans and North Pacific
     Subtropical Gyre field samples, with laboratory culture observations used to resolve mechanisms.

--- a/kb/communities/Urine_Nitrification_SynCom.yaml
+++ b/kb/communities/Urine_Nitrification_SynCom.yaml
@@ -28,7 +28,7 @@ environment_term:
   preferred_term: laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Synthetic and real urine nitrification reactors.
 taxonomy:
 - taxon_term:

--- a/kb/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.yaml
+++ b/kb/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.yaml
@@ -46,7 +46,7 @@ environment_term:
   preferred_term: mine-tailings-derived laboratory microbial consortium microcosm
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Laboratory microbial consortia derived from mine tailings and propagated
     under dozens of growth conditions in defined media, with monoculture and
     co-culture growth assays used to validate predicted interactions.

--- a/kb/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.yaml
+++ b/kb/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.yaml
@@ -16,8 +16,8 @@ community_category: METHANOGENESIS
 environment_term:
   preferred_term: freshwater wetland soil
   term:
-    id: ENVO:00000044
-    label: wetland
+    id: ENVO:00000043
+    label: wetland area
   notes: Freshwater lacustrine wetland soil community represented by laboratory
     microcosms that perturb wetland redox and sulfate availability.
 taxonomy:

--- a/kb/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.yaml
+++ b/kb/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.yaml
@@ -30,7 +30,7 @@ environment_term:
   preferred_term: laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Synthetic microbial community for enzyme production and wheat straw pretreatment before anaerobic
     digestion.
 taxonomy:

--- a/kb/communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.yaml
+++ b/kb/communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.yaml
@@ -43,7 +43,7 @@ environment_term:
   preferred_term: synthetic laboratory auxotroph coculture
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
+    label: laboratory environment
   notes: Controlled laboratory coculture used to test reciprocal auxotroph rescue and metabolite cross-feeding.
 taxonomy:
 - taxon_term:

--- a/scripts/term_fix_apply.py
+++ b/scripts/term_fix_apply.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Apply ontology id/label corrections across community YAMLs (generalised).
+
+Like scripts/chebi_fix_apply.py but for any ontology prefix. Edit ADAPTER,
+REPOINT and RELABEL below per run. Labels are always taken from OAK's live
+canonical label, so id+label stay consistent.
+
+  REPOINT[(old_id, old_label)] = new_id  -> rewrite id to new_id, label to canon[new_id]
+  RELABEL{(old_id, old_label)}           -> keep id, rewrite label to canon[old_id]
+
+Usage: uv run python scripts/term_fix_apply.py [--dry-run]
+"""
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+DRY = "--dry-run" in sys.argv
+COMM = Path("kb/communities")
+ADAPTER = "sqlite:obo:envo"
+PREFIX = "ENVO"
+
+# (old_id, old_label) -> new_id   (label becomes canon[new_id])
+REPOINT = {
+    ("ENVO:00000035", "lake"): "ENVO:00000020",
+    ("ENVO:00000044", "wetland"): "ENVO:00000043",
+    ("ENVO:00000072", "mine tailing"): "ENVO:00000003",
+    ("ENVO:00002001", "wastewater treatment plant"): "ENVO:00002043",
+    ("ENVO:00002019", "hypersaline water"): "ENVO:00002012",
+    ("ENVO:00002047", "waste water"): "ENVO:00002001",
+    ("ENVO:00002149", "marine environment"): "ENVO:01000320",
+    ("ENVO:00002179", "permafrost"): "ENVO:00000134",
+    ("ENVO:00002186", "acid mine drainage"): "ENVO:00001997",
+    ("ENVO:00002230", "regolith"): "ENVO:01000747",
+    ("ENVO:00002233", "rhizosphere"): "ENVO:00005801",
+    ("ENVO:00002874", "contaminated soil"): "ENVO:00002116",
+    ("ENVO:01000605", "bioreactor"): "ENVO:00002123",
+    ("ENVO:01000650", "mine tailings"): "ENVO:00000003",
+    ("ENVO:01001063", "sulfide-rich spring"): "ENVO:00000126",
+    ("ENVO:01001242", "freshwater environment"): "ENVO:01000306",
+    ("ENVO:01000017", "subsurface environment"): "ENVO:01000942",
+    ("ENVO:0001998", "human gut environment"): "ENVO:2100002",
+    ("ENVO:00002009", "feces environment"): "ENVO:00002003",
+    ("ENVO:00002359", "river sediment"): "ENVO:00002127",
+}
+
+# (old_id, old_label) where id is the correct/acceptable term; relabel to canon[old_id]
+RELABEL = {
+    ("ENVO:00000044", "bog"),               # canon: peatland (peat bog)
+    ("ENVO:00002046", "sludge"),            # canon: activated sludge
+    ("ENVO:01001405", "laboratory bioreactor"),  # canon: laboratory environment
+    ("ENVO:01001405", "laboratory culture"),     # canon: laboratory environment
+}
+
+# Intentionally left for manual curation (no clean ENVO term):
+#   ENVO:00000274 "soda lake" (=continental rise), ENVO:00002009 "feces environment"
+#   (=obsolete), ENVO:00002229 "anaerobic environment" (=arenosol), ENVO:00002359
+#   "river sediment" (=None), ENVO:0001998 "human gut environment" (=None),
+#   ENVO:01001442 "phyllosphere" (=agriculture)
+
+ID_RE = re.compile(rf"^(\s*)id:\s*({PREFIX}:\d+)\s*$")
+LBL_RE = re.compile(r"^(\s*)label:\s*(.+?)\s*$")
+
+need_ids = sorted({n for n in REPOINT.values()} | {o for (o, _l) in RELABEL})
+proc = subprocess.run(["uv", "run", "runoak", "-i", ADAPTER, "info", *need_ids],
+                      capture_output=True, text=True)
+canon = {}
+for line in proc.stdout.splitlines():
+    m = re.match(rf"^({PREFIX}:\d+)\s*!\s*(.*)$", line.strip())
+    if m:
+        canon[m.group(1)] = m.group(2).strip()
+bad = [i for i in need_ids if not canon.get(i) or canon[i].lower() in ("none", "")]
+if bad:
+    print("ABORT: missing canonical labels for:", bad)
+    sys.exit(1)
+
+changes = 0
+files_touched = set()
+per_pair = {}
+for f in sorted(COMM.glob("*.yaml")):
+    L = f.read_text().splitlines(keepends=True)
+    out = list(L)
+    for i in range(len(L) - 1):
+        m = ID_RE.match(L[i].rstrip("\n"))
+        if not m:
+            continue
+        indent, oid = m.group(1), m.group(2)
+        lm = LBL_RE.match(L[i + 1].rstrip("\n"))
+        if not lm:
+            continue
+        key = (oid, lm.group(2))
+        if key in REPOINT:
+            nid = REPOINT[key]
+            out[i] = f"{indent}id: {nid}\n"
+            out[i + 1] = f"{lm.group(1)}label: {canon[nid]}\n"
+            changes += 1; files_touched.add(f.name); per_pair[key] = per_pair.get(key, 0) + 1
+        elif key in RELABEL:
+            out[i + 1] = f"{lm.group(1)}label: {canon[oid]}\n"
+            changes += 1; files_touched.add(f.name); per_pair[key] = per_pair.get(key, 0) + 1
+    if not DRY:
+        f.write_text("".join(out))
+
+print(f"{'DRY-RUN: ' if DRY else ''}{changes} line-pairs changed across {len(files_touched)} files")
+print(f"{len(per_pair)} of {len(REPOINT)+len(RELABEL)} rules matched")
+for k in (set(REPOINT) | RELABEL) - set(per_pair):
+    print("  UNMATCHED:", k)

--- a/scripts/term_label_audit.py
+++ b/scripts/term_label_audit.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Audit ontology id/label consistency across community YAMLs vs OAK canonical labels.
+
+Generalises scripts/chebi_label_audit.py to all ontology prefixes used in
+kb/communities (NCBITaxon, GO, ENVO, UBERON, CL, CHEBI). Extracts every
+`id: <PREFIX>:NNN` line + the immediately-following `label:` line and compares
+the in-file label to the OAK canonical label for that id.
+
+Usage:
+  uv run python scripts/term_label_audit.py [PREFIX ...]
+  (default: GO ENVO UBERON CL ; NCBITaxon/CHEBI must be named explicitly
+   because their sqlite adapters are large/slow to load)
+"""
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+COMM = Path("kb/communities")
+ADAPTER = {
+    "NCBITaxon": "sqlite:obo:ncbitaxon",
+    "GO": "sqlite:obo:go",
+    "ENVO": "sqlite:obo:envo",
+    "UBERON": "sqlite:obo:uberon",
+    "CL": "sqlite:obo:cl",
+    "CHEBI": "sqlite:obo:chebi",
+}
+LBL_RE = re.compile(r"^\s*label:\s*(.+?)\s*$")
+
+prefixes = [a for a in sys.argv[1:] if a in ADAPTER] or ["GO", "ENVO", "UBERON", "CL"]
+
+
+def norm(s):
+    return " ".join(s.split()).strip().lower()
+
+
+for prefix in prefixes:
+    id_re = re.compile(rf"^\s*id:\s*({prefix}:\d+)\s*$")
+    pair_files = defaultdict(set)
+    id_labels = defaultdict(set)
+    for f in sorted(COMM.glob("*.yaml")):
+        lines = f.read_text().splitlines()
+        for i, ln in enumerate(lines):
+            m = id_re.match(ln)
+            if not m or i + 1 >= len(lines):
+                continue
+            lm = LBL_RE.match(lines[i + 1])
+            if lm:
+                pair_files[(m.group(1), lm.group(1))].add(f.name)
+                id_labels[m.group(1)].add(lm.group(1))
+
+    ids = sorted(id_labels)
+    if not ids:
+        print(f"\n## {prefix}: no terms in corpus")
+        continue
+    canon = {}
+    proc = subprocess.run(["uv", "run", "runoak", "-i", ADAPTER[prefix], "info", *ids],
+                          capture_output=True, text=True)
+    for line in proc.stdout.splitlines():
+        mm = re.match(rf"^({prefix}:\d+)\s*!\s*(.*)$", line.strip())
+        if mm:
+            canon[mm.group(1)] = mm.group(2).strip()
+
+    mism = []
+    for (cid, lbl), files in sorted(pair_files.items()):
+        c = canon.get(cid)
+        if c is None or c == "" or c.lower() in ("none", "obsolete"):
+            mism.append((cid, lbl, c or "(NOT FOUND)", sorted(files)))
+        elif norm(lbl) != norm(c):
+            mism.append((cid, lbl, c, sorted(files)))
+
+    print(f"\n## {prefix}: {len(ids)} unique ids, {len(mism)} mismatching (id,label) pairs")
+    print(f"{'id':<16}{'in-file label':<40}{'OAK canonical':<40}files")
+    print("-" * 130)
+    for cid, lbl, c, files in mism:
+        fl = ",".join(b.replace(".yaml", "") for b in files)
+        if len(fl) > 48:
+            fl = fl[:45] + "..."
+        print(f"{cid:<16}{lbl[:39]:<40}{c[:39]:<40}{fl}")


### PR DESCRIPTION
The project's `validate-terms` only checks ENVO id *existence*, not that the id's label matches the curated label — so a large set of `environment_term` ids that resolve to **unrelated ENVO terms** slipped through QC. ENVO ids are stable (never reused), so these are genuine errors.

A new OAK-verified sweep (`scripts/term_label_audit.py`, generalizing the CHEBI audit to all ontologies) found **27 mismatching (id,label) pairs**; this fixes **24 (146 file occurrences)** by repointing each to the correct ENVO id (label taken from OAK canonical).

## Examples (in-file label → what the id actually resolved to → corrected id)
| label | was | → |
|---|---|---|
| rhizosphere | `ENVO:00002233` (albeluvisol) | `ENVO:00005801` |
| lake | `ENVO:00000035` (marsh) | `ENVO:00000020` |
| bioreactor | `ENVO:01000605` (**car**) | `ENVO:00002123` |
| marine environment | `ENVO:00002149` (sea water) | `ENVO:01000320` |
| permafrost | `ENVO:00002179` (intertidal sediment) | `ENVO:00000134` |
| acid mine drainage | `ENVO:00002186` (contaminated water) | `ENVO:00001997` |
| contaminated soil | `ENVO:00002874` (**air conditioning unit**) | `ENVO:00002116` |
| sulfide-rich spring | `ENVO:01001063` (oxic water) | `ENVO:00000126` |
| freshwater environment | `ENVO:01001242` (canopy) | `ENVO:01000306` |
| human gut environment | `ENVO:0001998` (none) | `ENVO:2100002` |
| feces environment | `ENVO:00002009` (obsolete) | `ENVO:00002003` |
| river sediment | `ENVO:00002359` (none) | `ENVO:00002127` |

…plus mine-tailings, wastewater-treatment-plant, hypersaline water, waste water, regolith, subsurface, and relabels (bog→peatland, sludge→activated sludge, laboratory bioreactor/culture→laboratory environment).

**3 left for manual curation** (no clean ENVO term): soda lake (`ENVO:00000274`), anaerobic environment (`ENVO:00002229`), phyllosphere (`ENVO:01001442`).

## Tooling (added)
- `scripts/term_label_audit.py` — reusable QC across NCBITaxon/GO/ENVO/UBERON/CL/CHEBI
- `scripts/term_fix_apply.py` — generalized id/label corrector (this ENVO map)

## Test plan
- `just test` → 136 passed
- All changed files validate clean; re-audit drops ENVO 27 → 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)