### PR TITLE
Backfill related_ingredients in THOR + EcoFAB via PMC full text (round 8)

### DIFF
--- a/kb/communities/EcoFAB_Ring_Trial_SynCom17.yaml
+++ b/kb/communities/EcoFAB_Ring_Trial_SynCom17.yaml
@@ -788,3 +788,20 @@ associated_datasets:
   url: https://img.jgi.doe.gov/
   description: Annotated whole genome sequences for all 17 SynCom bacterial isolates, searchable by isolate
     name or GOLD Project ID.
+related_ingredients:
+- preferred_term: amino acid
+  chebi_term:
+    id: CHEBI:33709
+    label: amino acid
+  relevance: Root-exudate-derived class whose relative abundance drops in SynCom17 treatment — the
+    targeted LC-MS metabolomics identifies amino acids as the dominant chemical class of the second
+    cluster (lower abundance in SynCom17 vs SynCom16/axenic), evidencing Paraburkholderia-driven
+    amino-acid uptake from B. distachyon exudates.
+  evidence:
+  - reference: PMID:40920748
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: A second large cluster consisted of metabolites with lower relative concentrations in the
+      SynCom17 treatment, represented mainly by amino acids
+    explanation: Names amino acids as the metabolite class whose abundance Paraburkholderia-dominated
+      SynCom17 lowers in the rhizosphere exudate metabolome.

--- a/kb/communities/THOR_Rhizosphere_Model_Community.yaml
+++ b/kb/communities/THOR_Rhizosphere_Model_Community.yaml
@@ -220,4 +220,50 @@ associated_datasets:
     evidence_source: IN_VITRO
     snippet: Comparative metatranscriptomics on THOR revealed global patterns of interspecies transcriptional regulation
     explanation: Links the THOR record to a metatranscriptomic characterization study.
+related_ingredients:
+- preferred_term: koreenceine A
+  chebi_term:
+    id: CHEBI:212242
+    label: Koreenceine A
+  relevance: Pseudomonas-koreensis-produced alkaloid antibiotic whose accumulation directly inhibits
+    Flavobacterium johnsoniae growth — Lozano et al. 2019 establish that B. cereus selectively reduces
+    koreenceine A levels in triple culture, the mechanism behind the emergent F. johnsoniae protection.
+  evidence:
+  - reference: PMID:30837345
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: B. cereus protects F. johnsoniae by selectively reducing the levels of koreenceine A and C
+      accumulated by P. koreensis
+    explanation: Names koreenceine A as a P. koreensis alkaloid whose B. cereus-mediated suppression
+      protects F. johnsoniae.
+- preferred_term: koreenceine C
+  chebi_term:
+    id: CHEBI:212237
+    label: Koreenceine C
+  relevance: Second P. koreensis alkaloid antibiotic in the koreenceine A/B/C family that influences
+    F. johnsoniae growth — same B. cereus-mediated reduction underlies the emergent THOR protective
+    interaction.
+  evidence:
+  - reference: PMID:30837345
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: B. cereus protects F. johnsoniae by selectively reducing the levels of koreenceine A and C
+      accumulated by P. koreensis
+    explanation: Names koreenceine C as the second alkaloid whose B. cereus suppression underlies
+      THOR's emergent F. johnsoniae protection.
+- preferred_term: koreenceine B
+  chebi_term:
+    id: CHEBI:212248
+    label: Koreenceine B
+  relevance: Third member of the koreenceine A/B/C family — Lozano et al. 2019 note that B. cereus
+    has only a minor effect on koreenceine B levels, distinguishing it from A and C in the THOR
+    metabolite-modulation phenotype.
+  evidence:
+  - reference: PMID:30837345
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The addition of B. cereus to cocultures of P. koreensis and F. johnsoniae severely reduced
+      the accumulation of koreenceine A and C, with a minor effect on the level of koreenceine B
+    explanation: Names koreenceine B as the third koreenceine alkaloid family member, mostly
+      insensitive to B. cereus modulation.
 metal_relevance: NOT_APPLICABLE

--- a/references_cache/pmc_full_pmid_30837345.txt
+++ b/references_cache/pmc_full_pmid_30837345.txt
@@ -1,0 +1,245 @@
+Introducing THOR, a Model Microbiome for Genetic Dissection of Community Behavior
+
+The manipulation and engineering of microbiomes could lead to improved human health, environmental sustainability, and agricultural productivity. However, microbiomes have proven difficult to alter in predictable ways, and their emergent properties are poorly understood. The history of biology has demonstrated the power of model systems to understand complex problems such as gene expression or development. Therefore, a defined and genetically tractable model community would be useful to dissect microbiome assembly, maintenance, and processes. We have developed a tractable model rhizosphere microbiome, designated THOR, containing Pseudomonas koreensis, Flavobacterium johnsoniae, and Bacillus cereus, which represent three dominant phyla in the rhizosphere, as well as in soil and the mammalian gut. The model community demonstrates emergent properties, and the members are amenable to genetic dissection. We propose that THOR will be a useful model for investigations of community-level interactions.
+
+ABSTRACT
+
+The quest to manipulate microbiomes has intensified, but many microbial communities have proven to be recalcitrant to sustained change. Developing model communities amenable to genetic dissection will underpin successful strategies for shaping microbiomes by advancing an understanding of community interactions. We developed a model community with representatives from three dominant rhizosphere taxa, the Firmicutes, Proteobacteria, and Bacteroidetes. We chose Bacillus cereus as a model rhizosphere firmicute and characterized 20 other candidates, including “hitchhikers” that coisolated with B. cereus from the rhizosphere. Pairwise analysis produced a hierarchical interstrain-competition network. We chose two hitchhikers, Pseudomonas koreensis from the top tier of the competition network and Flavobacterium johnsoniae from the bottom of the network, to represent the Proteobacteria and Bacteroidetes, respectively. The model community has several emergent properties, induction of dendritic expansion of B. cereus colonies by either of the other members, and production of more robust biofilms by the three members together than individually. Moreover, P. koreensis produces a novel family of alkaloid antibiotics that inhibit growth of F. johnsoniae, and production is inhibited by B. cereus. We designate this community THOR, because the members are the hitchhikers of the rhizosphere. The genetic, genomic, and biochemical tools available for dissection of THOR provide the means to achieve a new level of understanding of microbial community behavior.
+
+INTRODUCTION
+
+Modern understanding of microbiomes has been accompanied by recognition of their vast complexity, which complicates their study and manipulation. Powerful -omics approaches that profile community features such as genomes, metabolites, and transcripts have illuminated the richness of many communities. These global portraits of complex communities have been complemented by genetic and biochemical dissection of much simpler communities and, in particular, binary interactions of one bacterial species with one host, such as bacterial symbionts of legume roots and squid light organs. The study of these systems has elucidated the pathways regulating interactions among bacteria and between bacteria and their environments.
+
+The explosion of understanding of two-species interactions has generated a scientific thirst for more tools to attain mechanistic understanding of multispecies community behaviors. Model systems consisting of more than one microbial member include communities in flies, the medicinal leech, and engineered systems. Key among the traits that demand more mechanistic studies are the components of community assembly and robustness, which is the ability to resist and recover from change. Understanding these traits has particular value today, as many researchers aim to modify microbial communities to achieve outcomes to improve human health, environmental sustainability, and agricultural productivity.
+
+Over the last century, the challenge to alter microbial communities in predictable ways has stymied microbiologists. Examples include attempts to change the human gut microbiome by ingestion of yogurt or probiotics or to alter plant microbiomes with inundative application of disease-suppressive microorganisms. Few treatments have induced long-term changes due to intrinsic community robustness.
+
+Communities express emergent properties, which are traits that cannot be predicted from the individual members. For example, metabolic exchange between yeast and Acetobacter spp. yields a mixture of volatile compounds attractive to Drosophila hosts that was not produced by either microbe in pure culture. Such higher-order or emergent properties of communities might explain the difficulty in manipulating them. In addition, many communities contain functional redundancy that is likely to contribute to robustness.
+
+Classical genetic analysis, defined as the isolation and study of mutants, in model organisms has advanced understanding of processes such as gene regulation in Escherichia coli and the mouse and development in flies and nematodes, but such reductionist genetic approaches are inaccessible in most microbial community-level analyses. A genetically tractable model system for studying microbial community assembly and robustness has the potential to transform our understanding of community processes. The scientific community recognizes the power of model systems in relation to microbial communities, and many groups have started to address this call. Importantly, common microbiome principles will only emerge with a diverse set of models to interrogate. Toward this end, we developed a model system involving three bacterial species, Pseudomonas koreensis, Flavobacterium johnsoniae, and Bacillus cereus, which interact under field and laboratory conditions, are amenable to genetic analysis, and represent three major phyla in microbiomes on plant roots and in the human gut.
+
+RESULTS
+
+Source of community members.
+
+We sought a model community that is simple and contains genetically tractable species that likely interact under natural conditions, both competitively and cooperatively. We drew upon our previous work demonstrating the peculiar tendency of B. cereus to carry “hitchhikers” when the bacterium is isolated from soybean roots. These biological hitchhikers are cryptic bacteria that become visible in culture only after apparently pure cultures of B. cereus are maintained at 4°C for several weeks. It is important to note that biological hitchhiking involves a physical association and is distinct from genetic hitchhiking which selects for neutral alleles. Most hitchhikers are members of the Bacteroidetes phylum, with a small proportion from the Proteobacteria and Actinomycetes. We selected 21 candidates that include B. cereus UW85, 12 hitchhikers, and eight other isolates from the roots that harbored the hitchhikers (Fig. 1B and C). These isolates represented the four dominant phyla present in the rhizosphere, Firmicutes, Proteobacteria, Bacteroidetes, and Actinobacteria.
+
+Network analysis of inhibitory interactions among rhizosphere isolates. (A) Venn diagram of the inhibitory interactions identified between the isolates as determined by the presence of zones of inhibition in three media: Luria-Bertani agar (LBA), ½-strength tryptic soy agar (TSA), and 1/10-strength TSA. (B) Colors indicate phylogeny of isolates used in the inhibitory matrix and network. (C) Inhibitory interaction matrix between B. cereus UW85 and hitchhiker isolates in three media. Potential producers, which are isolates tested for the ability to inhibit others, are on the y axis, and receivers, which are isolates tested for inhibition by others, are on the x axis. There are two different color codes used in panel C. One indicates the phylogeny of isolates in the row and column title, and the second one for the matrix results using the colors scheme shown in the Venn diagram corresponding to the medium in which the interaction appears. (D) Hierarchy scoring scheme used to organize the isolates in the hierarchy interaction network, in which black is the focal point. (E and F) Inhibitory interaction network organized by hierarchy score. (E) Inhibitory interactions generated from the isolates with high hierarchy scores. (F) Inhibitory interactions generated from the isolates with medium and low hierarchy scores. (G) Reciprocal inhibitory interactions observed in the inhibitory network. Orange indicates interactions observed in only 1 medium, and black indicates interactions observed in 2 or 3 media.
+
+Higher-order organization structures in an inhibitory interaction network of rhizosphere isolates.
+
+Competition plays an important role in microbial communities. To identify competitive interference interactions in our collection of 21 rhizosphere isolates, we evaluated them in pairs for inhibition of the other members in three different media. Of 105 inhibitory interactions detected, 71 interactions (68%) were conserved under at least two growth conditions, and 27 interactions were conserved under all three conditions (Fig. 1A). From the 105 inhibitory interactions observed among the rhizosphere bacteria, we constructed a matrix (Fig. 1C). The strains display a high degree of interaction, indicated by high connectance (value of C = 0.24, which represents the fraction of all possible interactions or number of interactions/number of species2). On average, each isolate interacted with six other isolates as either the source or target of inhibition. The interaction matrix appears to be producer determined with a negative sender-receiver asymmetry value (Q) of −0.31. This suggests that the structure of the inhibitory networks is more controlled by the producers and their secreted antibiotics than by the tester strains. Connectance values reported previously for diverse food-web structures are between 0.026 and 0.315, and the strains tested in this study had a value of 0.24, indicating high connectance.
+
+To detect higher-order community organization mediated by inhibitory interactions, we used a hierarchy-scoring scheme in which the ability to inhibit was given a positive score and sensitivity generated a negative score (Fig. 1D). We observed inhibitory hierarchical interactions in which the top isolates of the network inhibit isolates that receive a medium score, and in turn, these medium-scoring isolates inhibit isolates that receive a lower score (Fig. 1E and F).
+
+The four isolates that received the highest score, Delftia acidovorans and three Pseudomonas spp., were responsible for 58 (55%) of the inhibitory interactions (Fig. 1E). Nonhierarchical interactions were infrequent (6%), and these were largely reciprocal interactions between six isolates with middle and low scores, such as Lysobacter sp. strain RI17 (Fig. 1G), which is inhibited by five isolates under almost all conditions. Reciprocal inhibition by the Lysobacter sp. against these strains appeared predominantly under the lower-nutrient condition (1/10-strength tryptic soy agar [TSA]).
+
+P. koreensis isolate inhibits members of the Bacteroidetes in root exudates.
+
+Three of the strains inhibited most of the other isolates, placing them at the top of the inhibitory network. These strains were all members of the Pseudomonas fluorescens complex. They are the only members of the collection that consistently inhibit Bacteroidetes isolates, which is the most abundant phylum among the coisolates of B. cereus, making the inhibitory activities of these P. fluorescens members of particular interest. In addition, members of the P. fluorescens group have been shown to alter the structure of microbial communities on roots, making the inhibition of Bacteroidetes of interest to understand communities. To determine whether the three Pseudomonas strains similarly inhibit members of the Bacteroidetes, we tested them against F. johnsoniae CI04. Pseudomonas sp. CI14 and Pseudomonas sp. RI46 inhibited F. johnsoniae CI04 growth in standard medium and P. koreensis CI12 inhibited F. johnsoniae CI04 only in root exudate (Fig. 2A). Against a panel of diverse rhizosphere isolates grown in root exudate, P. koreensis CI12 inhibited primarily Bacteroidetes strains (Fig. 2B).
+
+Coculture of rhizosphere isolates with Pseudomonas spp. and B. cereus UW85. (A) Competition experiments between F. johnsoniae CI04 and either Pseudomonas sp. CI14, Pseudomonas sp. RI46, or P. koreensis CI12 in three media, Luria-Bertani broth (LB), ½-strength tryptic soy broth (TSB), and soybean root exudate. (B) Rhizosphere isolates were grown alone or in coculture with P. koreensis CI12 in soybean root exudate. Colored bars under x axis indicate phylogenetic groups as in Fig. 1. (C) F. johnsoniae CI04 grown alone, in coculture with P. koreensis CI12 or B. cereus UW85, and in triple culture with P. koreensis CI12 and B. cereus UW85. Gray dotted line, limit of detection.
+
+B. cereus protects F. johnsoniae from P. koreensis by modulating levels of koreenceine metabolites.
+
+To explore the ecology of B. cereus and its hitchhikers, P. koreensis CI12 and F. johnsoniae CI04, we added B. cereus UW85 to the coculture of the hitchhikers. Unpredictably, B. cereus UW85 enabled the growth of F. johnsoniae CI04 in coculture with P. koreensis CI12 (Fig. 2C) without affecting the growth of P. koreensis CI12 (Fig. S1). F. johnsoniae protection is dependent upon B. cereus arrival at stationary phase (Fig. S2). B. subtilis NCIB3160, a well-studied spore-forming bacterium, also protected F. johnsoniae in a stationary-phase-dependent manner (Fig. S2). Among three B. subtilis NCIB3160 mutants affected in transcriptional regulators related to stationary phase, only the mutant affected in spo0H, which controls the early transition from exponential to stationary phase, was unable to protect F. johnsoniae from P. koreensis (Fig. 3). An spo0H mutant in B. cereus UW85 also did not protect F. johnsoniae from P. koreensis (Fig. 3).
+
+Effect of Bacillus spp. on populations of F. johnsoniae in the presence of P. koreensis. Triple culture was of P. koreensis CI12, F. johnsoniae CI04, and either B. subtilis NCIB3160 or B. cereus UW85, or their mutants. Gray dotted line, limit of detection.
+
+We recently described a P. koreensis family of bacterial alkaloids, koreenceine A, B, and C, that influence the growth of F. johnsoniae in root exudates. Cell filtrates of cocultures of P. koreensis and F. johnsoniae inhibit F. johnsoniae growth, whereas filtrates of P. koreensis cultured alone or with both F. johnsoniae and B. cereus do not inhibit F. johnsoniae growth (Table 1). The levels of koreenceine A, B, and C were higher when P. koreensis was cocultured with F. johnsoniae than when it was cultured alone (Table 1). The addition of B. cereus to cocultures of P. koreensis and F. johnsoniae severely reduced the accumulation of koreenceine A and C, with a minor effect on the level of koreenceine B. The B. cereus Δspo0H mutant did not protect F. johnsoniae in triple culture, nor did it reduce the accumulation of koreenceine A and C as substantially as did wild type B. cereus (Table 1). We propose that B. cereus protects F. johnsoniae by selectively reducing the levels of koreenceine A and C accumulated by P. koreensis.
+
+Accumulation of koreenceine A, B, and C in coculture with F. johnsoniae or B. cereusa
+
+Source of cell extracts	F. johnsoniae growth (107 CFU/ml)	Accumulation (relative ion counts × 105) of:	 	Koreenceine A 	Koreenceine B 	Koreenceine C 	 	P. koreensis	1.4 ± 0.4	3.6 ± 0.4	62.9 ± 5.5	3.2 ± 0.4	 	P. koreensis with F. johnsoniae	ND	75.9 ± 11.4	275.9 ± 17.9	35.3 ± 6.5	 	P. koreensis with F. johnsoniae and B. cereus WT	6.3 ± 1.2	3.1 ± 0.4	167.6 ± 17.3	0.7 ± 0.2	 	P. koreensis with F. johnsoniae and B. cereus spo0H	ND	31.5 ± 9.8	310.1 ± 54.1	7.4 ± 2.6
+
+Koreenceine A, B, and C concentrations are expressed as ion counts from LC/HR-ESI-QTOF-MS analysis from cell filtrates of cultures of P. koreensis CI12 grown alone, with F. johnsoniae CI04, F. johnsoniae CI04 and B. cereus UW85 wild type, or with F. johnsoniae CI04 and B. cereus UW85 spo0H. F. johnsoniae CI04 population growth in the corresponding conditions in CFU per milliliter. ND, not detected.
+
+Rhizosphere isolates modulate B. cereus colony expansion.
+
+Among 20 rhizosphere isolates, six isolates induced B. cereus patches to expand in a dendritic pattern when plated on a lawn of the corresponding isolate on 1/10-strength TSA (Fig. 4). B. cereus was the only isolate of the collection that displayed colony expansion. A similar motility pattern has been observed in B. cereus translocating in an artificial soil microcosm, suggesting that this motility might be important in adapting to the soil environment. In pure culture, B. cereus colonies expanded in an irregular pattern with dense branches and asymmetrical bulges, whereas on lawns of the six isolates, including P. koreensis and F. johnsoniae, expansion was greater and radially symmetrical (Fig. 4 and 5A and Table S1). Colonies of B. cereus spread into the neighboring colonies of F. johnsoniae CI04 and P. koreensis CI12 when the two strains were grown in close proximity on plates (Fig. 5B). B. cereus spread both around and across P. koreensis CI12, and across, but not around, F. johnsoniae CI04. B. cereus did not display colony expansion when in contact with or proximal to Paenibacillus sp. strain RI40 (Fig. 5).
+
+B. cereus UW85 colony expansion in the presence of the rhizosphere isolates. (A) Schematic representation of the spread-patch plates. (B) B. cereus UW85 grown alone. (C) B. cereus UW85 grown on a lawn of each member of the community. Photographs were taken after 4 days at 28°C. Arrows indicate the limits of the B. cereus colony.
+
+Effect of community members on B. cereus UW85 colony expansion. (A) B. cereus UW85 plasmid-dependent GFP strain grown alone or on a lawn of P. koreensis CI12, F. johnsoniae CI04, or Paenibacillus sp. RI40. Bright-field (BF) and GFP imaging of colonies 5 days after inoculation. (B) B. cereus UW85 GFP strain grown in close proximity to a colony of P. koreensis CI12, F. johnsoniae CI04, or Paenibacillus sp. RI40. Arrows indicate B. cereus UW85 expansion over colonies of the other isolates. Bright-field, GFP channel, and overlay of the two channels of plates after 2 days of growth (F. johnsoniae CI04) and after 5 days of growth (P. koreensis CI12 and Paenibacillus sp. RI40).
+
+Rhizosphere isolates modulate Pseudomonas biofilm formation.
+
+Among the hitchhikers and rhizosphere isolates, Pseudomonas sp. isolates produced the most robust biofilms (Fig. 6A). In pairwise tests, poor biofilm producers changed the behavior of isolates of Pseudomonas spp. (Fig. 6B to D). When alone, P. koreensis CI12 produced maximum biofilm at 18 h, after which the biofilm began to dissociate (Fig. S3). F. johnsoniae CI04 and B. cereus UW85 each increased the maximum biofilm formed by P. koreensis CI12 at 18 h and reduced the rate of biofilm dissociation (Fig. 6E and F). A mixture of all three strains followed the same pattern as the pairs, although the triple mixture maintained more biofilm at 36 h (P < 0.01) (Fig. 6F), suggesting that F. johnsoniae CI04 and B. cereus UW85 together sustain the P. koreensis CI12 biofilm longer than either alone.
+
+Biofilm formation by rhizosphere isolates. Biofilm was quantified by measuring the optical density at 595 nm (OD595) after staining with crystal violet. (A) Crystal violet quantification of biofilm formation for each of the 21 isolates at 12 and 24 h after inoculation. (B to D) Pseudomonas biofilm production when grown with a poor biofilm producer normalized against Pseudomonas biofilm in pure culture at 12 and 24 h, either Pseudomonas sp. RI46 (B), Pseudomonas sp. CI14 (C), or P. koreensis CI12 (D). (E) Biofilm formation by P. koreensis CI12 growing alone, in coculture with either F. johnsoniae CI04 or B. cereus UW85, and in triple culture at 12, 18, 24, and 36 h. (F) P. koreensis CI12 biofilm production when grown with two other isolates normalized against P. koreensis growth in pure culture. *, P < 0.01. Colored bars under the x axis indicate phylogenetic groups as in Fig. 1. Gray dotted line, limit of detection.
+
+DISCUSSION
+
+We constructed a model community built upon microbes isolated from the soybean rhizosphere. We selected B. cereus as the first member of the community because of its ubiquitous distribution in soil and on roots and its influence on the rhizosphere. Approximately 3% to 5% of B. cereus colonies isolated from roots carry “hitchhikers,” other species that are only visible in culture over time in cold storage. B. cereus and its hitchhikers are derived from the same habitat and appear to have a physically intimate association, suggesting that their interactions in culture are relevant to the natural community; therefore, the second and third candidates for the model community were chosen from among the hitchhikers.
+
+The second candidate was F. johnsoniae, a member of the Bacteroidetes, the most abundant group of hitchhikers. B. cereus enables F. johnsoniae to grow in soybean and alfalfa root exudate by providing fragments of peptidoglycan as a carbon source. The third candidate for the model community was P. koreensis, which inhibits the growth of F. johnsoniae in soybean root exudates but not when B. cereus is present. Other interactions among these three species include modulation of B. cereus colony expansion by F. johnsoniae and P. koreensis and enhancement of P. koreensis biofilm formation by B. cereus and F. johnsoniae. These three candidates are genetically tractable, their genomes have been sequenced, they represent three phyla that dominate the rhizosphere and other host-associated communities, and they display both competitive and cooperative interactions. We designate the model community containing B. cereus, F. johnsoniae, and P. koreensis “THOR” to indicate that the members are the hitchhikers of the rhizosphere.
+
+THOR has two emergent properties, colony expansion and biofilm formation, that are increased by the complete community and could not be predicted from the behavior of the individuals. Each is observed with several combinations of community members, demonstrating functional redundancy in the system. B. cereus colony expansion likely reflects other bacteria affecting B. cereus motility. To our knowledge, this is the first report to indicate that B. cereus motility is influenced by social interactions. Motility influenced by social interactions is a rapidly growing field of research that has already demonstrated diverse mechanisms by which bacteria modulate motility in other species, including diffusible metabolites and cell-to-cell contact. The B. cereus dendritic growth patterns described here have been associated with sliding motility in semisolid agar under low-nutrient conditions and in artificial soil microcosms. Sliding is a passive appendage-independent translocation mechanism mediated by expansive forces of a growing colony accelerated by biosurfactants. Future experiments will determine whether B. cereus colony expansion over a bacterial lawn is mediated by sliding and whether the inducing bacteria enable this motility with biosurfactants.
+
+Biofilm produced by P. koreensis CI12 was augmented and sustained by other THOR members. P. koreensis CI12 is a member of the P. fluorescens complex, which contains many members that promote growth and suppress disease of plants, processes often dependent upon biofilm formation. The community modulation of P. koreensis CI12 biofilm formation and persistence could be a strategy to maintain bacteria in the rhizosphere. The social interactions among the members of the THOR model community provide an experimental system to probe mechanisms of P. koreensis biofilm assembly and disassembly and its role in P. koreensis lifestyle within a rhizosphere community.
+
+In addition to having emergent community properties, THOR members interact in several ways that are common in communities. B. cereus increases F. johnsoniae growth through nutritional enhancement and protects it from growth inhibition by P. koreensis, illustrating how pairwise interactions can be modulated by other members of the community, a phenomenon observed previously in synthetic communities. Growth interference and enhancement have been considered rare in naturally occurring communities because these behaviors often cannot be predicted from pairwise interactions. Our results further reinforce the importance of community modulation of behaviors observed in pairwise studies.
+
+THOR was constructed from a collection of 21 rhizosphere isolates that share several properties, such as high interactivity and higher-order organization mediated by antagonistic interactions, observed in other communities containing isolates of a single genus. We show that these properties can originate from phylogenetically diverse bacteria. We propose that the high microbial diversity detected in soil and rhizosphere communities could be in part achieved by hierarchical inhibition coupled with modulation of inhibition.
+
+A genetically tractable community with defined composition in a controlled environment offers the opportunity to dissect the mechanisms by which communities are established, function, and maintain their integrity in the face of perturbation. Rigorous testing of the numerous mechanistic hypotheses about community behavior that have been generated by -omics analyses requires systems in which variables can be isolated. This is offered in genetically tractable systems in which the functions of individual genes can be established through mutant analysis, and the impact of environmental factors can be studied by manipulating each variable. Therefore, model systems that can be fully dissected need to be part of the arsenal of tools to advance microbial ecology to a new platform of experimental power and causal inference.
+
+We present THOR as a simple multiphylum genetically tractable system with diverse community characteristics, some of which are the result of emergent properties. To capture the impact of multi-organism interactions and emergent properties, communities need to be studied as single genetic entities. Metagenomics introduced the concept of the community as the unit of study for genomes; similarly, “metagenetic” analysis will apply genetic analysis at the community level for mechanistic understanding. Such understanding will be key to designing interventions to achieve outcomes in the health of humans, the environment, and the agroecosystem.
+
+MATERIALS AND METHODS
+
+Bacterial strains and culture conditions.
+
+B. cereus UW85 and 20 coisolates and rhizosphere isolates were reported previously (Table S2). B. subtilis NCIB3160 wild-type (WT) and spo0A, spo0H, and sigF mutant strains were a gift from Roberto Kolter at Harvard University. Bacterial strains were propagated on 1/10-strength tryptic soy agar (TSA) and grown in liquid culture in 1/2-strength tryptic soy broth (TSB) at 28°C with vigorous shaking. Bacillus spores were quantified by plating on 1/10-strength TSA after heating at 80°C for 10 min.
+
+Production of root exudates.
+
+Soybean seeds were surface disinfected with 6% sodium hypochlorite for 10 min, washed with sterilized deionized water, transferred to water agar plates, and allowed to germinate for 3 days in the dark at 25°C. Seedlings were grown in a hydroponic system using modified Hoagland’s plant growth solution. Root exudate was collected after 10 days of plant growth in a chamber (12-h photoperiod, 25°C), filter sterilized, and stored at −20°C. An amino acid mix of equal parts alanine, aspartate, leucine, serine, threonine, and valine was added to the root exudate at a final concentration of 6 mM.
+
+Generating an inhibitory interaction network between rhizosphere bacteria.
+
+The presence or absence of inhibitory interactions between strains in our collection was evaluated following a modified spread-patch method. Strains were grown individually for 20 h. One-milliliter aliquots of cultures of each strain were centrifuged (6,000 × g, 6 min) and resuspended in 1 ml of the same medium (undiluted cultures), and a 1:100 dilution of each strain was prepared in the same medium (diluted culture). Inhibitory interactions were evaluated in three different medium plates, Luria-Bertani agar, 1/2-strength TSA, and 1/10-strength TSA. Plates were spread with 100 μl of the diluted cultures and spotted with 10 μl of the undiluted cultures, with four strains per plate. Plates were then incubated at 28°C and inspected for zones of inhibition after 2 days. A network of inhibitory interactions was then generated using the inhibitory interaction matrix that summarizes the detected interactions under the three conditions evaluated, where each node of the network represents one of the bacterial strains and each edge represents growth inhibition of the target. A simple hierarchy scoring was created to assign hierarchy levels based on Wright and Vetsigian. Each strain was assigned one “reward” point for inhibiting another strain and one “penalty” point for each strain that inhibited it. One penalty point was also assigned for reciprocal interactions. Networks were visualized using Cytoscape software. The sender-receiver asymmetry (Q) was calculated from the inhibitory interaction matrix, as reported by Vetsigian et al..
+
+Competition assays in liquid culture.
+
+Strains were grown individually for 16 to 20 h. A 1-ml sample was removed from each overnight culture, and the cells were washed once and resuspended in phosphate-buffered saline (PBS). Culture medium was inoculated with ∼106 F. johnsoniae cells ml−1 and ∼107 Pseudomonas sp. cells ml−1. B. cereus and B. subtilis were inoculated at densities between ∼104 cells ml−1 and ∼107 cells ml−1, depending upon the experiment. When evaluating the susceptibility of each strain to P. koreensis CI12 inhibition in root exudate, all strains except CI12 were inoculated at a final density of 1/1,000 their overnight culture density. Cultures were incubated with agitation for 2 days at 28°C. Samples were withdrawn periodically to evaluate bacterial growth by serial dilution and plating. The initial densities were determined on either LB or LB containing kanamycin (10 μg ml−1). At every other time point, Pseudomonas sp. colonies were counted on LB plates, Bacillus spp. were selected on LB plates containing polymyxin B (4 μg ml−1), and all other strains were selected on LB plates containing kanamycin (10 μg ml−1). Plates were incubated at 28°C for 2 days.
+
+Chromosomal deletion of spo0H in B. cereus.
+
+The gene encoding the Spo0H sigma factor was deleted using a chromosomal integration vector with a thermosensitive origin of replication that introduces the deletion with no marker. Construction of the spo0H deletion cassette was accomplished by a modified version of overlap extension (OE) PCR strategy. Fragments 1 kb upstream and 1 kb downstream of the spo0H gene were amplified using primers mut_spo0HA1/mut_spo0HA2 and mut_spo0HB1/mut_spo0HB2, respectively (Table S3). The PCR products were cloned in pENTR/d-TOPO, generating pmut_spo0H_ENTR. Primers mut_spo0HA1 and mut_spo0HB2 were designed to include a BamHI site in the 5′ region to allow transfer. The spo0H deletion construct was recovered from pmut_spo0H_ENTR using BamHI and cloned in the BamHI site of pMAD, generating pmut_spo0H_MAD in E. coli GM2929. Gene replacement was carried out in a manner similar to the method described previously. Briefly, pmut_spo0H_MAD was introduced into B. cereus UW85 by electroporation in 0.2-cm cuvettes with a Gene Pulser (Bio-Rad Laboratories) set at 1.2 kV. The surviving cells were cultured on 1/2-strength TSA plates with erythromycin (3 μg ml−1) and 5-bromo-4-chloro-3-indolyl-β-d-glucuronic acid (X-Gal; 50 μg ml−1) at 28°C. Strains that had undergone the single recombination event were selected on plates containing erythromycin (3 μg ml−1) at 40.5°C. To select for a second crossover event, single recombinant clones were grown at 28°C in nonselective medium, diluted into fresh medium, grown at 40.5°C, and plated for single colonies on 1/2-strength TSA with X-Gal (50 μg ml−1) at 40.5°C. White colonies, which were putative double recombinants, were confirmed by PCR using mut_spo0HA1 and mut_spo0HB2 for the deletion of spo0H.
+
+Identification of koreenceine metabolites produced by P. koreensis CI12 in the presence of other rhizosphere members.
+
+P. koreensis CI12 was grown alone, in coculture, or in triple culture with other rhizosphere members in root exudate at 28°C with agitation. Five milliliters of cultures was centrifuged (6,000 × g, 6 min), and supernatants were filtered using a 0.22-μm-pore-size polyethersulfone (PES) membrane filter (Millipore). The cell-free cultures were mixed with 6 ml of 2-butanol. Six milliliters of the organic phase was concentrated using a GeneVac EZ-2 Plus instrument (SP Scientific). Crude extracts were resuspended in methanol and analyzed on an Agilent 6120 single quadrupole liquid chromatography-mass spectrometry (LC/MS) system (Phenomenex Kinetex C18 column, 250 by 4.6 mm, 5 μm; flow rate, 0.7 ml min−1; mobile phase composition, H2O and acetonitrile [ACN] containing 0.1% trifluoroacetic acid [TFA]; method, 0 to 30 min, 10 to 100% ACN; hold for 5 min, 100% ACN; 1 min, 100 to 10% ACN). High-resolution electrospray ionization mass spectrometry (HR-ESI-MS) data were obtained using an Agilent iFunnel 6550 quadrupole time of flight (Q-TOF) mass spectrometer fitted with an electrospray ionization (ESI) source coupled to an Agilent (USA) 1290 Infinity high-performance liquid chromatography (HPLC) system.
+
+B. cereus motility assay.
+
+B. cereus motility was evaluated using the same modified spread-patch method described above. We used B. cereus UW85/pAD123_31-26 as a green fluorescent protein (GFP) reporter. The images were captured using a custom Macroscope. The detector was a Canon EOS 600D Rebel T3i equipped with a Canon EFS 60-mm Macro lens. GFP was excited with a light-emitting diode (LED) using a 470/40 filter and collected with a 480/30 filter. Remote control of the camera and LED was achieved using custom software.
+
+Microtiter plate biofilm assays.
+
+The ability of the rhizosphere community to form a biofilm was estimated in 96-well polystyrene microtiter plates, as described previously, with some modifications. Briefly, strains were grown at 28°C for 20 h; cultures were centrifuged (6,000 × g, 6 min) and resuspended in sterile 10 mM NaCl to an optical density (OD) of 0.004 for Pseudomonas spp. and 0.001 for the other isolates. Cell suspensions were placed in sterile flat-bottomed microtiter plates as single species, pairs, or triple species in root exudate. Plates were covered with sterile breathable sealing film and incubated at 20°C. Cell density was determined by spectrophotometric measurement at 600 nm at the final time point (BioTek Synergy HT microplate reader). Planktonic cells were discarded, and wells were washed three times with water. Biofilms attached to the wells were stained with 0.1% crystal violet, washed three times with water, and dried. The stain was dissolved with 33% acetic acid, and its concentration was determined spectrophotometrically at 595 nm. Visualization and statistical analyses were performed with the GraphPad Prism 7 software. Differences between groups were tested for statistical significance (Student’s t test). Significance levels were set to a P value of <0.01 (*).
+
+Citation Lozano GL, Bravo JI, Garavito Diago MF, Park HB, Hurley A, Peterson SB, Stabb EV, Crawford JM, Broderick NA, Handelsman J. 2019. Introducing THOR, a model microbiome for genetic dissection of community behavior. mBio 10:e02846-18. https://doi.org/10.1128/mBio.02846-18.
+
+REFERENCES
+
+Sequencing and beyond: integrating molecular “omics” for microbial community profiling
+
+The rules of engagement in the legume-rhizobial symbiosis
+
+The winnowing: establishing the squid-vibrio symbiosis
+
+Gut-associated microbes of Drosophila melanogaster
+
+Gut homeostasis in a microbial world: insights from Drosophila melanogaster
+
+Lessons from digestive-tract symbioses between bacteria and invertebrates
+
+Synthetic microbial ecosystems: an exciting tool to understand and apply microbial communities
+
+Rules of engagement: interspecies interactions that regulate microbial communities
+
+Fundamentals of microbial community resistance and resilience
+
+Probiotics, gut microbiota, and their influence on host health and disease
+
+Disease suppressive soils: new insights from the soil microbiome
+
+Geomicrobiology: how molecular-scale interactions underpin biogeochemical systems
+
+Metabolite exchange between microbiome members produces compounds that influence Drosophila behavior
+
+Bacterial social interactions and the emergence of community-intrinsic properties
+
+Need for laboratory ecosystems to unravel the structures and functions of soil microbial communities mediated by chemistry
+
+In search of model ecological systems for understanding specialized metabolism
+
+Using cultivated microbial communities to dissect microbiome assembly: challenges, limitations, and the path ahead
+
+Deciphering microbial interactions in synthetic human gut microbiome communities
+
+Cheese rind communities provide tractable systems for in situ and in vitro studies of microbial diversity
+
+Simplified and representative bacterial community of maize roots
+
+Draft genome sequence of Pseudomonas koreensis CI12, a Bacillus cereus “hitchhiker” from the soybean rhizosphere
+
+Peptidoglycan from Bacillus cereus mediates commensalism with rhizosphere bacteria from the Cytophaga-Flavobacterium group
+
+Genetic hitchhiking
+
+Structure and functions of the bacterial microbiota of plants
+
+Competition, not cooperation, dominates interactions among culturable microbial species
+
+Structure and evolution of Streptomyces interaction networks in soil and in silico
+
+Food-web structure and network theory: the role of connectance and size
+
+Pseudomonas biocontrol agents of soilborne pathogens: looking back over 30 years
+
+Molecular genetics of sporulation in Bacillus subtilis
+
+Bacterial analogs of plant piperidine alkaloids mediate microbial interactions in a rhizosphere model system
+
+Analysis of the life cycle of the soil saprophyte Bacillus cereus in liquid soil extract and in soil
+
+Zwittermicin A-producing strains of Bacillus cereus from diverse soils
+
+Enhancement of soybean nodulation by Bacillus cereus UW85 in the field and in a growth chamber
+
+Use of cluster and discriminant analyses to compare rhizosphere bacterial communities following biological perturbation
+
+Effect of Bacillus cereus UW85 on the yield of soybean at two field sites in Wisconsin
+
+Bacillus cereus UW85 inoculation effects on growth, nodulation, and N accumulation in grain legumes: field studies
+
+Draft genome sequence of biocontrol agent Bacillus cereus UW85
+
+Draft genome sequence of Flavobacterium johnsoniae CI04, an isolate from the soybean rhizosphere
+
+A global atlas of the dominant bacteria found in soil
+
+Integrated analysis of root microbiomes of soybean and wheat from agricultural fields
+
+Towards efficient crude oil degradation by a mixed bacterial consortium
+
+Metabolic characterization of cold active Pseudomonas, Arthrobacter, Bacillus, and Flavobacterium spp. from Western Himalayas
+
+Bacillus species in the intestine of termites and other soil invertebrates
+
+Health implications associated with exposure to farmed and wild sea turtles
+
+Antibiotic stimulation of a Bacillus subtilis migratory response
+
+Social motility: interaction between two sessile soil bacteria leads to emergence of surface motility
+
+Biosurfactant production and surface translocation are regulated by PlcR in Bacillus cereus ATCC 14579 under low-nutrient conditions
+
+Sliding on the surface: bacterial spreading without an active motor
+
+Biofilm formation by plant-associated bacteria
+
+Counteraction of antibiotic production and degradation stabilizes microbial communities
+
+Coexistence of antibiotic-producing and antibiotic-sensitive bacteria in biofilms is mediated by resistant bacteria
+
+Community structure follows simple assembly rules in microbial microcosms
+
+Antagonism influences assembly of a Bacillus guild in a local community and is depicted as a food-chain network
+
+Inhibitory interactions promote frequent bistability among competing bacteria
+
+Metagenetics: spending our inheritance on the future
+
+The water-culture method for growing plants without soil
+
+Cytoscape: a software environment for integrated models of biomolecular interaction networks
+
+A quadruple-enterotoxin-deficient mutant of Bacillus thuringiensis remains insecticidal
+
+A vector for promoter trapping in Bacillus cereus
+
+Air-liquid interface biofilms of Bacillus cereus: formation, sporulation, and dispersion

--- a/references_cache/pmc_full_pmid_40920748.txt
+++ b/references_cache/pmc_full_pmid_40920748.txt
@@ -1,0 +1,677 @@
+Breaking the reproducibility barrier with standardized protocols for plant–microbiome research
+
+Inter-laboratory replicability is crucial yet challenging in microbiome research. Leveraging microbiomes to promote soil health and plant growth requires understanding underlying molecular mechanisms using reproducible experimental systems. In a global collaborative effort involving five laboratories, we aimed to help advance reproducibility in microbiome studies by testing our ability to replicate synthetic community assembly experiments. Our study compared fabricated ecosystems constructed using two different synthetic bacterial communities, the model grass Brachypodium distachyon, and sterile EcoFAB 2.0 devices. All participating laboratories observed consistent inoculum-dependent changes in plant phenotype, root exudate composition, and final bacterial community structure, where Paraburkholderia sp. OAS925 could dramatically shift microbiome composition. Comparative genomics and exudate utilization linked the pH-dependent colonization ability of Paraburkholderia, which was further confirmed with motility assays. The study provides detailed protocols, benchmarking datasets, and best practices to help advance replicable science and inform future multi-laboratory reproducibility studies.
+
+Reproducing microbiome experiments across laboratories is a major challenge in soil and plant health research. In a collaborative effort involving five laboratories, this study achieved consistent, inoculum-dependent results, providing detailed protocols, datasets and best practices to promote reproducibility in plant microbiome studies.
+
+1. Introduction
+
+As recent perspective papers have highlighted, establishing model microbiomes is a pressing need in environmental microbiology. Several years ago, a vision was presented for developing and validating standardized ‘fabricated ecosystems’ to enable replicable studies of microbiomes in ecologically relevant contexts, akin to the adoption of shared model organisms. A fabricated ecosystem is defined as a closed laboratory ecological system where all biotic and abiotic factors are initially specified/controlled. Synthetic microbial communities (SynComs) are valuable tools for bridging the gap between natural communities and studies involving axenic cultures and isolates. By limiting complexity yet retaining functional diversity and microbe-microbe interactions, SynComs can be used to unravel mechanisms underlying complex interactions, providing critical insights into community assembly processes, microbial interactions, and host physiology, e.g., plant host. These interactions between the host and its microbes define the holobiont concept, where the plant and its microbiome form a single dynamic ecological unit. However, standardization is essential to fully leverage the potential of SynComs and achieve replicable plant microbiome studies. This requires overcoming several challenges, including the availability of strains and standardized protocols for their growth in the laboratory. To address these challenges, we recently developed a standardized model community of 17 bacterial isolates from a grass rhizosphere available through a public biobank (DSMZ), along with cryopreservation and resuscitation protocols.
+
+Other aspects to enable replicable microbiome studies must be standardized, including sterile habitats and protocols for sample collection and analysis. As initial steps towards this vision, we developed a first-generation sterile container for fabricated ecosystems (EcoFAB device) and performed a multi-laboratory study demonstrating the reproducible physiology of the model grass Brachypodium distachyon. Recently, it was found that Paraburkholderia sp. OAS925 dominated other members of the model 17-member SynCom for B. distachyon root colonization. Additionally, we have since developed an improved EcoFAB 2.0 device that enables highly reproducible plant growth. The next step towards standardization is to test the replicability of microbiome formation, plant responses to microbiomes, and root exudation using these standardized laboratory habitats and SynComs. This can be achieved through inter-laboratory comparison studies or ring trials—a powerful tool in proficiency testing of analytical methods that are currently underutilized in microbiome research.
+
+Here, we describe a five-laboratory international ring trial investigating the reproducibility of B. distachyon phenotypes, exometabolite profiles, and microbiome assembly within the EcoFAB 2.0 device. The experiment compared the recruitment of the full SynCom versus one lacking the dominant root colonizer Paraburkholderia sp. OAS925. To minimize variation required in all laboratories, almost all supplies (e.g., EcoFABs 2.0, seeds, SynCom inoculum, filters) were distributed from the organizing laboratory, and detailed protocols, including annotated videos, were created. Each laboratory measured plant phenotypes and collected samples for 16S rRNA amplicon sequencing and metabolomic analyses by LC–MS/MS. A single laboratory performed all the sequencing and metabolomic analyses to minimize analytical variation. Follow-up in vitro assays and comparative genomics were conducted to gain insights into mechanisms leading to Paraburkholderia sp. OAS925 dominance. Overall, the study demonstrates consistent plant traits across multiple laboratories and provides publicly accessible benchmarking data for other labs to leverage, replicate, and extend this work. In addition, we describe the challenges we encountered in performing this study, thus providing information that can facilitate future microbiome reproducibility studies.
+
+2. Results
+
+2.1. Study design and logistics
+
+Our main objective was to develop and test methods to reproducibly study plant microbiomes within the sterile EcoFAB 2.0 device (Fig 1a). We hypothesized that the inclusion of Paraburkholderia sp. OAS925, a dominant B. distachyon root colonizer into SynCom, would reproducibly influence the microbiome assembly, metabolite production, and plant growth across multiple laboratories using the EcoFAB 2.0 device. To test the hypothesis, we deployed the grass B. distachyon with a SynCom consisting of 16 or 17 members (either with or without Paraburkholderia sp. OAS925) that was originally developed to span the diversity of bacteria isolated from a grass rhizosphere, including representatives from the Actinomycetota, Bacillota, Pseudomonadota, and Bacteroidota phyla (Fig 1b). Our study was conducted across five laboratories (designated A–E) and consisted of four treatments with seven biological replicates each (Fig 1a): an axenic (mock-inoculated) sterile plant control, SynCom16-inoculated plants, SynCom17-inoculated plants, and plant-free medium control. Each laboratory followed written protocols and annotated videos, gathered root and unfiltered media samples for 16S rRNA amplicon sequencing, filtered media for metabolomics, measured plant biomass, and performed root scans. At the end of the study, the collected data and samples were sent to the organizing laboratory for sequencing, metabolomics, and data analysis.
+
+Overview of the interlaboratory comparison study.
+
+(a) Experimental design where five laboratories across three continents conducted the same experiment using shipped materials. These included a detailed protocol (https://dx.doi.org/10.17504/protocols.io.kxygxyydkl8j/v1), SynComs and Mock solution stocks, light and temperature loggers, Brachypodium distachyon seeds, EcoFAB 2.0 device parts, and various lab supplies (growth medium, filters, sampling tubes). We inoculated B. distachyon plants with either a 16- or 17-member SynCom, with controls being axenic plants and medium-only technical control (Mock-inoculated), n = 7. We tested sterility and imaged roots at multiple time points. Finally, we quantified plant biomass, analyzed exudate metabolite composition, and measured root and medium microbiomes. (b) The phylogenomic tree is based on 120 marker genes, where SynCom members are highlighted in bold, with phylum-level classification shown by colored strips and SynCom membership by circles (SynCom16 in blue, SynCom17 in orange). The 2 closest taxonomic genomes are included, with GenBank accession numbers in parentheses. Nodes with over 50 bootstrap support values from 100 replicates are labeled. Chloroflexus aggregans (bold gray) served as an outgroup. The 17 genomes can be accessed via Hugging Face (https://doi.org/10.57967/hf/5885) or links in S2 Table.
+
+The detailed protocol with embedded annotated videos used by all five laboratories is available via protocols.io (https://dx.doi.org/10.17504/protocols.io.kxygxyydkl8j/v1). The general procedure follows these steps: (i) EcoFAB 2.0 device assembly; (ii) B. distachyon seed dehusking, surface sterilization, and stratification at 4 °C for 3 days; (iii) Germination on agar plates for 3 days; (iv) Transfer of seedlings to the EcoFAB 2.0 device for an additional 4 days of growth; (v) Sterility test and SynCom inoculation into the EcoFAB 2.0 device; (vi) Water refill and root imaging at three timepoints; (vii) Sampling and plant harvest at 22 days after inoculation (DAI). Since differences in labware and material can cause experimental variation, the protocol specifies the part numbers used in this study. Organizers provided critical components, including growth chamber data loggers, in the initial package of nonperishable supplies, while the SynComs and freshly collected seeds were shipped just before the study. Given the time zone differences, it was difficult to synchronize all activities, so each laboratory performed the experiment independently within 1.5 months of each other (S1 Table). All participants followed data collection templates and image examples.
+
+2.2. Protocols resulted in reproducibly sterile conditions
+
+During the study, all participating laboratories tested the sterility of the EcoFABs 2.0 devices by incubating spent medium on Luria–Bertani (LB) agar plates at two different time points. Less than 1% (2 out of 210) of all tests showed colony formation (Fig 2a). Namely, a single colony was observed in one treatment of laboratory D in SynCom17, and multiple colonies for laboratory B in medium-only control (plate had cracked lid).
+
+Plant phenomics and EcoFAB 2.0 device sterility.
+
+(a) Sterility of uninoculated EcoFAB 2.0 devices tested across laboratories A–E and treatments (Trt.: Ax-Axenic, 16-SynCom16, 17-SynCom17, Tx-Medium technical control) at day 0 and day 22 after inoculation (DAI). The medium from these devices was incubated on LB agar plates for 22 days to observe bacterial colony formation. Each square represents one test with gray fill indicating sterility and black contamination. The photos of the agar sterility test can be found at https://doi.org/10.6084/m9.figshare.26409220. (b) Plant biomass weight combined across all laboratories (Lab A–E in different colors), measured as shoot dry weight, shoot and root fresh weight. One-way ANOVA with Tukey test, n = 7, ns p > 0.5, *p < 0.05, **p < 0.01, ***p < 0.001. The shoot photos can be found at https://doi.org/10.6084/m9.figshare.26409310. (c) Root system development was analyzed using RhizoNet (Lab B–E) and ImageJ (Lab A). The raw root pixel counts were normalized to the maximum value in each lab. Two-way ANOVA with Dunnet’s test vs. Axenic control, n = 7, ns p > 0.5, *p < 0.05, **p < 0.01, ***p < 0.001. The root scans and Rhizonet reports can be found at https://doi.org/10.6084/m9.figshare.26131291. The data underlying this figure can be found at https://doi.org/10.6084/m9.figshare.26401315.
+
+2.3. Reproducible plant growth
+
+When plant biomass data were combined across laboratories, we observed a significant decrease in shoot fresh weight and dry weight of plants inoculated with SynCom17, and to a lesser extent SynCom16, relative to the axenic treatment (Fig 2b). This said, we did observe some variability between laboratories (S1 Fig), which is presumably due to growth chamber differences including light quality (fluorescent versus LED growth lights), light intensity and temperature (S1 Table). Supporting this, the data loggers revealed variability in measured temperatures (S2a Fig) and photoperiod (S2b Fig). Image analysis of scanned roots (S3 Fig) revealed that SynCom17 caused a consistent decrease in root development observed after 14 DAI onwards (Fig 2c).
+
+2.4. Reproducible microbiome assembly
+
+SynComs were prepared using optical density at 600 nm (OD600) to colony-forming unit (CFU) conversions (S2 Table) to ensure equal cell numbers (final inoculum 1 × 105 bacterial cells per plant) and shipped on dry ice to each laboratory as 100× concentrated stocks in 20% glycerol. The cells were resuspended and added to 10-day-old B. distachyon seedlings in the EcoFAB 2.0. After 22 days of growth, the roots and media were sampled, shipped back to the organizing laboratory, sequenced (see S3 Table for read counts), and compared to the original inoculum. For both SynComs (SynCom16 and SynCom17), the community composition at 22 DAI differed from the inoculum (Fig 3). As hypothesized, the root microbiome inoculated with SynCom17 was dominated by Paraburkholderia sp. OAS925 across all laboratories (98 ± 0.03% average relative abundance ± SD). In its absence (SynCom16), other isolates showed high relative abundance in the root microbiome with increased variability across laboratories, namely Rhodococcus sp. OAS809 (68 ± 33%), Mycobacterium sp. OAE908 (14 ± 27%), and Methylobacterium sp. OAE515 (15 ± 20%). The most dominant microbial isolates detected in root samples were also typically present in the media samples (S4a Fig). Ordination plots showed clear separations between SynCom16 and SynCom17 microbiomes for both root and media, with generally higher variability between samples for the SynCom16 microbiome (S4b Fig). There was a minimal contribution of unknown reads in all samples, consistent with the observed sterility of the controls. The three samples with the highest proportion of unknown reads (>2.5%) contained operational taxonomic units (OTUs) associated with human microbes (S4 Table), suggesting introduction during handling. Furthermore, SynCom17 treatment in laboratory D did not show unknown reads (S3 Table), suggesting that the failed sterility test (Fig 2a) was likely caused by plate downstream contamination.
+
+Root microbiome.
+
+Microbiome composition of Brachypodium distachyon roots and starting inoculum of plants inoculated with SynCom16 or SynCom17 (±Paraburkholderia sp. OAS925). Letters indicate different laboratories, with each biological replicate shown (n = 7). The inoculum shows technical replicates (n = 3). The data underlying this figure can be found at https://doi.org/10.6084/m9.figshare.26401315 or in S3 Table.
+
+2.5. Reproducible rhizosphere metabolome
+
+The spent medium from each fabricated ecosystem was filtered and shipped to the organizing laboratory for LC–MS/MS analysis (S5 Table), followed by targeted and untargeted metabolomics to determine the root exudate composition and metabolite profiles in the presence of different SynComs in the rhizosphere. The targeted analysis identified 60 metabolites spanning diverse metabolite classes (S6 Table). Hierarchical clustering revealed general clustering by treatment and not laboratory (Fig 4), consistent with the experimental reproducibility observed with plant growth phenotypes and root microbiome composition. Furthermore, the metabolite clustering showed several treatment-dependent metabolite changes. The first large cluster included diverse metabolites increased in the SynCom17 treatment. A second large cluster consisted of metabolites with lower relative concentrations in the SynCom17 treatment, represented mainly by amino acids. A third, much smaller cluster consisting primarily of nucleosides(tides) increased in the SynCom16 or both SynCom treatments. This finding highlights the prominent impact of the community dominated by Paraburkholderia sp. OAS925 on modulation of metabolite composition in the rhizosphere. This was further supported by untargeted metabolomics on 833 detected features that showed a clear separation between rhizosphere metabolomes of axenic plants and SynCom17, which was reproducible across all laboratories (S5 Fig). These changes may be due to metabolite production or uptake by the microbes or plant roots or the activity of extracellular enzymes.
+
+Targeted metabolomic analysis of rhizosphere.
+
+We show mean values for 60 identified metabolites for each lab/treatment combination (n = 7), row-normalized to the average sum peak height per lab. Row colors indicate metabolite classes. Cluster 1: Abundant in SynCom17; Cluster 2: Low in SynCom17; Cluster 3: Abundant in SynCom16 or both SynComs. The data underlying this figure can be found at https://doi.org/10.6084/m9.figshare.26401315 or in S6 Table.
+
+2.6. Statistical evaluation of variation between labs
+
+Ordination analysis using non-metric multidimensional scaling (NMDS) for microbiome (S4b Fig) and metabolome data (S5 Fig) showed a clear separation between treatments, but some separation between labs. To explore this in more detail, we quantified the lab- versus treatment-associated variation by analysis of variation (ANOVA) (S7 Table), pairwise tests (S8 Table), and coefficient of variation (CV).
+
+ANOVA analysis of microbial abundance showed that more microbes were significantly different due to the treatments versus lab doing the experiment, across both roots and media (S6a Fig). When investigating the source of variation, we observed microbe-dependent results, with the lab accounting for <18% of the variation, while SynCom treatment had a larger contribution in several microbes, especially Praburkholderia, Rhodococcus, and Methylobacterium (S6b Fig). CV analysis showed consistent trends for both root and media samples, with SynCom16 displaying higher within-lab variability than SynCom17 in all labs (S6c Fig). Between-lab CVs were similar across treatments. Overall, the observed microbial abundance levels were more dependent on treatment than lab.
+
+Metabolite levels were more affected by the lab-associated factors than the microbial abundances. However, treatment was still the primary influence in the majority of the metabolites. Both lab and treatment significantly affected the majority of the 60 identified metabolites (S7a Fig). Comparing these results between the various labs, we found that 7–23 metabolites were significantly different in specific pairwise lab comparisons, with lab pair A–B being the most different, and labs A–D, C–D, and B–D most similar to one another (S7b Fig). This said, most metabolites were primarily influenced by treatment rather than lab, though a subset, especially salsolinol, tyramine, and dopamine showed notable lab effects (S7c Fig). Metabolites in Axenic and SynCom17 treatments had lower CV than SynCom16 in all labs, and the within-lab CV was approximately the same as the between-lab CV (S7d Fig). Together, these results support the conclusion that metabolite abundances were largely treatment-driven, though some metabolites were sensitive to lab-specific differences.
+
+2.7. Colonization by Paraburkholderia
+
+Given the reproducible impacts of Paraburkholderia sp. OAS925 on our fabricated ecosystems, including plant growth phenotypes, microbiome structure, and rhizosphere exometabolites, we performed additional analyses to gain insights into potential mechanisms that may explain its dominance. Comparative genomic analysis showed that the Paraburkholderia sp. OAS925 genome (IMG/M Taxon ID: 2931840637) uniquely includes acid resistance genes such as glutamate and arginine transporters and decarboxylases (S8 Fig) and a gene module coding for a Type 3 Secretion System (T3SS), which was not found in any other member of the SynCom (S9 Table).
+
+We inoculated B. distachyon with a red fluorescent protein (RFP) expressing Paraburkholderia sp. OAS925 to investigate spatial-temporal root colonization in EcoFAB 2.0. Clear RFP signals were detected at the root tip and in the maturation zone at 1 DAI, with increased biofilm formation observed at 3 DAI (S9 Fig). We noted both sessile colonies on the rhizoplane (S1 Video) and active swimming surrounding root cells (S2 Video).
+
+The biofilm formation and motility observed during microscopy motivated the follow-up in vitro assays to further assess these characteristics across isolates. Paraburkholderia sp. OAS925 exhibited the sixth-highest biofilm formation and the most liquid-culture growth (S10 Fig), highlighting its potential to outgrow many other bacteria in SynCom17.
+
+Swimming motility assays on soft agar revealed that Paraburkholderia sp. OAS925 had the highest motility within the first 24 h (S11a Fig). Additionally, compared to other isolates with similar motility phenotypes (S11b Fig), it maintained fast swimming in acidic conditions (S11c Fig) in the range of the hydroponic medium (pH 5.5–6.0 at the start of the experiment). KEGG mapping (map02040) showed the presence of flagellar assembly genes, suggesting that the observed motility is due to flagella.
+
+3. Discussion
+
+There is an urgent need to move towards replicable experimental systems to address common difficulties in reproducing microbiome experiments. Here, we report what, to our knowledge, is the first multi-laboratory microbiome reproducibility study. We constructed fabricated ecosystems using two SynComs, the model plant B. distachyon Bd21-3, and sterile EcoFAB 2.0 devices. These, in combination with written protocols and annotated videos, generally resulted in reproducible plant growth phenotypes, host microbiomes, and exometabolomes across five laboratories spanning three continents. Of the 210 sterility tests performed across the 5 labs, only 2 potential contamination events were detected (Fig 2a). One of these was from a plate with a cracked lid, and so we conclude that the EcoFAB 2.0 devices and protocols were effectively able to achieve sterility across all labs.
+
+The magnitude of laboratory-specific effects on microbiome and metabolome data varied across our study, with laboratory factors explaining <18% of the variation in 16S rRNA sequencing data, but having a greater impact on specific exometabolites, where 15 metabolites had variation >18% (S7 Table). For example, hexosaminic acid, deoxycytidine, and N-acetylputrescine were highly reproducible between labs, whereas salsolinol, tyramine, and dopamine showed greater variability. The biochemical connection between these metabolites (salsolinol derived from dopamine, which is synthesized from tyramine) and dopamine’s instability (prone to oxidation) may contribute to their high variability across laboratories. These findings suggest opportunities to reduce metabolite variability through refined sample collection, handling, and storage. Together, these findings emphasize the importance of accounting for laboratory-specific effects when interpreting metabolome data, and highlight the need for standardized methods to minimize variability to generate high-quality data that can be integrated across labs (e.g., using AI).
+
+Our study confirms previous findings that Paraburkholderia sp. OAS925 dominates the root microbiome of B. distachyon when part of the SynCom. Similar results were observed for another grass, Avena barbata, grown in its native soil, where members of the order Burkholderiales were the most active bacteria in the rhizosphere based on carbohydrate depolymerization. Soil pH, organic carbon availability, oxygen levels and redox status are key factors influencing microbial community composition. Our study suggests several traits that likely help contribute to the dominance of Paraburkholderia sp. OAS925 in SynCom17. For example, its high motility in acidic environments (S11c Fig), such as the rhizosphere, might facilitate quick colonization of ecological niches and affect community assembly. Its ability to utilize amino acids like arginine, glutamine, and glutamate (Fig 4) provides a possible mechanism for cytoplasm de-acidification to maintain motility-enabling transmembrane proton gradient. These results align with a previous study showing that Pseudomonas simiae genes involved in motility, carbohydrate metabolism, cell wall biosynthesis, and amino acid transport aid in colonization of Arabidopsis roots. Interestingly, in SynCom16, Rhodococcus often dominates on roots (Fig 3) and shares fast growth (S10 Fig) and high motility (S11a Fig) with Paraburkholderia.
+
+Both SynCom16 and SynCom17 decreased plant biomass, with SynCom17 having a more pronounced effect (Figs 2 and S1). The observed dominant colonization by Paraburkholderia (S9 Fig, S1 and S2 Videos) or other bacteria might disrupt plant nutrient homeostasis, as the root microbiome plays a crucial role in forming root diffusion barriers and maintaining plant mineral nutrient balance. Furthermore, the observation of a T3SS (S9 Table) is consistent with previous findings in Paraburkholderia genomes and has been shown to play a role in root colonization and virulence. Future studies should investigate the role of T3SS in the dominance of Paraburkholderia sp. OAS925 in SynCom17 treatments and the associated plant biomass decrease. Additionally, future testing of the effects of Paraburkholderia sp. OAS925 and other dominant isolates on plant growth can provide additional insights into the extent that the observed growth effects are indeed a direct result of a single strain.
+
+By organizing this ring trial, we learned valuable lessons that can be useful for future studies (Fig 5). First, it is important to perform pilot studies to optimize methods before initiating any multi-laboratory study. Long-distance sample and inoculum shipping posed challenges, especially given unpredictable long delays in customs and potential thawing due to dry ice sublimation. Microorganism shipments require engagement with shippers and familiarity with country-specific import/export legal regulations. We also observed variability in plant biomass (Fig 2b), which could be attributed to differences, especially in light and temperature (S2 Fig) between the growth chambers used in each laboratory (S1 Table). Additionally, standardization of the scanner model for automated root system analysis could help reduce variability and improve reproducibility. Ideally, the same equipment would be used, with a real-time readout of environmental conditions, although this would significantly increase the cost of the study.
+
+Framework for conducting reproducible multi-lab microbiome studies.
+
+This figure summarizes key factors and lessons for standardizing microbiome experiments. It highlights the essential elements for organizing reproducible studies and offers insights into the organization of future microbiome multi-lab studies.
+
+Despite our detailed protocols and annotated videos, several challenges remain to replicate microbiome studies, underscoring the importance of using the data from this study to benchmark future studies. We recommend using the comment section on protocols.io for ongoing refinement and clarification, allowing the procedure to evolve as a living document. To provide FAIR (Findable, Accessible, Interoperable, and Reusable) data access and enable others to use these data for benchmarking, integration, and extension, all data from this study are available via the National Microbiome Data Collaborative (NMDC) project page (https://data.microbiomedata.org/details/study/nmdc:sty-11-ev70y104). The EcoFAB 2.0 devices (up to 50 pieces), B. distachyon Bd21-3 plant line, and metabolomics methods used in this study are currently freely available to domestic and international researchers via Joint Genome Institute (JGI) User Programs (https://jgi.doe.gov/), subject to a competitive scientific review process. The 16S rRNA sequencing is readily available via commercial and academic sequencing centers. Although the relative abundance of organisms should ideally not correlate with the sequencing facility, sample handling, DNA extraction, and bioinformatics can significantly impact results, underscoring the need to consider protocols when making comparisons. Another challenge we see is that the strains of our SynCom are currently available as individual strains, so batch variation would be reduced if culture collections or private companies provided ready-to-use SynCom mixtures.
+
+This study demonstrates that multiple geographically dispersed laboratories can reproduce SynCom-driven changes in plant phenotypes, community assembly, and exometabolite profiles. This was a challenging yet essential step in the vision outlined by Zengler and colleagues to verify the reproducibility of experimental systems and protocols, which enable scientists to replicate and build on each other’s work. We see several ways these methods can help advance the field: first, scientists can replicate the study and compare their results against those reported here before extending the findings with additional modifications (e.g., adding phages, fungi, engineered strains, different hosts, new devices, etc.). Second, scientists can generate experimental data through replication and benchmarking, enabling integrative computational analyses that control laboratory-specific effects. Providing FAIR data and accompanying metadata and protocols, as done here, will be an essential step in achieving this vision. Such efforts would greatly enhance the application of machine learning to make generalizable discoveries drawn from multiple studies, ultimately leading to understanding microbial processes in complex natural environments.
+
+4. Materials and methods
+
+4.1. Preparation of synthetic bacterial communities
+
+The bacterial isolates originate from the switchgrass rhizosphere and are available at DSMZ as individual strains or as a collection (DSM 200000SY, inquire at contact@dsmz.de). Glycerol stocks had their 16S gene (27F - 1492R) sequenced to confirm isolate identity and purity. Each verified isolate was streaked on a preferred medium (S2 Table), and a single colony was inoculated into liquid culture. After 2–8 days at 27 °C, cultures were centrifuged at 5,000 g and washed with ½ Murashige and Skoog (MS) basal salts medium. The washed cultures were used to create SynComs by measuring OD600, converting to CFU, and combining them to 2e7 cells/ml each (1:1 ratio) in 20% glycerol for cryopreservation. We used SynComs composed of equal numbers of cells for the constituent strains, which is a widely used approach. A 20% glycerol in ½ MS basal salts was a mock solution. Solutions were aliquoted (100 µL) in microcentrifuge tubes and stored at −80 °C. The participants diluted the solutions 100-fold, assuming 50% cell survival during freezing-thawing, resulting in a final theoretical CFU of 1e5/plant. Serial dilution established the OD600 to CFU conversions, and a hemocytometer was used to measure Gottfriedia sp. OAE603.
+
+The inoculums were distributed to five participants: Lawrence Berkeley National Laboratory (LBNL), USA (organizer); the University of Melbourne, Australia; the University of North Carolina at Chapel Hill, USA; Forschungszentrum Jülich, Germany; and the Max Planck Institute for Plant Breeding Research, Germany. Empty tubes were shipped first to estimate speed, dry ice sublimation, and select vendors. Shipments included content declaration, receiver cover letter, and country-specific permits. Identifying the closest phylogenetic species for each isolate helped avoid customs delays. Shipments to Germany were classified as biosafety level 1 (BSL1) and sent via FedEx International Priority with 8.2 kg of dry ice as a delivered-at-place with a proforma invoice detailing freight charges and goods value. The SynCom import to Australia required a permit for conditionally non-prohibited goods under the Biosecurity Act 2015 Section 179 (1) and was sent via Aeronet Worldwide with 22.68 kg of dry ice, which was refilled during the 9-day transit. The shipment to North Carolina used FedEx Standard Overnight with 9 kg of dry ice.
+
+4.2. Experimental setup and plant growth conditions
+
+Participating laboratories assembled EcoFAB 2.0 devices and followed the experimental protocol (https://dx.doi.org/10.17504/protocols.io.kxygxyydkl8j/v1). In summary, B. distachyon Bd21-3 seeds were surface-sterilized, plated on ½ MS basal salts with 1.5% phytoagar, and stratified for 3 days at 4 °C. The plates were then moved to the growth chamber with a 14 h photoperiod (16 h for lab C) at 26 °C and 10 h dark at 20 °C with photosynthetic photon flux density (PPFD) at 110–140 µmol/m2/s and 70% humidity if tunable. Each lab used two data loggers (HOBO MX2202 and UA-002-64) to track illuminance in lux normalized to maximum value per lab (for dark duration confirmation) and temperature. After 3 days, germinated seeds were transferred to sterile EcoFAB 2.0 devices with 9 mL of ½ MS basal salts (pH 5.5–6.0) and placed back in the chamber. After 4 days, plants were inoculated with Mock, SynCom16, or SynCom17, resuspended from 100 µL stocks to 10 ml using sterile ½ MS basal salts. Each EcoFAB 2.0 device received 1 ml of inoculum, resulting in a glycerol concentration of 0.02% in 10 ml of hydroponic medium. The treatment groups included: i) Mock-inoculated axenic plant control, ii) SynCom16-inoculated plants, iii) SynCom17-inoculated plants, and iv) Mock-inoculated technical control (plant-free). The sterility of the uninoculated devices was tested at 0 and 22 DAI by incubating hydroponic medium on LB agar plates for 22 days. Evaporated water was re-supplied and roots imaged by scanning every seven days. Some laboratories shifted their root imaging timepoints based on scanner availability. Plant harvest and sampling happened at 22 DAI.
+
+4.3. Root phenotyping
+
+To automate root analysis from flatbed scanner images, we used RhizoNet, a workflow for precise root segmentation, ideal for tangled roots in EcoFAB 2.0 devices. Lab A’s scans faced issues with condensation and reflections, causing low contrast; thus, SmartRoot V4.21 was used instead. The raw root measurements from both methods were normalized to the maximum value for each lab.
+
+4.4. Samples collection and shipment
+
+Sample collection and initial processing were performed independently in each lab. We collected 50 µL of the unfiltered growth medium for amplicon sequencing. The remaining spent medium was filtered via a 0.2 µm PES filter for metabolomic analysis, collected in polypropylene tubes (lab A: VWR 21008-103, labs B–E: VWR 93000-026) and stored at −80 °C before shipment. The root and shoot were separated during plant harvest, fresh weights were measured, roots were frozen for microbiome analysis by amplicon sequencing, and shoots were lyophilized for dry weight measurement. The filtered medium, unfiltered medium, and frozen roots were shipped to LBNL on dry ice with gel packs. The loggers were shipped separately at room temperature. To import intact frozen B. distachyon roots to the USA required a Controlled Import Permit (PPQ Form 588), supplier declaration, and TSCA Certification. Samples from Germany were shipped via DHL Medical Express (2 days) on 10 kg of dry ice, from Australia via Cryopdp (5 days) on 24 kg dry ice with a refill request, and from North Carolina via FedEx Priority Overnight on 9 kg dry ice (1 day).
+
+4.5. Analysis of rhizosphere metabolites
+
+At the LBNL, hydroponic medium samples were lyophilized (Labconco, Kansas City, MO). Empty tubes were used as extraction controls. During extraction, samples were kept on dry ice, and Solvents were chilled at −20 °C. The dried material was suspended in 1mL methanol (MX0486, Sigma), vortexed, and transferred to a microcentrifuge tube, followed by residue collection with an additional 0.5mL methanol. Samples were then sonicated (97043-944, VWR) in ice water for 15 min, centrifuged at 10,000g for 5 min at 10 °C, and supernatants transferred to new tubes. Supernatants were dried overnight by vacuum concentration (SpeedVac, Thermo). The following morning, samples were resuspended in 150 µL methanol containing internal standard mix (S5 Table), vortexed, and centrifuged at 10,000g for 5 min at 10 °C. Supernatants were filtered with 0.22 µm PVDF filters (UFC30GV, Millipore), transferred to amber glass vials with inserts (5,188−6,592, Agilent), and sealed with screw caps (5,185−5,820, Agilent). Samples were analyzed by LC-MS/MS, with polar metabolites separation using hydrophilic liquid interaction chromatography (column 683775-924, Agilent) on an Agilent 1290 HPLC system, followed by detection in positive ion mode on a Thermo Orbitrap Exploris 120 Mass Spectrometer (S5 Table). Samples were injected in positive mode, with methanol blanks between each sample; internal and external controls were used for quality control.
+
+For untargeted metabolomics, the mzML files were processed via MZMine 3.0 to create a feature list using a custom batch process (S1 File). The features with MS2 spectrum were then annotated in GNPS2 using spectral metabolite libraries. Features with MS2, retention time (RT) > 0.6 min, and exudate sample max peak height >10× of extraction and technical controls were included, resulting in 833 features across all samples and labs. For targeted metabolomics, metabolites were identified (S6 Table) by analyzing the data with an in-house library of m/z, RT, and MS2 fragmentation information from authentic reference standards using Metabolite Atlas (https://github.com/biorack/metatlas). Only metabolites with a maximum exudate sample peak height >3× of extraction and technical controls were included. The identified metabolites were manually classified using the PubChem Classification Browser (https://pubchem.ncbi.nlm.nih.gov/classification/).
+
+4.6. Microbiome analysis by amplicon sequencing
+
+DNA was extracted from ground roots and media using the DNeasy PowerSoil Pro Kit (Qiagen), following the manufacturer’s instructions with minor modifications. Ground roots were mixed with a resuspension buffer, transferred to bead-beating tubes, and frozen at −80 °C. Samples were then thawed at 60 °C and bead-beaten using the FastPrep-24 system for 30 s at setting 5.0 (MP Biomedicals). The elution buffer pre-heated to 60 °C. Samples were extracted in batches with water-only samples as negative process controls. Glycerol stocks for 16- and 17-SynCom and a glycerol-only mock were included for time-zero data.
+
+PCR amplification of V4 amplicons was performed in two steps. Library amplicons were generated using the Illumina i7 and i5 index/adapter sequences with V4 primers 515F (Parada) (GTGYCAGCMGCCGCGGTAA) and 806R (Apprill) (GGACTACNVGGGTWTCTAAT). Amplification used pooled primers on a Bio-RAD CFX 384 Real-Time PCR system with QuantiNova SYBR Green PCR kit (Qiagen) in 10 µL reactions with primers at 4 µM and mitochondrial and chloroplast PNA blockers (PNA Bio) at 1.25 µM. Amplification was initiated at 95 °C for 3 min, followed by the cycle: 95 °C for 8 s, 78 °C for 10 s, 54 °C for 5 s, and 60 °C for 30 s, followed by fluorescence measurement. Root samples were amplified for 22 cycles and media samples for 30 cycles with at least 1 replicate. To allow direct comparison, the SynCom16 and SynCom17 inocula were each amplified for both 22 and 30 PCR cycles, mirroring the amplification conditions used for root and media samples, respectively. Libraries were purified at least twice to remove excess primers using the Mag-Bind TotalPure NGS beads (0.8×), and targets were quantified using the QuantiFluor dsDNA System (Promega). Libraries were then pooled (i.e., root and media samples separately) and purified again. The concentration of the pooled library was determined using the Qubit dsDNA Assay Kit (BR or HS, Invitrogen). The flowcell was sequenced on the Illumina MiSeq sequencer using MiSeq Reagent kits, V3 (600-cycle), following a 2 × 00 indexed run recipe. MiSeq reads were processed using Usearch (v11.0.667). Reads were merged, trimmed, and short sequences removed using the ‘fastq_mergepairs, fastx_truncate, and fastq_filter’ commands. An initial OTU table was generated with the ‘fastx_uniques, cluster_otus, and otutab’ functions, and OTUs were assigned to SynCom members using the ‘annot’ function with V4 reference sequences. The three samples with the most unknown reads were analyzed via NCBI Microbial Nucleotide BLAST with Representative Genomes database and MegaBLAST algorithm to identify potential matches. The relative abundance of each SynCom member was calculated as the proportion of total microbial reads (excluding plant reads) per sample.
+
+4.7. Growth and biofilm formation assays for bacterial isolates
+
+Lab A conducted the biofilm formation assays. The crystal violet assay for biofilm formation was modified from a previous method. Isolates were grown in R2A, washed, and resuspended in a 30 mM phosphate buffer. They were inoculated into the plates with NLDM medium at a 1:10 (v/v) ratio (final volume of 100 µL and initial OD600 of 0.02) and incubated statically at 30 °C for 3 days (n = 4–5) and growth was measured at OD600. After incubation, wells were washed 3× with MilliQ water, air-dried, and stained with 125 µL of crystal violet solution (0.1% v/v crystal violet, 1% v/v methanol, and 1% v/v isopropanol in Milli-Q water) for 30 min at RT. Wells were rinsed 3× with MilliQ water, destained with 125 µL of 30% acetic acid for 30–60 min at RT, and absorbance at 550 nm (OD550) of the destaining solution was measured.
+
+4.8. Genomic analysis of bacterial isolates
+
+All isolates were grown in R2A except Bradyrhizobium sp. OAE829, which was grown in 1/10 R2A. High molecular weight genomic DNA was extracted from bacterial pellets with the Monarch HMW DNA Extraction Kit (New England Biolabs) or the MasterPure Complete DNA Purification Kit (Lucigen). The genomic DNA was submitted to the JGI for sequencing using PacBio Sequel II or Illumina NovaSeq S4. Genomes were stored in the Genomes OnLine Database (GOLD), followed by submission to the Integrated Microbial Genomes and Microbiomes (IMG/M) (https://img.jgi.doe.gov/) for annotation. The annotated genomes can be accessed via Hugging Face (https://doi.org/10.57967/hf/5885) or IMG/M under the listed Taxon ID or GOLD Project ID (S2 Table): Arthrobacter sp. OAP107 (2931867202, Gp0588953), Gottfriedia sp. OAE603 (2931797537, Gp0588949, formerly known as Bacillus sp. OAE603), Bosea sp. OAE506 (2931782253, Gp0589672), Bradyrhizobium sp. OAE829 (2931808876, Gp0589676), Brevibacillus sp. OAP136 (2931855177, Gp0588951), Paraburkholderia sp. OAS925 (2931840637, Gp0589681, formerly known as Burkholderia sp. OAS925), Chitinophaga sp. OAE865 (2931817136, Gp0589677), Lysobacter sp. OAE881 (2931823763, Gp0589678), Marmoricola sp. OAE513 (2931787146, Gp0589673), Methylobacterium sp. OAE515 (2931791092, Gp0589674), Mucilaginibacter sp. OAE612 (2931861231, Gp0588952), Mycobacterium sp. OAE908 (2852593896, Gp0440934), Niastella sp. OAS944 (2931847253, Gp0589682), Paenibacillus sp. OAE614 (2931801854, Gp0589675), Rhizobium sp. OAE497 (2931775946, Gp0589671), Rhodococcus sp. OAS809 (2931833612, Gp0589680), Variovorax sp. OAS795 (2931827682, Gp0588950).
+
+Comparative genomics was conducted using genome statistics and KEGG pathways protein-coding gene abundance from IMG/M. Based on the genes involved in acid resistance of Escherichia coli, including Glutamine/Glutamate and Arginine membrane transporters (GadC and AdiC), glutaminase (YbaS), and decarboxylases (GadA, GadB, and AdiA), we searched for genes annotated with similar functions (GltIJKL, HisPMQ-ArgT, GlnHPQ, glsA, GAD, AdiA). KEGG module coverage was compared between Paraburkholderia sp. OAS925 and the other 16 genomes using the “Statistical Analysis” tool from IMG using Fisher’s exact test and modules with a corrected p-value <10−05 were manually inspected for a potential link to plant root colonization.
+
+A phylogenomic tree of the 17 SynCom members was constructed using the GTDB-tk workflow, incorporating 120 marker proteins for multiple sequence alignment. Fasttree generated the tree, which included two closely related genomes for context, and it was visualized with Interactive Tree Of Life (iTOL). The phylum-level taxonomic classification is indicated for each member. Bootstrap values, derived from 100 replicates, are displayed for nodes with over 50 bootstrap support values. Chloroflexus aggregans served as an outgroup to root the tree.
+
+4.9. Fluorescent microscopy
+
+Lab A conducted the plant growth and microscopy. The pGinger plasmid 23100 containing the RFP gene under the kanamycin (Kan) resistance marker was introduced into Paraburkholderia sp. OAS925, as described previously. Briefly, 1mL of Paraburkholderia sp. OAS925 grown overnight at 30 °C in R2A medium was mixed with 1 mL of E. coli S17 dapE-harboring the pGinger plasmid grown overnight at 37 °C on LB medium with Kan at 50 µg/mL and diaminopimelic acid (DAP) at 300 µM. The mixture was pelleted for 1 min at 10,000g and then resuspended in 100 µL water with 300 µM DAP. This mixture was then placed onto an R2A agar plate and incubated overnight at 30 °C. The bacterial mix was then scraped, resuspended in water, and plated on R2A with Kan 50 µg/mL. Transconjugants were verified via fluorescent microscopy and colony PCR.
+
+The Paraburkholderia sp. OAS925 expressing RFP was grown overnight in 7 mL of R2A medium with Kan 20 mg/L, shaken at 200 rpm at 27 °C. The cells were pelleted by centrifugation at 4,000g for 10 min, resuspended in ½ MS basal salts, and used to inoculate 3-day-old plants in EcoFABs 2.0 at a starting OD600 of 0.01. A flatbed scanner captured root architecture to indicate microscopy locations at 1 and 3 DAI. The EVOS M5000 imaging system (Thermo Fisher) was used for inverted microscopy, merging txRED and bright-field images. Uninoculated plants served as controls for autofluorescence.
+
+4.10. Motility assays
+
+Lab A conducted the motility assays. Pre-cultures were grown in 8 ml of liquid medium shaken at 200 rpm, at 27 °C in the dark, for 5–8 days. The swimming motility was tested by observing colony spreading on R2A soft agar plates (0.3% w/v). Initially, motility was tested for all 17 isolates at pH 7.2. Then, Paraburkholderia, Gottfriedia, or Brevibacillus were tested at pH 4, 5, 6, 7, 8, or 9 (adjusted with 1M HCl or 0.5M NaOH). Each 10 cm Petri dish containing 30 ml of solidified medium was inoculated with 5 µL of culture at the center (n = 3). Plates were incubated at 27 °C in the dark, and the motility ring diameter was measured after 24 and 45 h.
+
+4.11. Data management, statistical analyses, software, and data visualization
+
+The participating laboratories uploaded plant biomass data, root scans, and photos into a shared Google folder with structured directories and spreadsheets. The heat maps were generated with RStudio version 4.0.5 using heatmap.2 in the ggplots package. The NMDS plots were also generated in RStudio using vegan package version 2.5-7. GraphPad Prism 10 version 10.2.3 generated all other plots and statistical analyses. Biorender.com was used to create graphical overviews. Microsoft Excel version 16.78.3 was used to store and manipulate data frames.
+
+Statistical analysis of cross-laboratory variation included a two-way ANOVA by measuring significance of main effects and their interactions, calculation of source of variation as sum of squares of main effects and total sum of squares, and CV that was measured as a ratio between the standard deviation σ to the mean μ. The statistical analysis was applied to microbe abundance data from 16S rRNA sequencing and raw peak heights for 60 identified rhizosphere metabolites. Additionally, metabolite intensities were also analyzed by pairwise comparisons. The ANOVA and pairwise tests were done in Python v 3.8 using the Pingouin package version 0.5.5. The default ANOVA command was used between lab and treatment. The default pairwise tests command was used between lab and treatment with a p-value adjustment of Benjamini/Hochberg FDR correction. The code can be found at https://doi.org/10.6084/m9.figshare.29700029.
+
+Supporting information
+
+Abbreviations
+
+:
+
+ANOVA
+
+analysis of variation
+
+CFU
+
+colony-forming unit
+
+CV
+
+coefficient of variation
+
+DAI
+
+days after inoculation
+
+DAP
+
+diaminopimelic acid
+
+DSMZ
+
+Leibniz-Institute DSMZ-German Collection of Microorganisms and Cell Cultures
+
+EcoFAB
+
+fabricated ecosystem
+
+IMG/M
+
+Integrated Microbial Genomes and Microbiomes
+
+KEGG
+
+Kyoto Encyclopedia of Genes and Genomes
+
+LB
+
+Luria–Bertani
+
+LBNL
+
+Lawrence Berkeley National Laboratory
+
+LC-MS/MS
+
+liquid chromatography-tandem mass spectrometry
+
+MS
+
+Murashige and Skoog
+
+NMDC
+
+National Microbiome Data Collaborative
+
+NMDS
+
+Non-metric Multidimensional Scaling
+
+OD600
+
+optical density at 600 nm
+
+OTU
+
+operational taxonomic unit
+
+RFP
+
+red fluorescent protein
+
+RT
+
+retention time
+
+SynCom
+
+synthetic community
+
+T3SS
+
+Type 3 Secretion System
+
+References
+
+EcoFABs: advancing microbiome science through standardized fabricated ecosystems
+
+We have a community problem
+
+Establishing causality: opportunities of synthetic communities for plant microbiome research
+
+From microbial dynamics to functionality in the rhizosphere: a systematic review of the opportunities with synthetic microbial communities
+
+Coordination between microbiota and root endodermis supports plant mineral nutrient homeostasis
+
+A single bacterial genus maintains root growth in a complex microbiome
+
+The importance of the microbiome of the plant holobiont
+
+Community standards and future opportunities for synthetic communities in plant-microbiota research
+
+A reproducible and tunable synthetic soil microbial community provides new insights into microbial ecology
+
+Multilab EcoFAB study shows highly reproducible physiology and depletion of soil metabolites by a model grass
+
+Impact of inoculation practices on microbiota assembly and community stability in a fabricated ecosystem
+
+Reproducible growth of Brachypodium in EcoFAB 2.0 reveals that nitrogen form and starvation modulate root exudation
+
+The potential of handheld near infrared spectroscopy to detect food adulteration: results of a global, multi-instrument inter-laboratory study
+
+The International Harmonized Protocol for the proficiency testing of analytical chemistry laboratories (IUPAC Technical Report)
+
+Dynamic root exudate chemistry and microbial substrate preferences drive patterns in rhizosphere microbial community assembly
+
+Rhizosphere microbiome mediates systemic root metabolite exudation by root-to-root signaling
+
+Responses of extracellular enzymes to simple and complex nutrient inputs
+
+A defined medium for cultivation and exometabolite profiling of soil bacteria
+
+Identifying and overcoming threats to reproducibility, replicability, robustness, and generalizability in microbiome research
+
+Complexity of dopamine metabolism
+
+Dopamine autoxidation is controlled by acidic pH
+
+Niche differentiation is spatially and temporally regulated in the rhizosphere
+
+Embracing the unknown: disentangling the complexities of the soil microbiome
+
+Priority effects in microbiome assembly
+
+Synthetic microbiota reveal priority effects and keystone strains in the Arabidopsis phyllosphere
+
+Rhizosphere size and shape: temporal dynamics and spatial stationarity
+
+L-glutamine provides acid resistance for Escherichia coli through enzymatic release of ammonia
+
+Effect of intracellular pH on rotational speed of bacterial flagellar motors
+
+Genome-wide identification of bacterial plant colonization genes
+
+Dry ice sublimation performance as affected by binding agent, density, and age
+
+Protocols.io: virtual communities for protocol development and discussion
+
+The National Microbiome Data Collaborative Data Portal: an integrated multi-omics microbiome data resource
+
+Assessment of variation in microbial community amplicon sequencing by the Microbiome Quality Control (MBQC) project consortium
+
+Root microbiota drive direct integration of phosphate stress and immunity
+
+Microbial interkingdom interactions in roots promote Arabidopsis survival
+
+RhizoNet segments plant roots to assess biomass and growth for enabling self-driving labs
+
+A novel image-analysis toolbox enabling quantitative analysis of root system architecture
+
+Integrative analysis of multimodal mass spectrometry data in MZmine 3
+
+Sharing and community curation of mass spectrometry data with Global Natural Products Social Molecular Networking
+
+Dealing with the unknown: metabolomics and metabolite atlases
+
+Standardized multi-omics of Earth’s microbiomes reveals microbial and metabolite diversity
+
+Search and clustering orders of magnitude faster than BLAST
+
+Microtiter plate assays to assess antibiofilm activity against bacteria
+
+Twenty-five years of Genomes OnLine Database (GOLD): data updates and new features in v.9
+
+The IMG/M data management and analysis system v.7: content updates and new features
+
+The IMG/M data management and analysis system v.6.0: new tools and advanced capabilities
+
+GTDB: an ongoing census of bacterial and archaeal diversity through a phylogenetically consistent, rank normalized and complete genome-based taxonomy
+
+FastTree 2—approximately maximum-likelihood trees for large alignments
+
+Interactive Tree Of Life (iTOL) v5: an online tool for phylogenetic tree display and annotation
+
+The pGinger family of expression plasmids
+
+Warnes GR, Bolker B, Bonebakker L, Gentleman R, Huber W, Liaw A, et al. gplots: Various R Programming Tools for Plotting Data. R package version 3.1.3.1. 2024 [cited 31 Mar 2024]. Available from: https://CRAN.R-project.org/package=gplots
+
+Oksanen J, Blanchet FG, Friendly M, Kindt R, Legendre P, McGlinn D, et al. vegan: Community Ecology Package. 2020. Available from: http://CRAN.R-project.org/package=vegan
+
+10.1371/journal.pbio.3003358.r001
+
+Decision Letter 0
+
+Vazquez Hernandez
+
+Melissa
+
+This is an open access article distributed under the terms of the Creative Commons Attribution License , which permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited.
+
+17 Jan 2025
+
+Dear Trent,
+
+Thank you for submitting your manuscript entitled "Multi-laboratory Study Establishes Reproducible Methods for Plant-Microbiome Research in Fabricated Ecosystems" for consideration as a Methods and Resources by PLOS Biology.
+
+Your manuscript has now been evaluated by the PLOS Biology editorial staff, as well as by an academic editor with relevant expertise, and I am writing to let you know that we would like to send your submission out for external peer review. We would like to suggest to change the type of article to Meta-Research Article since we think might fit better. Meta-Research Articles examine how biological research is designed, carried out, communicated and evaluated; We welcome both exploratory and confirmatory research that has the potential to drive change in research and evaluation practices in the life sciences and beyond.
+
+However, before we can send your manuscript to reviewers, we need you to complete your submission by providing the metadata that is required for full assessment. To this end, please login to Editorial Manager where you will find the paper in the 'Submissions Needing Revisions' folder on your homepage. Please click 'Revise Submission' from the Action Links and complete all additional questions in the submission questionnaire. If you agree with the change in Article type, please, when adding the rest of the metadata choose "Meta-Research Article".
+
+Once your full submission is complete, your paper will undergo a series of checks in preparation for peer review. After your manuscript has passed the checks it will be sent out for review. To provide the metadata for your submission, please Login to Editorial Manager (https://www.editorialmanager.com/pbiology) within two working days, i.e. by Jan 19 2025 11:59PM.
+
+If your manuscript has been previously peer-reviewed at another journal, PLOS Biology is willing to work with those reviews in order to avoid re-starting the process. Submission of the previous reviews is entirely optional and our ability to use them effectively will depend on the willingness of the previous journal to confirm the content of the reports and share the reviewer identities. Please note that we reserve the right to invite additional reviewers if we consider that additional/independent reviewers are needed, although we aim to avoid this as far as possible. In our experience, working with previous reviews does save time.
+
+If you would like us to consider previous reviewer reports, please edit your cover letter to let us know and include the name of the journal where the work was previously considered and the manuscript ID it was given. In addition, please upload a response to the reviews as a 'Prior Peer Review' file type, which should include the reports in full and a point-by-point reply detailing how you have or plan to address the reviewers' concerns.
+
+During the process of completing your manuscript submission, you will be invited to opt-in to posting your pre-review manuscript as a bioRxiv preprint. Visit http://journals.plos.org/plosbiology/s/preprints for full details. If you consent to posting your current manuscript as a preprint, please upload a single Preprint PDF.
+
+Feel free to email us at plosbiology@plos.org if you have any queries relating to your submission.
+
+Have a nice weekend,
+
+Melissa
+
+Melissa Vazquez Hernandez, Ph.D.
+
+Associate Editor
+
+PLOS Biology
+
+mvazquezhernandez@plos.org
+
+10.1371/journal.pbio.3003358.r002
+
+Decision Letter 1
+
+Vazquez Hernandez
+
+Melissa
+
+This is an open access article distributed under the terms of the Creative Commons Attribution License , which permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited.
+
+26 Mar 2025
+
+Dear Trent,
+
+Thank you for your patience while your manuscript "Multi-laboratory Study Establishes Reproducible Methods for Plant-Microbiome Research in Fabricated Ecosystems" was peer-reviewed at PLOS Biology. It has now been evaluated by the PLOS Biology editors, an Academic Editor with relevant expertise, and by two independent reviewers. First of all I would like to apologize for the extremely long delay on giving you a decision, this is really out of the normal.
+
+In light of the reviews, which you will find at the end of this email, we would like to invite you to revise the work to thoroughly address the reviewers' reports. As you will see below, the reviewers are positive about the relevance and novelty of the study, yet some concerns have raised during revision. Reviewer 1 mentions that you might be missing additional analysis on the differences that exist between the labs. The reviewer suggests to model microbiome data including the lab as a factor, consider how uneven the inoculum seems to be, and clarify several points on their experiments. While most of the comments from Reviewer 2 could be addressed with further discussion and clarification in the text, the reviewer mentions that perhaps you should re-do the experiments to ensure absence of contamination. Additionally, the reviewer mentions some experiments to answer e.g. how does a single strain Paraburkholderia sp. OAS925 affects B. distachyon growth.
+
+IMPORTANT: after discussion with the Academic Editor and the reviewers, while we think reanalysis of the data might be necessary, we do not expect that you re-do any experiment as contamination tends to be a reality in such studies.
+
+Given the extent of revision needed, we cannot make a decision about publication until we have seen the revised manuscript and your response to the reviewers' comments. Your revised manuscript is likely to be sent for further evaluation by all or a subset of the reviewers.
+
+In addition to these revisions, you will need to complete some formatting changes, which you will receive in a follow up email. A member of our team will be in touch with a set of requests shortly.
+
+We expect to receive your revised manuscript within 3 months. Please email us (plosbiology@plos.org) if you have any questions or concerns, or would like to request an extension.
+
+At this stage, your manuscript remains formally under active consideration at our journal; please notify us by email if you do not intend to submit a revision so that we may withdraw it.
+
+**IMPORTANT - SUBMITTING YOUR REVISION**
+
+Your revisions should address the specific points made by each reviewer. Please submit the following files along with your revised manuscript:
+
+1. A 'Response to Reviewers' file - this should detail your responses to the editorial requests, present a point-by-point response to all of the reviewers' comments, and indicate the changes made to the manuscript.
+
+*NOTE: In your point-by-point response to the reviewers, please provide the full context of each review. Do not selectively quote paragraphs or sentences to reply to. The entire set of reviewer comments should be present in full and each specific point should be responded to individually, point by point.
+
+You should also cite any additional relevant literature that has been published since the original submission and mention any additional citations in your response.
+
+2. In addition to a clean copy of the manuscript, please also upload a 'track-changes' version of your manuscript that specifies the edits made. This should be uploaded as a "Revised Article with Changes Highlighted" file type.
+
+*Re-submission Checklist*
+
+When you are ready to resubmit your revised manuscript, please refer to this re-submission checklist: https://plos.io/Biology_Checklist
+
+To submit a revised version of your manuscript, please go to https://www.editorialmanager.com/pbiology/ and log in as an Author. Click the link labelled 'Submissions Needing Revision' where you will find your submission record.
+
+Please make sure to read the following important policies and guidelines while preparing your revision:
+
+*Published Peer Review*
+
+Please note while forming your response, if your article is accepted, you may have the opportunity to make the peer review history publicly available. The record will include editor decision letters (with reviews) and your responses to reviewer comments. If eligible, we will contact you to opt in or out. Please see here for more details:
+
+https://blogs.plos.org/plos/2019/05/plos-journals-now-open-for-published-peer-review/
+
+*PLOS Data Policy*
+
+Please note that as a condition of publication PLOS' data policy (http://journals.plos.org/plosbiology/s/data-availability) requires that you make available all data used to draw the conclusions arrived at in your manuscript. If you have not already done so, you must include any data used in your manuscript either in appropriate repositories, within the body of the manuscript, or as supporting information (N.B. this includes any numerical values that were used to generate graphs, histograms etc.). For an example see here: http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1001908#s5
+
+*Blot and Gel Data Policy*
+
+We require the original, uncropped and minimally adjusted images supporting all blot and gel results reported in an article's figures or Supporting Information files. We will require these files before a manuscript can be accepted so please prepare them now, if you have not already uploaded them. Please carefully read our guidelines for how to prepare and upload this data: https://journals.plos.org/plosbiology/s/figures#loc-blot-and-gel-reporting-requirements
+
+*Protocols deposition*
+
+To enhance the reproducibility of your results, we recommend that if applicable you deposit your laboratory protocols in protocols.io, where a protocol can be assigned its own identifier (DOI) such that it can be cited independently in the future. Additionally, PLOS ONE offers an option for publishing peer-reviewed Lab Protocol articles, which describe protocols hosted on protocols.io. Read more information on sharing protocols at https://plos.org/protocols?utm_medium=editorial-email&utm_source=authorletters&utm_campaign=protocols
+
+Thank you again for your submission to our journal. We hope that our editorial process has been constructive thus far, and we welcome your feedback at any time. Please don't hesitate to contact us if you have any questions or comments.
+
+Sincerely,
+
+Melissa
+
+Melissa Vazquez Hernandez, Ph.D.
+
+Associate Editor
+
+PLOS Biology
+
+mvazquezhernandez@plos.org
+
+------------------------------------
+
+REVIEWERS' COMMENTS:
+
+------------------------------------
+
+Reviewer #1:
+
+This manuscript addresses the important and rarely-investigated issue of replicability of results between labs, specifically applied here to microbiome research. The organizers got together 5 participating labs and distributed an axenic growth chamber, pre-mixed microbial communities, plant seeds, and specific instructions to attempt to reproduce the same experiment as faithfully as possible. Much, but not all, of the experiment replicated. The paper is interesting, but should do some additional analyses on the results, particularly related to the differences that do exist between labs. The authors focused mainly on how Paraburkholderia completely overtook the community in all labs. To some extent, the detailed look at Paraburkholderia feels like a bit of a distraction from the main interesting points about reproducibility, because it is SOOO dominant. Focusing on this obscures other instructive differences, which I think should be more central. More specific comments follow, not in any particular order.
+
+>> The authors should model microbiome data including lab as a factor. How much of the variation in community in SynCom 16 is due to lab? How much remains unexplained? For community 17, after removing Paraburkholderia reads, what is left? There are unsatisfyingly few stats.
+
+>> A couple things are curious about the inoculum. First, it appears quite uneven - I suppose the 16 or 17 members were intended to be mixed quite evenly. Can this be further explained? Second, the inoculum seems to bear nearly no resemblance to the ultimate community. Even Paraburkholderia seems not to be present in any substantial amount in the inoculum. Can the authors please present a table of percentages (in supplemental would be OK) that lists the median % of each community member in the inoculum and also in the ultimate community?
+
+>>Related to the inoculum, it is odd that the inoculum in Figure 3 (plants) appears different than the inoculum in figure S3 (media). Were the media and plant inoculations NOT done simultaneously, such that independent inocula batches were thawed for the media?
+
+>>Particularly the media in Fig. S3, there are visible bars of "unknown" sequences colored black. What is the diversity of "unknown" in this? For example, if the "unknown" is all the same thing, isn't that a clear case of contamination? And if it's a mix of different things, how to explain it?
+
+>> it is odd that the inoculum in Figure 3 (plants) appears different than the inoculum in figure S3 (media). Were the media and plant inoculations NOT done simultaneously, such that independent inocula batches were thawed for the media?
+
+>> For some analysis (eg microscopy) was done in the main host lab. I think it is worth identifying which of the labs that was. Those analysis could mention, for example, that microscropy was conducted on plants grown in Lab A.
+
+>> In Figure S1, each column (group of measurements of the same phenotype) should have the same Y axis so that the plots can be compared. And I think it's further preferable that columns and rows are switched, such that one can look across from left to right and see the shoot dry weight in each lab, for example.
+
+>>Likewise in Figure S2, the Y axes should be made comparable. The temperature side is OK, but the light levels are highly variable across labs and this should be immediately apparent looking at the graphs, but it's somewhat hidden due to the variable axes.
+
+>>Fig. 2A is confusing. The barplots look like this is a continuous distribution, but as I understand it, if a device was sterile, it gets a grey box, and if it's contaminated, it gets a black box. It would be clearer if the boxes were separated so they could be seen as discrete data points, or even I think it would be clearer if the Y axis showed # of contaminated boxes and most are 0 and those that got contaminated go to 1. For example. But it's confusing as is.
+
+>> in Fig 2C, there are some differences between the labs in terms of measurement times. Lab B took a measurement at 4 days? Lab E did 0 days but skipped 14 days? What happened here, a miscommunication or technical failure or something?
+
+>> Figure S4, putting each lab with a totally different NMDS2 plot is difficult (for me) to interpret. Is not it easier and more informative to simply use the combined lab plot to generate the spacings for the NMDS and simply erase the points from the other labs so that points from a single lab can be shown individually?
+
+>> In the methods, please include the min/max/median sequencing depth for the microbiome samples.
+
+>>Line 276.. the authors say the ecofab devices are "free". Surely this can't be true, or must have some limits. Please revise to clarify. It means free if one is part of a JGI user program? Is that limited to USA? Grant recipients of some form? Etc.
+
+------------------------------------
+
+Reviewer #2 (Mengcen Wang):
+
+This study addresses a critical challenge in microbiome research, inter-laboratory reproducibility, by assessing the consistency of synthetic community assembly experiments across multiple laboratories. The authors leverage ecosystems involving Brachypodium distachyon, two different synthetic bacterial communities, and sterile EcoFAB 2.0 devices, providing valuable insights into inoculum-dependent microbiome shifts and plant responses. While the study is generally well-structured and presents important findings, some areas require further clarification and improvement:
+
+1. It was indicated that the root system development was analyzed using RhizoNet (Lab B-E) and ImageJ (Lab A). Why did these five laboratories not standardize their analytical methods to minimize variability and improve reproducibility? Furthermore, it would be beneficial to include representative images of root systems.
+
+2. In line135-139, the uninoculated EcoFAB 2.0 sterility tests across laboratories A-E shown that the treatments of laboratory D in SynCom17 and laboratory B in medium-only control were contaminated. It would be more appropriate to redo the experiments to ensure the absence of contamination and further validate the reliability of the results.
+
+3. The SynCom17, which contained the dominating bacteria Paraburkholderia sp. OAS925 could reduce root growth of B. distachyon. How about the effects of the single strain Paraburkholderia sp. OAS925 on B. distachyon growth?
+
+4. L209-210 what does " its potential to outgrow competitors when cultured with common soil metabolites in the NLDM " mean?
+
+5. L226-L228, "This finding is consistent with a previous study showing Paraburkholderia sp. OAS925 dominance in the B. distachyon root and rhizosphere microbiota and decreased fresh root biomass." However, in Figure 2b, the shoot fresh weight (FW) of plants treated with both SynCom 16 and SynCom 17 was significantly reduced compared to axenic conditions. Moreover, no significant difference was observed between SynCom 16 and SynCom 17 treatments, suggesting that the SynCom 16 community, even without the addition of Paraburkholderia sp. OAS925, is sufficient to reduce shoot FW levels. Therefore, this does not conclusively demonstrate that the reduction in shoot FW under SynCom 17 treatment is specifically driven by Paraburkholderia sp. OAS925.
+
+6. In L303, the manuscript does not clearly explain the rationale behind the 1:1 ratio of strains in the SynComs. It is recommended to provide additional explanation to enhance the scientific rigor and credibility of the study.
+
+7. In L362, the authors indicate that the hydroponic medium sample was used as the root exudate for metabolomic analysis. But how did they rule out potential interference from bacterial metabolites in the medium?
+
+8. The colonization of bacteria in B. distachyon roots can be influenced by various external factors. The assessment of bacterial motility on liquid soft agar only reflects swimming ability in liquid culture media and does not provide definitive evidence that Paraburkholderia sp. OAS925 can outcompete other members during SynCom colonization.
+
+9. The analysis of microbial community and metabolome data is crucial for the research conclusions. However, it is not clear in the paper whether significance analysis was performed on this part of the data and what methods were used. If there is relevant analysis, please provide a complete description.
+
+10. It is recommended to present the analysis conclusions of some data in the supplementary information to enrich the content of the main text.
+
+10.1371/journal.pbio.3003358.r003
+
+Author response to Decision Letter 2
+
+23 Jun 2025
+
+10.1371/journal.pbio.3003358.r004
+
+Decision Letter 2
+
+Vazquez Hernandez
+
+Melissa
+
+This is an open access article distributed under the terms of the Creative Commons Attribution License , which permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited.
+
+25 Jul 2025
+
+Dear Trent,
+
+I hope you are doing great. Thank you for your patience while we considered your revised manuscript "Multi-laboratory Study Establishes Reproducible Methods for Plant-Microbiome Research in Fabricated Ecosystems" for publication as a Meta-Research Article at PLOS Biology. This revised version of your manuscript has been evaluated by the PLOS Biology editors, and the original reviewers.
+
+Based on the reviews, we are likely to accept this manuscript for publication, provided you satisfactorily address the remaining editorial points. Please be aware that Academic Editor was unavailable and there might be a possibility that they might have an additional request, which I would communicate with you if it were the case. Please make sure to address the following data and other policy-related requests.
+
+a) We routinely suggest changes to titles to ensure maximum accessibility for a broad, non-specialist readership, and to ensure they reflect the contents of the paper. In this case, we would suggest a minor edit to the title, as follows. Please ensure you change both the manuscript file and the online submission system, as they need to match for final acceptance:
+
+"Protocols, benchmarking datasets and best practices for reproducible research on plant-microbiome interactions"
+
+b) You may be aware of the PLOS Data Policy, which requires that all data be made available without restriction: http://journals.plos.org/plosbiology/s/data-availability. For more information, please also see this editorial: http://dx.doi.org/10.1371/journal.pbio.1001797
+
+Please supply the numerical values either in the a supplementary file or as a permanent DOI’d deposition for the following figures:
+
+Figure 2bc, 3, 4, S1, S2ab, S4ab, S5, S6bc, S7bcd, S8, S9, S11ac
+
+NOTE: the numerical data provided should include all replicates AND the way in which the plotted mean and errors were derived (it should not present only the mean/average values).
+
+*I am aware that there is some raw data in Figshare but it is not clear if it belongs to these figures. If this is the case, I need you to provide the necessary information to be able to replicate each figure. However, it might be easier to just provide an excel file with the raw data for each figure.
+
+c) Please cite the location of the data clearly in all relevant main and supplementary Figure legends, e.g. “The data underlying this Figure can be found in S1 Data” or “The data underlying this Figure can be found in https://doi.org/10.5281/zenodo.XXXXX”
+
+d) Could you please confirm that the repositories you used are publicly available?
+
+e) Please ensure that your Data Statement in the submission system accurately describes where your data can be found and is in final format, as it will be published as written there
+
+f) Per journal policy, if you have generated any custom code during the course of this investigation, please make it available without restrictions. Please ensure that the code is sufficiently well documented and reusable, and that your Data Statement in the Editorial Manager submission system accurately describes where your code can be found.
+
+As you address these items, please take this last chance to review your reference list to ensure that it is complete and correct. If you have cited papers that have been retracted, please include the rationale for doing so in the manuscript text, or remove these references and replace them with relevant current references. Any changes to the reference list should be mentioned in the cover letter that accompanies your revised manuscript.
+
+In addition to these revisions, you may need to complete some formatting changes, which you will receive in a follow up email. A member of our team will be in touch with a set of requests shortly. If you do not receive a separate email within a few days, please assume that checks have been completed, and no additional changes are required.
+
+We expect to receive your revised manuscript within two weeks.
+
+To submit your revision, please go to https://www.editorialmanager.com/pbiology/ and log in as an Author. Click the link labelled 'Submissions Needing Revision' to find your submission record. Your revised submission must include the following:
+
+- a cover letter that should detail your responses to any editorial requests, if applicable, and whether changes have been made to the reference list
+
+- a Response to Reviewers file that provides a detailed response to the reviewers' comments (if applicable, if not applicable please do not delete your existing 'Response to Reviewers' file.)
+
+- a track-changes file indicating any changes that you have made to the manuscript.
+
+NOTE: If Supporting Information files are included with your article, note that these are not copyedited and will be published as they are submitted. Please ensure that these files are legible and of high quality (at least 300 dpi) in an easily accessible file format. For this reason, please be aware that any references listed in an SI file will not be indexed. For more information, see our Supporting Information guidelines:
+
+https://journals.plos.org/plosbiology/s/supporting-information
+
+*Published Peer Review History*
+
+Please note that you may have the opportunity to make the peer review history publicly available. The record will include editor decision letters (with reviews) and your responses to reviewer comments. If eligible, we will contact you to opt in or out. Please see here for more details:
+
+https://plos.org/published-peer-review-history/
+
+*Press*
+
+Should you, your institution's press office or the journal office choose to press release your paper, please ensure you have opted out of Early Article Posting on the submission form. We ask that you notify us as soon as possible if you or your institution is planning to press release the article.
+
+*Protocols deposition*
+
+To enhance the reproducibility of your results, we recommend that if applicable you deposit your laboratory protocols in protocols.io, where a protocol can be assigned its own identifier (DOI) such that it can be cited independently in the future. Additionally, PLOS ONE offers an option for publishing peer-reviewed Lab Protocol articles, which describe protocols hosted on protocols.io. Read more information on sharing protocols at https://plos.org/protocols?utm_medium=editorial-email&utm_source=authorletters&utm_campaign=protocols
+
+Please do not hesitate to contact me should you have any questions.
+
+Sincerely,
+
+Melissa
+
+Melissa Vazquez Hernandez, Ph.D.
+
+Associate Editor
+
+mvazquezhernandez@plos.org
+
+PLOS Biology
+
+------------------------------------------------------------------------
+
+REVIEWERS' COMMENTS:
+
+------------------------------------------------------------------------
+
+Reviewer #1: Apologies for taking a couple extra days on the review. After looking at the resubmitted materials, the authors have done a nice job of shifting the focus further towards inter-lab reproducibility, including addressing that statistically. They have also clarified my earlier points of confusion.
+
+The authors have asked "For your convenience below is a figure incorporating the number of amplification cycles to clarify that these reflect the preparation of the different sample types (30 PCR cycles for Media and 22 cycles for Root to achieve similar DNA yield). Let us know if you see a value in including it in the manuscript. We believe that a simple statement in M&M should be sufficient:"
+
+I agree with the authors that the statement they go on to propose is sufficient. I think the paper can be accepted.
+
+------------------------------------------------------------------------
+
+Reviewer #2 (Mengcen Wang): The authors have addressed my concerns, and I therefore recommend its publication.
+
+10.1371/journal.pbio.3003358.r005
+
+Decision Letter 3
+
+Vazquez Hernandez
+
+Melissa
+
+This is an open access article distributed under the terms of the Creative Commons Attribution License , which permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited.
+
+10 Aug 2025
+
+Dear Trent,
+
+Thank you for the submission of your revised Meta-Research Article "Breaking the reproducibility barrier with standardized protocols for plant-microbiome research" for publication in PLOS Biology. On behalf of my colleagues and the Academic Editor, Cara Haney, I am pleased to say that we can in principle accept your manuscript for publication, provided you address any remaining formatting and reporting issues. These will be detailed in an email you should receive within 2-3 business days from our colleagues in the journal operations team; no action is required from you until then. Please note that we will not be able to formally accept your manuscript and schedule it for publication until you have completed any requested changes.
+
+Please take a minute to log into Editorial Manager at http://www.editorialmanager.com/pbiology/, click the "Update My Information" link at the top of the page, and update your user information to ensure an efficient production process.
+
+PRESS
+
+We frequently collaborate with press offices. If your institution or institutions have a press office, please notify them about your upcoming paper at this point, to enable them to help maximise its impact. If the press office is planning to promote your findings, we would be grateful if they could coordinate with biologypress@plos.org. If you have previously opted in to the early version process, we ask that you notify us immediately of any press plans so that we may opt out on your behalf.
+
+We also ask that you take this opportunity to read our Embargo Policy regarding the discussion, promotion and media coverage of work that is yet to be published by PLOS. As your manuscript is not yet published, it is bound by the conditions of our Embargo Policy. Please be aware that this policy is in place both to ensure that any press coverage of your article is fully substantiated and to provide a direct link between such coverage and the published work. For full details of our Embargo Policy, please visit http://www.plos.org/about/media-inquiries/embargo-policy/.
+
+Thank you again for choosing PLOS Biology for publication and supporting Open Access publishing. We look forward to publishing your study.
+
+Sincerely,
+
+Melissa
+
+Melissa Vazquez Hernandez, Ph.D., Ph.D.
+
+Associate Editor
+
+PLOS Biology
+
+mvazquezhernandez@plos.org


### PR DESCRIPTION
## Summary
Round 8 of the deferred backfill (continues #118–#124). Four OAK-verified metabolites across two files via BioC PMC full-text scanning.

| File | New related_ingredients | Source (PMC full text) |
|---|---|---|
| THOR_Rhizosphere_Model_Community | koreenceine A (CHEBI:212242), koreenceine B (CHEBI:212248), koreenceine C (CHEBI:212237) | PMID:30837345 |
| EcoFAB_Ring_Trial_SynCom17 | amino acid (CHEBI:33709) | PMID:40920748 |

**Adoption:** 125 → 127 of 265 (+2 files; +4 metabolites).

## Test plan
- [x] \`just validate\` clean for both files.
- [x] All snippets verbatim from cached PMC full-text files.
- [x] CHEBI ids OAK-verified canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)