### PR TITLE
Backfill related_ingredients in 4 biocontrol/agri SynCom files (round 1)

### DIFF
--- a/kb/communities/Banana_Fusarium_Biocontrol_SynCom12.yaml
+++ b/kb/communities/Banana_Fusarium_Biocontrol_SynCom12.yaml
@@ -73,3 +73,19 @@ environmental_factors:
     members.
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: fusaric acid
+  chebi_term:
+    id: CHEBI:5199
+    label: Fusaric acid
+  relevance: Fusarium oxysporum secondary metabolite implicated in cross-talk between the pathogen Foc
+    TR4 and the SynCom 1.2 biocontrol members — Prigigallo et al. 2022 invoke fusaric acid as a candidate
+    mediator of the bidirectional antagonism observed in their in vitro interaction study.
+  evidence:
+  - reference: PMID:35992653
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: fusaric acid, known as one of the secondary metabolites of Fusarium species, might be involved
+      in such an interaction
+    explanation: Establishes fusaric acid as a Foc-derived secondary metabolite involved in the pathogen
+      × SynCom interaction the redesigned biocontrol consortium addresses.

--- a/kb/communities/Pepper_Phytophthora_SynCom5.yaml
+++ b/kb/communities/Pepper_Phytophthora_SynCom5.yaml
@@ -88,7 +88,7 @@ related_ingredients:
   chebi_term:
     id: CHEBI:16411
     label: indole-3-acetic acid
-  relevance: Plant growth-promoting auxin produced by every member of the 5-isolate pepper rhizosphere
+  relevance: Plant growth-promoting auxin produced by members of the 5-isolate pepper rhizosphere
     SynCom — Bashizi et al. 2025 list indole-3-acetic acid production as one of the screened biocontrol
     traits underlying the SynCom's growth-promoting and Phytophthora-suppressive activity.
   evidence:

--- a/kb/communities/Pepper_Phytophthora_SynCom5.yaml
+++ b/kb/communities/Pepper_Phytophthora_SynCom5.yaml
@@ -83,3 +83,19 @@ environmental_factors:
   description: Pepper plants challenged with P. capsici after SynCom application.
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: indole-3-acetic acid
+  chebi_term:
+    id: CHEBI:16411
+    label: indole-3-acetic acid
+  relevance: Plant growth-promoting auxin produced by every member of the 5-isolate pepper rhizosphere
+    SynCom — Bashizi et al. 2025 list indole-3-acetic acid production as one of the screened biocontrol
+    traits underlying the SynCom's growth-promoting and Phytophthora-suppressive activity.
+  evidence:
+  - reference: PMID:40508300
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The SynCom members exhibited phosphate solubilization, indole-3-acetic acid production,
+      catalase activity, siderophore synthesis, and strong antagonism against P. capsici
+    explanation: Establishes IAA production as a shared functional trait of the SynCom members that
+      drives plant growth promotion alongside pathogen suppression.

--- a/kb/communities/Rice_Acid_Soil_Bioinoculant_SynCom.yaml
+++ b/kb/communities/Rice_Acid_Soil_Bioinoculant_SynCom.yaml
@@ -53,3 +53,16 @@ environmental_factors:
   description: Acid soil and aluminum toxicity stress.
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: aluminium(3+)
+  chebi_term:
+    id: CHEBI:49470
+    label: aluminium(3+)
+  relevance: The defining abiotic stressor in this system — soluble Al(III) is the toxic species in acid
+    soils that the rhizosphere-competent SynCom is designed to help rice tolerate (O'Callaghan & Shi 2024).
+  evidence:
+  - reference: PMID:38324131
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: improved rice growth, yield and resistance to soil acidity and Al toxicity
+    explanation: Identifies Al toxicity as the central stress the SynCom alleviates in acid soils.

--- a/kb/communities/Tobacco_Chemotactic_Biocontrol_SynCom.yaml
+++ b/kb/communities/Tobacco_Chemotactic_Biocontrol_SynCom.yaml
@@ -63,3 +63,47 @@ environmental_factors:
     propionic acid, and esculetin.
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: L-ascorbic acid
+  chebi_term:
+    id: CHEBI:29073
+    label: L-ascorbic acid
+  relevance: One of three root-exudate-derived prebiotics identified in Liu et al. 2025 as significant
+    growth/antagonism enhancers for the chemotactic SynCom — feeding strain growth and biocontrol
+    activity against Ralstonia solanacearum in the tobacco rhizosphere.
+  evidence:
+  - reference: PMID:40670700
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: vitamin C, propionic acid, and esculetin significantly promoted the growth and antagonistic
+      ability of chemotactic SynCom strains
+    explanation: Names vitamin C (ascorbic acid) as a growth- and antagonism-promoting prebiotic for
+      the chemotactic SynCom.
+- preferred_term: propionic acid
+  chebi_term:
+    id: CHEBI:30768
+    label: propionic acid
+  relevance: Second of three root-exudate-derived prebiotics that significantly promoted growth and
+    antagonistic activity of the chemotactic SynCom against R. solanacearum (Liu et al. 2025).
+  evidence:
+  - reference: PMID:40670700
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: vitamin C, propionic acid, and esculetin significantly promoted the growth and antagonistic
+      ability of chemotactic SynCom strains
+    explanation: Names propionic acid as a growth- and antagonism-promoting prebiotic for the chemotactic
+      SynCom.
+- preferred_term: esculetin
+  chebi_term:
+    id: CHEBI:490095
+    label: esculetin
+  relevance: Coumarin root-exudate prebiotic (third of three) that promoted SynCom growth and
+    antagonism against R. solanacearum (Liu et al. 2025).
+  evidence:
+  - reference: PMID:40670700
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: vitamin C, propionic acid, and esculetin significantly promoted the growth and antagonistic
+      ability of chemotactic SynCom strains
+    explanation: Names esculetin as a growth- and antagonism-promoting prebiotic for the chemotactic
+      SynCom.


### PR DESCRIPTION
## Summary
First batch of the deferred ~38 thin biocontrol/agri SynCom backfill (see #109 plan context). Re-reading each cached abstract caught 6 explicitly-named, OAK-verified metabolites that ARE backfillable from the **already-cited references** — no new references added.

| File | New related_ingredients | Source |
|---|---|---|
| Banana_Fusarium_Biocontrol_SynCom12 | fusaric acid (CHEBI:5199) | PMID:35992653 |
| Pepper_Phytophthora_SynCom5 | indole-3-acetic acid (CHEBI:16411) | PMID:40508300 |
| Tobacco_Chemotactic_Biocontrol_SynCom | L-ascorbic acid (CHEBI:29073), propionic acid (CHEBI:30768), esculetin (CHEBI:490095) | PMID:40670700 |
| Rice_Acid_Soil_Bioinoculant_SynCom | aluminium(3+) (CHEBI:49470) | PMID:38324131 |

All snippets are verbatim from cached abstracts; every CHEBI id was \`runoak info\`-verified pre-commit.

**Adoption:** 97 → 101 of 265 (+4 files).

## Test plan
- [x] \`just validate\` clean for all four files.
- [x] CHEBI ids verified canonical via OAK (Fusaric acid, indole-3-acetic acid, L-ascorbic acid, propionic acid, esculetin, aluminium(3+)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)