### PR TITLE
Fix validate-strict CI: pin setuptools<81 so pkg_resources is importable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,12 @@ dependencies = [
     "pandas>=2.0.0",
     "umap-learn>=0.5.0",
     "tqdm>=4.66.0",
+    # Provides pkg_resources, imported at load time by eutils (a transitive
+    # oaklib dep). uv does not install setuptools into the venv unless declared,
+    # so without this `from oaklib import get_adapter` fails in CI with
+    # ModuleNotFoundError: No module named 'pkg_resources'. Capped <81 because
+    # setuptools 81 removed pkg_resources entirely.
+    "setuptools>=61.0,<81",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -645,6 +645,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "requests" },
+    { name = "setuptools" },
     { name = "tqdm" },
     { name = "umap-learn" },
 ]
@@ -653,12 +654,14 @@ dependencies = [
 dev = [
     { name = "black" },
     { name = "deep-research-client", extra = ["cyberian"], marker = "python_full_version >= '3.12'" },
+    { name = "edison-client", marker = "python_full_version >= '3.12'" },
     { name = "mypy" },
     { name = "pandas-stubs", version = "2.3.3.260113", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas-stubs", version = "3.0.0.260204", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "python-dotenv" },
     { name = "ruff" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
@@ -683,6 +686,7 @@ requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "deep-research-client", extras = ["cyberian"], marker = "python_full_version >= '3.12' and extra == 'dev'", specifier = ">=0.2.4" },
+    { name = "edison-client", marker = "python_full_version >= '3.12' and extra == 'dev'", specifier = ">=0.11.0" },
     { name = "jinja2", specifier = ">=3.0.0" },
     { name = "koza", marker = "extra == 'koza'", specifier = ">=0.5.0" },
     { name = "linkml", specifier = ">=1.7.0" },
@@ -699,10 +703,12 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "rich", marker = "extra == 'llm'", specifier = ">=13.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "setuptools", specifier = ">=61.0,<81" },
     { name = "tqdm", specifier = ">=4.66.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.31.0" },
@@ -4947,11 +4953,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.0"
+version = "80.10.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/f3/748f4d6f65d1756b9ae577f329c951cda23fb900e4de9f70900ced962085/setuptools-82.0.0.tar.gz", hash = "sha256:22e0a2d69474c6ae4feb01951cb69d515ed23728cf96d05513d36e42b62b37cb", size = 1144893 }
+sdist = { url = "https://files.pythonhosted.org/packages/76/95/faf61eb8363f26aa7e1d762267a8d602a1b26d4f3a1e758e92cb3cb8b054/setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70", size = 1200343 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/c6/76dc613121b793286a3f91621d7b75a2b493e0390ddca50f11993eadf192/setuptools-82.0.0-py3-none-any.whl", hash = "sha256:70b18734b607bd1da571d097d236cfcfacaf01de45717d59e6e04b96877532e0", size = 1003468 },
+    { url = "https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173", size = 1064234 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`validate-strict` has been failing on `main` (e.g. commit `c473601e`) — unrelated to PR content:

```
ModuleNotFoundError: No module named 'pkg_resources'
  from oaklib import get_adapter        # via linkml-term-validator + the
                                        # empty-adapter test's oaklib import
  ...
  from eutils import Client
  import pkg_resources                  # eutils/__init__.py:4
```

`eutils` (a transitive `oaklib` dependency) imports `pkg_resources` at module load time. Two things combine to break it in CI:

1. **uv does not install `setuptools` into the venv** unless it is a declared dependency — so `pkg_resources` was simply absent.
2. **setuptools 81 removed `pkg_resources`** entirely, so even a default `setuptools` pull would not have fixed it going forward.

(Locally the failure was masked: Python 3.14 resolves an `eutils` that doesn't import `pkg_resources`, so the tests passed.)

## Fix

Declare `setuptools>=61.0,<81` as a runtime dependency. The `<81` cap guarantees a `pkg_resources`-bearing setuptools (resolves to `80.10.2`). `uv.lock` is regenerated to match; it also picks up the previously-unsynced `edison-client` / `python-dotenv` dev entries, which fixes a latent `uv sync --frozen` staleness.

## Test plan

- [x] `uv sync --frozen --all-extras` clean
- [x] `uv run python -c "import pkg_resources; from oaklib import get_adapter"` → OK
- [x] `uv run pytest tests/ -q --no-cov` → **183 passed, 7 deselected**

🤖 Generated with [Claude Code](https://claude.com/claude-code)