### PR TITLE
Port id-label validator 0ea8e15 hardening + add pin guard recipes

### DIFF
--- a/.github/workflows/label-correspondence.yaml
+++ b/.github/workflows/label-correspondence.yaml
@@ -23,6 +23,17 @@ permissions:
   contents: read
 
 jobs:
+  # Cross-repo durability guard: the validator is vendored byte-identical across
+  # the Mech repos, so fail fast if this copy drifts from its pinned sha256.
+  # Fast and dependency-free (no uv / OAK), so it blocks even though the drift
+  # report below is non-blocking.
+  validator-pin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify validator pin
+        run: sha256sum -c scripts/.validate_id_label_correspondence.sha256
+
   label-drift-report:
     runs-on: ubuntu-latest
     steps:

--- a/conf/id_label_targets.yaml
+++ b/conf/id_label_targets.yaml
@@ -1,6 +1,18 @@
 # Targets for scripts/validate_id_label_correspondence.py (Engine B).
-# See docs/ID_LABEL_CORRESPONDENCE.md. Prefixes not in `adapters` (e.g.
-# CommunityMech:, CultureMech:, MediaIngredientMech:) are SKIPPED_NO_ADAPTER.
+#
+# Declares which surfaces carry ontology (id, label) pairs and how strictly
+# the label must correspond to the id's ontology label.
+#
+# A CURIE prefix is handled three ways:
+#   * in `adapters`          → looked up against that OAK ontology.
+#   * in `ignored_prefixes`  → legitimate non-ontology id (cas:, MIM:, …);
+#                              SKIPPED_NO_ADAPTER, never looked up.
+#   * neither                → UNKNOWN_PREFIX (ERROR) — a typo (CHBEI:) or an
+#                              unexpected new prefix that must be triaged (added
+#                              to `adapters` or `ignored_prefixes`) rather than
+#                              silently passing the gate. Ids with NO prefix at
+#                              all (UNMAPPED_0001) are a benign skip.
+# See docs/ID_LABEL_CORRESPONDENCE.md.
 
 adapters:
   NCBITaxon: sqlite:obo:ncbitaxon
@@ -9,6 +21,24 @@ adapters:
   GO: sqlite:obo:go
   UBERON: sqlite:obo:uberon
   CL: sqlite:obo:cl
+
+# Legitimate NON-ontology id prefixes — skipped without a lookup, but
+# acknowledged so a typoed ontology prefix (CHBEI:, CHEB:) is NOT mistaken for
+# one of these and instead fails as UNKNOWN_PREFIX. Keep in sync with the
+# prefixes actually emitted into (id, label) target fields. If `validate-products`
+# fires UNKNOWN_PREFIX on a real but uncovered prefix, triage it here.
+ignored_prefixes:
+  - CommunityMech          # community record ids (this repo)
+  - CultureMech            # culture-media record ids (sibling Mech)
+  - MediaIngredientMech    # ingredient record ids (sibling Mech, long form)
+  - MIM                    # MediaIngredientMech record ids (short form)
+  - cas                    # CAS registry numbers
+  - registry               # generic registry fallback
+  - kgmicrobe.compound     # KG-Microbe compound nodes
+  - kgmicrobe.ingredient   # KG-Microbe ingredient nodes
+  - mediadive.ingredient   # MediaDive ingredient nodes
+  - mediadive.solution     # MediaDive solution nodes
+  - mediadive.compound     # MediaDive compound nodes
 
 synonym_scope: exact_related
 

--- a/conf/id_label_targets.yaml
+++ b/conf/id_label_targets.yaml
@@ -54,7 +54,13 @@ targets:
     # cycle because the ontology has no clean replacement (true terminal
     # obsoletes, MF-vs-BP context mismatches, taxa absent from the current
     # OAK snapshot). Each entry includes a one-line `reason` for review.
-    # Verdict for matching pairs: OK_EXCEPTION (non-error).
+    #
+    # NOT ENFORCED by the current shared validator: the byte-identical script
+    # ported in PR #132 dropped the `exceptions`/OK_EXCEPTION mechanism, so
+    # these entries are inert and surface as MISMATCH/ID_NOT_FOUND findings in
+    # report mode. Retained as triage documentation; restoring an enforcement
+    # path is tracked in issue #134 (must be resolved before `validate-products`
+    # is switched to a blocking gate).
     exceptions:
       # --- CHEBI (11) ---
       - { id: "CHEBI:33104", label: "chromium(III) hydroxide", reason: "no clean CHEBI term; needs minting" }
@@ -100,6 +106,8 @@ targets:
     # Residuals that flow into the KGX export from the community YAMLs, plus
     # one exporter-side label choice ("mercury(2+) cation") that diverges
     # from OAK canonical by design.
+    # NOT ENFORCED by the current shared validator — see communities_yaml note
+    # above and issue #134.
     exceptions:
       - { id: "CHEBI:16793", label: "mercury(2+) cation", reason: "exporter-side label (kgx_export.py line 82) uses the +cation suffix; OAK canonical is mercury(2+)" }
       - { id: "ENVO:00000274", label: "soda lake", reason: "see communities_yaml exception" }

--- a/justfile
+++ b/justfile
@@ -88,6 +88,29 @@ validate-products:
 report-label-drift:
     uv run python scripts/validate_id_label_correspondence.py -c conf/id_label_targets.yaml --report reports/label_drift.tsv
 
+# Durability guard: fail if scripts/validate_id_label_correspondence.py drifts
+# from the pinned sha256 (it is vendored byte-identical across the Mech repos —
+# see the file's own docstring). CI runs this so an accidental edit to one copy
+# can't silently diverge. Uses sha256sum on CI (ubuntu), shasum -a 256 on macOS.
+verify-validator-pin:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum -c scripts/.validate_id_label_correspondence.sha256
+    else
+        shasum -a 256 -c scripts/.validate_id_label_correspondence.sha256
+    fi
+
+# Intentional sync only: re-pin the sha256 to the CURRENT script contents after
+# a deliberate, all-repos byte-identical update. Run this in every Mech copy.
+refresh-validator-pin:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    f=scripts/validate_id_label_correspondence.py
+    if command -v sha256sum >/dev/null 2>&1; then h=$(sha256sum "$f" | cut -d' ' -f1); else h=$(shasum -a 256 "$f" | cut -d' ' -f1); fi
+    printf '%s  %s\n' "$h" "$f" > scripts/.validate_id_label_correspondence.sha256
+    echo "re-pinned $f to $h"
+
 # Validate schema-level ontology term meanings
 validate-schema-terms:
     uv run linkml-term-validator validate-schema src/communitymech/schema/communitymech.yaml

--- a/scripts/.validate_id_label_correspondence.sha256
+++ b/scripts/.validate_id_label_correspondence.sha256
@@ -1,1 +1,1 @@
-9c9fb6bc2007c29080e2f3e56b6948704e33808d04cf6dd3161fab32eb85261c  scripts/validate_id_label_correspondence.py
+706987057cd83610ac62e6c82b55383ee529e34d299af3fa74fe2639deef8f6f  scripts/validate_id_label_correspondence.py

--- a/scripts/validate_id_label_correspondence.py
+++ b/scripts/validate_id_label_correspondence.py
@@ -23,19 +23,51 @@ repos already use, and classifies the pair:
 
     OK_CANONICAL        label == canonical OBO label
     OK_SYNONYM          label is an accepted synonym (policy-dependent)
-    OK_EXCEPTION        pair is on the target's ``exceptions`` allow-list
-                        (residual the curator has knowingly accepted; e.g.
-                        obsolete-no-successor, no clean term yet)
+    OK_ID_ONLY          id resolves; label match WAIVED for this slot (the slot
+                        carries a curator-intended formula/common name, e.g.
+                        CHEBI:15377 "Distilled water" — see ``label_waived_keys``)
     MISMATCH            label is neither canonical nor an accepted synonym  (ERROR)
     ID_NOT_FOUND        id has an adapter but is absent from the ontology   (ERROR)
     EMPTY_LABEL         id present, label blank                             (ERROR)
-    SKIPPED_NO_ADAPTER  prefix has no configured OAK adapter (cas:, MIM:, …)
+    MISSING_COLUMN      a CONFIGURED id/label column is absent from a       (ERROR)
+                        tabular target that has data rows — without this the
+                        pair silently drops and enforce false-greens on drift
+    ADAPTER_ERROR       a CONFIGURED adapter failed to load                 (ERROR)
+    UNKNOWN_PREFIX      CURIE prefix is neither a configured ontology       (ERROR)
+                        adapter NOR an explicitly ``ignored_prefixes`` entry —
+                        i.e. a typo (``CHBEI:``) or an unexpected new prefix.
+                        Without this such ids silently fell through as
+                        SKIPPED_NO_ADAPTER and enforce false-greened on them.
+    SKIPPED_NO_ADAPTER  prefix is an explicitly ignored non-ontology prefix
+                        (``cas:``, ``MIM:``, ``kgmicrobe.compound:`` …) or the
+                        id has no CURIE prefix at all (e.g. ``UNMAPPED_0001``)
+    SKIPPED_EMPTY_ADAPTER  configured adapter loaded but holds no terms (e.g. a
+                        0-byte sqlite stub); db needs populating, data isn't wrong
 
 Policy (per target, ``conf/id_label_targets.yaml``)
     ``canonical``            accept only the canonical OBO label (strict;
                              mirrors the linkml-term-validator schema gate).
     ``canonical_or_synonym`` accept canonical OR a synonym within
                              ``synonym_scope`` (exact | exact_related | all).
+
+Per-target knobs (in addition to ``policy``/``synonym_scope``/``pairs``)
+    ``required: true``       fail enforce when the target's glob matches NO
+                             files (an expected artifact, e.g. an SSSOM export,
+                             wasn't built). Default false preserves the prior
+                             "skip-with-exit-0" behaviour for optional targets.
+    ``label_waived_keys``    slots that carry curator-intended labels (formula /
+                             common names) and so are EXEMPT from canonical-label
+                             matching but STILL id-existence checked (OK_ID_ONLY
+                             when the id resolves, ID_NOT_FOUND when it doesn't).
+                             For YAML targets the entries match the *parent key*
+                             of the id/label dict (e.g. ``term``, ``chebi_term``);
+                             for tabular targets they match the *id column name*
+                             (e.g. ``ontology_id``). This implements the product
+                             decision to KEEP labels like "D-glucose" / "NaCl"
+                             rather than relabel them to the OBO canonical form.
+                             Unlike ``exclude_keys`` (which prunes the whole
+                             subtree and checks nothing), label-waived slots are
+                             still validated for id existence.
 
 Modes
     ``--report PATH``  write a TSV of every non-OK pair and exit 0 (baseline).
@@ -70,7 +102,29 @@ def _safe_rel(path: Path) -> str:
 
 
 # Verdict classes that should fail an --enforce run.
-_ERROR_VERDICTS = {"MISMATCH", "ID_NOT_FOUND", "EMPTY_LABEL"}
+# ADAPTER_ERROR is fatal: a configured adapter that fails to LOAD must never be
+# silently downgraded to SKIPPED_NO_ADAPTER (which would let an enforce run pass
+# while checking nothing). MISSING_COLUMN is likewise fatal: a configured
+# id/label column that is absent from a populated tabular target used to be a
+# stderr-only warning, so enforce exited 0 even though the pair was never
+# checked (Engine-B false-green). MISSING_GLOB is emitted for a ``required: true``
+# target whose glob matched no files (an expected artifact wasn't built).
+_ERROR_VERDICTS = {
+    "MISMATCH",
+    "ID_NOT_FOUND",
+    "EMPTY_LABEL",
+    "MISSING_COLUMN",
+    "MISSING_GLOB",
+    "ADAPTER_ERROR",
+    "UNKNOWN_PREFIX",
+}
+
+# Verdicts that are accepted (do NOT get recorded as findings and never fail
+# enforce). OK_ID_ONLY is a pass: the id resolved and the slot's label was
+# intentionally waived (curator-intended formula/common name).
+_OK_VERDICTS = {"OK_CANONICAL", "OK_SYNONYM", "OK_ID_ONLY"}
+# Benign skips: not OK (still surfaced in the report) but never fail enforce.
+_SKIP_VERDICTS = {"SKIPPED_NO_ADAPTER", "SKIPPED_EMPTY_ADAPTER"}
 
 _CURIE_RE = re.compile(r"^([A-Za-z][A-Za-z0-9.]*):(.+)$")
 _WS_RE = re.compile(r"\s+")
@@ -98,6 +152,19 @@ def prefix_of(curie: str) -> str | None:
     return m.group(1) if m else None
 
 
+# Sentinel returned by ``AdapterPool.get`` when a CONFIGURED adapter fails to
+# load. Distinct from ``None`` (prefix not configured → legitimate skip) so the
+# caller can raise a fatal ADAPTER_ERROR instead of a benign SKIPPED_NO_ADAPTER.
+LOAD_FAILED = object()
+
+# Sentinel for a CONFIGURED adapter that loads but contains no terms (e.g. a
+# 0-byte ``~/.data/oaklib/micro.db`` stub that OAK opens happily but that yields
+# ``label() == None`` for every id). Without this, every id under such a prefix
+# would be reported as a false ``ID_NOT_FOUND``. Treated as a benign skip
+# (``SKIPPED_EMPTY_ADAPTER``) — the db needs populating, the data isn't wrong.
+EMPTY_ADAPTER = object()
+
+
 class AdapterPool:
     """Lazily loads OAK adapters, but ONLY for prefixes in the allowlist.
 
@@ -105,32 +172,122 @@ class AdapterPool:
     prefixes without an entry (``cas:``, ``MIM:``, ``kgmicrobe.compound:``,
     ``DSMZ``, …) are never looked up — they are reported as
     ``SKIPPED_NO_ADAPTER`` instead of triggering a futile ontology download.
+
+    Prefix matching is case-insensitive: data carries lowercase ``mesh:`` while
+    the allowlist (and OAK's OBO CURIEs) use uppercase ``MESH:``. ``get`` keys
+    on the canonical allowlist case, and callers can rewrite the CURIE prefix
+    via ``canonical_prefix`` so the lookup actually resolves.
+
+    ``get`` returns one of three things:
+
+    * ``None``          — prefix is not in the allowlist (legitimate skip).
+    * ``LOAD_FAILED``   — prefix IS configured but its adapter raised on load.
+    * an OAK adapter    — ready to query.
+
+    The ``LOAD_FAILED`` case is deliberately NOT collapsed into ``None`` so a
+    broken-but-configured adapter surfaces as a fatal verdict rather than
+    silently passing an enforce run.
     """
 
     def __init__(self, adapters: dict[str, str]):
         self._selectors = adapters
+        # Case-insensitive prefix lookup: data carries lowercase `mesh:` while
+        # the allowlist (and OAK's OBO CURIEs) use uppercase `MESH:`. Map any
+        # casing of a data prefix back to its canonical allowlist key.
+        self._canonical: dict[str, str] = {key.casefold(): key for key in adapters}
         self._cache: dict[str, Any] = {}
 
-    def get(self, prefix: str | None):
-        if not prefix or prefix not in self._selectors:
+    def canonical_prefix(self, prefix: str | None) -> str | None:
+        """Return the allowlist key matching ``prefix`` case-insensitively."""
+        if not prefix:
             return None
-        if prefix not in self._cache:
+        return self._canonical.get(prefix.casefold())
+
+    def get(self, prefix: str | None):
+        key = self.canonical_prefix(prefix)
+        if key is None:
+            return None
+        if key not in self._cache:
             try:
                 from oaklib import get_adapter
 
-                self._cache[prefix] = get_adapter(self._selectors[prefix])
+                adapter = get_adapter(self._selectors[key])
             except Exception as exc:  # pragma: no cover - environment dependent
-                print(f"  ! failed to load adapter for {prefix}: {exc}", file=sys.stderr)
-                self._cache[prefix] = None
-        return self._cache[prefix]
+                print(f"  ! failed to load adapter for {key}: {exc}", file=sys.stderr)
+                self._cache[key] = LOAD_FAILED
+            else:
+                self._cache[key] = EMPTY_ADAPTER if self._is_empty(adapter, key) else adapter
+        return self._cache[key]
+
+    @staticmethod
+    def _is_empty(adapter: Any, key: str) -> bool:
+        """True if the adapter loaded but holds no terms (e.g. a 0-byte sqlite).
+
+        Peeks a single entity (O(1)) rather than counting.
+
+        When ``entities()`` yields nothing the db is a clean empty (valid schema,
+        no rows) and is treated as an empty stub. When ``entities()`` *raises*
+        (e.g. ``no such table: node``) we do NOT trust the error text alone —
+        a partially-migrated or corrupt LIVE ontology (real tables, one missing)
+        raises the same way, and masking it as a benign skip would let real drift
+        pass an enforce run (the exact false-pass this guards against). We only
+        return True when ``_is_uninitialized_stub`` POSITIVELY confirms the
+        backing sqlite is an uninitialized stub (0 bytes / 0 tables); otherwise
+        return False so the prefix's rows surface as ID_NOT_FOUND/error verdicts.
+        """
+        try:
+            return next(iter(adapter.entities()), None) is None
+        except Exception as exc:  # pragma: no cover - environment dependent
+            if AdapterPool._is_uninitialized_stub(adapter):
+                return True
+            print(f"  ! emptiness probe failed for {key}: {exc}", file=sys.stderr)
+            return False
+
+    @staticmethod
+    def _is_uninitialized_stub(adapter: Any) -> bool:
+        """Positively confirm the adapter's sqlite backing store is an
+        uninitialized stub — a 0-byte file or a sqlite with NO tables at all.
+
+        Anything that has tables is a real (possibly broken/partial) db, not a
+        benign stub, and must not be masked. Returns False on any uncertainty
+        (path unresolvable, non-sqlite backend, probe error) so the caller never
+        silently downgrades a real defect to a skip.
+        """
+        url = getattr(getattr(adapter, "engine", None), "url", None)
+        db_path = getattr(url, "database", None)
+        if not db_path:
+            return False  # not a resolvable sqlite file → don't risk masking
+        try:
+            p = Path(db_path)
+            if not p.exists():
+                return False
+            if p.stat().st_size == 0:
+                return True  # 0-byte stub (OAK's sqlite:obo:micro shape)
+            import sqlite3
+
+            con = sqlite3.connect(f"file:{p}?mode=ro", uri=True)
+            try:
+                n = con.execute(
+                    "SELECT count(*) FROM sqlite_master WHERE type='table'"
+                ).fetchone()[0]
+            finally:
+                con.close()
+            return n == 0
+        except Exception:  # pragma: no cover - environment dependent
+            return False
 
 
-def accepted_labels(adapter: Any, curie: str, scope: str) -> tuple[str | None, set[str], bool]:
+def accepted_labels(
+    adapter: Any, curie: str, scope: str, *, include_synonyms: bool = True
+) -> tuple[str | None, set[str], bool]:
     """Return (canonical_label, accepted_normalized_set, id_found).
 
-    ``accepted_normalized_set`` always contains the canonical label; with a
-    non-``canonical`` policy the caller widens it via ``scope`` synonyms.
-    ``id_found`` is False when the id is absent from the ontology.
+    ``accepted_normalized_set`` always contains the canonical label; when
+    ``include_synonyms`` is set it is widened via ``scope`` synonyms. Callers
+    using a strict ``canonical`` policy never consult synonyms, so they pass
+    ``include_synonyms=False`` to skip the (potentially expensive)
+    ``entity_alias_map`` lookup entirely. ``id_found`` is False when the id is
+    absent from the ontology.
     """
     try:
         canonical = adapter.label(curie)
@@ -139,14 +296,15 @@ def accepted_labels(adapter: Any, curie: str, scope: str) -> tuple[str | None, s
     if canonical is None:
         return None, set(), False
     accepted = {normalize(canonical)}
-    alias_map: dict[str, list[str]] = {}
-    try:
-        alias_map = adapter.entity_alias_map(curie) or {}
-    except Exception:
-        alias_map = {}
-    for pred in _SYNONYM_PREDICATES.get(scope, _SYNONYM_PREDICATES["exact"]):
-        for alias in alias_map.get(pred, []) or []:
-            accepted.add(normalize(alias))
+    if include_synonyms:
+        alias_map: dict[str, list[str]] = {}
+        try:
+            alias_map = adapter.entity_alias_map(curie) or {}
+        except Exception:
+            alias_map = {}
+        for pred in _SYNONYM_PREDICATES.get(scope, _SYNONYM_PREDICATES["exact"]):
+            for alias in alias_map.get(pred, []) or []:
+                accepted.add(normalize(alias))
     return canonical, accepted, True
 
 
@@ -157,12 +315,33 @@ def classify(
     adapter: Any,
     policy: str,
     scope: str,
+    lookup_curie: str | None = None,
+    label_waived: bool = False,
 ) -> dict[str, Any]:
-    """Classify one (id, label) pair into a verdict dict."""
-    canonical, accepted, found = accepted_labels(adapter, curie, scope)
+    """Classify one (id, label) pair into a verdict dict.
+
+    ``curie`` is reported verbatim; ``lookup_curie`` (when given) is the
+    case-normalized CURIE actually passed to the adapter so that, e.g., a
+    lowercase ``mesh:`` row resolves against OAK's uppercase ``MESH:`` ids.
+    Synonyms are only built when the policy actually consults them.
+
+    ``label_waived`` marks slots that carry curator-intended formula/common
+    names (e.g. CHEBI:15377 "Distilled water"): id existence is still
+    enforced (ID_NOT_FOUND fires for a bogus id) but the canonical-label
+    match is skipped — a resolvable id yields OK_ID_ONLY regardless of label.
+    """
+    # When the label is waived we never consult synonyms (the label isn't
+    # being compared at all), so skip the potentially expensive alias lookup.
+    include_synonyms = (policy != "canonical") and not label_waived
+    canonical, accepted, found = accepted_labels(
+        adapter, lookup_curie or curie, scope, include_synonyms=include_synonyms
+    )
     base = {"id": curie, "label": label, "canonical": canonical or ""}
     if not found:
         return {**base, "verdict": "ID_NOT_FOUND"}
+    if label_waived:
+        # Id resolved; the curator label is intentional, so accept it as-is.
+        return {**base, "verdict": "OK_ID_ONLY"}
     if label is None or str(label).strip() == "":
         return {**base, "verdict": "EMPTY_LABEL"}
     norm_label = normalize(label)
@@ -173,77 +352,151 @@ def classify(
     return {**base, "verdict": "MISMATCH"}
 
 
-# -- exceptions allow-list ------------------------------------------------
-
-def load_exceptions(target: dict[str, Any]) -> set[tuple[str, str]]:
-    """Return the (curie, normalized_label) pairs the target accepts as-is.
-
-    The ``exceptions`` field on a target is a list of mappings, each with at
-    least ``id`` and ``label``. Optional ``reason`` is documentation only;
-    pairs are matched on (id, normalized(label)) so a missing or alternative
-    casing for ``reason`` doesn't affect matching.
-    """
-    out: set[tuple[str, str]] = set()
-    for entry in target.get("exceptions") or []:
-        curie = str(entry.get("id", "")).strip()
-        label = str(entry.get("label", ""))
-        if curie:
-            out.add((curie, normalize(label)))
-    return out
-
-
 # -- target readers -------------------------------------------------------
 
-def _read_tabular_rows(path: Path, fmt: str) -> tuple[list[str], list[dict[str, str]]]:
-    """Read a TSV/CSV, skipping SSSOM ``#`` comment-prelude lines."""
+def _read_tabular_rows(
+    path: Path, fmt: str
+) -> tuple[list[str], list[dict[str, str]], list[int]]:
+    """Read a TSV/CSV, skipping ONLY the leading SSSOM ``#`` comment prelude.
+
+    Returns ``(fieldnames, rows, data_line_numbers)`` where each entry of
+    ``data_line_numbers`` is the TRUE 1-based physical file line where the
+    corresponding data row begins, so locators stay accurate even after the
+    prelude is removed. ``#`` lines that appear *after* the header are NOT
+    stripped (only the contiguous top-of-file prelude is), matching the SSSOM
+    convention where the metadata block precedes the table.
+
+    The physical line numbers come from the original file, so a quoted
+    multiline field could desync ``len(data_line_numbers)`` from ``len(rows)``;
+    the caller falls back to a post-header ordinal in that case.
+    """
     delim = "," if fmt == "csv" else "\t"
     with path.open(newline="", encoding="utf-8") as fh:
-        lines = [ln for ln in fh if not ln.lstrip().startswith("#")]
-    if not lines:
-        return [], []
+        raw = list(enumerate(fh, start=1))  # (physical_line_number, text)
+    # Strip only the contiguous prelude of ``#`` lines at the top of the file.
+    start = 0
+    while start < len(raw) and raw[start][1].lstrip().startswith("#"):
+        start += 1
+    body = raw[start:]
+    if not body:
+        return [], [], []
+    lines = [text for _, text in body]
+    # body[0] is the header; data rows begin at the next physical line.
+    data_line_numbers = [phys for phys, _ in body[1:]]
     reader = csv.DictReader(lines, delimiter=delim)
-    return list(reader.fieldnames or []), list(reader)
+    return list(reader.fieldnames or []), list(reader), data_line_numbers
 
 
-def iter_tabular(path: Path, fmt: str, pairs: list[list[str]]) -> Iterator[tuple[str, str, str]]:
-    """Yield (locator, id, label) for each configured id/label column pair."""
-    fields, rows = _read_tabular_rows(path, fmt)
+def iter_tabular(
+    path: Path,
+    fmt: str,
+    pairs: list[list[str]],
+    label_waived_cols: frozenset[str] = frozenset(),
+) -> Iterator[tuple[str, str, str, bool, str | None]]:
+    """Yield (locator, id, label, label_waived, verdict_override) for each pair.
+
+    ``verdict_override`` is normally ``None`` (the caller classifies the pair).
+    For a configured id column that is ABSENT from a populated file it is
+    ``"MISSING_COLUMN"`` — an ERROR-class verdict, so enforce no longer
+    false-greens on column drift (it used to be a stderr-only warning that the
+    caller never saw as a finding). ``label_waived`` is True when the pair's id
+    column is listed in ``label_waived_cols`` (curator-intended label slot).
+    """
+    fields, rows, line_numbers = _read_tabular_rows(path, fmt)
     field_set = set(fields)
-    usable = [(i, l) for (i, l) in pairs if i in field_set and l in field_set]
-    for n, row in enumerate(rows, start=2):  # row 1 is the header
+    # Keep any pair whose id column exists; a missing label column is allowed
+    # so an id present without its label still gets an EMPTY_LABEL verdict
+    # rather than being silently dropped.
+    usable = [(i, l) for (i, l) in pairs if i in field_set]
+    # RISK (fixed): a configured pair whose ID or LABEL column is absent must
+    # NOT vanish silently. When the file has data rows, emit a MISSING_COLUMN
+    # ERROR finding per absent column so an enforce run FAILS instead of
+    # passing while checking nothing. (Still also warn to stderr for context.)
+    if rows:
+        for (i, l) in pairs:
+            missing = [c for c in (i, l) if c not in field_set]
+            if missing:
+                print(
+                    f"  ! {_safe_rel(path)}: configured id/label pair "
+                    f"[{i}/{l}] — missing column(s) {missing}; "
+                    f"present columns: {sorted(field_set)}",
+                    file=sys.stderr,
+                )
+                yield (
+                    f"columns [{i}/{l}]",
+                    f"missing:{','.join(missing)}",
+                    f"present:{sorted(field_set)}",
+                    False,
+                    "MISSING_COLUMN",
+                )
+    for idx, row in enumerate(rows):
+        # True physical line number when available (a quoted multiline field
+        # could desync the count); else fall back to the post-header ordinal.
+        line_no = line_numbers[idx] if idx < len(line_numbers) else idx + 2
         for id_col, label_col in usable:
             curie = (row.get(id_col) or "").strip()
             if not curie:
                 continue
             label = (row.get(label_col) or "").strip()
-            yield f"row {n} [{id_col}/{label_col}]", curie, label
+            waived = id_col in label_waived_cols
+            yield f"line {line_no} [{id_col}/{label_col}]", curie, label, waived, None
 
 
-def _walk_yaml(node: Any, pairs: list[tuple[str, str]], path: str) -> Iterator[tuple[str, str, str]]:
+def _walk_yaml(
+    node: Any,
+    pairs: list[tuple[str, str]],
+    path: str,
+    exclude_keys: frozenset[str] = frozenset(),
+    label_waived_keys: frozenset[str] = frozenset(),
+    waived: bool = False,
+) -> Iterator[tuple[str, str, str, bool, str | None]]:
     if isinstance(node, dict):
         for id_key, label_key in pairs:
-            if id_key in node and label_key in node:
+            # An id present without its sibling label must still be checked
+            # (yields EMPTY_LABEL), so we do NOT require label_key to exist.
+            if id_key in node:
                 curie = node.get(id_key)
                 if isinstance(curie, str) and curie.strip():
                     label = node.get(label_key)
                     label = label if isinstance(label, str) else ""
-                    yield f"{path}.{id_key}", curie.strip(), (label or "").strip()
+                    yield f"{path}.{id_key}", curie.strip(), (label or "").strip(), waived, None
         for k, v in node.items():
-            yield from _walk_yaml(v, pairs, f"{path}.{k}")
+            # Skip excluded grounding blocks entirely (no checks at all).
+            if k in exclude_keys:
+                continue
+            # label_waived_keys: descend, but mark everything under this key as
+            # label-waived so its id/label dicts get id-existence-only checking
+            # (curator-intended formula/common names, e.g. CHEBI:15377
+            # "Distilled water" under a `term:` block). ``waived`` is sticky
+            # for the subtree so a nested id/label pair stays waived.
+            child_waived = waived or (k in label_waived_keys)
+            yield from _walk_yaml(
+                v, pairs, f"{path}.{k}", exclude_keys, label_waived_keys, child_waived
+            )
     elif isinstance(node, list):
         for idx, item in enumerate(node):
-            yield from _walk_yaml(item, pairs, f"{path}[{idx}]")
+            yield from _walk_yaml(
+                item, pairs, f"{path}[{idx}]", exclude_keys, label_waived_keys, waived
+            )
 
 
-def iter_yaml(path: Path, pairs: list[list[str]]) -> Iterator[tuple[str, str, str]]:
-    """Yield (locator, id, label) from a YAML doc by recursively finding dicts
-    that carry BOTH an id key and its sibling label key."""
+def iter_yaml(
+    path: Path,
+    pairs: list[list[str]],
+    exclude_keys: frozenset[str] = frozenset(),
+    label_waived_keys: frozenset[str] = frozenset(),
+) -> Iterator[tuple[str, str, str, bool, str | None]]:
+    """Yield (locator, id, label, label_waived, verdict_override) from a YAML
+    doc by recursively finding dicts that carry an id key (and, when present,
+    its sibling label key)."""
     try:
         doc = yaml.safe_load(path.read_text())
     except Exception as exc:  # pragma: no cover
         print(f"  ! failed to parse {path}: {exc}", file=sys.stderr)
         return
-    yield from _walk_yaml(doc, [(a, b) for a, b in pairs], path.name)
+    yield from _walk_yaml(
+        doc, [(a, b) for a, b in pairs], path.name, exclude_keys, label_waived_keys
+    )
 
 
 # -- driver ---------------------------------------------------------------
@@ -253,6 +506,7 @@ def load_config(config_path: Path) -> dict[str, Any]:
     if not isinstance(cfg, dict):
         raise SystemExit(f"Config is not a mapping: {config_path}")
     cfg.setdefault("adapters", {})
+    cfg.setdefault("ignored_prefixes", [])
     cfg.setdefault("synonym_scope", "exact_related")
     cfg.setdefault("targets", [])
     return cfg
@@ -262,6 +516,10 @@ def run(config_path: Path, report_path: Path | None) -> int:
     cfg = load_config(config_path)
     pool = AdapterPool(cfg["adapters"])
     default_scope = cfg["synonym_scope"]
+    # Explicitly-ignored non-ontology prefixes (cas:, MIM:, kgmicrobe.compound: …).
+    # A prefixed id whose prefix is neither a configured adapter NOR listed here
+    # is a typo / unexpected prefix → UNKNOWN_PREFIX (ERROR), not a silent skip.
+    ignored_prefixes_cf = {str(p).casefold() for p in cfg["ignored_prefixes"]}
 
     findings: list[dict[str, Any]] = []
     counts: dict[str, int] = {}
@@ -271,39 +529,79 @@ def run(config_path: Path, report_path: Path | None) -> int:
         policy = target.get("policy", "canonical_or_synonym")
         scope = target.get("synonym_scope", default_scope)
         pairs = target.get("pairs", [])
-        exceptions = load_exceptions(target)
+        exclude_keys = frozenset(target.get("exclude_keys", []) or [])
+        label_waived_keys = frozenset(target.get("label_waived_keys", []) or [])
+        required = bool(target.get("required", False))
         globs = target.get("glob")
         glob_list = globs if isinstance(globs, list) else [globs]
         paths: list[Path] = []
         for g in glob_list:
             paths.extend(sorted(REPO_ROOT.glob(g)))
         if not paths:
-            print(f"  - {name}: no files match {glob_list}")
+            # RISK (fixed): a `required: true` target whose glob matches NO
+            # files means an expected artifact (e.g. output/*.sssom.tsv) was
+            # never built. That used to skip with exit 0, so validate-products
+            # greened on a missing product. Emit a MISSING_GLOB ERROR finding.
+            if required:
+                print(f"  ! {name}: REQUIRED target — no files match {glob_list}")
+                rec = {"id": ",".join(str(g) for g in glob_list), "label": "",
+                       "canonical": "", "verdict": "MISSING_GLOB"}
+                counts["MISSING_GLOB"] = counts.get("MISSING_GLOB", 0) + 1
+                findings.append({
+                    "surface": name, "file": "(no match)",
+                    "locator": f"glob {glob_list}", "policy": policy, **rec,
+                })
+            else:
+                print(f"  - {name}: no files match {glob_list}")
             continue
         for path in paths:
             rel = _safe_rel(path)
             if kind == "yaml":
-                pairs_iter = iter_yaml(path, pairs)
+                pairs_iter = iter_yaml(path, pairs, exclude_keys, label_waived_keys)
             else:
-                pairs_iter = iter_tabular(path, target.get("format", "tsv"), pairs)
-            for locator, curie, label in pairs_iter:
-                prefix = prefix_of(curie)
-                adapter = pool.get(prefix)
-                if adapter is None:
-                    verdict = "SKIPPED_NO_ADAPTER"
-                    rec = {"id": curie, "label": label, "canonical": "", "verdict": verdict}
+                pairs_iter = iter_tabular(
+                    path, target.get("format", "tsv"), pairs, label_waived_keys
+                )
+            for locator, curie, label, label_waived, verdict_override in pairs_iter:
+                if verdict_override is not None:
+                    rec = {"id": curie, "label": label, "canonical": "",
+                           "verdict": verdict_override}
                 else:
-                    rec = classify(
-                        curie=curie, label=label, adapter=adapter, policy=policy, scope=scope
-                    )
-                    if rec["verdict"] not in ("OK_CANONICAL", "OK_SYNONYM") and (
-                        curie, normalize(label)
-                    ) in exceptions:
-                        rec["verdict"] = "OK_EXCEPTION"
+                    prefix = prefix_of(curie)
+                    adapter = pool.get(prefix)
+                    if adapter is None:
+                        # No configured adapter for this prefix. Distinguish an
+                        # explicitly-ignored non-ontology prefix (benign skip)
+                        # from an unexpected/typoed ontology prefix (ERROR). An
+                        # id with no CURIE prefix at all (UNMAPPED_0001) stays a
+                        # benign skip — it isn't claiming to be an ontology term.
+                        if prefix is not None and prefix.casefold() not in ignored_prefixes_cf:
+                            verdict = "UNKNOWN_PREFIX"
+                        else:
+                            verdict = "SKIPPED_NO_ADAPTER"
+                        rec = {"id": curie, "label": label, "canonical": "",
+                               "verdict": verdict}
+                    elif adapter is LOAD_FAILED:
+                        rec = {"id": curie, "label": label, "canonical": "",
+                               "verdict": "ADAPTER_ERROR"}
+                    elif adapter is EMPTY_ADAPTER:
+                        rec = {"id": curie, "label": label, "canonical": "",
+                               "verdict": "SKIPPED_EMPTY_ADAPTER"}
+                    else:
+                        # Rewrite the CURIE prefix to the canonical allowlist case
+                        # (e.g. mesh: -> MESH:) so OAK, which keys on uppercase OBO
+                        # prefixes, resolves the label instead of returning None.
+                        canonical_prefix = pool.canonical_prefix(prefix)
+                        lookup_curie = curie
+                        if canonical_prefix and prefix != canonical_prefix:
+                            lookup_curie = f"{canonical_prefix}:{curie.split(':', 1)[1]}"
+                        rec = classify(
+                            curie=curie, label=label, adapter=adapter, policy=policy,
+                            scope=scope, lookup_curie=lookup_curie,
+                            label_waived=label_waived,
+                        )
                 counts[rec["verdict"]] = counts.get(rec["verdict"], 0) + 1
-                if rec["verdict"] not in (
-                    "OK_CANONICAL", "OK_SYNONYM", "OK_EXCEPTION", "SKIPPED_NO_ADAPTER"
-                ):
+                if rec["verdict"] not in _OK_VERDICTS | _SKIP_VERDICTS:
                     findings.append({
                         "surface": name,
                         "file": str(rel),
@@ -317,11 +615,16 @@ def run(config_path: Path, report_path: Path | None) -> int:
     for verdict in (
         "OK_CANONICAL",
         "OK_SYNONYM",
-        "OK_EXCEPTION",
+        "OK_ID_ONLY",
         "MISMATCH",
         "ID_NOT_FOUND",
         "EMPTY_LABEL",
+        "MISSING_COLUMN",
+        "MISSING_GLOB",
+        "ADAPTER_ERROR",
+        "UNKNOWN_PREFIX",
         "SKIPPED_NO_ADAPTER",
+        "SKIPPED_EMPTY_ADAPTER",
     ):
         if verdict in counts:
             print(f"  {verdict:>20}: {counts[verdict]}")

--- a/tests/test_id_label_empty_adapter.py
+++ b/tests/test_id_label_empty_adapter.py
@@ -1,0 +1,143 @@
+"""Tests for the id-label validator's empty-adapter detection.
+
+A configured OAK adapter that loads but holds no terms (OAK's ``sqlite:obo:micro``
+selector points at a 0-byte stub whose tables don't exist) must NOT flag every id
+under that prefix as a false ``ID_NOT_FOUND`` — it is reclassified as the benign
+``SKIPPED_EMPTY_ADAPTER``.
+
+Crucially, a PARTIALLY-MIGRATED or corrupt LIVE ontology (real tables, one
+missing) raises the same ``no such table`` error but must NOT be masked as a
+benign skip — that would let real drift pass an enforce run. So "empty" is
+decided by a POSITIVE stub check (0-byte / 0-table backing sqlite), never by the
+error text alone. These pin that distinction with fake adapters + tiny on-disk
+sqlite files (CI-safe, no OAK / network).
+"""
+
+import importlib.util
+import sqlite3
+from pathlib import Path
+
+_spec = importlib.util.spec_from_file_location(
+    "validate_id_label_correspondence",
+    Path(__file__).parent.parent / "scripts" / "validate_id_label_correspondence.py",
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+class _URL:
+    def __init__(self, database):
+        self.database = database
+
+
+class _Engine:
+    def __init__(self, database):
+        self.url = _URL(database)
+
+
+class _Adapter:
+    """Fake OAK adapter: entities() yields `items` or raises `exc`; optional
+    `db` path exposed via .engine.url.database (mimics OAK's SqlImplementation)."""
+
+    def __init__(self, items=(), exc=None, db=None):
+        self._items, self._exc = list(items), exc
+        self.engine = _Engine(db) if db is not None else None
+
+    def entities(self):
+        if self._exc:
+            raise self._exc
+        return iter(self._items)
+
+
+_NO_SUCH_TABLE = Exception("(sqlite3.OperationalError) no such table: node")
+
+
+# -- _is_uninitialized_stub: the positive empty-stub check ------------------
+
+def test_stub_true_for_zero_byte_file(tmp_path):
+    p = tmp_path / "micro.db"
+    p.touch()  # 0 bytes
+    assert mod.AdapterPool._is_uninitialized_stub(_Adapter(db=str(p))) is True
+
+
+def test_stub_true_for_tableless_sqlite(tmp_path):
+    p = tmp_path / "empty.db"
+    sqlite3.connect(str(p)).close()  # valid sqlite, no tables
+    assert mod.AdapterPool._is_uninitialized_stub(_Adapter(db=str(p))) is True
+
+
+def test_stub_false_for_sqlite_with_tables(tmp_path):
+    p = tmp_path / "live.db"
+    con = sqlite3.connect(str(p))
+    con.execute("CREATE TABLE statements (subject TEXT)")
+    con.commit()
+    con.close()
+    # has tables → a real (possibly broken) db, never a benign stub
+    assert mod.AdapterPool._is_uninitialized_stub(_Adapter(db=str(p))) is False
+
+
+def test_stub_false_for_missing_path(tmp_path):
+    assert mod.AdapterPool._is_uninitialized_stub(_Adapter(db=str(tmp_path / "nope.db"))) is False
+
+
+def test_stub_false_when_no_engine():
+    assert mod.AdapterPool._is_uninitialized_stub(_Adapter()) is False
+
+
+# -- _is_empty: combines the probe with the positive stub check -------------
+
+def test_empty_when_no_entities():
+    assert mod.AdapterPool._is_empty(_Adapter(items=[]), "x") is True
+
+
+def test_empty_when_probe_raises_and_db_is_zero_byte(tmp_path):
+    p = tmp_path / "micro.db"
+    p.touch()
+    assert mod.AdapterPool._is_empty(_Adapter(exc=_NO_SUCH_TABLE, db=str(p)), "micro") is True
+
+
+def test_NOT_empty_when_probe_raises_but_db_has_tables(tmp_path):
+    # THE REGRESSION GUARD: partially-migrated live db (tables present, one
+    # missing) raises "no such table" yet must NOT be masked as empty.
+    p = tmp_path / "chebi.db"
+    con = sqlite3.connect(str(p))
+    con.execute("CREATE TABLE statements (subject TEXT)")
+    con.commit()
+    con.close()
+    assert mod.AdapterPool._is_empty(_Adapter(exc=_NO_SUCH_TABLE, db=str(p)), "chebi") is False
+
+
+def test_NOT_empty_on_no_such_table_without_resolvable_db():
+    # error text alone is never enough — no path to confirm a stub → not empty.
+    assert mod.AdapterPool._is_empty(_Adapter(exc=_NO_SUCH_TABLE), "chebi") is False
+
+
+def test_empty_vs_nonempty_with_arbitrary_error(tmp_path):
+    p = tmp_path / "x.db"
+    p.touch()  # 0-byte stub still wins regardless of error text
+    assert mod.AdapterPool._is_empty(_Adapter(exc=Exception("disk I/O error"), db=str(p)), "x") is True
+    con = sqlite3.connect(str(p))  # now give it a table
+    con.execute("CREATE TABLE t (x)")
+    con.commit()
+    con.close()
+    # non-stub db + arbitrary probe error → stays non-empty (not masked)
+    assert mod.AdapterPool._is_empty(_Adapter(exc=Exception("disk I/O error"), db=str(p)), "x") is False
+
+
+def test_populated_adapter_not_empty():
+    assert mod.AdapterPool._is_empty(_Adapter(items=["CHEBI:15377"]), "chebi") is False
+
+
+def test_pool_get_returns_empty_sentinel(monkeypatch, tmp_path):
+    p = tmp_path / "micro.db"
+    p.touch()  # 0-byte stub
+    import oaklib
+
+    monkeypatch.setattr(oaklib, "get_adapter", lambda sel: _Adapter(exc=_NO_SUCH_TABLE, db=str(p)))
+    pool = mod.AdapterPool({"MICRO": "sqlite:obo:micro"})
+    assert pool.get("MICRO") is mod.EMPTY_ADAPTER
+    assert pool.get("micro") is mod.EMPTY_ADAPTER  # case-insensitive
+
+
+def test_empty_adapter_not_an_error_verdict():
+    assert "SKIPPED_EMPTY_ADAPTER" not in mod._ERROR_VERDICTS

--- a/tests/test_id_label_unknown_prefix.py
+++ b/tests/test_id_label_unknown_prefix.py
@@ -1,0 +1,69 @@
+"""Tests for the id-label validator's UNKNOWN_PREFIX gate.
+
+A CURIE whose prefix is neither a configured ontology adapter NOR an explicit
+``ignored_prefixes`` entry is a typo (``CHBEI:``) or an unexpected new prefix.
+It must FAIL enforce (UNKNOWN_PREFIX, an ERROR verdict) rather than silently
+passing as SKIPPED_NO_ADAPTER. Legit non-ontology prefixes (cas:, MIM: …) and
+prefix-less ids (UNMAPPED_0001) stay benign skips.
+
+Driven through ``run()`` end-to-end with a temp config + TSV using only
+UNCONFIGURED prefixes, so no real OAK adapter / network is touched.
+"""
+
+import importlib.util
+import textwrap
+from pathlib import Path
+
+_spec = importlib.util.spec_from_file_location(
+    "validate_id_label_correspondence",
+    Path(__file__).parent.parent / "scripts" / "validate_id_label_correspondence.py",
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+def _setup(tmp_path, monkeypatch, rows: str):
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+    (tmp_path / "products.tsv").write_text("ontology_id\tontology_label\n" + rows)
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(textwrap.dedent("""
+        adapters: {}
+        ignored_prefixes: [cas, MIM]
+        synonym_scope: exact
+        targets:
+          - name: products
+            kind: tabular
+            format: tsv
+            glob: products.tsv
+            policy: canonical_or_synonym
+            pairs:
+              - [ontology_id, ontology_label]
+    """))
+    return cfg
+
+
+def test_typoed_prefix_fails_enforce(tmp_path, monkeypatch):
+    # CHBEI: is a typo of CHEBI: — neither adapter nor ignored → UNKNOWN_PREFIX.
+    cfg = _setup(tmp_path, monkeypatch, "CHBEI:15377\twater\n")
+    assert mod.run(cfg, report_path=None) == 2
+
+
+def test_ignored_and_prefixless_pass_enforce(tmp_path, monkeypatch):
+    # cas:/MIM: are explicitly ignored; UNMAPPED_1 has no CURIE prefix at all.
+    cfg = _setup(
+        tmp_path, monkeypatch,
+        "cas:50-00-0\tformaldehyde\nMIM:000123\tfoo\nUNMAPPED_1\tmystery\n",
+    )
+    assert mod.run(cfg, report_path=None) == 0
+
+
+def test_report_mode_still_exit_zero_but_records_unknown(tmp_path, monkeypatch):
+    cfg = _setup(tmp_path, monkeypatch, "CHBEI:15377\twater\n")
+    report = tmp_path / "drift.tsv"
+    assert mod.run(cfg, report_path=report) == 0  # baseline mode never fails
+    body = report.read_text()
+    assert "UNKNOWN_PREFIX" in body and "CHBEI:15377" in body
+
+
+def test_unknown_prefix_is_error_verdict():
+    assert "UNKNOWN_PREFIX" in mod._ERROR_VERDICTS


### PR DESCRIPTION
## Summary

- Brings `scripts/validate_id_label_correspondence.py` to **byte-identical parity** with MIM's current copy (sha `706987057c…`) by porting [MIM commit 0ea8e15](https://github.com/CultureBotAI/MediaIngredientMech/commit/0ea8e155) — "id-label validator: close two enforce false-pass paths"
- Wires up the cross-repo **pin guard** (`verify-validator-pin` / `refresh-validator-pin` + `.sha256` sidecar) that CommunityMech was missing entirely

## What 0ea8e15 fixes

Two enforce-mode false-greens flagged in the original adversarial review of MIM PR #45:

1. **[critical]** "no such table" no longer trusts the error text alone — a positive `_is_uninitialized_stub()` probe (0-byte file or 0 tables) is required before downgrading to the benign `SKIPPED_EMPTY_ADAPTER`. A partially-migrated LIVE ontology now surfaces real `ID_NOT_FOUND` errors instead of silently passing.
2. **[high]** Typoed/unexpected ontology prefixes (`CHBEI:`, `CHEB:`) used to fall through `pool.get()→None` as `SKIPPED_NO_ADAPTER`. New `ignored_prefixes` conf knob lists legitimate non-ontology prefixes; anything not in `adapters` AND not in `ignored_prefixes` now fails as `UNKNOWN_PREFIX` (ERROR). Prefix-less ids (`UNMAPPED_0001`) stay benign.

## CommunityMech-specific notes

- `conf/id_label_targets.yaml`: kept the repo-specific `adapters` (NCBITaxon, ENVO, CHEBI, GO, UBERON, CL), `targets`, and `exceptions` intact. New `ignored_prefixes` list reflects what CommunityMech consumes (cross-Mech ids + cas + kgmicrobe.* + mediadive.*). If `just validate-products` later fires `UNKNOWN_PREFIX` on a real but uncovered prefix, triage it here.
- `justfile`: added the pin recipes right after `report-label-drift`.
- Unrelated dirty files in the working tree (`uv.lock`, `references_cache/*`) were intentionally left out of this commit.

## Test plan

- [x] `just refresh-validator-pin` → repins to `706987057c…`
- [x] `just verify-validator-pin` → OK
- [x] `uv run pytest tests/test_id_label_empty_adapter.py tests/test_id_label_unknown_prefix.py -v` → 17/17 pass (no OAK/network — fake adapters + temp sqlite)
- [ ] Reviewer: confirm `ignored_prefixes` list is complete enough that a future `just validate-products` enforce run doesn't fire spurious `UNKNOWN_PREFIX` on benign CommunityMech ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)