### PR TITLE
Carry forward 4 unique items from PR #116 (Engine B foundation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ pages/style.css
 
 # Claude Code local agent state
 .claude/
+
+# linkml-term-validator / OAK label cache
+cache/

--- a/scripts/.validate_id_label_correspondence.sha256
+++ b/scripts/.validate_id_label_correspondence.sha256
@@ -1,0 +1,1 @@
+9c9fb6bc2007c29080e2f3e56b6948704e33808d04cf6dd3161fab32eb85261c  scripts/validate_id_label_correspondence.py

--- a/tests/data/optional_binding/omits_bound_optionals.yaml
+++ b/tests/data/optional_binding/omits_bound_optionals.yaml
@@ -1,0 +1,15 @@
+id: CommunityMech:999999
+name: Optional-Binding Regression Community
+description: >-
+  Fixture for the optional-slot binding regression test. It exercises the two
+  optional slots that carry an id↔label binding with obligation_level REQUIRED
+  (RelatedMedia.shared_environment_term and RelatedIngredient.chebi_term) by
+  OMITTING both. An absent optional slot must NOT trip the REQUIRED obligation,
+  so linkml-term-validator --labels must pass on this instance.
+related_media:
+- preferred_term: Test Medium
+  culturemech_id: CultureMech:000001
+  # shared_environment_term deliberately omitted (optional; REQUIRED binding)
+related_ingredients:
+- preferred_term: Test Ingredient
+  # chebi_term deliberately omitted (optional; REQUIRED binding)

--- a/tests/test_optional_binding_obligation.py
+++ b/tests/test_optional_binding_obligation.py
@@ -1,0 +1,82 @@
+"""Regression test for REQUIRED id↔label bindings on OPTIONAL slots.
+
+Two optional slots in the schema carry an id↔label binding with
+``obligation_level: REQUIRED``:
+
+* ``RelatedMedia.shared_environment_term``
+* ``RelatedIngredient.chebi_term``
+
+Both slots are ``required: false``. The REQUIRED obligation is meant to enforce
+the id↔label *correspondence* when the term IS present — it must NOT turn the
+optional slot into a de-facto required slot. This test pins that contract:
+
+1. An instance that OMITS both bound optional slots validates clean.
+2. (positive control) An instance with a PRESENT-but-WRONG label still fails,
+   proving the binding gate is actually engaged rather than silently inert.
+
+The test shells out to ``linkml-term-validator validate-data --labels`` (the
+same gate ``just validate`` uses) and is skipped when that CLI is unavailable.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA = REPO_ROOT / "src" / "communitymech" / "schema" / "communitymech.yaml"
+FIXTURE = REPO_ROOT / "tests" / "data" / "optional_binding" / "omits_bound_optionals.yaml"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("linkml-term-validator") is None,
+    reason="linkml-term-validator CLI not installed",
+)
+
+
+def _validate(data_path: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            "linkml-term-validator",
+            "validate-data",
+            str(data_path),
+            "-s",
+            str(SCHEMA),
+            "--labels",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_absent_optional_bound_slot_does_not_trip_required_obligation():
+    """Omitting the optional bound slots must validate clean (exit 0)."""
+    result = _validate(FIXTURE)
+    assert result.returncode == 0, (
+        "Absent optional slot tripped the REQUIRED binding obligation.\n"
+        "If this fails, downgrade the obligation_level on "
+        "RelatedMedia.shared_environment_term and RelatedIngredient.chebi_term "
+        "to a non-required level (e.g. RECOMMENDED).\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+def test_present_wrong_label_is_caught(tmp_path: Path):
+    """Positive control: a present term with a wrong label must fail (gate is live)."""
+    bad = tmp_path / "wrong_label.yaml"
+    bad.write_text(
+        "id: CommunityMech:999998\n"
+        "name: Wrong Label Control\n"
+        "related_ingredients:\n"
+        "- preferred_term: Test Ingredient\n"
+        "  chebi_term:\n"
+        "    id: CHEBI:15377\n"
+        "    label: definitely not the right label for water\n"
+    )
+    result = _validate(bad)
+    assert result.returncode != 0, (
+        "Binding gate did not catch a present-but-wrong label; the absent-slot "
+        "pass would then be meaningless.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
## Summary
PR #116 was the original Engine B foundation PR. Its bulk was carried in **PR #109** via the vendored byte-identical \`scripts/validate_id_label_correspondence.py\` (with #109 additionally adding the OK_EXCEPTION mechanism on top).

This PR carries the **4 remaining items** from #116 that #109 didn't include:

| Item | Purpose |
|---|---|
| \`.gitignore\` — exclude \`cache/\` | OAK label cache directory created during validation |
| \`scripts/.validate_id_label_correspondence.sha256\` | Integrity sidecar for the vendored validator. **Regenerated against current main's copy** (which includes #109's OK_EXCEPTION) — sha256 differs from the original #116 hash |
| \`tests/data/optional_binding/omits_bound_optionals.yaml\` | Test fixture |
| \`tests/test_optional_binding_obligation.py\` | Regression test that REQUIRED id↔label bindings on OPTIONAL slots do NOT promote those slots to de-facto required (pins the contract for \`shared_environment_term\` and \`chebi_term\`) |

With this landed, **PR #116 can be closed as fully superseded**.

## Test plan
- [x] \`uv run pytest tests/test_optional_binding_obligation.py -v\` — 2 passed in 4.86s.
  - test_absent_optional_bound_slot_does_not_trip_required_obligation
  - test_present_wrong_label_is_caught

🤖 Generated with [Claude Code](https://claude.com/claude-code)