### PR TITLE
NCBITaxon residual cleanup: fix 15 more wrong ids (31 occurrences)

### DIFF
--- a/kb/communities/AMD_Nitrososphaerota_Archaeal.yaml
+++ b/kb/communities/AMD_Nitrososphaerota_Archaeal.yaml
@@ -92,7 +92,7 @@ taxonomy:
 - taxon_term:
     preferred_term: Nitrososphaera-like archaeon
     term:
-      id: NCBITaxon:1783275
+      id: NCBITaxon:497726
       label: Nitrososphaera
     notes: 'Mesophilic ammonia-oxidizing archaea related to Nitrososphaera viennensis but adapted to acidic
       conditions (pH 3.5-5.0). Detected in AMD-impacted sediments through 16S rRNA and amoA gene sequencing,
@@ -431,7 +431,7 @@ ecological_interactions:
   source_taxon:
     preferred_term: Nitrososphaera-like archaeon
     term:
-      id: NCBITaxon:1783275
+      id: NCBITaxon:497726
       label: Nitrososphaera
   target_taxon:
     preferred_term: Candidatus Nitrosotalea devanaterra

--- a/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
+++ b/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
@@ -46,7 +46,7 @@ taxonomy:
 - taxon_term:
     preferred_term: anammox bacterium
     term:
-      id: NCBITaxon:67854
+      id: NCBITaxon:203682
       label: Planctomycetota
     notes: Anaerobic ammonium-oxidizing bacterium that drives nitrogen removal
       in the bioreactor; outcompeted during destabilization.
@@ -93,7 +93,7 @@ ecological_interactions:
   target_taxon:
     preferred_term: anammox bacterium
     term:
-      id: NCBITaxon:67854
+      id: NCBITaxon:203682
       label: Planctomycetota
   metabolites:
   - preferred_term: nitrate

--- a/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
+++ b/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
@@ -74,8 +74,8 @@ taxonomy:
 - taxon_term:
     preferred_term: Lactobacillus kefiri
     term:
-      id: NCBITaxon:33963
-      label: Lactobacillus kefiri
+      id: NCBITaxon:33962
+      label: Lentilactobacillus kefiri
   functional_role:
   - SECONDARY_FERMENTER
   evidence:
@@ -89,7 +89,7 @@ taxonomy:
 - taxon_term:
     preferred_term: Acetobacter fabarum
     term:
-      id: NCBITaxon:728467
+      id: NCBITaxon:483199
       label: Acetobacter fabarum
   functional_role:
   - CROSS_FEEDER
@@ -203,7 +203,7 @@ ecological_interactions:
   source_taxon:
     preferred_term: Acetobacter fabarum
     term:
-      id: NCBITaxon:728467
+      id: NCBITaxon:483199
       label: Acetobacter fabarum
   metabolites:
   - preferred_term: L-lactate

--- a/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
+++ b/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
@@ -88,7 +88,7 @@ taxonomy:
 - taxon_term:
     preferred_term: Bacteroides ovatus
     term:
-      id: NCBITaxon:28116
+      id: NCBITaxon:821
       label: Phocaeicola vulgatus
   strain_designation:
     strain_name: DSM1896

--- a/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
+++ b/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
@@ -54,8 +54,8 @@ taxonomy:
 - taxon_term:
     preferred_term: Methanosaeta concilii
     term:
-      id: NCBITaxon:2224
-      label: Methanosaeta concilii
+      id: NCBITaxon:2223
+      label: Methanothrix soehngenii
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:

--- a/kb/communities/Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community.yaml
+++ b/kb/communities/Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community.yaml
@@ -26,8 +26,8 @@ taxonomy:
 - taxon_term:
     preferred_term: deep-aquifer CPR bacteria
     term:
-      id: NCBITaxon:1783234
-      label: Patescibacteria
+      id: NCBITaxon:1783273
+      label: Patescibacteria group
     notes: CPR bacterial putative symbionts unable to synthesize complete
       membrane lipids; carry unusually abundant lysolipids.
   functional_role:
@@ -95,8 +95,8 @@ ecological_interactions:
   target_taxon:
     preferred_term: deep-aquifer CPR bacteria
     term:
-      id: NCBITaxon:1783234
-      label: Patescibacteria
+      id: NCBITaxon:1783273
+      label: Patescibacteria group
   evidence:
   - reference: PMID:32203118
     supports: SUPPORT

--- a/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
+++ b/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
@@ -100,7 +100,7 @@ taxonomy:
 - taxon_term:
     preferred_term: Thermoplasmatales archaea
     term:
-      id: NCBITaxon:51571
+      id: NCBITaxon:2301
       label: Thermoplasmatales
   abundance_level: ABUNDANT
   evidence:

--- a/kb/communities/East_River_Hillslope_Riparian_Transect_Community.yaml
+++ b/kb/communities/East_River_Hillslope_Riparian_Transect_Community.yaml
@@ -67,8 +67,8 @@ taxonomy:
 - taxon_term:
     preferred_term: riparian saturated sediment Candidate Phyla Radiation bacteria
     term:
-      id: NCBITaxon:1783234
-      label: Patescibacteria
+      id: NCBITaxon:1783273
+      label: Patescibacteria group
     notes: The article reports Candidate Phyla Radiation bacteria in riparian
       saturated sediments.
   functional_role:
@@ -163,8 +163,8 @@ ecological_interactions:
   source_taxon:
     preferred_term: riparian saturated sediment Candidate Phyla Radiation bacteria
     term:
-      id: NCBITaxon:1783234
-      label: Patescibacteria
+      id: NCBITaxon:1783273
+      label: Patescibacteria group
   evidence:
   - reference: PMID:31380022
     supports: SUPPORT

--- a/kb/communities/EcoFAB_Ring_Trial_SynCom17.yaml
+++ b/kb/communities/EcoFAB_Ring_Trial_SynCom17.yaml
@@ -169,8 +169,8 @@ taxonomy:
 - taxon_term:
     preferred_term: Bosea sp. OAE506
     term:
-      id: NCBITaxon:85413
-      label: Bosea <a-proteobacteria>
+      id: NCBITaxon:169215
+      label: Bosea
   strain_designation:
     strain_name: OAE506
     isolation_source: Switchgrass rhizosphere soil
@@ -457,8 +457,8 @@ ecological_interactions:
   target_taxon:
     preferred_term: Bosea sp. OAE506
     term:
-      id: NCBITaxon:85413
-      label: Bosea <a-proteobacteria>
+      id: NCBITaxon:169215
+      label: Bosea
   biological_processes:
   - preferred_term: interspecies interaction between organisms
     term:

--- a/kb/communities/Episymbiotic_CPR_DPANN_Groundwater_Community.yaml
+++ b/kb/communities/Episymbiotic_CPR_DPANN_Groundwater_Community.yaml
@@ -26,8 +26,8 @@ taxonomy:
 - taxon_term:
     preferred_term: groundwater CPR (Candidate Phyla Radiation) bacteria
     term:
-      id: NCBITaxon:1783234
-      label: Patescibacteria
+      id: NCBITaxon:1783273
+      label: Patescibacteria group
     notes: 31 percent of pristine groundwater communities; episymbionts that
       attach to host cells.
   abundance_level: DOMINANT
@@ -90,8 +90,8 @@ ecological_interactions:
   source_taxon:
     preferred_term: groundwater CPR (Candidate Phyla Radiation) bacteria
     term:
-      id: NCBITaxon:1783234
-      label: Patescibacteria
+      id: NCBITaxon:1783273
+      label: Patescibacteria group
   target_taxon:
     preferred_term: groundwater CPR/DPANN host bacteria and archaea
     term:

--- a/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
+++ b/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
@@ -106,7 +106,7 @@ taxonomy:
 - taxon_term:
     preferred_term: Pauljensenia sp. (MAG ACT2)
     term:
-      id: NCBITaxon:2767049
+      id: NCBITaxon:2740557
       label: Pauljensenia
     notes: 'Actinobacteriota member (up to 29.6% relative abundance). Produces succinic acid from lactose.
 

--- a/kb/communities/Lac_Pavin_Stratified_Lake_Community.yaml
+++ b/kb/communities/Lac_Pavin_Stratified_Lake_Community.yaml
@@ -27,8 +27,8 @@ taxonomy:
 - taxon_term:
     preferred_term: water-column Candidate Phyla Radiation (CPR) bacteria
     term:
-      id: NCBITaxon:1783234
-      label: Patescibacteria
+      id: NCBITaxon:1783273
+      label: Patescibacteria group
     notes: CPR bacteria in the water column encode form II/III and form
       III-related RuBisCO enzymes.
   functional_role:

--- a/kb/communities/MSC1_Dominant_Core.yaml
+++ b/kb/communities/MSC1_Dominant_Core.yaml
@@ -76,7 +76,7 @@ taxonomy:
 - taxon_term:
     preferred_term: Bosea sp.
     term:
-      id: NCBITaxon:85413
+      id: NCBITaxon:169215
       label: Bosea
   abundance_level: COMMON
   functional_role:
@@ -348,7 +348,7 @@ ecological_interactions:
   target_taxon:
     preferred_term: Bosea sp.
     term:
-      id: NCBITaxon:85413
+      id: NCBITaxon:169215
       label: Bosea
   biological_processes:
   - preferred_term: interspecies interaction between organisms

--- a/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
+++ b/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
@@ -140,7 +140,7 @@ taxonomy:
 - taxon_term:
     preferred_term: Thermoproteota
     term:
-      id: NCBITaxon:2283796
+      id: NCBITaxon:28889
       label: Thermoproteota
     notes: Archaeal MAGs recovered from EFPC sediment metagenomes.
   functional_role:

--- a/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
+++ b/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
@@ -40,8 +40,8 @@ taxonomy:
 - taxon_term:
     preferred_term: Thaumarchaeota
     term:
-      id: NCBITaxon:1783272
-      label: Thaumarchaeota
+      id: NCBITaxon:651137
+      label: Nitrososphaerota
     notes: 'Dominant archaeal lineage representing basal Thaumarchaeota clades adapted to deep subsurface
       thermophilic conditions. Naica Thaumarchaeota possess archaeal ammonia monooxygenase (amoA) genes,
       demonstrating their role in autotrophic ammonia oxidation coupled to CO₂ fixation. High GC content
@@ -226,8 +226,8 @@ ecological_interactions:
   source_taxon:
     preferred_term: Thaumarchaeota
     term:
-      id: NCBITaxon:1783272
-      label: Thaumarchaeota
+      id: NCBITaxon:651137
+      label: Nitrososphaerota
   metabolites:
   - preferred_term: ammonia
     term:

--- a/kb/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.yaml
+++ b/kb/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.yaml
@@ -68,8 +68,8 @@ taxonomy:
 - taxon_term:
     preferred_term: BGC-encoding CPR bacterium
     term:
-      id: NCBITaxon:1783234
-      label: Patescibacteria
+      id: NCBITaxon:1783273
+      label: Patescibacteria group
     notes: A CPR genome encoded a ribosomally synthesized linear
       azole/azoline-containing peptide BGC, a capacity also seen in other
       publicly available CPR genomes.

--- a/kb/communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.yaml
+++ b/kb/communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.yaml
@@ -27,8 +27,8 @@ taxonomy:
 - taxon_term:
     preferred_term: soil Candidate Phyla Radiation (CPR) bacteria
     term:
-      id: NCBITaxon:1783234
-      label: Patescibacteria
+      id: NCBITaxon:1783273
+      label: Patescibacteria group
     notes: Includes Doudnabacteria (SM2F11), Saccharibacteria, Parcubacteria,
       and Microgenomates recovered from grassland soil.
   functional_role:

--- a/kb/communities/Soil_Corrinoid_B12_Reservoir_Community.yaml
+++ b/kb/communities/Soil_Corrinoid_B12_Reservoir_Community.yaml
@@ -26,7 +26,7 @@ taxonomy:
 - taxon_term:
     preferred_term: corrinoid-supplying Thermoproteota
     term:
-      id: NCBITaxon:651137
+      id: NCBITaxon:28889
       label: Thermoproteota
   functional_role:
   - PRIMARY_PRODUCER

--- a/kb/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.yaml
+++ b/kb/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.yaml
@@ -60,8 +60,8 @@ taxonomy:
 - taxon_term:
     preferred_term: Candidate Phyla Radiation (CPR) bacteria
     term:
-      id: NCBITaxon:1783234
-      label: Patescibacteria
+      id: NCBITaxon:1783273
+      label: Patescibacteria group
     notes: The biofilm hosts diverse CPR lineages (Gracilibacteria,
       Absconditabacteria, Saccharibacteria, Peregrinibacteria, Berkelbacteria,
       Microgenomates, Parcubacteria), with imaging suggesting episymbiotic
@@ -117,8 +117,8 @@ ecological_interactions:
   source_taxon:
     preferred_term: Candidate Phyla Radiation (CPR) bacteria
     term:
-      id: NCBITaxon:1783234
-      label: Patescibacteria
+      id: NCBITaxon:1783273
+      label: Patescibacteria group
   target_taxon:
     preferred_term: Thiothrix
     term:

--- a/kb/communities/Urine_Nitrification_SynCom.yaml
+++ b/kb/communities/Urine_Nitrification_SynCom.yaml
@@ -61,7 +61,7 @@ taxonomy:
 - taxon_term:
     preferred_term: Acidovorax delafieldii
     term:
-      id: NCBITaxon:80867
+      id: NCBITaxon:47920
       label: Acidovorax delafieldii
   functional_role:
   - CROSS_FEEDER


### PR DESCRIPTION
Second pass over the 30 NCBITaxon mismatches left for manual curation in #106. Harder OAK lookups resolved **15 of them (31 file occurrences)** — several still pointing at unrelated organisms or untracked archaeal-phylum reorganization.

## Fixed
| in-file label | id resolved to | → |
|---|---|---|
| Thermoplasmatales | `51571` → *Ascosphaera flava* (a **fungus**) | `2301` |
| Planctomycetota | `67854` → *Actinobacillus succinogenes* | `203682` |
| Phocaeicola vulgatus | `28116` → *Bacteroides ovatus* | `821` |
| Acidovorax delafieldii | `80867` → *Paracidovorax avenae* | `47920` |
| Bosea ×2 | `85413` → *Allobosea* | `169215` |
| Methanosaeta concilii | `2224` → *M. thermoacetophila* | `2223` (Methanothrix soehngenii, senior synonym) |
| Thaumarchaeota | `1783272` → *Bacillati* | `651137` (Nitrososphaerota) |
| Nitrososphaera | `1783275` → *Thermoproteati* | `497726` |
| Thermoproteota ×2 | `2283796`/`651137` | `28889` |
| Patescibacteria | `1783234` | `1783273` (Patescibacteria group) |
| Pauljensenia `2767049`, Acetobacter fabarum `728467`, Lactobacillus kefiri `33963` | deleted/wrong | correct |

## Still unresolvable (15)
Newer species absent by name in this OAK ncbitaxon snapshot (Nitrosotalea devanaterra, Kazachstania exigua, Ochrobactrum spp., Syntrophus, Clostridium straminisolvens, Stenotrophomonas goyi, Rhizobium pusense) and candidate phyla present only at strain level (Asgard, DPANN, Micrarchaeota, Dormibacterota, Eisenbacteria, OP3) + Ca. Phormidium alkaliphilum. These need a newer taxonomy snapshot or manual NCBI lookup.

## Test plan
- `just test` → 136 passed
- All 20 changed files validate clean; NCBITaxon audit 30 → 15

🤖 Generated with [Claude Code](https://claude.com/claude-code)