### PR TITLE
Add id↔label correspondence validation (canonical label gate + product checker)

### DIFF
--- a/.github/workflows/label-correspondence.yaml
+++ b/.github/workflows/label-correspondence.yaml
@@ -1,0 +1,59 @@
+name: label-correspondence
+
+# Phase 1 (report-only): generate the id↔label drift report and upload it as an
+# artifact. Does NOT fail the build — it surfaces existing label drift for
+# triage. Phase 2 will switch to the blocking gates (`just validate-terms-all`
+# + `just validate-products`).
+
+on:
+  pull_request:
+    paths: &trigger_paths
+      - "kb/communities/**"
+      - "output/kgx/**"
+      - "src/communitymech/schema/**"
+      - "scripts/validate_id_label_correspondence.py"
+      - "conf/id_label_targets.yaml"
+      - ".github/workflows/label-correspondence.yaml"
+  push:
+    branches: [main]
+    paths: *trigger_paths
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  label-drift-report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+          enable-cache: true
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      # Cache OAK sqlite ontologies (NCBITaxon/ENVO/CHEBI/GO) across runs.
+      - name: Cache OAK ontologies
+        uses: actions/cache@v4
+        with:
+          path: ~/.data/oaklib
+          key: oaklib-${{ runner.os }}-v1
+
+      - name: Generate id↔label drift report (non-blocking)
+        run: just report-label-drift
+
+      - name: Upload drift report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: label-drift-report-${{ github.run_id }}
+          path: reports/label_drift.tsv
+          if-no-files-found: warn

--- a/.github/workflows/label-correspondence.yaml
+++ b/.github/workflows/label-correspondence.yaml
@@ -12,6 +12,7 @@ on:
       - "output/kgx/**"
       - "src/communitymech/schema/**"
       - "scripts/validate_id_label_correspondence.py"
+      - "scripts/.validate_id_label_correspondence.sha256"
       - "conf/id_label_targets.yaml"
       - ".github/workflows/label-correspondence.yaml"
   push:
@@ -46,6 +47,12 @@ jobs:
         with:
           path: ~/.data/oaklib
           key: oaklib-${{ runner.os }}-v1
+
+      # Durability guard: fail the build if the vendored validator script has
+      # drifted from its pinned sha256 (the .py is byte-identical across the
+      # Mech repos; an accidental one-copy edit must not silently diverge).
+      - name: Verify id↔label validator pin
+        run: just verify-validator-pin
 
       - name: Generate id↔label drift report (non-blocking)
         run: just report-label-drift

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ pages/style.css
 
 # Claude Code local agent state
 .claude/
+
+# linkml-term-validator / OAK label cache
+cache/

--- a/conf/id_label_targets.yaml
+++ b/conf/id_label_targets.yaml
@@ -1,0 +1,31 @@
+# Targets for scripts/validate_id_label_correspondence.py (Engine B).
+# See docs/ID_LABEL_CORRESPONDENCE.md. Prefixes not in `adapters` (e.g.
+# CommunityMech:, CultureMech:, MediaIngredientMech:) are SKIPPED_NO_ADAPTER.
+
+adapters:
+  NCBITaxon: sqlite:obo:ncbitaxon
+  ENVO: sqlite:obo:envo
+  CHEBI: sqlite:obo:chebi
+  GO: sqlite:obo:go
+  UBERON: sqlite:obo:uberon
+  CL: sqlite:obo:cl
+
+synonym_scope: exact_related
+
+targets:
+  # data inputs (community YAMLs) — term.{id,label} blocks — strict canonical
+  - name: communities_yaml
+    kind: yaml
+    glob: "kb/communities/*.yaml"
+    policy: canonical
+    pairs:
+      - [id, label]
+
+  # data product: KGX node export carries (id, name) — canonical OR synonym
+  - name: kgx_nodes
+    kind: tabular
+    format: tsv
+    glob: "output/kgx/nodes.tsv"
+    policy: canonical_or_synonym
+    pairs:
+      - [id, name]

--- a/justfile
+++ b/justfile
@@ -88,6 +88,29 @@ validate-products:
 report-label-drift:
     uv run python scripts/validate_id_label_correspondence.py -c conf/id_label_targets.yaml --report reports/label_drift.tsv
 
+# Durability guard: fail if scripts/validate_id_label_correspondence.py drifts
+# from the pinned sha256 (it is vendored byte-identical across the Mech repos —
+# see the file's own docstring). CI runs this so an accidental edit to one copy
+# can't silently diverge. Uses sha256sum on CI (ubuntu), shasum -a 256 on macOS.
+verify-validator-pin:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum -c scripts/.validate_id_label_correspondence.sha256
+    else
+        shasum -a 256 -c scripts/.validate_id_label_correspondence.sha256
+    fi
+
+# Intentional sync only: re-pin the sha256 to the CURRENT script contents after
+# a deliberate, all-repos byte-identical update. Run this in every Mech copy.
+refresh-validator-pin:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    f=scripts/validate_id_label_correspondence.py
+    if command -v sha256sum >/dev/null 2>&1; then h=$(sha256sum "$f" | cut -d' ' -f1); else h=$(shasum -a 256 "$f" | cut -d' ' -f1); fi
+    printf '%s  %s\n' "$h" "$f" > scripts/.validate_id_label_correspondence.sha256
+    echo "re-pinned $f to $h"
+
 # Validate schema-level ontology term meanings
 validate-schema-terms:
     uv run linkml-term-validator validate-schema src/communitymech/schema/communitymech.yaml

--- a/justfile
+++ b/justfile
@@ -65,13 +65,28 @@ validate-cross-repo-ids-all:
 validate-terms FILE:
     uv run linkml-term-validator validate-data {{FILE}} -s src/communitymech/schema/communitymech.yaml --labels
 
-# Validate terms in all community files
+# Validate terms in all community files. Now that the schema binds the
+# descriptor `term` slots, --labels verifies term.label is the CANONICAL
+# ontology label for term.id. Fails (non-zero) if any file has label drift.
 validate-terms-all:
     #!/usr/bin/env bash
+    set -uo pipefail
+    rc=0
     for file in kb/communities/*.yaml; do
-        echo "\\nValidating terms in $file..."
-        uv run linkml-term-validator validate-data "$file" -s src/communitymech/schema/communitymech.yaml --labels
+        echo "Validating terms in $file..."
+        uv run linkml-term-validator validate-data "$file" -s src/communitymech/schema/communitymech.yaml --labels || rc=1
     done
+    exit $rc
+
+# id↔label gate (Engine B): verify (id,label) pairs in DATA PRODUCTS
+# (KGX node export) correspond to the ontology. Exits 2 on any mismatch.
+validate-products:
+    uv run python scripts/validate_id_label_correspondence.py -c conf/id_label_targets.yaml
+
+# Baseline (non-failing): unified id↔label drift report across community
+# YAMLs + KGX products to reports/label_drift.tsv. Use before enforcing.
+report-label-drift:
+    uv run python scripts/validate_id_label_correspondence.py -c conf/id_label_targets.yaml --report reports/label_drift.tsv
 
 # Validate schema-level ontology term meanings
 validate-schema-terms:

--- a/scripts/.validate_id_label_correspondence.sha256
+++ b/scripts/.validate_id_label_correspondence.sha256
@@ -1,0 +1,1 @@
+0a446a80ae932f229a45d69995f1e68a1409ef0bb89479a77d5f08265ee0c582  scripts/validate_id_label_correspondence.py

--- a/scripts/validate_id_label_correspondence.py
+++ b/scripts/validate_id_label_correspondence.py
@@ -28,6 +28,8 @@ repos already use, and classifies the pair:
     EMPTY_LABEL         id present, label blank                             (ERROR)
     ADAPTER_ERROR       a CONFIGURED adapter failed to load                 (ERROR)
     SKIPPED_NO_ADAPTER  prefix has no configured OAK adapter (cas:, MIM:, …)
+    SKIPPED_EMPTY_ADAPTER  configured adapter loaded but holds no terms (e.g. a
+                        0-byte sqlite stub); db needs populating, data isn't wrong
 
 Policy (per target, ``conf/id_label_targets.yaml``)
     ``canonical``            accept only the canonical OBO label (strict;
@@ -104,6 +106,13 @@ def prefix_of(curie: str) -> str | None:
 # caller can raise a fatal ADAPTER_ERROR instead of a benign SKIPPED_NO_ADAPTER.
 LOAD_FAILED = object()
 
+# Sentinel for a CONFIGURED adapter that loads but contains no terms (e.g. a
+# 0-byte ``~/.data/oaklib/micro.db`` stub that OAK opens happily but that yields
+# ``label() == None`` for every id). Without this, every id under such a prefix
+# would be reported as a false ``ID_NOT_FOUND``. Treated as a benign skip
+# (``SKIPPED_EMPTY_ADAPTER``) — the db needs populating, the data isn't wrong.
+EMPTY_ADAPTER = object()
+
 
 class AdapterPool:
     """Lazily loads OAK adapters, but ONLY for prefixes in the allowlist.
@@ -151,11 +160,33 @@ class AdapterPool:
             try:
                 from oaklib import get_adapter
 
-                self._cache[key] = get_adapter(self._selectors[key])
+                adapter = get_adapter(self._selectors[key])
             except Exception as exc:  # pragma: no cover - environment dependent
                 print(f"  ! failed to load adapter for {key}: {exc}", file=sys.stderr)
                 self._cache[key] = LOAD_FAILED
+            else:
+                self._cache[key] = EMPTY_ADAPTER if self._is_empty(adapter, key) else adapter
         return self._cache[key]
+
+    @staticmethod
+    def _is_empty(adapter: Any, key: str) -> bool:
+        """True if the adapter loaded but holds no terms (e.g. a 0-byte sqlite).
+
+        Peeks a single entity (O(1)) rather than counting. Two empty shapes:
+        a valid-but-termless db (``entities()`` yields nothing), and an
+        uninitialized 0-byte sqlite stub whose tables don't exist yet
+        (``entities()`` raises ``no such table`` — OAK's ``sqlite:obo:micro``
+        points at exactly such a stub). Any *other* probe error is treated as
+        non-empty so a genuinely broken adapter still surfaces per-id verdicts
+        rather than being masked as an empty skip.
+        """
+        try:
+            return next(iter(adapter.entities()), None) is None
+        except Exception as exc:  # pragma: no cover - environment dependent
+            if "no such table" in str(exc).lower():  # uninitialized/0-byte stub
+                return True
+            print(f"  ! emptiness probe failed for {key}: {exc}", file=sys.stderr)
+            return False
 
 
 def accepted_labels(
@@ -380,6 +411,9 @@ def run(config_path: Path, report_path: Path | None) -> int:
                 elif adapter is LOAD_FAILED:
                     rec = {"id": curie, "label": label, "canonical": "",
                            "verdict": "ADAPTER_ERROR"}
+                elif adapter is EMPTY_ADAPTER:
+                    rec = {"id": curie, "label": label, "canonical": "",
+                           "verdict": "SKIPPED_EMPTY_ADAPTER"}
                 else:
                     # Rewrite the CURIE prefix to the canonical allowlist case
                     # (e.g. mesh: -> MESH:) so OAK, which keys on uppercase OBO
@@ -393,7 +427,8 @@ def run(config_path: Path, report_path: Path | None) -> int:
                         scope=scope, lookup_curie=lookup_curie,
                     )
                 counts[rec["verdict"]] = counts.get(rec["verdict"], 0) + 1
-                if rec["verdict"] not in ("OK_CANONICAL", "OK_SYNONYM", "SKIPPED_NO_ADAPTER"):
+                if rec["verdict"] not in ("OK_CANONICAL", "OK_SYNONYM",
+                                          "SKIPPED_NO_ADAPTER", "SKIPPED_EMPTY_ADAPTER"):
                     findings.append({
                         "surface": name,
                         "file": str(rel),
@@ -412,6 +447,7 @@ def run(config_path: Path, report_path: Path | None) -> int:
         "EMPTY_LABEL",
         "ADAPTER_ERROR",
         "SKIPPED_NO_ADAPTER",
+        "SKIPPED_EMPTY_ADAPTER",
     ):
         if verdict in counts:
             print(f"  {verdict:>20}: {counts[verdict]}")

--- a/scripts/validate_id_label_correspondence.py
+++ b/scripts/validate_id_label_correspondence.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Validate that every ontology ID carries its correct ontology LABEL.
+
+Shared, schema/config-driven id↔label correspondence checker. Vendored
+**byte-identical** across the Mech repos (CultureMech / MIM / CommunityMech)
+— the same convention as ``scripts/_edison_capture.py``. Verify with
+``md5``; a fix here must be synced to all copies.
+
+Why this exists
+---------------
+``linkml-term-validator validate-data --labels`` only checks that the
+label of an ontology ID matches the ontology — and only for LinkML data
+instances (YAML) whose schema declares a ``binding``. It does NOT cover
+**data products**: SSSOM TSVs, mapping CSVs, KGX node tables, and review
+TSVs all carry (id, label) columns that no LinkML tool reads. This script
+closes that gap and also produces a single cross-surface drift report.
+
+What it checks
+--------------
+For every (id, label) pair in the configured targets it resolves the
+canonical label (and synonyms) from the same OAK sqlite adapters the
+repos already use, and classifies the pair:
+
+    OK_CANONICAL        label == canonical OBO label
+    OK_SYNONYM          label is an accepted synonym (policy-dependent)
+    MISMATCH            label is neither canonical nor an accepted synonym  (ERROR)
+    ID_NOT_FOUND        id has an adapter but is absent from the ontology   (ERROR)
+    EMPTY_LABEL         id present, label blank                             (ERROR)
+    SKIPPED_NO_ADAPTER  prefix has no configured OAK adapter (cas:, MIM:, …)
+
+Policy (per target, ``conf/id_label_targets.yaml``)
+    ``canonical``            accept only the canonical OBO label (strict;
+                             mirrors the linkml-term-validator schema gate).
+    ``canonical_or_synonym`` accept canonical OR a synonym within
+                             ``synonym_scope`` (exact | exact_related | all).
+
+Modes
+    ``--report PATH``  write a TSV of every non-OK pair and exit 0 (baseline).
+    (default)          enforce: exit 2 if any ERROR-class pair is found.
+
+Usage::
+
+    python scripts/validate_id_label_correspondence.py -c conf/id_label_targets.yaml
+    python scripts/validate_id_label_correspondence.py -c conf/id_label_targets.yaml \\
+        --report reports/label_drift.tsv
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from pathlib import Path
+from typing import Any, Iterator
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _safe_rel(path: Path) -> str:
+    """``path`` relative to the repo when possible; else its absolute string."""
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+# Verdict classes that should fail an --enforce run.
+_ERROR_VERDICTS = {"MISMATCH", "ID_NOT_FOUND", "EMPTY_LABEL"}
+
+_CURIE_RE = re.compile(r"^([A-Za-z][A-Za-z0-9.]*):(.+)$")
+_WS_RE = re.compile(r"\s+")
+
+# OAK alias predicates by synonym scope (always includes label + exact).
+_SYNONYM_PREDICATES = {
+    "exact": ["oio:hasExactSynonym"],
+    "exact_related": ["oio:hasExactSynonym", "oio:hasRelatedSynonym"],
+    "all": [
+        "oio:hasExactSynonym",
+        "oio:hasRelatedSynonym",
+        "oio:hasBroadSynonym",
+        "oio:hasNarrowSynonym",
+    ],
+}
+
+
+def normalize(text: str) -> str:
+    """Casefold, strip, collapse internal whitespace — for label comparison."""
+    return _WS_RE.sub(" ", str(text).strip()).casefold()
+
+
+def prefix_of(curie: str) -> str | None:
+    m = _CURIE_RE.match(str(curie).strip())
+    return m.group(1) if m else None
+
+
+class AdapterPool:
+    """Lazily loads OAK adapters, but ONLY for prefixes in the allowlist.
+
+    The allowlist (``adapters`` map in the config) is the safety boundary:
+    prefixes without an entry (``cas:``, ``MIM:``, ``kgmicrobe.compound:``,
+    ``DSMZ``, …) are never looked up — they are reported as
+    ``SKIPPED_NO_ADAPTER`` instead of triggering a futile ontology download.
+    """
+
+    def __init__(self, adapters: dict[str, str]):
+        self._selectors = adapters
+        self._cache: dict[str, Any] = {}
+
+    def get(self, prefix: str | None):
+        if not prefix or prefix not in self._selectors:
+            return None
+        if prefix not in self._cache:
+            try:
+                from oaklib import get_adapter
+
+                self._cache[prefix] = get_adapter(self._selectors[prefix])
+            except Exception as exc:  # pragma: no cover - environment dependent
+                print(f"  ! failed to load adapter for {prefix}: {exc}", file=sys.stderr)
+                self._cache[prefix] = None
+        return self._cache[prefix]
+
+
+def accepted_labels(adapter: Any, curie: str, scope: str) -> tuple[str | None, set[str], bool]:
+    """Return (canonical_label, accepted_normalized_set, id_found).
+
+    ``accepted_normalized_set`` always contains the canonical label; with a
+    non-``canonical`` policy the caller widens it via ``scope`` synonyms.
+    ``id_found`` is False when the id is absent from the ontology.
+    """
+    try:
+        canonical = adapter.label(curie)
+    except Exception:
+        canonical = None
+    if canonical is None:
+        return None, set(), False
+    accepted = {normalize(canonical)}
+    alias_map: dict[str, list[str]] = {}
+    try:
+        alias_map = adapter.entity_alias_map(curie) or {}
+    except Exception:
+        alias_map = {}
+    for pred in _SYNONYM_PREDICATES.get(scope, _SYNONYM_PREDICATES["exact"]):
+        for alias in alias_map.get(pred, []) or []:
+            accepted.add(normalize(alias))
+    return canonical, accepted, True
+
+
+def classify(
+    *,
+    curie: str,
+    label: str,
+    adapter: Any,
+    policy: str,
+    scope: str,
+) -> dict[str, Any]:
+    """Classify one (id, label) pair into a verdict dict."""
+    canonical, accepted, found = accepted_labels(adapter, curie, scope)
+    base = {"id": curie, "label": label, "canonical": canonical or ""}
+    if not found:
+        return {**base, "verdict": "ID_NOT_FOUND"}
+    if label is None or str(label).strip() == "":
+        return {**base, "verdict": "EMPTY_LABEL"}
+    norm_label = normalize(label)
+    if canonical and norm_label == normalize(canonical):
+        return {**base, "verdict": "OK_CANONICAL"}
+    if policy == "canonical_or_synonym" and norm_label in accepted:
+        return {**base, "verdict": "OK_SYNONYM"}
+    return {**base, "verdict": "MISMATCH"}
+
+
+# -- target readers -------------------------------------------------------
+
+def _read_tabular_rows(path: Path, fmt: str) -> tuple[list[str], list[dict[str, str]]]:
+    """Read a TSV/CSV, skipping SSSOM ``#`` comment-prelude lines."""
+    delim = "," if fmt == "csv" else "\t"
+    with path.open(newline="", encoding="utf-8") as fh:
+        lines = [ln for ln in fh if not ln.lstrip().startswith("#")]
+    if not lines:
+        return [], []
+    reader = csv.DictReader(lines, delimiter=delim)
+    return list(reader.fieldnames or []), list(reader)
+
+
+def iter_tabular(path: Path, fmt: str, pairs: list[list[str]]) -> Iterator[tuple[str, str, str]]:
+    """Yield (locator, id, label) for each configured id/label column pair."""
+    fields, rows = _read_tabular_rows(path, fmt)
+    field_set = set(fields)
+    usable = [(i, l) for (i, l) in pairs if i in field_set and l in field_set]
+    for n, row in enumerate(rows, start=2):  # row 1 is the header
+        for id_col, label_col in usable:
+            curie = (row.get(id_col) or "").strip()
+            if not curie:
+                continue
+            label = (row.get(label_col) or "").strip()
+            yield f"row {n} [{id_col}/{label_col}]", curie, label
+
+
+def _walk_yaml(node: Any, pairs: list[tuple[str, str]], path: str) -> Iterator[tuple[str, str, str]]:
+    if isinstance(node, dict):
+        for id_key, label_key in pairs:
+            if id_key in node and label_key in node:
+                curie = node.get(id_key)
+                if isinstance(curie, str) and curie.strip():
+                    label = node.get(label_key)
+                    label = label if isinstance(label, str) else ""
+                    yield f"{path}.{id_key}", curie.strip(), (label or "").strip()
+        for k, v in node.items():
+            yield from _walk_yaml(v, pairs, f"{path}.{k}")
+    elif isinstance(node, list):
+        for idx, item in enumerate(node):
+            yield from _walk_yaml(item, pairs, f"{path}[{idx}]")
+
+
+def iter_yaml(path: Path, pairs: list[list[str]]) -> Iterator[tuple[str, str, str]]:
+    """Yield (locator, id, label) from a YAML doc by recursively finding dicts
+    that carry BOTH an id key and its sibling label key."""
+    try:
+        doc = yaml.safe_load(path.read_text())
+    except Exception as exc:  # pragma: no cover
+        print(f"  ! failed to parse {path}: {exc}", file=sys.stderr)
+        return
+    yield from _walk_yaml(doc, [(a, b) for a, b in pairs], path.name)
+
+
+# -- driver ---------------------------------------------------------------
+
+def load_config(config_path: Path) -> dict[str, Any]:
+    cfg = yaml.safe_load(config_path.read_text())
+    if not isinstance(cfg, dict):
+        raise SystemExit(f"Config is not a mapping: {config_path}")
+    cfg.setdefault("adapters", {})
+    cfg.setdefault("synonym_scope", "exact_related")
+    cfg.setdefault("targets", [])
+    return cfg
+
+
+def run(config_path: Path, report_path: Path | None) -> int:
+    cfg = load_config(config_path)
+    pool = AdapterPool(cfg["adapters"])
+    default_scope = cfg["synonym_scope"]
+
+    findings: list[dict[str, Any]] = []
+    counts: dict[str, int] = {}
+    for target in cfg["targets"]:
+        name = target.get("name", target.get("glob", "?"))
+        kind = target.get("kind", "tabular")
+        policy = target.get("policy", "canonical_or_synonym")
+        scope = target.get("synonym_scope", default_scope)
+        pairs = target.get("pairs", [])
+        globs = target.get("glob")
+        glob_list = globs if isinstance(globs, list) else [globs]
+        paths: list[Path] = []
+        for g in glob_list:
+            paths.extend(sorted(REPO_ROOT.glob(g)))
+        if not paths:
+            print(f"  - {name}: no files match {glob_list}")
+            continue
+        for path in paths:
+            rel = _safe_rel(path)
+            if kind == "yaml":
+                pairs_iter = iter_yaml(path, pairs)
+            else:
+                pairs_iter = iter_tabular(path, target.get("format", "tsv"), pairs)
+            for locator, curie, label in pairs_iter:
+                prefix = prefix_of(curie)
+                adapter = pool.get(prefix)
+                if adapter is None:
+                    verdict = "SKIPPED_NO_ADAPTER"
+                    rec = {"id": curie, "label": label, "canonical": "", "verdict": verdict}
+                else:
+                    rec = classify(
+                        curie=curie, label=label, adapter=adapter, policy=policy, scope=scope
+                    )
+                counts[rec["verdict"]] = counts.get(rec["verdict"], 0) + 1
+                if rec["verdict"] not in ("OK_CANONICAL", "OK_SYNONYM", "SKIPPED_NO_ADAPTER"):
+                    findings.append({
+                        "surface": name,
+                        "file": str(rel),
+                        "locator": locator,
+                        "policy": policy,
+                        **rec,
+                    })
+
+    # Summary
+    print("\nid↔label correspondence summary:")
+    for verdict in (
+        "OK_CANONICAL",
+        "OK_SYNONYM",
+        "MISMATCH",
+        "ID_NOT_FOUND",
+        "EMPTY_LABEL",
+        "SKIPPED_NO_ADAPTER",
+    ):
+        if verdict in counts:
+            print(f"  {verdict:>20}: {counts[verdict]}")
+
+    if report_path is not None:
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        with report_path.open("w", newline="", encoding="utf-8") as fh:
+            w = csv.writer(fh, delimiter="\t")
+            w.writerow(
+                ["surface", "file", "locator", "id", "current_label",
+                 "canonical_label", "verdict", "policy"]
+            )
+            for f in findings:
+                w.writerow([
+                    f["surface"], f["file"], f["locator"], f["id"],
+                    f["label"], f["canonical"], f["verdict"], f["policy"],
+                ])
+        print(f"\nWrote {len(findings)} flagged pairs to {_safe_rel(report_path)}")
+        return 0
+
+    errors = [f for f in findings if f["verdict"] in _ERROR_VERDICTS]
+    if errors:
+        print(f"\n❌ {len(errors)} id↔label correspondence error(s):")
+        for f in errors[:50]:
+            print(f"  {f['verdict']}: {f['file']} {f['locator']} "
+                  f"{f['id']} label='{f['label']}' canonical='{f['canonical']}'")
+        if len(errors) > 50:
+            print(f"  ... {len(errors) - 50} more")
+        return 2
+    print("\n✅ All id↔label pairs correspond.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("-c", "--config", type=Path, default=REPO_ROOT / "conf" / "id_label_targets.yaml")
+    ap.add_argument("--report", type=Path, default=None,
+                    help="Write a drift TSV here and exit 0 (baseline mode).")
+    args = ap.parse_args(argv)
+    if not args.config.is_file():
+        print(f"Config not found: {args.config}", file=sys.stderr)
+        return 2
+    return run(args.config, args.report)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_id_label_correspondence.py
+++ b/scripts/validate_id_label_correspondence.py
@@ -23,9 +23,15 @@ repos already use, and classifies the pair:
 
     OK_CANONICAL        label == canonical OBO label
     OK_SYNONYM          label is an accepted synonym (policy-dependent)
+    OK_ID_ONLY          id resolves; label match WAIVED for this slot (the slot
+                        carries a curator-intended formula/common name, e.g.
+                        CHEBI:15377 "Distilled water" — see ``label_waived_keys``)
     MISMATCH            label is neither canonical nor an accepted synonym  (ERROR)
     ID_NOT_FOUND        id has an adapter but is absent from the ontology   (ERROR)
     EMPTY_LABEL         id present, label blank                             (ERROR)
+    MISSING_COLUMN      a CONFIGURED id/label column is absent from a       (ERROR)
+                        tabular target that has data rows — without this the
+                        pair silently drops and enforce false-greens on drift
     ADAPTER_ERROR       a CONFIGURED adapter failed to load                 (ERROR)
     SKIPPED_NO_ADAPTER  prefix has no configured OAK adapter (cas:, MIM:, …)
     SKIPPED_EMPTY_ADAPTER  configured adapter loaded but holds no terms (e.g. a
@@ -36,6 +42,25 @@ Policy (per target, ``conf/id_label_targets.yaml``)
                              mirrors the linkml-term-validator schema gate).
     ``canonical_or_synonym`` accept canonical OR a synonym within
                              ``synonym_scope`` (exact | exact_related | all).
+
+Per-target knobs (in addition to ``policy``/``synonym_scope``/``pairs``)
+    ``required: true``       fail enforce when the target's glob matches NO
+                             files (an expected artifact, e.g. an SSSOM export,
+                             wasn't built). Default false preserves the prior
+                             "skip-with-exit-0" behaviour for optional targets.
+    ``label_waived_keys``    slots that carry curator-intended labels (formula /
+                             common names) and so are EXEMPT from canonical-label
+                             matching but STILL id-existence checked (OK_ID_ONLY
+                             when the id resolves, ID_NOT_FOUND when it doesn't).
+                             For YAML targets the entries match the *parent key*
+                             of the id/label dict (e.g. ``term``, ``chebi_term``);
+                             for tabular targets they match the *id column name*
+                             (e.g. ``ontology_id``). This implements the product
+                             decision to KEEP labels like "D-glucose" / "NaCl"
+                             rather than relabel them to the OBO canonical form.
+                             Unlike ``exclude_keys`` (which prunes the whole
+                             subtree and checks nothing), label-waived slots are
+                             still validated for id existence.
 
 Modes
     ``--report PATH``  write a TSV of every non-OK pair and exit 0 (baseline).
@@ -72,8 +97,26 @@ def _safe_rel(path: Path) -> str:
 # Verdict classes that should fail an --enforce run.
 # ADAPTER_ERROR is fatal: a configured adapter that fails to LOAD must never be
 # silently downgraded to SKIPPED_NO_ADAPTER (which would let an enforce run pass
-# while checking nothing).
-_ERROR_VERDICTS = {"MISMATCH", "ID_NOT_FOUND", "EMPTY_LABEL", "ADAPTER_ERROR"}
+# while checking nothing). MISSING_COLUMN is likewise fatal: a configured
+# id/label column that is absent from a populated tabular target used to be a
+# stderr-only warning, so enforce exited 0 even though the pair was never
+# checked (Engine-B false-green). MISSING_GLOB is emitted for a ``required: true``
+# target whose glob matched no files (an expected artifact wasn't built).
+_ERROR_VERDICTS = {
+    "MISMATCH",
+    "ID_NOT_FOUND",
+    "EMPTY_LABEL",
+    "MISSING_COLUMN",
+    "MISSING_GLOB",
+    "ADAPTER_ERROR",
+}
+
+# Verdicts that are accepted (do NOT get recorded as findings and never fail
+# enforce). OK_ID_ONLY is a pass: the id resolved and the slot's label was
+# intentionally waived (curator-intended formula/common name).
+_OK_VERDICTS = {"OK_CANONICAL", "OK_SYNONYM", "OK_ID_ONLY"}
+# Benign skips: not OK (still surfaced in the report) but never fail enforce.
+_SKIP_VERDICTS = {"SKIPPED_NO_ADAPTER", "SKIPPED_EMPTY_ADAPTER"}
 
 _CURIE_RE = re.compile(r"^([A-Za-z][A-Za-z0-9.]*):(.+)$")
 _WS_RE = re.compile(r"\s+")
@@ -228,6 +271,7 @@ def classify(
     policy: str,
     scope: str,
     lookup_curie: str | None = None,
+    label_waived: bool = False,
 ) -> dict[str, Any]:
     """Classify one (id, label) pair into a verdict dict.
 
@@ -235,14 +279,24 @@ def classify(
     case-normalized CURIE actually passed to the adapter so that, e.g., a
     lowercase ``mesh:`` row resolves against OAK's uppercase ``MESH:`` ids.
     Synonyms are only built when the policy actually consults them.
+
+    ``label_waived`` marks slots that carry curator-intended formula/common
+    names (e.g. CHEBI:15377 "Distilled water"): id existence is still
+    enforced (ID_NOT_FOUND fires for a bogus id) but the canonical-label
+    match is skipped — a resolvable id yields OK_ID_ONLY regardless of label.
     """
-    include_synonyms = policy != "canonical"
+    # When the label is waived we never consult synonyms (the label isn't
+    # being compared at all), so skip the potentially expensive alias lookup.
+    include_synonyms = (policy != "canonical") and not label_waived
     canonical, accepted, found = accepted_labels(
         adapter, lookup_curie or curie, scope, include_synonyms=include_synonyms
     )
     base = {"id": curie, "label": label, "canonical": canonical or ""}
     if not found:
         return {**base, "verdict": "ID_NOT_FOUND"}
+    if label_waived:
+        # Id resolved; the curator label is intentional, so accept it as-is.
+        return {**base, "verdict": "OK_ID_ONLY"}
     if label is None or str(label).strip() == "":
         return {**base, "verdict": "EMPTY_LABEL"}
     norm_label = normalize(label)
@@ -288,26 +342,47 @@ def _read_tabular_rows(
     return list(reader.fieldnames or []), list(reader), data_line_numbers
 
 
-def iter_tabular(path: Path, fmt: str, pairs: list[list[str]]) -> Iterator[tuple[str, str, str]]:
-    """Yield (locator, id, label) for each configured id/label column pair."""
+def iter_tabular(
+    path: Path,
+    fmt: str,
+    pairs: list[list[str]],
+    label_waived_cols: frozenset[str] = frozenset(),
+) -> Iterator[tuple[str, str, str, bool, str | None]]:
+    """Yield (locator, id, label, label_waived, verdict_override) for each pair.
+
+    ``verdict_override`` is normally ``None`` (the caller classifies the pair).
+    For a configured id column that is ABSENT from a populated file it is
+    ``"MISSING_COLUMN"`` — an ERROR-class verdict, so enforce no longer
+    false-greens on column drift (it used to be a stderr-only warning that the
+    caller never saw as a finding). ``label_waived`` is True when the pair's id
+    column is listed in ``label_waived_cols`` (curator-intended label slot).
+    """
     fields, rows, line_numbers = _read_tabular_rows(path, fmt)
     field_set = set(fields)
     # Keep any pair whose id column exists; a missing label column is allowed
     # so an id present without its label still gets an EMPTY_LABEL verdict
     # rather than being silently dropped.
     usable = [(i, l) for (i, l) in pairs if i in field_set]
-    # RISK: a configured pair whose ID column is absent must NOT vanish silently.
-    # Warn loudly when the file has rows but a configured pair can't be applied
-    # at all. (A missing LABEL column alone is fine — it yields EMPTY_LABEL.)
+    # RISK (fixed): a configured pair whose ID or LABEL column is absent must
+    # NOT vanish silently. When the file has data rows, emit a MISSING_COLUMN
+    # ERROR finding per absent column so an enforce run FAILS instead of
+    # passing while checking nothing. (Still also warn to stderr for context.)
     if rows:
         for (i, l) in pairs:
-            if i not in field_set or l not in field_set:
-                missing = [c for c in (i, l) if c not in field_set]
+            missing = [c for c in (i, l) if c not in field_set]
+            if missing:
                 print(
                     f"  ! {_safe_rel(path)}: configured id/label pair "
                     f"[{i}/{l}] — missing column(s) {missing}; "
                     f"present columns: {sorted(field_set)}",
                     file=sys.stderr,
+                )
+                yield (
+                    f"columns [{i}/{l}]",
+                    f"missing:{','.join(missing)}",
+                    f"present:{sorted(field_set)}",
+                    False,
+                    "MISSING_COLUMN",
                 )
     for idx, row in enumerate(rows):
         # True physical line number when available (a quoted multiline field
@@ -318,7 +393,8 @@ def iter_tabular(path: Path, fmt: str, pairs: list[list[str]]) -> Iterator[tuple
             if not curie:
                 continue
             label = (row.get(label_col) or "").strip()
-            yield f"line {line_no} [{id_col}/{label_col}]", curie, label
+            waived = id_col in label_waived_cols
+            yield f"line {line_no} [{id_col}/{label_col}]", curie, label, waived, None
 
 
 def _walk_yaml(
@@ -326,7 +402,9 @@ def _walk_yaml(
     pairs: list[tuple[str, str]],
     path: str,
     exclude_keys: frozenset[str] = frozenset(),
-) -> Iterator[tuple[str, str, str]]:
+    label_waived_keys: frozenset[str] = frozenset(),
+    waived: bool = False,
+) -> Iterator[tuple[str, str, str, bool, str | None]]:
     if isinstance(node, dict):
         for id_key, label_key in pairs:
             # An id present without its sibling label must still be checked
@@ -336,30 +414,44 @@ def _walk_yaml(
                 if isinstance(curie, str) and curie.strip():
                     label = node.get(label_key)
                     label = label if isinstance(label, str) else ""
-                    yield f"{path}.{id_key}", curie.strip(), (label or "").strip()
+                    yield f"{path}.{id_key}", curie.strip(), (label or "").strip(), waived, None
         for k, v in node.items():
-            # Skip excluded grounding blocks (e.g. mediaingredientmech_chebi_term,
-            # whose label is intentionally MIM's preferred_term, not the OBO
-            # canonical label, so a `canonical` policy would false-MISMATCH it).
+            # Skip excluded grounding blocks entirely (no checks at all).
             if k in exclude_keys:
                 continue
-            yield from _walk_yaml(v, pairs, f"{path}.{k}", exclude_keys)
+            # label_waived_keys: descend, but mark everything under this key as
+            # label-waived so its id/label dicts get id-existence-only checking
+            # (curator-intended formula/common names, e.g. CHEBI:15377
+            # "Distilled water" under a `term:` block). ``waived`` is sticky
+            # for the subtree so a nested id/label pair stays waived.
+            child_waived = waived or (k in label_waived_keys)
+            yield from _walk_yaml(
+                v, pairs, f"{path}.{k}", exclude_keys, label_waived_keys, child_waived
+            )
     elif isinstance(node, list):
         for idx, item in enumerate(node):
-            yield from _walk_yaml(item, pairs, f"{path}[{idx}]", exclude_keys)
+            yield from _walk_yaml(
+                item, pairs, f"{path}[{idx}]", exclude_keys, label_waived_keys, waived
+            )
 
 
 def iter_yaml(
-    path: Path, pairs: list[list[str]], exclude_keys: frozenset[str] = frozenset()
-) -> Iterator[tuple[str, str, str]]:
-    """Yield (locator, id, label) from a YAML doc by recursively finding dicts
-    that carry an id key (and, when present, its sibling label key)."""
+    path: Path,
+    pairs: list[list[str]],
+    exclude_keys: frozenset[str] = frozenset(),
+    label_waived_keys: frozenset[str] = frozenset(),
+) -> Iterator[tuple[str, str, str, bool, str | None]]:
+    """Yield (locator, id, label, label_waived, verdict_override) from a YAML
+    doc by recursively finding dicts that carry an id key (and, when present,
+    its sibling label key)."""
     try:
         doc = yaml.safe_load(path.read_text())
     except Exception as exc:  # pragma: no cover
         print(f"  ! failed to parse {path}: {exc}", file=sys.stderr)
         return
-    yield from _walk_yaml(doc, [(a, b) for a, b in pairs], path.name, exclude_keys)
+    yield from _walk_yaml(
+        doc, [(a, b) for a, b in pairs], path.name, exclude_keys, label_waived_keys
+    )
 
 
 # -- driver ---------------------------------------------------------------
@@ -388,47 +480,69 @@ def run(config_path: Path, report_path: Path | None) -> int:
         scope = target.get("synonym_scope", default_scope)
         pairs = target.get("pairs", [])
         exclude_keys = frozenset(target.get("exclude_keys", []) or [])
+        label_waived_keys = frozenset(target.get("label_waived_keys", []) or [])
+        required = bool(target.get("required", False))
         globs = target.get("glob")
         glob_list = globs if isinstance(globs, list) else [globs]
         paths: list[Path] = []
         for g in glob_list:
             paths.extend(sorted(REPO_ROOT.glob(g)))
         if not paths:
-            print(f"  - {name}: no files match {glob_list}")
+            # RISK (fixed): a `required: true` target whose glob matches NO
+            # files means an expected artifact (e.g. output/*.sssom.tsv) was
+            # never built. That used to skip with exit 0, so validate-products
+            # greened on a missing product. Emit a MISSING_GLOB ERROR finding.
+            if required:
+                print(f"  ! {name}: REQUIRED target — no files match {glob_list}")
+                rec = {"id": ",".join(str(g) for g in glob_list), "label": "",
+                       "canonical": "", "verdict": "MISSING_GLOB"}
+                counts["MISSING_GLOB"] = counts.get("MISSING_GLOB", 0) + 1
+                findings.append({
+                    "surface": name, "file": "(no match)",
+                    "locator": f"glob {glob_list}", "policy": policy, **rec,
+                })
+            else:
+                print(f"  - {name}: no files match {glob_list}")
             continue
         for path in paths:
             rel = _safe_rel(path)
             if kind == "yaml":
-                pairs_iter = iter_yaml(path, pairs, exclude_keys)
+                pairs_iter = iter_yaml(path, pairs, exclude_keys, label_waived_keys)
             else:
-                pairs_iter = iter_tabular(path, target.get("format", "tsv"), pairs)
-            for locator, curie, label in pairs_iter:
-                prefix = prefix_of(curie)
-                adapter = pool.get(prefix)
-                if adapter is None:
+                pairs_iter = iter_tabular(
+                    path, target.get("format", "tsv"), pairs, label_waived_keys
+                )
+            for locator, curie, label, label_waived, verdict_override in pairs_iter:
+                if verdict_override is not None:
                     rec = {"id": curie, "label": label, "canonical": "",
-                           "verdict": "SKIPPED_NO_ADAPTER"}
-                elif adapter is LOAD_FAILED:
-                    rec = {"id": curie, "label": label, "canonical": "",
-                           "verdict": "ADAPTER_ERROR"}
-                elif adapter is EMPTY_ADAPTER:
-                    rec = {"id": curie, "label": label, "canonical": "",
-                           "verdict": "SKIPPED_EMPTY_ADAPTER"}
+                           "verdict": verdict_override}
                 else:
-                    # Rewrite the CURIE prefix to the canonical allowlist case
-                    # (e.g. mesh: -> MESH:) so OAK, which keys on uppercase OBO
-                    # prefixes, resolves the label instead of returning None.
-                    canonical_prefix = pool.canonical_prefix(prefix)
-                    lookup_curie = curie
-                    if canonical_prefix and prefix != canonical_prefix:
-                        lookup_curie = f"{canonical_prefix}:{curie.split(':', 1)[1]}"
-                    rec = classify(
-                        curie=curie, label=label, adapter=adapter, policy=policy,
-                        scope=scope, lookup_curie=lookup_curie,
-                    )
+                    prefix = prefix_of(curie)
+                    adapter = pool.get(prefix)
+                    if adapter is None:
+                        rec = {"id": curie, "label": label, "canonical": "",
+                               "verdict": "SKIPPED_NO_ADAPTER"}
+                    elif adapter is LOAD_FAILED:
+                        rec = {"id": curie, "label": label, "canonical": "",
+                               "verdict": "ADAPTER_ERROR"}
+                    elif adapter is EMPTY_ADAPTER:
+                        rec = {"id": curie, "label": label, "canonical": "",
+                               "verdict": "SKIPPED_EMPTY_ADAPTER"}
+                    else:
+                        # Rewrite the CURIE prefix to the canonical allowlist case
+                        # (e.g. mesh: -> MESH:) so OAK, which keys on uppercase OBO
+                        # prefixes, resolves the label instead of returning None.
+                        canonical_prefix = pool.canonical_prefix(prefix)
+                        lookup_curie = curie
+                        if canonical_prefix and prefix != canonical_prefix:
+                            lookup_curie = f"{canonical_prefix}:{curie.split(':', 1)[1]}"
+                        rec = classify(
+                            curie=curie, label=label, adapter=adapter, policy=policy,
+                            scope=scope, lookup_curie=lookup_curie,
+                            label_waived=label_waived,
+                        )
                 counts[rec["verdict"]] = counts.get(rec["verdict"], 0) + 1
-                if rec["verdict"] not in ("OK_CANONICAL", "OK_SYNONYM",
-                                          "SKIPPED_NO_ADAPTER", "SKIPPED_EMPTY_ADAPTER"):
+                if rec["verdict"] not in _OK_VERDICTS | _SKIP_VERDICTS:
                     findings.append({
                         "surface": name,
                         "file": str(rel),
@@ -442,9 +556,12 @@ def run(config_path: Path, report_path: Path | None) -> int:
     for verdict in (
         "OK_CANONICAL",
         "OK_SYNONYM",
+        "OK_ID_ONLY",
         "MISMATCH",
         "ID_NOT_FOUND",
         "EMPTY_LABEL",
+        "MISSING_COLUMN",
+        "MISSING_GLOB",
         "ADAPTER_ERROR",
         "SKIPPED_NO_ADAPTER",
         "SKIPPED_EMPTY_ADAPTER",

--- a/scripts/validate_id_label_correspondence.py
+++ b/scripts/validate_id_label_correspondence.py
@@ -26,6 +26,7 @@ repos already use, and classifies the pair:
     MISMATCH            label is neither canonical nor an accepted synonym  (ERROR)
     ID_NOT_FOUND        id has an adapter but is absent from the ontology   (ERROR)
     EMPTY_LABEL         id present, label blank                             (ERROR)
+    ADAPTER_ERROR       a CONFIGURED adapter failed to load                 (ERROR)
     SKIPPED_NO_ADAPTER  prefix has no configured OAK adapter (cas:, MIM:, …)
 
 Policy (per target, ``conf/id_label_targets.yaml``)
@@ -112,6 +113,11 @@ class AdapterPool:
     ``DSMZ``, …) are never looked up — they are reported as
     ``SKIPPED_NO_ADAPTER`` instead of triggering a futile ontology download.
 
+    Prefix matching is case-insensitive: data carries lowercase ``mesh:`` while
+    the allowlist (and OAK's OBO CURIEs) use uppercase ``MESH:``. ``get`` keys
+    on the canonical allowlist case, and callers can rewrite the CURIE prefix
+    via ``canonical_prefix`` so the lookup actually resolves.
+
     ``get`` returns one of three things:
 
     * ``None``          — prefix is not in the allowlist (legitimate skip).
@@ -125,32 +131,44 @@ class AdapterPool:
 
     def __init__(self, adapters: dict[str, str]):
         self._selectors = adapters
+        # Case-insensitive prefix lookup: data carries lowercase `mesh:` while
+        # the allowlist (and OAK's OBO CURIEs) use uppercase `MESH:`. Map any
+        # casing of a data prefix back to its canonical allowlist key.
+        self._canonical: dict[str, str] = {key.casefold(): key for key in adapters}
         self._cache: dict[str, Any] = {}
 
-    def get(self, prefix: str | None):
-        if not prefix or prefix not in self._selectors:
+    def canonical_prefix(self, prefix: str | None) -> str | None:
+        """Return the allowlist key matching ``prefix`` case-insensitively."""
+        if not prefix:
             return None
-        if prefix not in self._cache:
+        return self._canonical.get(prefix.casefold())
+
+    def get(self, prefix: str | None):
+        key = self.canonical_prefix(prefix)
+        if key is None:
+            return None
+        if key not in self._cache:
             try:
                 from oaklib import get_adapter
 
-                self._cache[prefix] = get_adapter(self._selectors[prefix])
+                self._cache[key] = get_adapter(self._selectors[key])
             except Exception as exc:  # pragma: no cover - environment dependent
-                print(f"  ! failed to load adapter for {prefix}: {exc}", file=sys.stderr)
-                self._cache[prefix] = LOAD_FAILED
-        return self._cache[prefix]
+                print(f"  ! failed to load adapter for {key}: {exc}", file=sys.stderr)
+                self._cache[key] = LOAD_FAILED
+        return self._cache[key]
 
 
 def accepted_labels(
-    adapter: Any, curie: str, scope: str, policy: str = "canonical_or_synonym"
+    adapter: Any, curie: str, scope: str, *, include_synonyms: bool = True
 ) -> tuple[str | None, set[str], bool]:
     """Return (canonical_label, accepted_normalized_set, id_found).
 
-    ``accepted_normalized_set`` always contains the canonical label; with a
-    non-``canonical`` policy it is widened via ``scope`` synonyms. Under the
-    strict ``canonical`` policy synonyms are never accepted, so the (potentially
-    expensive) ``entity_alias_map`` lookup is skipped entirely.
-    ``id_found`` is False when the id is absent from the ontology.
+    ``accepted_normalized_set`` always contains the canonical label; when
+    ``include_synonyms`` is set it is widened via ``scope`` synonyms. Callers
+    using a strict ``canonical`` policy never consult synonyms, so they pass
+    ``include_synonyms=False`` to skip the (potentially expensive)
+    ``entity_alias_map`` lookup entirely. ``id_found`` is False when the id is
+    absent from the ontology.
     """
     try:
         canonical = adapter.label(curie)
@@ -159,7 +177,7 @@ def accepted_labels(
     if canonical is None:
         return None, set(), False
     accepted = {normalize(canonical)}
-    if policy != "canonical":
+    if include_synonyms:
         alias_map: dict[str, list[str]] = {}
         try:
             alias_map = adapter.entity_alias_map(curie) or {}
@@ -178,9 +196,19 @@ def classify(
     adapter: Any,
     policy: str,
     scope: str,
+    lookup_curie: str | None = None,
 ) -> dict[str, Any]:
-    """Classify one (id, label) pair into a verdict dict."""
-    canonical, accepted, found = accepted_labels(adapter, curie, scope, policy)
+    """Classify one (id, label) pair into a verdict dict.
+
+    ``curie`` is reported verbatim; ``lookup_curie`` (when given) is the
+    case-normalized CURIE actually passed to the adapter so that, e.g., a
+    lowercase ``mesh:`` row resolves against OAK's uppercase ``MESH:`` ids.
+    Synonyms are only built when the policy actually consults them.
+    """
+    include_synonyms = policy != "canonical"
+    canonical, accepted, found = accepted_labels(
+        adapter, lookup_curie or curie, scope, include_synonyms=include_synonyms
+    )
     base = {"id": curie, "label": label, "canonical": canonical or ""}
     if not found:
         return {**base, "verdict": "ID_NOT_FOUND"}
@@ -198,83 +226,109 @@ def classify(
 
 def _read_tabular_rows(
     path: Path, fmt: str
-) -> tuple[list[str], list[tuple[int, dict[str, str]]]]:
+) -> tuple[list[str], list[dict[str, str]], list[int]]:
     """Read a TSV/CSV, skipping ONLY the leading SSSOM ``#`` comment prelude.
 
-    Returns ``(fieldnames, [(true_line_number, row), …])``. The line numbers are
-    the row's 1-based position in the original file, so locators stay accurate
-    even after the prelude is removed. ``#`` lines that appear *after* the header
-    are NOT stripped (only the contiguous top-of-file prelude is), matching the
-    SSSOM convention where the metadata block precedes the table.
+    Returns ``(fieldnames, rows, data_line_numbers)`` where each entry of
+    ``data_line_numbers`` is the TRUE 1-based physical file line where the
+    corresponding data row begins, so locators stay accurate even after the
+    prelude is removed. ``#`` lines that appear *after* the header are NOT
+    stripped (only the contiguous top-of-file prelude is), matching the SSSOM
+    convention where the metadata block precedes the table.
+
+    The physical line numbers come from the original file, so a quoted
+    multiline field could desync ``len(data_line_numbers)`` from ``len(rows)``;
+    the caller falls back to a post-header ordinal in that case.
     """
     delim = "," if fmt == "csv" else "\t"
     with path.open(newline="", encoding="utf-8") as fh:
-        raw = fh.readlines()
+        raw = list(enumerate(fh, start=1))  # (physical_line_number, text)
     # Strip only the contiguous prelude of ``#`` lines at the top of the file.
     start = 0
-    while start < len(raw) and raw[start].lstrip().startswith("#"):
+    while start < len(raw) and raw[start][1].lstrip().startswith("#"):
         start += 1
     body = raw[start:]
     if not body:
-        return [], []
-    reader = csv.DictReader(body, delimiter=delim)
-    fields = list(reader.fieldnames or [])
-    # body[0] is the header at file line (start + 1); first data row at start + 2.
-    numbered = [(start + 2 + i, row) for i, row in enumerate(reader)]
-    return fields, numbered
+        return [], [], []
+    lines = [text for _, text in body]
+    # body[0] is the header; data rows begin at the next physical line.
+    data_line_numbers = [phys for phys, _ in body[1:]]
+    reader = csv.DictReader(lines, delimiter=delim)
+    return list(reader.fieldnames or []), list(reader), data_line_numbers
 
 
 def iter_tabular(path: Path, fmt: str, pairs: list[list[str]]) -> Iterator[tuple[str, str, str]]:
     """Yield (locator, id, label) for each configured id/label column pair."""
-    fields, rows = _read_tabular_rows(path, fmt)
+    fields, rows, line_numbers = _read_tabular_rows(path, fmt)
     field_set = set(fields)
-    usable = [(i, l) for (i, l) in pairs if i in field_set and l in field_set]
-    # RISK: a configured pair whose columns are absent must NOT vanish silently.
-    # Warn loudly when the file has rows but a configured pair can't be applied.
+    # Keep any pair whose id column exists; a missing label column is allowed
+    # so an id present without its label still gets an EMPTY_LABEL verdict
+    # rather than being silently dropped.
+    usable = [(i, l) for (i, l) in pairs if i in field_set]
+    # RISK: a configured pair whose ID column is absent must NOT vanish silently.
+    # Warn loudly when the file has rows but a configured pair can't be applied
+    # at all. (A missing LABEL column alone is fine — it yields EMPTY_LABEL.)
     if rows:
         for (i, l) in pairs:
             if i not in field_set or l not in field_set:
                 missing = [c for c in (i, l) if c not in field_set]
                 print(
                     f"  ! {_safe_rel(path)}: configured id/label pair "
-                    f"[{i}/{l}] skipped — missing column(s) {missing}; "
+                    f"[{i}/{l}] — missing column(s) {missing}; "
                     f"present columns: {sorted(field_set)}",
                     file=sys.stderr,
                 )
-    for lineno, row in rows:
+    for idx, row in enumerate(rows):
+        # True physical line number when available (a quoted multiline field
+        # could desync the count); else fall back to the post-header ordinal.
+        line_no = line_numbers[idx] if idx < len(line_numbers) else idx + 2
         for id_col, label_col in usable:
             curie = (row.get(id_col) or "").strip()
             if not curie:
                 continue
             label = (row.get(label_col) or "").strip()
-            yield f"line {lineno} [{id_col}/{label_col}]", curie, label
+            yield f"line {line_no} [{id_col}/{label_col}]", curie, label
 
 
-def _walk_yaml(node: Any, pairs: list[tuple[str, str]], path: str) -> Iterator[tuple[str, str, str]]:
+def _walk_yaml(
+    node: Any,
+    pairs: list[tuple[str, str]],
+    path: str,
+    exclude_keys: frozenset[str] = frozenset(),
+) -> Iterator[tuple[str, str, str]]:
     if isinstance(node, dict):
         for id_key, label_key in pairs:
-            if id_key in node and label_key in node:
+            # An id present without its sibling label must still be checked
+            # (yields EMPTY_LABEL), so we do NOT require label_key to exist.
+            if id_key in node:
                 curie = node.get(id_key)
                 if isinstance(curie, str) and curie.strip():
                     label = node.get(label_key)
                     label = label if isinstance(label, str) else ""
                     yield f"{path}.{id_key}", curie.strip(), (label or "").strip()
         for k, v in node.items():
-            yield from _walk_yaml(v, pairs, f"{path}.{k}")
+            # Skip excluded grounding blocks (e.g. mediaingredientmech_chebi_term,
+            # whose label is intentionally MIM's preferred_term, not the OBO
+            # canonical label, so a `canonical` policy would false-MISMATCH it).
+            if k in exclude_keys:
+                continue
+            yield from _walk_yaml(v, pairs, f"{path}.{k}", exclude_keys)
     elif isinstance(node, list):
         for idx, item in enumerate(node):
-            yield from _walk_yaml(item, pairs, f"{path}[{idx}]")
+            yield from _walk_yaml(item, pairs, f"{path}[{idx}]", exclude_keys)
 
 
-def iter_yaml(path: Path, pairs: list[list[str]]) -> Iterator[tuple[str, str, str]]:
+def iter_yaml(
+    path: Path, pairs: list[list[str]], exclude_keys: frozenset[str] = frozenset()
+) -> Iterator[tuple[str, str, str]]:
     """Yield (locator, id, label) from a YAML doc by recursively finding dicts
-    that carry BOTH an id key and its sibling label key."""
+    that carry an id key (and, when present, its sibling label key)."""
     try:
         doc = yaml.safe_load(path.read_text())
     except Exception as exc:  # pragma: no cover
         print(f"  ! failed to parse {path}: {exc}", file=sys.stderr)
         return
-    yield from _walk_yaml(doc, [(a, b) for a, b in pairs], path.name)
+    yield from _walk_yaml(doc, [(a, b) for a, b in pairs], path.name, exclude_keys)
 
 
 # -- driver ---------------------------------------------------------------
@@ -302,6 +356,7 @@ def run(config_path: Path, report_path: Path | None) -> int:
         policy = target.get("policy", "canonical_or_synonym")
         scope = target.get("synonym_scope", default_scope)
         pairs = target.get("pairs", [])
+        exclude_keys = frozenset(target.get("exclude_keys", []) or [])
         globs = target.get("glob")
         glob_list = globs if isinstance(globs, list) else [globs]
         paths: list[Path] = []
@@ -313,7 +368,7 @@ def run(config_path: Path, report_path: Path | None) -> int:
         for path in paths:
             rel = _safe_rel(path)
             if kind == "yaml":
-                pairs_iter = iter_yaml(path, pairs)
+                pairs_iter = iter_yaml(path, pairs, exclude_keys)
             else:
                 pairs_iter = iter_tabular(path, target.get("format", "tsv"), pairs)
             for locator, curie, label in pairs_iter:
@@ -326,8 +381,16 @@ def run(config_path: Path, report_path: Path | None) -> int:
                     rec = {"id": curie, "label": label, "canonical": "",
                            "verdict": "ADAPTER_ERROR"}
                 else:
+                    # Rewrite the CURIE prefix to the canonical allowlist case
+                    # (e.g. mesh: -> MESH:) so OAK, which keys on uppercase OBO
+                    # prefixes, resolves the label instead of returning None.
+                    canonical_prefix = pool.canonical_prefix(prefix)
+                    lookup_curie = curie
+                    if canonical_prefix and prefix != canonical_prefix:
+                        lookup_curie = f"{canonical_prefix}:{curie.split(':', 1)[1]}"
                     rec = classify(
-                        curie=curie, label=label, adapter=adapter, policy=policy, scope=scope
+                        curie=curie, label=label, adapter=adapter, policy=policy,
+                        scope=scope, lookup_curie=lookup_curie,
                     )
                 counts[rec["verdict"]] = counts.get(rec["verdict"], 0) + 1
                 if rec["verdict"] not in ("OK_CANONICAL", "OK_SYNONYM", "SKIPPED_NO_ADAPTER"):

--- a/scripts/validate_id_label_correspondence.py
+++ b/scripts/validate_id_label_correspondence.py
@@ -67,7 +67,10 @@ def _safe_rel(path: Path) -> str:
 
 
 # Verdict classes that should fail an --enforce run.
-_ERROR_VERDICTS = {"MISMATCH", "ID_NOT_FOUND", "EMPTY_LABEL"}
+# ADAPTER_ERROR is fatal: a configured adapter that fails to LOAD must never be
+# silently downgraded to SKIPPED_NO_ADAPTER (which would let an enforce run pass
+# while checking nothing).
+_ERROR_VERDICTS = {"MISMATCH", "ID_NOT_FOUND", "EMPTY_LABEL", "ADAPTER_ERROR"}
 
 _CURIE_RE = re.compile(r"^([A-Za-z][A-Za-z0-9.]*):(.+)$")
 _WS_RE = re.compile(r"\s+")
@@ -95,6 +98,12 @@ def prefix_of(curie: str) -> str | None:
     return m.group(1) if m else None
 
 
+# Sentinel returned by ``AdapterPool.get`` when a CONFIGURED adapter fails to
+# load. Distinct from ``None`` (prefix not configured → legitimate skip) so the
+# caller can raise a fatal ADAPTER_ERROR instead of a benign SKIPPED_NO_ADAPTER.
+LOAD_FAILED = object()
+
+
 class AdapterPool:
     """Lazily loads OAK adapters, but ONLY for prefixes in the allowlist.
 
@@ -102,6 +111,16 @@ class AdapterPool:
     prefixes without an entry (``cas:``, ``MIM:``, ``kgmicrobe.compound:``,
     ``DSMZ``, …) are never looked up — they are reported as
     ``SKIPPED_NO_ADAPTER`` instead of triggering a futile ontology download.
+
+    ``get`` returns one of three things:
+
+    * ``None``          — prefix is not in the allowlist (legitimate skip).
+    * ``LOAD_FAILED``   — prefix IS configured but its adapter raised on load.
+    * an OAK adapter    — ready to query.
+
+    The ``LOAD_FAILED`` case is deliberately NOT collapsed into ``None`` so a
+    broken-but-configured adapter surfaces as a fatal verdict rather than
+    silently passing an enforce run.
     """
 
     def __init__(self, adapters: dict[str, str]):
@@ -118,15 +137,19 @@ class AdapterPool:
                 self._cache[prefix] = get_adapter(self._selectors[prefix])
             except Exception as exc:  # pragma: no cover - environment dependent
                 print(f"  ! failed to load adapter for {prefix}: {exc}", file=sys.stderr)
-                self._cache[prefix] = None
+                self._cache[prefix] = LOAD_FAILED
         return self._cache[prefix]
 
 
-def accepted_labels(adapter: Any, curie: str, scope: str) -> tuple[str | None, set[str], bool]:
+def accepted_labels(
+    adapter: Any, curie: str, scope: str, policy: str = "canonical_or_synonym"
+) -> tuple[str | None, set[str], bool]:
     """Return (canonical_label, accepted_normalized_set, id_found).
 
     ``accepted_normalized_set`` always contains the canonical label; with a
-    non-``canonical`` policy the caller widens it via ``scope`` synonyms.
+    non-``canonical`` policy it is widened via ``scope`` synonyms. Under the
+    strict ``canonical`` policy synonyms are never accepted, so the (potentially
+    expensive) ``entity_alias_map`` lookup is skipped entirely.
     ``id_found`` is False when the id is absent from the ontology.
     """
     try:
@@ -136,14 +159,15 @@ def accepted_labels(adapter: Any, curie: str, scope: str) -> tuple[str | None, s
     if canonical is None:
         return None, set(), False
     accepted = {normalize(canonical)}
-    alias_map: dict[str, list[str]] = {}
-    try:
-        alias_map = adapter.entity_alias_map(curie) or {}
-    except Exception:
-        alias_map = {}
-    for pred in _SYNONYM_PREDICATES.get(scope, _SYNONYM_PREDICATES["exact"]):
-        for alias in alias_map.get(pred, []) or []:
-            accepted.add(normalize(alias))
+    if policy != "canonical":
+        alias_map: dict[str, list[str]] = {}
+        try:
+            alias_map = adapter.entity_alias_map(curie) or {}
+        except Exception:
+            alias_map = {}
+        for pred in _SYNONYM_PREDICATES.get(scope, _SYNONYM_PREDICATES["exact"]):
+            for alias in alias_map.get(pred, []) or []:
+                accepted.add(normalize(alias))
     return canonical, accepted, True
 
 
@@ -156,7 +180,7 @@ def classify(
     scope: str,
 ) -> dict[str, Any]:
     """Classify one (id, label) pair into a verdict dict."""
-    canonical, accepted, found = accepted_labels(adapter, curie, scope)
+    canonical, accepted, found = accepted_labels(adapter, curie, scope, policy)
     base = {"id": curie, "label": label, "canonical": canonical or ""}
     if not found:
         return {**base, "verdict": "ID_NOT_FOUND"}
@@ -172,15 +196,32 @@ def classify(
 
 # -- target readers -------------------------------------------------------
 
-def _read_tabular_rows(path: Path, fmt: str) -> tuple[list[str], list[dict[str, str]]]:
-    """Read a TSV/CSV, skipping SSSOM ``#`` comment-prelude lines."""
+def _read_tabular_rows(
+    path: Path, fmt: str
+) -> tuple[list[str], list[tuple[int, dict[str, str]]]]:
+    """Read a TSV/CSV, skipping ONLY the leading SSSOM ``#`` comment prelude.
+
+    Returns ``(fieldnames, [(true_line_number, row), …])``. The line numbers are
+    the row's 1-based position in the original file, so locators stay accurate
+    even after the prelude is removed. ``#`` lines that appear *after* the header
+    are NOT stripped (only the contiguous top-of-file prelude is), matching the
+    SSSOM convention where the metadata block precedes the table.
+    """
     delim = "," if fmt == "csv" else "\t"
     with path.open(newline="", encoding="utf-8") as fh:
-        lines = [ln for ln in fh if not ln.lstrip().startswith("#")]
-    if not lines:
+        raw = fh.readlines()
+    # Strip only the contiguous prelude of ``#`` lines at the top of the file.
+    start = 0
+    while start < len(raw) and raw[start].lstrip().startswith("#"):
+        start += 1
+    body = raw[start:]
+    if not body:
         return [], []
-    reader = csv.DictReader(lines, delimiter=delim)
-    return list(reader.fieldnames or []), list(reader)
+    reader = csv.DictReader(body, delimiter=delim)
+    fields = list(reader.fieldnames or [])
+    # body[0] is the header at file line (start + 1); first data row at start + 2.
+    numbered = [(start + 2 + i, row) for i, row in enumerate(reader)]
+    return fields, numbered
 
 
 def iter_tabular(path: Path, fmt: str, pairs: list[list[str]]) -> Iterator[tuple[str, str, str]]:
@@ -188,13 +229,25 @@ def iter_tabular(path: Path, fmt: str, pairs: list[list[str]]) -> Iterator[tuple
     fields, rows = _read_tabular_rows(path, fmt)
     field_set = set(fields)
     usable = [(i, l) for (i, l) in pairs if i in field_set and l in field_set]
-    for n, row in enumerate(rows, start=2):  # row 1 is the header
+    # RISK: a configured pair whose columns are absent must NOT vanish silently.
+    # Warn loudly when the file has rows but a configured pair can't be applied.
+    if rows:
+        for (i, l) in pairs:
+            if i not in field_set or l not in field_set:
+                missing = [c for c in (i, l) if c not in field_set]
+                print(
+                    f"  ! {_safe_rel(path)}: configured id/label pair "
+                    f"[{i}/{l}] skipped — missing column(s) {missing}; "
+                    f"present columns: {sorted(field_set)}",
+                    file=sys.stderr,
+                )
+    for lineno, row in rows:
         for id_col, label_col in usable:
             curie = (row.get(id_col) or "").strip()
             if not curie:
                 continue
             label = (row.get(label_col) or "").strip()
-            yield f"row {n} [{id_col}/{label_col}]", curie, label
+            yield f"line {lineno} [{id_col}/{label_col}]", curie, label
 
 
 def _walk_yaml(node: Any, pairs: list[tuple[str, str]], path: str) -> Iterator[tuple[str, str, str]]:
@@ -267,8 +320,11 @@ def run(config_path: Path, report_path: Path | None) -> int:
                 prefix = prefix_of(curie)
                 adapter = pool.get(prefix)
                 if adapter is None:
-                    verdict = "SKIPPED_NO_ADAPTER"
-                    rec = {"id": curie, "label": label, "canonical": "", "verdict": verdict}
+                    rec = {"id": curie, "label": label, "canonical": "",
+                           "verdict": "SKIPPED_NO_ADAPTER"}
+                elif adapter is LOAD_FAILED:
+                    rec = {"id": curie, "label": label, "canonical": "",
+                           "verdict": "ADAPTER_ERROR"}
                 else:
                     rec = classify(
                         curie=curie, label=label, adapter=adapter, policy=policy, scope=scope
@@ -291,6 +347,7 @@ def run(config_path: Path, report_path: Path | None) -> int:
         "MISMATCH",
         "ID_NOT_FOUND",
         "EMPTY_LABEL",
+        "ADAPTER_ERROR",
         "SKIPPED_NO_ADAPTER",
     ):
         if verdict in counts:

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -21,6 +21,7 @@ prefixes:
   PMID: http://www.ncbi.nlm.nih.gov/pubmed/
   doi: https://doi.org/
   xsd: http://www.w3.org/2001/XMLSchema#
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
 
 default_prefix: communitymech
 
@@ -472,7 +473,11 @@ classes:
         description: The ontology term ID (e.g., NCBITaxon:1140, CHEBI:17992)
         required: true
       label:
-        description: The human-readable label for the term
+        slot_uri: rdfs:label
+        description: >-
+          The CANONICAL ontology label for `id` (e.g. "activated sludge" for
+          ENVO:00002046). Verified against the ontology by the id↔label gate;
+          free/project names belong in the sibling `preferred_term`, not here.
         required: true
 
   EvidenceItem:
@@ -516,6 +521,10 @@ classes:
         description: NCBITaxon ontology term
         range: Term
         required: true
+        # id↔label gate (range-less binding → label check, no enum expansion)
+        bindings:
+          - binds_value_of: id
+            obligation_level: REQUIRED
       notes:
         description: Additional notes about this organism
 
@@ -529,6 +538,9 @@ classes:
         description: CHEBI ontology term
         range: Term
         required: true
+        bindings:
+          - binds_value_of: id
+            obligation_level: REQUIRED
       concentration:
         description: Measured concentration or amount
       notes:
@@ -544,6 +556,9 @@ classes:
         description: GO biological process term
         range: Term
         required: true
+        bindings:
+          - binds_value_of: id
+            obligation_level: REQUIRED
       notes:
         description: Additional notes
 
@@ -557,6 +572,9 @@ classes:
         description: ENVO ontology term
         range: Term
         required: true
+        bindings:
+          - binds_value_of: id
+            obligation_level: REQUIRED
       notes:
         description: Additional notes
 
@@ -812,6 +830,9 @@ classes:
           CultureMech source_environment.
         range: Term
         required: false
+        bindings:
+          - binds_value_of: id
+            obligation_level: REQUIRED
       relevance_notes:
         description: Why this medium is relevant to the community
         range: string
@@ -841,6 +862,9 @@ classes:
         description: CHEBI ontology term for the ingredient compound
         range: Term
         required: false
+        bindings:
+          - binds_value_of: id
+            obligation_level: REQUIRED
       relevance:
         description: Why this ingredient is relevant to the community
         required: false

--- a/tests/data/optional_binding/omits_bound_optionals.yaml
+++ b/tests/data/optional_binding/omits_bound_optionals.yaml
@@ -1,0 +1,15 @@
+id: CommunityMech:999999
+name: Optional-Binding Regression Community
+description: >-
+  Fixture for the optional-slot binding regression test. It exercises the two
+  optional slots that carry an id↔label binding with obligation_level REQUIRED
+  (RelatedMedia.shared_environment_term and RelatedIngredient.chebi_term) by
+  OMITTING both. An absent optional slot must NOT trip the REQUIRED obligation,
+  so linkml-term-validator --labels must pass on this instance.
+related_media:
+- preferred_term: Test Medium
+  culturemech_id: CultureMech:000001
+  # shared_environment_term deliberately omitted (optional; REQUIRED binding)
+related_ingredients:
+- preferred_term: Test Ingredient
+  # chebi_term deliberately omitted (optional; REQUIRED binding)

--- a/tests/test_optional_binding_obligation.py
+++ b/tests/test_optional_binding_obligation.py
@@ -1,0 +1,82 @@
+"""Regression test for REQUIRED id↔label bindings on OPTIONAL slots.
+
+Two optional slots in the schema carry an id↔label binding with
+``obligation_level: REQUIRED``:
+
+* ``RelatedMedia.shared_environment_term``
+* ``RelatedIngredient.chebi_term``
+
+Both slots are ``required: false``. The REQUIRED obligation is meant to enforce
+the id↔label *correspondence* when the term IS present — it must NOT turn the
+optional slot into a de-facto required slot. This test pins that contract:
+
+1. An instance that OMITS both bound optional slots validates clean.
+2. (positive control) An instance with a PRESENT-but-WRONG label still fails,
+   proving the binding gate is actually engaged rather than silently inert.
+
+The test shells out to ``linkml-term-validator validate-data --labels`` (the
+same gate ``just validate`` uses) and is skipped when that CLI is unavailable.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA = REPO_ROOT / "src" / "communitymech" / "schema" / "communitymech.yaml"
+FIXTURE = REPO_ROOT / "tests" / "data" / "optional_binding" / "omits_bound_optionals.yaml"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("linkml-term-validator") is None,
+    reason="linkml-term-validator CLI not installed",
+)
+
+
+def _validate(data_path: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            "linkml-term-validator",
+            "validate-data",
+            str(data_path),
+            "-s",
+            str(SCHEMA),
+            "--labels",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_absent_optional_bound_slot_does_not_trip_required_obligation():
+    """Omitting the optional bound slots must validate clean (exit 0)."""
+    result = _validate(FIXTURE)
+    assert result.returncode == 0, (
+        "Absent optional slot tripped the REQUIRED binding obligation.\n"
+        "If this fails, downgrade the obligation_level on "
+        "RelatedMedia.shared_environment_term and RelatedIngredient.chebi_term "
+        "to a non-required level (e.g. RECOMMENDED).\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+def test_present_wrong_label_is_caught(tmp_path: Path):
+    """Positive control: a present term with a wrong label must fail (gate is live)."""
+    bad = tmp_path / "wrong_label.yaml"
+    bad.write_text(
+        "id: CommunityMech:999998\n"
+        "name: Wrong Label Control\n"
+        "related_ingredients:\n"
+        "- preferred_term: Test Ingredient\n"
+        "  chebi_term:\n"
+        "    id: CHEBI:15377\n"
+        "    label: definitely not the right label for water\n"
+    )
+    result = _validate(bad)
+    assert result.returncode != 0, (
+        "Binding gate did not catch a present-but-wrong label; the absent-slot "
+        "pass would then be meaningless.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
## Summary

Makes **id↔label correspondence** a checked invariant: every ontology ID must carry its **correct** ontology label — not just exist. `linkml-term-validator validate-data --labels` silently passed wrong labels because `--labels` only fires for slots with a LinkML `binding`, and the schema had none (corrupting `ENVO:00002046`'s label still reported "✅ Validation passed").

## Two engines

**Engine A — LinkML-native gate (YAML).** `communitymech.yaml` marks `Term.label` `slot_uri: rdfs:label` and gives every descriptor `term` slot (Taxon/Metabolite/BiologicalProcess/Environment) plus `shared_environment_term` and `RelatedIngredient.chebi_term` a **range-less** `binding` (`binds_value_of: id`). A range-less binding triggers the OAK label check *without* an enum-membership check (which would need per-ontology tree expansion). `validate-terms[-all]` now **fail** on label drift.

**Engine B — shared OAK validator (products).** `scripts/validate_id_label_correspondence.py` (config-driven; **vendored byte-identical** across the Mech repos) checks `output/kgx/nodes.tsv` (`id`/`name`) against the canonical label + exact/related synonyms. `conf/id_label_targets.yaml` lists surfaces + the OAK adapter allowlist.

## Policy (Hybrid)

Schema `term.label` = **canonical** OBO label (free/project names live in `preferred_term`); product `name`/`*_label` accept canonical **or** an exact/related synonym.

## Rollout = report → baseline → enforce

- Recipes: `validate-terms-all` (now fails on drift + propagates exit code), `validate-products`, `report-label-drift`.
- CI workflow `label-correspondence.yaml` is **report-only / non-blocking** (uploads `reports/label_drift.tsv`). Blocking gates stay out of CI until drift is triaged.

## Testing

- Schema passes structural validation (21 classes).
- Gate test: a corrupted community file (`ENVO:00002046`→garbage, `NCBITaxon:28216`→garbage) **fails** with "Label mismatch" — and independently surfaced obsolete `GO:0055114`.
- Engine B vendored byte-identical (md5 matches MIM/CultureMech).

The `id-label-correspondence` skill lives under `.claude/` (gitignored in this repo, so local-only, like the repo's other skills). `docs/ID_LABEL_CORRESPONDENCE.md` carries the cross-repo rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)