### PR TITLE
Engine B exceptions + GO/NCBITaxon residual cleanup (48 line-pairs, 28 files)

### DIFF
--- a/.github/workflows/label-correspondence.yaml
+++ b/.github/workflows/label-correspondence.yaml
@@ -1,0 +1,59 @@
+name: label-correspondence
+
+# Phase 1 (report-only): generate the id↔label drift report and upload it as an
+# artifact. Does NOT fail the build — it surfaces existing label drift for
+# triage. Phase 2 will switch to the blocking gates (`just validate-terms-all`
+# + `just validate-products`).
+
+on:
+  pull_request:
+    paths: &trigger_paths
+      - "kb/communities/**"
+      - "output/kgx/**"
+      - "src/communitymech/schema/**"
+      - "scripts/validate_id_label_correspondence.py"
+      - "conf/id_label_targets.yaml"
+      - ".github/workflows/label-correspondence.yaml"
+  push:
+    branches: [main]
+    paths: *trigger_paths
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  label-drift-report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+          enable-cache: true
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      # Cache OAK sqlite ontologies (NCBITaxon/ENVO/CHEBI/GO) across runs.
+      - name: Cache OAK ontologies
+        uses: actions/cache@v4
+        with:
+          path: ~/.data/oaklib
+          key: oaklib-${{ runner.os }}-v1
+
+      - name: Generate id↔label drift report (non-blocking)
+        run: just report-label-drift
+
+      - name: Upload drift report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: label-drift-report-${{ github.run_id }}
+          path: reports/label_drift.tsv
+          if-no-files-found: warn

--- a/conf/id_label_targets.yaml
+++ b/conf/id_label_targets.yaml
@@ -1,0 +1,79 @@
+# Targets for scripts/validate_id_label_correspondence.py (Engine B).
+# See docs/ID_LABEL_CORRESPONDENCE.md. Prefixes not in `adapters` (e.g.
+# CommunityMech:, CultureMech:, MediaIngredientMech:) are SKIPPED_NO_ADAPTER.
+
+adapters:
+  NCBITaxon: sqlite:obo:ncbitaxon
+  ENVO: sqlite:obo:envo
+  CHEBI: sqlite:obo:chebi
+  GO: sqlite:obo:go
+  UBERON: sqlite:obo:uberon
+  CL: sqlite:obo:cl
+
+synonym_scope: exact_related
+
+targets:
+  # data inputs (community YAMLs) — term.{id,label} blocks — strict canonical
+  - name: communities_yaml
+    kind: yaml
+    glob: "kb/communities/*.yaml"
+    policy: canonical
+    pairs:
+      - [id, label]
+    # Curator-accepted residuals: (id, label) pairs that survive every audit
+    # cycle because the ontology has no clean replacement (true terminal
+    # obsoletes, MF-vs-BP context mismatches, taxa absent from the current
+    # OAK snapshot). Each entry includes a one-line `reason` for review.
+    # Verdict for matching pairs: OK_EXCEPTION (non-error).
+    exceptions:
+      # --- CHEBI (11) ---
+      - { id: "CHEBI:33104", label: "chromium(III) hydroxide", reason: "no clean CHEBI term; needs minting" }
+      - { id: "CHEBI:34818", label: "humic acid", reason: "no clean CHEBI term; needs minting" }
+      - { id: "CHEBI:38292", label: "uranyl(2+)", reason: "no clean CHEBI term; needs minting" }
+      - { id: "CHEBI:46662", label: "organic matter", reason: "no clean CHEBI term; needs minting" }
+      - { id: "CHEBI:75315", label: "N-tetradecanoyl-L-homoserine lactone", reason: "CHEBI id resolves to no canonical label in OAK" }
+      - { id: "CHEBI:75317", label: "N-(3-hydroxy-dodecanoyl)-L-homoserine lactone", reason: "CHEBI id resolves to an unrelated compound" }
+      - { id: "CHEBI:75318", label: "N-(3-hydroxy-tetradecanoyl)-L-homoserine lactone", reason: "CHEBI id resolves to an unrelated compound" }
+      - { id: "CHEBI:82328", label: "lead sulfide", reason: "no clean CHEBI term; needs minting" }
+      - { id: "CHEBI:82332", label: "zinc sulfide", reason: "no clean CHEBI term; needs minting" }
+      - { id: "CHEBI:86154", label: "sodium metasilicate", reason: "no clean CHEBI term; needs minting" }
+      - { id: "CHEBI:89981", label: "yeast extract", reason: "no clean CHEBI term; canonical (LPS with O-antigen) is wrong" }
+      # --- ENVO (3) ---
+      - { id: "ENVO:00000274", label: "soda lake", reason: "no clean ENVO term; canonical (continental rise) is wrong" }
+      - { id: "ENVO:00002229", label: "anaerobic environment", reason: "no clean ENVO term; canonical (arenosol) is wrong" }
+      - { id: "ENVO:01001442", label: "phyllosphere", reason: "no clean ENVO term; canonical (agriculture) is wrong" }
+      # --- GO (12) ---
+      - { id: "GO:0015103", label: "inorganic anion transmembrane transporter activity", reason: "obsolete; OAK canonical is the obsolete-prefixed string itself; no clean current MF term" }
+      - { id: "GO:0019439", label: "aromatic compound catabolic process", reason: "obsolete; replaced_by (catabolic process) is too broad" }
+      - { id: "GO:0050151", label: "nitrite oxidoreductase activity", reason: "no current GO term for nitrite oxidase activity" }
+      - { id: "GO:0051238", label: "sequestering of metal ion", reason: "obsolete; replaced_by is a molecular-function term (PR #105 already reverted)" }
+      - { id: "GO:0051704", label: "multi-organism process", reason: "true terminal obsolete; no replaced_by" }
+      - { id: "GO:0055114", label: "oxidation-reduction process", reason: "true terminal obsolete; no replaced_by" }
+      - { id: "GO:0070812", label: "organohalide respiration", reason: "no replaced_by; closest is GO:0090345 organohalogen metabolic (not respiration)" }
+      - { id: "GO:0071704", label: "organic substance catabolic process", reason: "obsolete; no clean replaced_by" }
+      - { id: "GO:0071704", label: "organic substance metabolic process", reason: "obsolete; no clean replaced_by" }
+      - { id: "GO:0080001", label: "regulation of primary cell wall biogenesis", reason: "no current GO term; only plant-type variant exists" }
+      - { id: "GO:0140352", label: "regulation of microbial community composition", reason: "no GO term for this concept" }
+      - { id: "GO:1901575", label: "organic substance catabolic process", reason: "obsolete; no clean replaced_by" }
+      # --- NCBITaxon (2) ---
+      - { id: "NCBITaxon:1807132", label: "Candidatus Phormidium alkaliphilum", reason: "absent from current OAK ncbitaxon snapshot and kg-microbe ncbitaxon TSV" }
+      - { id: "NCBITaxon:3050471", label: "Stenotrophomonas goyi", reason: "absent from current OAK ncbitaxon snapshot and kg-microbe ncbitaxon TSV" }
+
+  # data product: KGX node export carries (id, name) — canonical OR synonym
+  - name: kgx_nodes
+    kind: tabular
+    format: tsv
+    glob: "output/kgx/nodes.tsv"
+    policy: canonical_or_synonym
+    pairs:
+      - [id, name]
+    # Residuals that flow into the KGX export from the community YAMLs, plus
+    # one exporter-side label choice ("mercury(2+) cation") that diverges
+    # from OAK canonical by design.
+    exceptions:
+      - { id: "CHEBI:16793", label: "mercury(2+) cation", reason: "exporter-side label (kgx_export.py line 82) uses the +cation suffix; OAK canonical is mercury(2+)" }
+      - { id: "ENVO:00000274", label: "soda lake", reason: "see communities_yaml exception" }
+      - { id: "ENVO:00002229", label: "anaerobic environment", reason: "see communities_yaml exception" }
+      - { id: "ENVO:01001442", label: "phyllosphere", reason: "see communities_yaml exception" }
+      - { id: "NCBITaxon:1807132", label: "Candidatus Phormidium alkaliphilum", reason: "see communities_yaml exception" }
+      - { id: "NCBITaxon:3050471", label: "Stenotrophomonas goyi", reason: "see communities_yaml exception" }

--- a/justfile
+++ b/justfile
@@ -65,13 +65,28 @@ validate-cross-repo-ids-all:
 validate-terms FILE:
     uv run linkml-term-validator validate-data {{FILE}} -s src/communitymech/schema/communitymech.yaml --labels
 
-# Validate terms in all community files
+# Validate terms in all community files. Now that the schema binds the
+# descriptor `term` slots, --labels verifies term.label is the CANONICAL
+# ontology label for term.id. Fails (non-zero) if any file has label drift.
 validate-terms-all:
     #!/usr/bin/env bash
+    set -uo pipefail
+    rc=0
     for file in kb/communities/*.yaml; do
-        echo "\\nValidating terms in $file..."
-        uv run linkml-term-validator validate-data "$file" -s src/communitymech/schema/communitymech.yaml --labels
+        echo "Validating terms in $file..."
+        uv run linkml-term-validator validate-data "$file" -s src/communitymech/schema/communitymech.yaml --labels || rc=1
     done
+    exit $rc
+
+# id↔label gate (Engine B): verify (id,label) pairs in DATA PRODUCTS
+# (KGX node export) correspond to the ontology. Exits 2 on any mismatch.
+validate-products:
+    uv run python scripts/validate_id_label_correspondence.py -c conf/id_label_targets.yaml
+
+# Baseline (non-failing): unified id↔label drift report across community
+# YAMLs + KGX products to reports/label_drift.tsv. Use before enforcing.
+report-label-drift:
+    uv run python scripts/validate_id_label_correspondence.py -c conf/id_label_targets.yaml --report reports/label_drift.tsv
 
 # Validate schema-level ontology term meanings
 validate-schema-terms:

--- a/kb/communities/AMD_Acidophile_Heterotroph_Network.yaml
+++ b/kb/communities/AMD_Acidophile_Heterotroph_Network.yaml
@@ -297,8 +297,8 @@ ecological_interactions:
       label: aerobic respiration
   - preferred_term: nitrogen compound metabolic process
     term:
-      id: GO:0006807
-      label: nitrogen compound metabolic process
+      id: GO:0008152
+      label: metabolic process
   evidence:
   - reference: doi:10.3389/fmicb.2015.00475
     supports: SUPPORT

--- a/kb/communities/AMD_Nitrososphaerota_Archaeal.yaml
+++ b/kb/communities/AMD_Nitrososphaerota_Archaeal.yaml
@@ -43,8 +43,8 @@ taxonomy:
 - taxon_term:
     preferred_term: Candidatus Nitrosotalea devanaterra
     term:
-      id: NCBITaxon:1379270
-      label: Candidatus Nitrosotalea devanaterra
+      id: NCBITaxon:1078905
+      label: Nitrosotalea devaniterrae
     notes: 'Obligately acidophilic ammonia-oxidizing archaeon from the phylum Nitrososphaerota, class
       Nitrososphaeria. This chemolithoautotrophic organism represents the first cultivated acidophilic
       AOA, isolated from acidic agricultural soil (pH 4.5). Grows optimally at pH 4.0-5.5 with extraordinary
@@ -222,8 +222,8 @@ ecological_interactions:
   source_taxon:
     preferred_term: Candidatus Nitrosotalea devanaterra
     term:
-      id: NCBITaxon:1379270
-      label: Candidatus Nitrosotalea devanaterra
+      id: NCBITaxon:1078905
+      label: Nitrosotalea devaniterrae
   metabolites:
   - preferred_term: ammonium
     term:
@@ -310,8 +310,8 @@ ecological_interactions:
   target_taxon:
     preferred_term: Candidatus Nitrosotalea devanaterra
     term:
-      id: NCBITaxon:1379270
-      label: Candidatus Nitrosotalea devanaterra
+      id: NCBITaxon:1078905
+      label: Nitrosotalea devaniterrae
   metabolites:
   - preferred_term: nitrite
     term:
@@ -374,8 +374,8 @@ ecological_interactions:
   target_taxon:
     preferred_term: Candidatus Nitrosotalea devanaterra
     term:
-      id: NCBITaxon:1379270
-      label: Candidatus Nitrosotalea devanaterra
+      id: NCBITaxon:1078905
+      label: Nitrosotalea devaniterrae
   metabolites:
   - preferred_term: organic molecular entity
     term:
@@ -436,8 +436,8 @@ ecological_interactions:
   target_taxon:
     preferred_term: Candidatus Nitrosotalea devanaterra
     term:
-      id: NCBITaxon:1379270
-      label: Candidatus Nitrosotalea devanaterra
+      id: NCBITaxon:1078905
+      label: Nitrosotalea devaniterrae
   metabolites:
   - preferred_term: ammonium
     term:
@@ -498,8 +498,8 @@ ecological_interactions:
   source_taxon:
     preferred_term: Candidatus Nitrosotalea devanaterra
     term:
-      id: NCBITaxon:1379270
-      label: Candidatus Nitrosotalea devanaterra
+      id: NCBITaxon:1078905
+      label: Nitrosotalea devaniterrae
   metabolites:
   - preferred_term: urea
     term:

--- a/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
+++ b/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
@@ -107,8 +107,8 @@ ecological_interactions:
   biological_processes:
   - preferred_term: nitrogen compound metabolic process
     term:
-      id: GO:0006807
-      label: nitrogen compound metabolic process
+      id: GO:0008152
+      label: metabolic process
   evidence:
   - reference: PMID:31980038
     supports: SUPPORT

--- a/kb/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.yaml
+++ b/kb/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.yaml
@@ -25,8 +25,8 @@ taxonomy:
 - taxon_term:
     preferred_term: Atabeyarchaeia (Asgard)
     term:
-      id: NCBITaxon:1655434
-      label: Asgard group
+      id: NCBITaxon:1935183
+      label: Promethearchaeati
     notes: Two complete genomes were reconstructed for soil-associated
       Atabeyarchaeia, a new Asgard lineage described in this study.
   functional_role:
@@ -42,8 +42,8 @@ taxonomy:
 - taxon_term:
     preferred_term: Freyarchaeia (Asgard)
     term:
-      id: NCBITaxon:1655434
-      label: Asgard group
+      id: NCBITaxon:1935183
+      label: Promethearchaeati
     notes: A complete Freyarchaeia genome was reconstructed for the wetland
       soil community.
   functional_role:
@@ -81,8 +81,8 @@ ecological_interactions:
   source_taxon:
     preferred_term: Atabeyarchaeia (Asgard)
     term:
-      id: NCBITaxon:1655434
-      label: Asgard group
+      id: NCBITaxon:1935183
+      label: Promethearchaeati
   target_taxon:
     preferred_term: wetland soil methanogens
     term:

--- a/kb/communities/Australian_Lead_Zinc_Polymetallic.yaml
+++ b/kb/communities/Australian_Lead_Zinc_Polymetallic.yaml
@@ -502,8 +502,8 @@ ecological_interactions:
       label: response to pH
   - preferred_term: cellular pH homeostasis
     term:
-      id: GO:0030641
-      label: regulation of cellular pH
+      id: GO:0051453
+      label: regulation of intracellular pH
   - preferred_term: response to metal ion
     term:
       id: GO:0010038

--- a/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
+++ b/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
@@ -104,8 +104,8 @@ taxonomy:
 - taxon_term:
     preferred_term: Kazachstania exigua
     term:
-      id: NCBITaxon:1380867
-      label: Kazachstania exigua
+      id: NCBITaxon:34358
+      label: Maudiozyma exigua
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -233,8 +233,8 @@ ecological_interactions:
   source_taxon:
     preferred_term: Kazachstania exigua
     term:
-      id: NCBITaxon:1380867
-      label: Kazachstania exigua
+      id: NCBITaxon:34358
+      label: Maudiozyma exigua
   metabolites:
   - preferred_term: L-lactate
     term:

--- a/kb/communities/Cinnamate_Degradation_Consortium.yaml
+++ b/kb/communities/Cinnamate_Degradation_Consortium.yaml
@@ -35,8 +35,8 @@ taxonomy:
 - taxon_term:
     preferred_term: Syntrophus sp.
     term:
-      id: NCBITaxon:2426
-      label: Syntrophus
+      id: NCBITaxon:43773
+      label: Syntrophus <bacteria>
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -104,8 +104,8 @@ ecological_interactions:
   source_taxon:
     preferred_term: Syntrophus sp.
     term:
-      id: NCBITaxon:2426
-      label: Syntrophus
+      id: NCBITaxon:43773
+      label: Syntrophus <bacteria>
   metabolites:
   - preferred_term: benzoate
     term:

--- a/kb/communities/Episymbiotic_CPR_DPANN_Groundwater_Community.yaml
+++ b/kb/communities/Episymbiotic_CPR_DPANN_Groundwater_Community.yaml
@@ -52,8 +52,8 @@ taxonomy:
 - taxon_term:
     preferred_term: groundwater DPANN archaea
     term:
-      id: NCBITaxon:1934217
-      label: DPANN group
+      id: NCBITaxon:1783276
+      label: Nanobdellati
     notes: Up to 4 percent of pristine groundwater communities; episymbionts
       that attach to host cells.
   abundance_level: ABUNDANT

--- a/kb/communities/Grassland_Soil_WetUp_Virus_Host_Community.yaml
+++ b/kb/communities/Grassland_Soil_WetUp_Virus_Host_Community.yaml
@@ -96,8 +96,8 @@ ecological_interactions:
   biological_processes:
   - preferred_term: virus-host interaction
     term:
-      id: GO:0019048
-      label: modulation by virus of host process
+      id: GO:0044003
+      label: symbiont-mediated perturbation of host process
   evidence:
   - reference: PMID:37730729
     supports: SUPPORT

--- a/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
+++ b/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
@@ -404,8 +404,8 @@ ecological_interactions:
   biological_processes:
   - preferred_term: dissimilatory sulfate reduction
     term:
-      id: GO:0019419
-      label: sulfate reduction (assimilatory)
+      id: GO:0000103
+      label: sulfate assimilation
   - preferred_term: sulfide oxidation
     term:
       id: GO:0070221

--- a/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
+++ b/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
@@ -404,8 +404,8 @@ ecological_interactions:
   biological_processes:
   - preferred_term: dissimilatory sulfate reduction
     term:
-      id: GO:0000103
-      label: sulfate assimilation
+      id: GO:0019420
+      label: dissimilatory sulfate reduction
   - preferred_term: sulfide oxidation
     term:
       id: GO:0070221

--- a/kb/communities/Industrial_Bioreactor_Consortium.yaml
+++ b/kb/communities/Industrial_Bioreactor_Consortium.yaml
@@ -667,7 +667,7 @@ ecological_interactions:
       label: organic substance metabolic process
   - preferred_term: heterotrophic metabolism
     term:
-      id: GO:0019318
+      id: GO:0019319
       label: hexose biosynthetic process
   evidence:
   - reference: PMID:30499003

--- a/kb/communities/Infant_Gut_DNA_Phage_Succession_Community.yaml
+++ b/kb/communities/Infant_Gut_DNA_Phage_Succession_Community.yaml
@@ -71,8 +71,8 @@ ecological_interactions:
   biological_processes:
   - preferred_term: virus-host interaction
     term:
-      id: GO:0019048
-      label: modulation by virus of host process
+      id: GO:0044003
+      label: symbiont-mediated perturbation of host process
   evidence:
   - reference: PMID:38096814
     supports: SUPPORT

--- a/kb/communities/Lac_Pavin_Stratified_Lake_Community.yaml
+++ b/kb/communities/Lac_Pavin_Stratified_Lake_Community.yaml
@@ -44,8 +44,8 @@ taxonomy:
 - taxon_term:
     preferred_term: sediment DPANN archaea
     term:
-      id: NCBITaxon:1934217
-      label: DPANN group
+      id: NCBITaxon:1783276
+      label: Nanobdellati
     notes: DPANN archaea recovered from Lac Pavin sediments encode RuBisCO
       enzymes, suggesting CO2-fixation potential.
   functional_role:

--- a/kb/communities/Lotus_LjSC3.yaml
+++ b/kb/communities/Lotus_LjSC3.yaml
@@ -257,8 +257,8 @@ ecological_interactions:
       label: biological process involved in symbiotic interaction
   - preferred_term: root colonization
     term:
-      id: GO:0044409
-      label: single-species biofilm formation on root
+      id: GO:0044010
+      label: single-species biofilm formation
   evidence:
   - reference: PMID:34312531
     supports: SUPPORT

--- a/kb/communities/Maize_Root_Simplified_Community.yaml
+++ b/kb/communities/Maize_Root_Simplified_Community.yaml
@@ -75,8 +75,8 @@ taxonomy:
 - taxon_term:
     preferred_term: Ochrobactrum pituitosum AA2
     term:
-      id: NCBITaxon:221109
-      label: Ochrobactrum pituitosum
+      id: NCBITaxon:571256
+      label: Brucella pituitosa
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -157,8 +157,8 @@ ecological_interactions:
       label: biological process involved in symbiotic interaction
   - preferred_term: root colonization
     term:
-      id: GO:0044409
-      label: single-species biofilm formation on root
+      id: GO:0044010
+      label: single-species biofilm formation
   evidence:
   - reference: PMID:28275097
     supports: SUPPORT
@@ -222,8 +222,8 @@ ecological_interactions:
   source_taxon:
     preferred_term: Ochrobactrum pituitosum AA2
     term:
-      id: NCBITaxon:221109
-      label: Ochrobactrum pituitosum
+      id: NCBITaxon:571256
+      label: Brucella pituitosa
   target_taxon:
     preferred_term: Zea mays
     term:

--- a/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
+++ b/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
@@ -105,8 +105,8 @@ taxonomy:
 - taxon_term:
     preferred_term: Eisenbacteria
     term:
-      id: NCBITaxon:1930587
-      label: Eisenbacteria
+      id: NCBITaxon:1817801
+      label: Candidatus Eiseniibacteriota
     notes: 'MAGs from this candidate phylum were recovered from EFPC sediment. Notable for containing
       selenium assimilatory metabolism traits.
 

--- a/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
+++ b/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
@@ -109,8 +109,8 @@ taxonomy:
 - taxon_term:
     preferred_term: Candidate Division OP3
     term:
-      id: NCBITaxon:445709
-      label: candidate division OP3
+      id: NCBITaxon:67812
+      label: Candidatus Omnitrophota
     notes: 'Bacterial lineage belonging to Candidate Division OP3 (now reclassified as Omnitrophica),
       a deeply branching bacterial phylum detected primarily in subsurface and geothermal environments.
       Naica OP3 bacteria exhibit high GC content in 16S rRNA sequences, indicating thermophilic adaptation
@@ -289,8 +289,8 @@ ecological_interactions:
   target_taxon:
     preferred_term: Candidate Division OP3
     term:
-      id: NCBITaxon:445709
-      label: candidate division OP3
+      id: NCBITaxon:67812
+      label: Candidatus Omnitrophota
   metabolites:
   - preferred_term: organic molecular entity
     term:

--- a/kb/communities/Panzhihua_Vanadium_Titanium_Tailings.yaml
+++ b/kb/communities/Panzhihua_Vanadium_Titanium_Tailings.yaml
@@ -187,8 +187,8 @@ taxonomy:
 - taxon_term:
     preferred_term: Ochrobactrum intermedium
     term:
-      id: NCBITaxon:194708
-      label: Ochrobactrum intermedium
+      id: NCBITaxon:94625
+      label: Brucella intermedia
     notes: 'Alphaproteobacterium (13 isolates) with exceptional heavy metal tolerance and plant growth-promoting
       capabilities in V-Ti tailings. Four Ochrobactrum isolates from P. pinnata nodules were initially
       identified as O. anthropi, closely related to O. intermedium. Ochrobactrum species are known for
@@ -451,7 +451,7 @@ ecological_interactions:
   - preferred_term: dissimilatory reduction
     term:
       id: GO:0019645
-      label: dissimilatory reduction
+      label: anaerobic electron transport chain
   - preferred_term: cellular detoxification
     term:
       id: GO:1990748
@@ -524,8 +524,8 @@ ecological_interactions:
       label: organic substance catabolic process
   - preferred_term: cellular carbohydrate metabolic process
     term:
-      id: GO:0044262
-      label: cellular carbohydrate metabolic process
+      id: GO:0005975
+      label: carbohydrate metabolic process
   downstream:
   - target: Nitrogen Fixation and Plant Growth Promotion
     description: Improved soil carbon supports rhizobial populations and symbiosis
@@ -621,8 +621,8 @@ ecological_interactions:
   source_taxon:
     preferred_term: Ochrobactrum intermedium
     term:
-      id: NCBITaxon:194708
-      label: Ochrobactrum intermedium
+      id: NCBITaxon:94625
+      label: Brucella intermedia
   target_taxon:
     preferred_term: Bradyrhizobium pachyrhizi
     term:

--- a/kb/communities/Polaromonas_Vanadium_Reduction_Community.yaml
+++ b/kb/communities/Polaromonas_Vanadium_Reduction_Community.yaml
@@ -238,7 +238,7 @@ ecological_interactions:
   - preferred_term: dissimilatory reduction
     term:
       id: GO:0019645
-      label: dissimilatory reduction
+      label: anaerobic electron transport chain
   - preferred_term: cellular detoxification
     term:
       id: GO:1990748

--- a/kb/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.yaml
+++ b/kb/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.yaml
@@ -217,8 +217,8 @@ ecological_interactions:
   biological_processes:
   - preferred_term: virus-host interaction
     term:
-      id: GO:0019048
-      label: modulation by virus of host process
+      id: GO:0044003
+      label: symbiont-mediated perturbation of host process
   evidence:
   - reference: PMID:30086797
     supports: SUPPORT

--- a/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
+++ b/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
@@ -167,7 +167,7 @@ taxonomy:
     preferred_term: Micrarchaeota (ARMAN-1/2)
     term:
       id: NCBITaxon:1801631
-      label: Candidatus Micrarchaeota
+      label: Microcaldota
     notes: 'Ultra-small archaea (200-400 nm diameter) with extremely reduced genomes
       (~1 Mb) discovered in Richmond Mine biofilms. ARMAN-1 and ARMAN-2 belong to
       Micrarchaeota phylum. These nanoorganisms possess complete TCA cycles, aerobic
@@ -467,7 +467,7 @@ ecological_interactions:
     preferred_term: Micrarchaeota (ARMAN-1/2)
     term:
       id: NCBITaxon:1801631
-      label: Candidatus Micrarchaeota
+      label: Microcaldota
   target_taxon:
     preferred_term: Parvarchaeota (ARMAN-4/5)
     term:

--- a/kb/communities/SF356_Cellulose_Degrader.yaml
+++ b/kb/communities/SF356_Cellulose_Degrader.yaml
@@ -21,8 +21,8 @@ taxonomy:
 - taxon_term:
     preferred_term: Clostridium straminisolvens CSK1
     term:
-      id: NCBITaxon:283683
-      label: Clostridium straminisolvens
+      id: NCBITaxon:253314
+      label: Acetivibrio straminisolvens
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -108,8 +108,8 @@ ecological_interactions:
   source_taxon:
     preferred_term: Clostridium straminisolvens CSK1
     term:
-      id: NCBITaxon:283683
-      label: Clostridium straminisolvens
+      id: NCBITaxon:253314
+      label: Acetivibrio straminisolvens
   metabolites:
   - preferred_term: cellulose
     term:
@@ -201,8 +201,8 @@ ecological_interactions:
   target_taxon:
     preferred_term: Clostridium straminisolvens CSK1
     term:
-      id: NCBITaxon:283683
-      label: Clostridium straminisolvens
+      id: NCBITaxon:253314
+      label: Acetivibrio straminisolvens
   metabolites:
   - preferred_term: cellulose
     term:

--- a/kb/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.yaml
+++ b/kb/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.yaml
@@ -54,8 +54,8 @@ taxonomy:
 - taxon_term:
     preferred_term: Candidatus Dormibacteraeota (prolific BGC producers)
     term:
-      id: NCBITaxon:1798711
-      label: Dormibacterota
+      id: NCBITaxon:2052312
+      label: Candidatus Dormiibacterota
   functional_role:
   - PRIMARY_DEGRADER
   evidence:

--- a/kb/communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.yaml
+++ b/kb/communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.yaml
@@ -44,8 +44,8 @@ taxonomy:
 - taxon_term:
     preferred_term: soil DPANN archaea
     term:
-      id: NCBITaxon:1934217
-      label: DPANN group
+      id: NCBITaxon:1783276
+      label: Nanobdellati
     notes: DPANN archaea recovered from the rare biosphere include
       Diapherotrites, Parvarchaeota, Aenigmarchaeota, Nanoarchaeota, and
       Nanohaloarchaeota.

--- a/kb/communities/Sorghum_SRC1_Subset.yaml
+++ b/kb/communities/Sorghum_SRC1_Subset.yaml
@@ -160,8 +160,8 @@ ecological_interactions:
       label: biological process involved in symbiotic interaction
   - preferred_term: root colonization
     term:
-      id: GO:0044409
-      label: single-species biofilm formation on root
+      id: GO:0044010
+      label: single-species biofilm formation
   evidence:
   - reference: doi:10.1093/ismejo/wrae126
     supports: SUPPORT

--- a/kb/communities/TYQ1_Nematode_Biocontrol_SynCom.yaml
+++ b/kb/communities/TYQ1_Nematode_Biocontrol_SynCom.yaml
@@ -44,8 +44,8 @@ taxonomy:
 - taxon_term:
     preferred_term: Rhizobium pusense TYQ1
     term:
-      id: NCBITaxon:655028
-      label: Rhizobium pusense
+      id: NCBITaxon:648995
+      label: Agrobacterium pusense
     notes: 'Keystone species and central metabolic hub. Directly inhibits root-knot nematodes and coordinates
       biofilm formation across the community. Its enrichment causes restructuring of the rhizobacterial
       community, leading to recruitment of 7 biomarker species.
@@ -206,8 +206,8 @@ ecological_interactions:
   source_taxon:
     preferred_term: Rhizobium pusense TYQ1
     term:
-      id: NCBITaxon:655028
-      label: Rhizobium pusense
+      id: NCBITaxon:648995
+      label: Agrobacterium pusense
   evidence:
   - reference: PMID:41660888
     supports: SUPPORT
@@ -225,8 +225,8 @@ ecological_interactions:
   source_taxon:
     preferred_term: Rhizobium pusense TYQ1
     term:
-      id: NCBITaxon:655028
-      label: Rhizobium pusense
+      id: NCBITaxon:648995
+      label: Agrobacterium pusense
   evidence:
   - reference: PMID:41660888
     supports: SUPPORT
@@ -243,8 +243,8 @@ ecological_interactions:
   source_taxon:
     preferred_term: Rhizobium pusense TYQ1
     term:
-      id: NCBITaxon:655028
-      label: Rhizobium pusense
+      id: NCBITaxon:648995
+      label: Agrobacterium pusense
   evidence:
   - reference: PMID:41660888
     supports: SUPPORT

--- a/kb/communities/Thermophilic_Pyrite_QS_Consortium.yaml
+++ b/kb/communities/Thermophilic_Pyrite_QS_Consortium.yaml
@@ -623,7 +623,7 @@ ecological_interactions:
       label: quorum sensing
   - preferred_term: negative regulation of cell motility
     term:
-      id: GO:0051271
+      id: GO:2000146
       label: negative regulation of cell motility
   - preferred_term: regulation of biofilm formation
     term:

--- a/scripts/term_fix_apply.py
+++ b/scripts/term_fix_apply.py
@@ -17,46 +17,37 @@ from pathlib import Path
 
 DRY = "--dry-run" in sys.argv
 COMM = Path("kb/communities")
-ADAPTER = "sqlite:obo:envo"
-PREFIX = "ENVO"
+ADAPTER = "sqlite:obo:ncbitaxon"
+PREFIX = "NCBITaxon"
 
 # (old_id, old_label) -> new_id   (label becomes canon[new_id])
+# Replacement ids cross-checked against the kg-microbe ncbitaxon snapshot
+# (/Users/marcin/.../kg-microbe/data/transformed/ontologies/ncbitaxon_nodes.tsv),
+# then verified to exist in OAK's current sqlite:obo:ncbitaxon adapter.
 REPOINT = {
-    ("ENVO:00000035", "lake"): "ENVO:00000020",
-    ("ENVO:00000044", "wetland"): "ENVO:00000043",
-    ("ENVO:00000072", "mine tailing"): "ENVO:00000003",
-    ("ENVO:00002001", "wastewater treatment plant"): "ENVO:00002043",
-    ("ENVO:00002019", "hypersaline water"): "ENVO:00002012",
-    ("ENVO:00002047", "waste water"): "ENVO:00002001",
-    ("ENVO:00002149", "marine environment"): "ENVO:01000320",
-    ("ENVO:00002179", "permafrost"): "ENVO:00000134",
-    ("ENVO:00002186", "acid mine drainage"): "ENVO:00001997",
-    ("ENVO:00002230", "regolith"): "ENVO:01000747",
-    ("ENVO:00002233", "rhizosphere"): "ENVO:00005801",
-    ("ENVO:00002874", "contaminated soil"): "ENVO:00002116",
-    ("ENVO:01000605", "bioreactor"): "ENVO:00002123",
-    ("ENVO:01000650", "mine tailings"): "ENVO:00000003",
-    ("ENVO:01001063", "sulfide-rich spring"): "ENVO:00000126",
-    ("ENVO:01001242", "freshwater environment"): "ENVO:01000306",
-    ("ENVO:01000017", "subsurface environment"): "ENVO:01000942",
-    ("ENVO:0001998", "human gut environment"): "ENVO:2100002",
-    ("ENVO:00002009", "feces environment"): "ENVO:00002003",
-    ("ENVO:00002359", "river sediment"): "ENVO:00002127",
+    ("NCBITaxon:1379270", "Candidatus Nitrosotalea devanaterra"): "NCBITaxon:1078905",  # → Nitrosotalea devaniterrae (spelling correction)
+    ("NCBITaxon:1380867", "Kazachstania exigua"): "NCBITaxon:34358",                    # → Maudiozyma exigua (genus rename)
+    ("NCBITaxon:1655434", "Asgard group"): "NCBITaxon:1935183",                          # → Promethearchaeati (phylum rename)
+    ("NCBITaxon:1798711", "Dormibacterota"): "NCBITaxon:2052312",                        # → Candidatus Dormiibacterota
+    ("NCBITaxon:1930587", "Eisenbacteria"): "NCBITaxon:1817801",                         # → Candidatus Eiseniibacteriota
+    ("NCBITaxon:1934217", "DPANN group"): "NCBITaxon:1783276",                           # → Nanobdellati
+    ("NCBITaxon:194708",  "Ochrobactrum intermedium"): "NCBITaxon:94625",                # → Brucella intermedia (genus rename)
+    ("NCBITaxon:221109",  "Ochrobactrum pituitosum"): "NCBITaxon:571256",                # → Brucella pituitosa (genus rename)
+    ("NCBITaxon:2426",    "Syntrophus"): "NCBITaxon:43773",                              # → Syntrophus <bacteria> (id 2426 now points to Teredinibacter)
+    ("NCBITaxon:283683",  "Clostridium straminisolvens"): "NCBITaxon:253314",            # → Acetivibrio straminisolvens (genus rename)
+    ("NCBITaxon:445709",  "candidate division OP3"): "NCBITaxon:67812",                  # → Candidatus Omnitrophota
+    ("NCBITaxon:655028",  "Rhizobium pusense"): "NCBITaxon:648995",                      # → Agrobacterium pusense (genus rename)
 }
 
-# (old_id, old_label) where id is the correct/acceptable term; relabel to canon[old_id]
+# (old_id, old_label) where the id is correct/current; relabel to OAK canonical.
 RELABEL = {
-    ("ENVO:00000044", "bog"),               # canon: peatland (peat bog)
-    ("ENVO:00002046", "sludge"),            # canon: activated sludge
-    ("ENVO:01001405", "laboratory bioreactor"),  # canon: laboratory environment
-    ("ENVO:01001405", "laboratory culture"),     # canon: laboratory environment
+    ("NCBITaxon:1801631", "Candidatus Micrarchaeota"),  # canon is now "Microcaldota" (same id)
 }
 
-# Intentionally left for manual curation (no clean ENVO term):
-#   ENVO:00000274 "soda lake" (=continental rise), ENVO:00002009 "feces environment"
-#   (=obsolete), ENVO:00002229 "anaerobic environment" (=arenosol), ENVO:00002359
-#   "river sediment" (=None), ENVO:0001998 "human gut environment" (=None),
-#   ENVO:01001442 "phyllosphere" (=agriculture)
+# Intentionally left for the conf/id_label_targets.yaml exceptions list
+# (not in current OAK ncbitaxon snapshot, even after kg-microbe cross-check):
+#   NCBITaxon:1807132 "Candidatus Phormidium alkaliphilum"
+#   NCBITaxon:3050471 "Stenotrophomonas goyi"
 
 ID_RE = re.compile(rf"^(\s*)id:\s*({PREFIX}:\d+)\s*$")
 LBL_RE = re.compile(r"^(\s*)label:\s*(.+?)\s*$")

--- a/scripts/validate_id_label_correspondence.py
+++ b/scripts/validate_id_label_correspondence.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Validate that every ontology ID carries its correct ontology LABEL.
+
+Shared, schema/config-driven id↔label correspondence checker. Vendored
+**byte-identical** across the Mech repos (CultureMech / MIM / CommunityMech)
+— the same convention as ``scripts/_edison_capture.py``. Verify with
+``md5``; a fix here must be synced to all copies.
+
+Why this exists
+---------------
+``linkml-term-validator validate-data --labels`` only checks that the
+label of an ontology ID matches the ontology — and only for LinkML data
+instances (YAML) whose schema declares a ``binding``. It does NOT cover
+**data products**: SSSOM TSVs, mapping CSVs, KGX node tables, and review
+TSVs all carry (id, label) columns that no LinkML tool reads. This script
+closes that gap and also produces a single cross-surface drift report.
+
+What it checks
+--------------
+For every (id, label) pair in the configured targets it resolves the
+canonical label (and synonyms) from the same OAK sqlite adapters the
+repos already use, and classifies the pair:
+
+    OK_CANONICAL        label == canonical OBO label
+    OK_SYNONYM          label is an accepted synonym (policy-dependent)
+    OK_EXCEPTION        pair is on the target's ``exceptions`` allow-list
+                        (residual the curator has knowingly accepted; e.g.
+                        obsolete-no-successor, no clean term yet)
+    MISMATCH            label is neither canonical nor an accepted synonym  (ERROR)
+    ID_NOT_FOUND        id has an adapter but is absent from the ontology   (ERROR)
+    EMPTY_LABEL         id present, label blank                             (ERROR)
+    SKIPPED_NO_ADAPTER  prefix has no configured OAK adapter (cas:, MIM:, …)
+
+Policy (per target, ``conf/id_label_targets.yaml``)
+    ``canonical``            accept only the canonical OBO label (strict;
+                             mirrors the linkml-term-validator schema gate).
+    ``canonical_or_synonym`` accept canonical OR a synonym within
+                             ``synonym_scope`` (exact | exact_related | all).
+
+Modes
+    ``--report PATH``  write a TSV of every non-OK pair and exit 0 (baseline).
+    (default)          enforce: exit 2 if any ERROR-class pair is found.
+
+Usage::
+
+    python scripts/validate_id_label_correspondence.py -c conf/id_label_targets.yaml
+    python scripts/validate_id_label_correspondence.py -c conf/id_label_targets.yaml \\
+        --report reports/label_drift.tsv
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from pathlib import Path
+from typing import Any, Iterator
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _safe_rel(path: Path) -> str:
+    """``path`` relative to the repo when possible; else its absolute string."""
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+# Verdict classes that should fail an --enforce run.
+_ERROR_VERDICTS = {"MISMATCH", "ID_NOT_FOUND", "EMPTY_LABEL"}
+
+_CURIE_RE = re.compile(r"^([A-Za-z][A-Za-z0-9.]*):(.+)$")
+_WS_RE = re.compile(r"\s+")
+
+# OAK alias predicates by synonym scope (always includes label + exact).
+_SYNONYM_PREDICATES = {
+    "exact": ["oio:hasExactSynonym"],
+    "exact_related": ["oio:hasExactSynonym", "oio:hasRelatedSynonym"],
+    "all": [
+        "oio:hasExactSynonym",
+        "oio:hasRelatedSynonym",
+        "oio:hasBroadSynonym",
+        "oio:hasNarrowSynonym",
+    ],
+}
+
+
+def normalize(text: str) -> str:
+    """Casefold, strip, collapse internal whitespace — for label comparison."""
+    return _WS_RE.sub(" ", str(text).strip()).casefold()
+
+
+def prefix_of(curie: str) -> str | None:
+    m = _CURIE_RE.match(str(curie).strip())
+    return m.group(1) if m else None
+
+
+class AdapterPool:
+    """Lazily loads OAK adapters, but ONLY for prefixes in the allowlist.
+
+    The allowlist (``adapters`` map in the config) is the safety boundary:
+    prefixes without an entry (``cas:``, ``MIM:``, ``kgmicrobe.compound:``,
+    ``DSMZ``, …) are never looked up — they are reported as
+    ``SKIPPED_NO_ADAPTER`` instead of triggering a futile ontology download.
+    """
+
+    def __init__(self, adapters: dict[str, str]):
+        self._selectors = adapters
+        self._cache: dict[str, Any] = {}
+
+    def get(self, prefix: str | None):
+        if not prefix or prefix not in self._selectors:
+            return None
+        if prefix not in self._cache:
+            try:
+                from oaklib import get_adapter
+
+                self._cache[prefix] = get_adapter(self._selectors[prefix])
+            except Exception as exc:  # pragma: no cover - environment dependent
+                print(f"  ! failed to load adapter for {prefix}: {exc}", file=sys.stderr)
+                self._cache[prefix] = None
+        return self._cache[prefix]
+
+
+def accepted_labels(adapter: Any, curie: str, scope: str) -> tuple[str | None, set[str], bool]:
+    """Return (canonical_label, accepted_normalized_set, id_found).
+
+    ``accepted_normalized_set`` always contains the canonical label; with a
+    non-``canonical`` policy the caller widens it via ``scope`` synonyms.
+    ``id_found`` is False when the id is absent from the ontology.
+    """
+    try:
+        canonical = adapter.label(curie)
+    except Exception:
+        canonical = None
+    if canonical is None:
+        return None, set(), False
+    accepted = {normalize(canonical)}
+    alias_map: dict[str, list[str]] = {}
+    try:
+        alias_map = adapter.entity_alias_map(curie) or {}
+    except Exception:
+        alias_map = {}
+    for pred in _SYNONYM_PREDICATES.get(scope, _SYNONYM_PREDICATES["exact"]):
+        for alias in alias_map.get(pred, []) or []:
+            accepted.add(normalize(alias))
+    return canonical, accepted, True
+
+
+def classify(
+    *,
+    curie: str,
+    label: str,
+    adapter: Any,
+    policy: str,
+    scope: str,
+) -> dict[str, Any]:
+    """Classify one (id, label) pair into a verdict dict."""
+    canonical, accepted, found = accepted_labels(adapter, curie, scope)
+    base = {"id": curie, "label": label, "canonical": canonical or ""}
+    if not found:
+        return {**base, "verdict": "ID_NOT_FOUND"}
+    if label is None or str(label).strip() == "":
+        return {**base, "verdict": "EMPTY_LABEL"}
+    norm_label = normalize(label)
+    if canonical and norm_label == normalize(canonical):
+        return {**base, "verdict": "OK_CANONICAL"}
+    if policy == "canonical_or_synonym" and norm_label in accepted:
+        return {**base, "verdict": "OK_SYNONYM"}
+    return {**base, "verdict": "MISMATCH"}
+
+
+# -- exceptions allow-list ------------------------------------------------
+
+def load_exceptions(target: dict[str, Any]) -> set[tuple[str, str]]:
+    """Return the (curie, normalized_label) pairs the target accepts as-is.
+
+    The ``exceptions`` field on a target is a list of mappings, each with at
+    least ``id`` and ``label``. Optional ``reason`` is documentation only;
+    pairs are matched on (id, normalized(label)) so a missing or alternative
+    casing for ``reason`` doesn't affect matching.
+    """
+    out: set[tuple[str, str]] = set()
+    for entry in target.get("exceptions") or []:
+        curie = str(entry.get("id", "")).strip()
+        label = str(entry.get("label", ""))
+        if curie:
+            out.add((curie, normalize(label)))
+    return out
+
+
+# -- target readers -------------------------------------------------------
+
+def _read_tabular_rows(path: Path, fmt: str) -> tuple[list[str], list[dict[str, str]]]:
+    """Read a TSV/CSV, skipping SSSOM ``#`` comment-prelude lines."""
+    delim = "," if fmt == "csv" else "\t"
+    with path.open(newline="", encoding="utf-8") as fh:
+        lines = [ln for ln in fh if not ln.lstrip().startswith("#")]
+    if not lines:
+        return [], []
+    reader = csv.DictReader(lines, delimiter=delim)
+    return list(reader.fieldnames or []), list(reader)
+
+
+def iter_tabular(path: Path, fmt: str, pairs: list[list[str]]) -> Iterator[tuple[str, str, str]]:
+    """Yield (locator, id, label) for each configured id/label column pair."""
+    fields, rows = _read_tabular_rows(path, fmt)
+    field_set = set(fields)
+    usable = [(i, l) for (i, l) in pairs if i in field_set and l in field_set]
+    for n, row in enumerate(rows, start=2):  # row 1 is the header
+        for id_col, label_col in usable:
+            curie = (row.get(id_col) or "").strip()
+            if not curie:
+                continue
+            label = (row.get(label_col) or "").strip()
+            yield f"row {n} [{id_col}/{label_col}]", curie, label
+
+
+def _walk_yaml(node: Any, pairs: list[tuple[str, str]], path: str) -> Iterator[tuple[str, str, str]]:
+    if isinstance(node, dict):
+        for id_key, label_key in pairs:
+            if id_key in node and label_key in node:
+                curie = node.get(id_key)
+                if isinstance(curie, str) and curie.strip():
+                    label = node.get(label_key)
+                    label = label if isinstance(label, str) else ""
+                    yield f"{path}.{id_key}", curie.strip(), (label or "").strip()
+        for k, v in node.items():
+            yield from _walk_yaml(v, pairs, f"{path}.{k}")
+    elif isinstance(node, list):
+        for idx, item in enumerate(node):
+            yield from _walk_yaml(item, pairs, f"{path}[{idx}]")
+
+
+def iter_yaml(path: Path, pairs: list[list[str]]) -> Iterator[tuple[str, str, str]]:
+    """Yield (locator, id, label) from a YAML doc by recursively finding dicts
+    that carry BOTH an id key and its sibling label key."""
+    try:
+        doc = yaml.safe_load(path.read_text())
+    except Exception as exc:  # pragma: no cover
+        print(f"  ! failed to parse {path}: {exc}", file=sys.stderr)
+        return
+    yield from _walk_yaml(doc, [(a, b) for a, b in pairs], path.name)
+
+
+# -- driver ---------------------------------------------------------------
+
+def load_config(config_path: Path) -> dict[str, Any]:
+    cfg = yaml.safe_load(config_path.read_text())
+    if not isinstance(cfg, dict):
+        raise SystemExit(f"Config is not a mapping: {config_path}")
+    cfg.setdefault("adapters", {})
+    cfg.setdefault("synonym_scope", "exact_related")
+    cfg.setdefault("targets", [])
+    return cfg
+
+
+def run(config_path: Path, report_path: Path | None) -> int:
+    cfg = load_config(config_path)
+    pool = AdapterPool(cfg["adapters"])
+    default_scope = cfg["synonym_scope"]
+
+    findings: list[dict[str, Any]] = []
+    counts: dict[str, int] = {}
+    for target in cfg["targets"]:
+        name = target.get("name", target.get("glob", "?"))
+        kind = target.get("kind", "tabular")
+        policy = target.get("policy", "canonical_or_synonym")
+        scope = target.get("synonym_scope", default_scope)
+        pairs = target.get("pairs", [])
+        exceptions = load_exceptions(target)
+        globs = target.get("glob")
+        glob_list = globs if isinstance(globs, list) else [globs]
+        paths: list[Path] = []
+        for g in glob_list:
+            paths.extend(sorted(REPO_ROOT.glob(g)))
+        if not paths:
+            print(f"  - {name}: no files match {glob_list}")
+            continue
+        for path in paths:
+            rel = _safe_rel(path)
+            if kind == "yaml":
+                pairs_iter = iter_yaml(path, pairs)
+            else:
+                pairs_iter = iter_tabular(path, target.get("format", "tsv"), pairs)
+            for locator, curie, label in pairs_iter:
+                prefix = prefix_of(curie)
+                adapter = pool.get(prefix)
+                if adapter is None:
+                    verdict = "SKIPPED_NO_ADAPTER"
+                    rec = {"id": curie, "label": label, "canonical": "", "verdict": verdict}
+                else:
+                    rec = classify(
+                        curie=curie, label=label, adapter=adapter, policy=policy, scope=scope
+                    )
+                    if rec["verdict"] not in ("OK_CANONICAL", "OK_SYNONYM") and (
+                        curie, normalize(label)
+                    ) in exceptions:
+                        rec["verdict"] = "OK_EXCEPTION"
+                counts[rec["verdict"]] = counts.get(rec["verdict"], 0) + 1
+                if rec["verdict"] not in (
+                    "OK_CANONICAL", "OK_SYNONYM", "OK_EXCEPTION", "SKIPPED_NO_ADAPTER"
+                ):
+                    findings.append({
+                        "surface": name,
+                        "file": str(rel),
+                        "locator": locator,
+                        "policy": policy,
+                        **rec,
+                    })
+
+    # Summary
+    print("\nid↔label correspondence summary:")
+    for verdict in (
+        "OK_CANONICAL",
+        "OK_SYNONYM",
+        "OK_EXCEPTION",
+        "MISMATCH",
+        "ID_NOT_FOUND",
+        "EMPTY_LABEL",
+        "SKIPPED_NO_ADAPTER",
+    ):
+        if verdict in counts:
+            print(f"  {verdict:>20}: {counts[verdict]}")
+
+    if report_path is not None:
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        with report_path.open("w", newline="", encoding="utf-8") as fh:
+            w = csv.writer(fh, delimiter="\t")
+            w.writerow(
+                ["surface", "file", "locator", "id", "current_label",
+                 "canonical_label", "verdict", "policy"]
+            )
+            for f in findings:
+                w.writerow([
+                    f["surface"], f["file"], f["locator"], f["id"],
+                    f["label"], f["canonical"], f["verdict"], f["policy"],
+                ])
+        print(f"\nWrote {len(findings)} flagged pairs to {_safe_rel(report_path)}")
+        return 0
+
+    errors = [f for f in findings if f["verdict"] in _ERROR_VERDICTS]
+    if errors:
+        print(f"\n❌ {len(errors)} id↔label correspondence error(s):")
+        for f in errors[:50]:
+            print(f"  {f['verdict']}: {f['file']} {f['locator']} "
+                  f"{f['id']} label='{f['label']}' canonical='{f['canonical']}'")
+        if len(errors) > 50:
+            print(f"  ... {len(errors) - 50} more")
+        return 2
+    print("\n✅ All id↔label pairs correspond.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("-c", "--config", type=Path, default=REPO_ROOT / "conf" / "id_label_targets.yaml")
+    ap.add_argument("--report", type=Path, default=None,
+                    help="Write a drift TSV here and exit 0 (baseline mode).")
+    args = ap.parse_args(argv)
+    if not args.config.is_file():
+        print(f"Config not found: {args.config}", file=sys.stderr)
+        return 2
+    return run(args.config, args.report)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -21,6 +21,7 @@ prefixes:
   PMID: http://www.ncbi.nlm.nih.gov/pubmed/
   doi: https://doi.org/
   xsd: http://www.w3.org/2001/XMLSchema#
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
 
 default_prefix: communitymech
 
@@ -472,7 +473,11 @@ classes:
         description: The ontology term ID (e.g., NCBITaxon:1140, CHEBI:17992)
         required: true
       label:
-        description: The human-readable label for the term
+        slot_uri: rdfs:label
+        description: >-
+          The CANONICAL ontology label for `id` (e.g. "activated sludge" for
+          ENVO:00002046). Verified against the ontology by the id↔label gate;
+          free/project names belong in the sibling `preferred_term`, not here.
         required: true
 
   EvidenceItem:
@@ -516,6 +521,10 @@ classes:
         description: NCBITaxon ontology term
         range: Term
         required: true
+        # id↔label gate (range-less binding → label check, no enum expansion)
+        bindings:
+          - binds_value_of: id
+            obligation_level: REQUIRED
       notes:
         description: Additional notes about this organism
 
@@ -529,6 +538,9 @@ classes:
         description: CHEBI ontology term
         range: Term
         required: true
+        bindings:
+          - binds_value_of: id
+            obligation_level: REQUIRED
       concentration:
         description: Measured concentration or amount
       notes:
@@ -544,6 +556,9 @@ classes:
         description: GO biological process term
         range: Term
         required: true
+        bindings:
+          - binds_value_of: id
+            obligation_level: REQUIRED
       notes:
         description: Additional notes
 
@@ -557,6 +572,9 @@ classes:
         description: ENVO ontology term
         range: Term
         required: true
+        bindings:
+          - binds_value_of: id
+            obligation_level: REQUIRED
       notes:
         description: Additional notes
 
@@ -812,6 +830,9 @@ classes:
           CultureMech source_environment.
         range: Term
         required: false
+        bindings:
+          - binds_value_of: id
+            obligation_level: REQUIRED
       relevance_notes:
         description: Why this medium is relevant to the community
         range: string
@@ -841,6 +862,9 @@ classes:
         description: CHEBI ontology term for the ingredient compound
         range: Term
         required: false
+        bindings:
+          - binds_value_of: id
+            obligation_level: REQUIRED
       relevance:
         description: Why this ingredient is relevant to the community
         required: false


### PR DESCRIPTION
## Summary

Part A of the "work on these next" plan (residuals from PRs #90–#107).
- **Ontology residuals**: 50 → 28 via 9 GO rules and 13 NCBITaxon rules (48 line-pairs across 28 community files).
- **Engine B**: adds `OK_EXCEPTION` verdict + per-target `exceptions:` allow-list so the 28 curator-accepted residuals stop appearing as MISMATCH/ID_NOT_FOUND.
- Validator now reports **5023 OK_CANONICAL, 184 OK_EXCEPTION, 0 errors** across `communities_yaml` and `kgx_nodes`.

### GO (9 rules, 15 line-pairs across 14 files)
7 REPOINTs via OAK `replaced_by` (IAO:0100001), 1 REPOINT for a bad-map (GO:0051271 → GO:2000146), 1 RELABEL for a rename (GO:0019645 → "anaerobic electron transport chain").

### NCBITaxon (13 rules, 33 line-pairs across 15 files)
All replacement ids verified against the **kg-microbe ncbitaxon snapshot** at `data/transformed/ontologies/ncbitaxon_nodes.tsv` and re-confirmed in OAK's current `sqlite:obo:ncbitaxon` adapter. Per [[ontology-term-cleanup]] memory, the OAK snapshot is NOT being refreshed — kg-microbe is the source of truth for current taxonomy.

- Genus renames: Ochrobactrum → Brucella (2 species), Kazachstania → Maudiozyma, Clostridium straminisolvens → Acetivibrio, Rhizobium pusense → Agrobacterium.
- Phylum/clade renames: Asgard group → Promethearchaeati; DPANN group → Nanobdellati; OP3 → Candidatus Omnitrophota; Eisenbacteria → Candidatus Eiseniibacteriota; Dormibacterota → Candidatus Dormiibacterota.
- Spelling/disambiguation: Nitrosotalea devaniterrae; NCBITaxon:2426 → NCBITaxon:43773 ("Syntrophus <bacteria>").
- 1 RELABEL: Candidatus Micrarchaeota → Microcaldota (same id).

### Engine B (`scripts/validate_id_label_correspondence.py`)
- New `OK_EXCEPTION` verdict (non-error).
- New `exceptions:` field on each target (list of `{id, label, reason}` mappings).
- Loads exceptions per target, applies after canonical/synonym checks.
- 28 communities_yaml entries + 6 kgx_nodes entries (mostly mirrored, plus the exporter-side `CHEBI:16793 mercury(2+) cation` divergence at `src/communitymech/export/kgx_export.py:82`).

### Cross-repo sync needed
`scripts/validate_id_label_correspondence.py` is vendored byte-identical across **CultureMech / MIM / CommunityMech**. The `OK_EXCEPTION` + `load_exceptions()` change here must be synced to those repos in a follow-up.

## Test plan
- [x] `uv run python scripts/term_label_audit.py CHEBI ENVO GO NCBITaxon` — residuals match the exceptions list (11 CHEBI + 3 ENVO + 12 GO + 2 NCBITaxon).
- [x] `uv run python scripts/validate_id_label_correspondence.py -c conf/id_label_targets.yaml` — exits 0; summary shows 5023 OK_CANONICAL / 184 OK_EXCEPTION / 0 errors.
- [x] `just validate-all` — every YAML validates against the schema.
- [x] `just test` — 136 passed, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)