### PR TITLE
Backfill related_ingredients in 3 more biocontrol/agri SynCom files (round 4)

### DIFF
--- a/kb/communities/LBNL_Brachypodium_Drought_SynCom15.yaml
+++ b/kb/communities/LBNL_Brachypodium_Drought_SynCom15.yaml
@@ -54,3 +54,32 @@ environmental_factors:
   description: Drought stress and in vitro versus in planta stability testing.
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: trehalose
+  chebi_term:
+    id: CHEBI:27082
+    label: trehalose
+  relevance: Osmoprotectant disaccharide whose biosynthesis genes were detected in SynCom-member
+    genomes — implicated in the Brachypodium drought-stress resilience the SynCom confers.
+  evidence:
+  - reference: PMID:40862137
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Genomic analysis of the individual strains was performed to reveal encoded plant growth-promoting
+      traits, including genes for the synthesis of osmoprotectants (trehalose and betaine)
+    explanation: Identifies trehalose biosynthesis as an encoded osmoprotectant trait of the SynCom
+      members.
+- preferred_term: glycine betaine
+  chebi_term:
+    id: CHEBI:17750
+    label: glycine betaine
+  relevance: The second of two osmoprotectants whose biosynthesis genes are encoded by SynCom-member
+    genomes — contributes to SynCom-mediated drought tolerance in Brachypodium.
+  evidence:
+  - reference: PMID:40862137
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: encoded plant growth-promoting traits, including genes for the synthesis of osmoprotectants
+      (trehalose and betaine)
+    explanation: Identifies glycine betaine biosynthesis as an encoded osmoprotectant trait of the SynCom
+      members.

--- a/kb/communities/LBNL_Brachypodium_Drought_SynCom15.yaml
+++ b/kb/communities/LBNL_Brachypodium_Drought_SynCom15.yaml
@@ -64,7 +64,7 @@ related_ingredients:
   evidence:
   - reference: PMID:40862137
     supports: SUPPORT
-    evidence_source: IN_VITRO
+    evidence_source: COMPUTATIONAL
     snippet: Genomic analysis of the individual strains was performed to reveal encoded plant growth-promoting
       traits, including genes for the synthesis of osmoprotectants (trehalose and betaine)
     explanation: Identifies trehalose biosynthesis as an encoded osmoprotectant trait of the SynCom
@@ -78,7 +78,7 @@ related_ingredients:
   evidence:
   - reference: PMID:40862137
     supports: SUPPORT
-    evidence_source: IN_VITRO
+    evidence_source: COMPUTATIONAL
     snippet: encoded plant growth-promoting traits, including genes for the synthesis of osmoprotectants
       (trehalose and betaine)
     explanation: Identifies glycine betaine biosynthesis as an encoded osmoprotectant trait of the SynCom

--- a/kb/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.yaml
+++ b/kb/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.yaml
@@ -249,3 +249,20 @@ rare_earth_elements_present: []
 metal_relevance: NOT_APPLICABLE
 metal_notes: No metal or rare earth element processing role is curated for this
   rice rhizosphere methane-mitigating community.
+related_ingredients:
+- preferred_term: methane
+  chebi_term:
+    id: CHEBI:16183
+    label: methane
+  relevance: The defining end-product whose emissions PSY-overexpressing transgenic rice reduces — Shi
+    et al. 2026 link the reduction (38% PSY1, 58% PSY2) to altered hydrogenotrophic methanogenesis
+    vs methane-consumption gene activity ratios in the rhizosphere community.
+  evidence:
+  - reference: PMID:41582156
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: two independent rice genotypes overexpressing genes for PLANT PEPTIDES CONTAINING SULFATED
+      TYROSINE (PSY) reduce cumulative CH4 emissions by 38% (PSY1) and 58% (PSY2) over 70 days of growth
+      compared with controls
+    explanation: Identifies methane (CH4) as the emission outcome the PSY-rhizosphere community
+      modulates.

--- a/kb/communities/Populus_Salt_Tolerant_SynComs.yaml
+++ b/kb/communities/Populus_Salt_Tolerant_SynComs.yaml
@@ -67,7 +67,7 @@ related_ingredients:
   evidence:
   - reference: PMID:40904019
     supports: SUPPORT
-    evidence_source: IN_VIVO
+    evidence_source: IN_VITRO
     snippet: a total of 512 strains were isolated from the high-salt rhizosphere soil of Populus
       euphratica through high-throughput cultivation
     explanation: Identifies high-salt rhizosphere as the source environment and NaCl as the abiotic

--- a/kb/communities/Populus_Salt_Tolerant_SynComs.yaml
+++ b/kb/communities/Populus_Salt_Tolerant_SynComs.yaml
@@ -56,3 +56,19 @@ environmental_factors:
   description: High-salinity plant stress assays comparing multiple SynCom formulations.
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: sodium chloride
+  chebi_term:
+    id: CHEBI:26710
+    label: sodium chloride
+  relevance: The defining abiotic stressor — Li et al. 2025 isolate the SynCom members from the
+    high-salt rhizosphere of the halophyte Populus euphratica specifically to confer NaCl tolerance
+    on hybrid poplar (Populus alba × Populus glandulosa).
+  evidence:
+  - reference: PMID:40904019
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: a total of 512 strains were isolated from the high-salt rhizosphere soil of Populus
+      euphratica through high-throughput cultivation
+    explanation: Identifies high-salt rhizosphere as the source environment and NaCl as the abiotic
+      stressor the SynComs are engineered to mitigate.


### PR DESCRIPTION
## Summary
Round 4 of the deferred ~38 thin biocontrol/agri backfill (continues #118-#120). Four OAK-verified metabolites across three files.

| File | New related_ingredients | Source |
|---|---|---|
| LBNL_Brachypodium_Drought_SynCom15 | trehalose (CHEBI:27082), glycine betaine (CHEBI:17750) | PMID:40862137 |
| PSY_Transgenic_Rice_Rhizosphere_Methane_Community | methane (CHEBI:16183) | PMID:41582156 |
| Populus_Salt_Tolerant_SynComs | sodium chloride (CHEBI:26710) | PMID:40904019 |

**Adoption:** 108 → 111 of 265 (+3 files; +4 metabolites).

## Test plan
- [x] \`just validate\` clean for all three files.
- [x] CHEBI ids OAK-verified canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)