### PR TITLE
Backfill related_ingredients in 3 more SynCom files (round 5)

### DIFF
--- a/kb/communities/CRC_Fusobacterium_Control_SynCom.yaml
+++ b/kb/communities/CRC_Fusobacterium_Control_SynCom.yaml
@@ -65,7 +65,7 @@ related_ingredients:
     label: L-tryptophan
   relevance: Aromatic amino acid whose metabolism the seven-member commensal SynCom enhances after
     F. nucleatum decolonization — one of the two key host-metabolism axes (tryptophan + secondary bile
-    acid) the SynCom restores to suppress CRC tumor growth (Cui et al. 2025).
+    acid) the SynCom restores to suppress CRC tumor growth (Zhou et al. 2025).
   evidence:
   - reference: PMID:40433987
     supports: SUPPORT

--- a/kb/communities/CRC_Fusobacterium_Control_SynCom.yaml
+++ b/kb/communities/CRC_Fusobacterium_Control_SynCom.yaml
@@ -58,3 +58,19 @@ environmental_factors:
     colorectal cancer model.
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: L-tryptophan
+  chebi_term:
+    id: CHEBI:16828
+    label: L-tryptophan
+  relevance: Aromatic amino acid whose metabolism the seven-member commensal SynCom enhances after
+    F. nucleatum decolonization — one of the two key host-metabolism axes (tryptophan + secondary bile
+    acid) the SynCom restores to suppress CRC tumor growth (Cui et al. 2025).
+  evidence:
+  - reference: PMID:40433987
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: it promotes F. nucleatum decolonization, and enhances tryptophan metabolism and secondary
+      bile acid conversion
+    explanation: Names tryptophan metabolism as one of two metabolic axes the SynCom restores after
+      F. nucleatum displacement.

--- a/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
+++ b/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
@@ -91,7 +91,7 @@ related_ingredients:
     id: CHEBI:18246
     label: (1->4)-beta-D-glucan
   relevance: The starting substrate of the quad-culture — R. cellulolyticum hydrolyzes cellulose,
-    initiating the cellulose-to-methane anaerobic degradation cascade modeled by the SynCom (Liu et al.
+    initiating the cellulose-to-methane anaerobic degradation cascade modeled by the SynCom (Wang et al.
     2023).
   evidence:
   - reference: PMID:36847519

--- a/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
+++ b/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
@@ -85,3 +85,74 @@ environmental_factors:
     and stoichiometric modeling.
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: cellulose
+  chebi_term:
+    id: CHEBI:18246
+    label: (1->4)-beta-D-glucan
+  relevance: The starting substrate of the quad-culture — R. cellulolyticum hydrolyzes cellulose,
+    initiating the cellulose-to-methane anaerobic degradation cascade modeled by the SynCom (Liu et al.
+    2023).
+  evidence:
+  - reference: PMID:36847519
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: distinct key metabolic processes in the anaerobic degradation of cellulose to methane and
+      CO2
+    explanation: Names cellulose as the substrate the quad-culture anaerobically degrades.
+- preferred_term: acetate
+  chebi_term:
+    id: CHEBI:15366
+    label: acetic acid
+  relevance: Cross-fed intermediate — acetate produced by the cellulolytic R. cellulolyticum is the
+    handoff substrate consumed by the acetoclastic methanogen M. concilii, the central cross-feeding
+    flux in the quad-culture's cellulose-to-methane cascade.
+  evidence:
+  - reference: PMID:36847519
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: cross-feeding of acetate from a cellulolytic bacterium to an acetoclastic methanogen
+    explanation: Names acetate as the cross-fed intermediate between the cellulolytic bacterium and
+      acetoclastic methanogen.
+- preferred_term: dihydrogen
+  chebi_term:
+    id: CHEBI:18276
+    label: dihydrogen
+  relevance: Cross-fed gas — H₂ is competed for between the sulfate-reducing D. vulgaris and the
+    hydrogenotrophic methanogen M. hungatei; sulfate addition shifts this competition, redistributing
+    methane vs sulfide production fluxes.
+  evidence:
+  - reference: PMID:36847519
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: competition of H2 between a sulfate reducing bacterium and a hydrogenotrophic methanogen
+    explanation: Names dihydrogen as the competed substrate between sulfate-reducer and
+      hydrogenotrophic methanogen.
+- preferred_term: methane
+  chebi_term:
+    id: CHEBI:16183
+    label: methane
+  relevance: One of two end-products (with CO2) of the quad-culture's anaerobic cellulose degradation
+    — methane output decreases with sulfate addition as electrons divert to sulfate reduction.
+  evidence:
+  - reference: PMID:36847519
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Sulfate addition enhanced sulfate reduction and decreased methane and CO2 productions
+    explanation: Names methane as an end-product of the cellulose-degradation cascade that responds
+      to sulfate-mediated electron-flow redistribution.
+- preferred_term: sulfate
+  chebi_term:
+    id: CHEBI:16189
+    label: sulfate
+  relevance: The added electron acceptor — sulfate addition strengthens metabolic handoffs from
+    R. cellulolyticum to M. concilii / D. vulgaris and intensifies M. hungatei × D. vulgaris H₂
+    competition, redirecting community flux from methanogenesis toward sulfate reduction.
+  evidence:
+  - reference: PMID:36847519
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Sulfate addition strengthened metabolic handoffs from R. cellulolyticum to M. concilii
+      and D. vulgaris and intensified substrate competition between M. hungatei and D. vulgaris
+    explanation: Names sulfate as the perturbation electron acceptor that reshapes community-level
+      handoffs and competition.

--- a/kb/communities/Pepper_Growth_Rhizosphere_SynCom.yaml
+++ b/kb/communities/Pepper_Growth_Rhizosphere_SynCom.yaml
@@ -61,7 +61,7 @@ related_ingredients:
     label: chlorophyll
   relevance: Photosynthetic pigment whose leaf content increased 29.65% after SynCom inoculation —
     one of the quantified plant-physiology readouts of SynCom-driven growth promotion in pepper
-    seedlings (Wei et al. 2025).
+    seedlings (You et al. 2025).
   evidence:
   - reference: PMID:39858916
     supports: SUPPORT

--- a/kb/communities/Pepper_Growth_Rhizosphere_SynCom.yaml
+++ b/kb/communities/Pepper_Growth_Rhizosphere_SynCom.yaml
@@ -54,3 +54,20 @@ environmental_factors:
   description: SynCom inoculated versus uninoculated pepper seedlings.
   evidence:
   - *id001
+related_ingredients:
+- preferred_term: chlorophyll
+  chebi_term:
+    id: CHEBI:28966
+    label: chlorophyll
+  relevance: Photosynthetic pigment whose leaf content increased 29.65% after SynCom inoculation —
+    one of the quantified plant-physiology readouts of SynCom-driven growth promotion in pepper
+    seedlings (Wei et al. 2025).
+  evidence:
+  - reference: PMID:39858916
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: SynCom inoculation significantly increased shoot height, stem diameter, fresh weight, dry
+      weight, chlorophyll content, leaf number, root vigor, root tips, total root length, and
+      root-specific surface area of pepper by 20.9%, 36.33%, 68.84%, 64.34%, 29.65%
+    explanation: Quantifies the chlorophyll-content increase as one of the SynCom-promoted pepper
+      growth readouts.


### PR DESCRIPTION
## Summary
Round 5 of the deferred ~38 thin biocontrol/agri backfill (continues #118-#121). Seven OAK-verified metabolites across three files.

| File | New related_ingredients | Source |
|---|---|---|
| Pepper_Growth_Rhizosphere_SynCom | chlorophyll (CHEBI:28966) | PMID:39858916 |
| CRC_Fusobacterium_Control_SynCom | L-tryptophan (CHEBI:16828) | PMID:40433987 |
| Cellulose_Methane_Quad_Culture_SynCom | cellulose (CHEBI:18246), acetate (CHEBI:15366), dihydrogen (CHEBI:18276), methane (CHEBI:16183), sulfate (CHEBI:16189) | PMID:36847519 |

**Adoption:** 111 → 114 of 265 (+3 files; +7 metabolites).

## Test plan
- [x] \`just validate\` clean for all three files.
- [x] CHEBI ids OAK-verified canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)