### PR TITLE
Backfill related_ingredients in 3 more biocontrol/agri SynCom files (round 3)

### DIFF
--- a/kb/communities/Arabidopsis_Phyllosphere_SynCom7.yaml
+++ b/kb/communities/Arabidopsis_Phyllosphere_SynCom7.yaml
@@ -56,3 +56,18 @@ environmental_factors:
     and pathogen recognition.
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: ethylene
+  chebi_term:
+    id: CHEBI:18153
+    label: ethene
+  relevance: Host hormone whose signaling axis (via EIN2) Bodenhausen et al. 2014 identify as a
+    plant-genetic factor that modulates Arabidopsis phyllosphere community composition.
+  evidence:
+  - reference: PMID:24743269
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: we identified ein2, which is involved in ethylene signaling, as a host factor modulating
+      the community's composition
+    explanation: Establishes ethylene signaling as a host pathway modulating phyllosphere community
+      composition.

--- a/kb/communities/Desert_Tomato_Salt_Stress_SynCom5.yaml
+++ b/kb/communities/Desert_Tomato_Salt_Stress_SynCom5.yaml
@@ -56,3 +56,17 @@ environmental_factors:
   description: High salt stress in natural non-sterile soil substrate.
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: sodium chloride
+  chebi_term:
+    id: CHEBI:26710
+    label: sodium chloride
+  relevance: The defining abiotic stressor — high salt (NaCl) in non-sterile soil is the stress the
+    desert-derived 5-strain SynCom protects tomato against (Schmitz et al. 2022).
+  evidence:
+  - reference: PMID:35444261
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: a SynCom of five bacterial strains, originating from the root of the desert plant Indigofera
+      argentea, protected tomato plants growing in a non-sterile substrate against a high salt stress
+    explanation: Identifies high salt stress as the abiotic challenge the SynCom alleviates.

--- a/kb/communities/Rice_Duckweed_Bacillus_SynCom.yaml
+++ b/kb/communities/Rice_Duckweed_Bacillus_SynCom.yaml
@@ -179,3 +179,45 @@ environmental_factors:
 metals_present: []
 metal_relevance: INCIDENTAL
 metal_notes: Metal/REE detected via environmental factor measurements
+related_ingredients:
+- preferred_term: indole-3-acetic acid
+  chebi_term:
+    id: CHEBI:16411
+    label: indole-3-acetic acid
+  relevance: Bacterial auxin recovered as a plant-growth-promoting metabolite of the complete 8-member
+    SynCom; auxin production is one of the division-of-labor specializations Song et al. 2026 map across
+    the SynCom members.
+  evidence:
+  - reference: PMID:41736136
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the complete SynCom uniquely recovered the full suite of plant-growth metabolites (e.g.,
+      indole-3-acetic acid, acetoin/2,3-butanediol)
+    explanation: Names indole-3-acetic acid as part of the SynCom-recovered plant-growth metabolite suite.
+- preferred_term: acetoin
+  chebi_term:
+    id: CHEBI:15688
+    label: acetoin
+  relevance: Volatile plant-growth-promoting metabolite (paired with 2,3-butanediol) produced by the
+    SynCom — part of the division-of-labor specialization that drives the SynCom's rice growth-promotion
+    activity.
+  evidence:
+  - reference: PMID:41736136
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the complete SynCom uniquely recovered the full suite of plant-growth metabolites (e.g.,
+      indole-3-acetic acid, acetoin/2,3-butanediol)
+    explanation: Names acetoin as a SynCom-produced plant-growth-promoting volatile metabolite.
+- preferred_term: surfactin
+  chebi_term:
+    id: CHEBI:29681
+    label: surfactin
+  relevance: Bacillus-derived lipopeptide antimicrobial recovered as one of the SynCom's antimicrobial
+    chemistries — contributes to the Rhizoctonia solani sheath blight suppression.
+  evidence:
+  - reference: PMID:41736136
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: antimicrobial chemistries (e.g., surfactin, bacillomycin, fengycin, difficidin)
+    explanation: Names surfactin as a SynCom-recovered antimicrobial lipopeptide underlying pathogen
+      suppression.


### PR DESCRIPTION
## Summary
Round 3 of the deferred ~38 thin biocontrol/agri backfill (continues #118, #119). Five OAK-verified metabolites across three files.

| File | New related_ingredients | Source |
|---|---|---|
| Rice_Duckweed_Bacillus_SynCom | indole-3-acetic acid (CHEBI:16411), acetoin (CHEBI:15688), surfactin (CHEBI:29681) | PMID:41736136 |
| Arabidopsis_Phyllosphere_SynCom7 | ethylene / ethene (CHEBI:18153) | PMID:24743269 |
| Desert_Tomato_Salt_Stress_SynCom5 | sodium chloride (CHEBI:26710) | PMID:35444261 |

**Adoption:** 105 → 108 of 265 (+3 files; +5 metabolites).

## Test plan
- [x] \`just validate\` clean for all three files.
- [x] CHEBI ids OAK-verified canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)