### PR TITLE
chore: make `just lint` green and gate it in CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,44 @@
+name: lint
+
+# Style + type gate (black --check, ruff, mypy). Previously `just lint` was
+# only ever run locally, so formatting/type debt accumulated unnoticed; this
+# job keeps it from regressing.
+
+on:
+  pull_request:
+    paths: &trigger_paths
+      - "src/**/*.py"
+      - "tests/**/*.py"
+      - "scripts/**/*.py"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/lint.yaml"
+  push:
+    branches: [main]
+    paths: *trigger_paths
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+          enable-cache: true
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: uv sync --frozen --all-extras
+      - name: black + ruff + mypy
+        run: |
+          uv run black --check src/ tests/
+          uv run ruff check src/ tests/
+          uv run mypy src/

--- a/justfile
+++ b/justfile
@@ -126,6 +126,9 @@ test:
 # Generate Python datamodel from schema
 gen-python:
     uv run gen-python src/communitymech/schema/communitymech.yaml > src/communitymech/datamodel/communitymech.py
+    # Format the generated file so `black --check src/` (just lint) stays green
+    # without a manual `just format` after every regen.
+    uv run black -q src/communitymech/datamodel/communitymech.py
 
 # Generate schema documentation
 gen-doc:

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -9,52 +9,18 @@
 import dataclasses
 import re
 from dataclasses import dataclass
-from datetime import (
-    date,
-    datetime,
-    time
-)
-from typing import (
-    Any,
-    ClassVar,
-    Dict,
-    List,
-    Optional,
-    Union
-)
+from datetime import date, datetime, time
+from typing import Any, ClassVar, Dict, List, Optional, Union
 
-from jsonasobj2 import (
-    JsonObj,
-    as_dict
-)
-from linkml_runtime.linkml_model.meta import (
-    EnumDefinition,
-    PermissibleValue,
-    PvFormulaOptions
-)
+from jsonasobj2 import JsonObj, as_dict
+from linkml_runtime.linkml_model.meta import EnumDefinition, PermissibleValue, PvFormulaOptions
 from linkml_runtime.utils.curienamespace import CurieNamespace
 from linkml_runtime.utils.enumerations import EnumDefinitionImpl
-from linkml_runtime.utils.formatutils import (
-    camelcase,
-    sfx,
-    underscore
-)
-from linkml_runtime.utils.metamodelcore import (
-    bnode,
-    empty_dict,
-    empty_list
-)
+from linkml_runtime.utils.formatutils import camelcase, sfx, underscore
+from linkml_runtime.utils.metamodelcore import bnode, empty_dict, empty_list
 from linkml_runtime.utils.slot import Slot
-from linkml_runtime.utils.yamlutils import (
-    YAMLRoot,
-    extended_float,
-    extended_int,
-    extended_str
-)
-from rdflib import (
-    Namespace,
-    URIRef
-)
+from linkml_runtime.utils.yamlutils import YAMLRoot, extended_float, extended_int, extended_str
+from rdflib import Namespace, URIRef
 
 from linkml_runtime.linkml_model.types import Boolean, Datetime, Float, String
 from linkml_runtime.utils.metamodelcore import Bool, XSDDateTime
@@ -63,18 +29,18 @@ metamodel_version = "1.7.0"
 version = None
 
 # Namespaces
-CHEBI = CurieNamespace('CHEBI', 'http://purl.obolibrary.org/obo/CHEBI_')
-CL = CurieNamespace('CL', 'http://purl.obolibrary.org/obo/CL_')
-ENVO = CurieNamespace('ENVO', 'http://purl.obolibrary.org/obo/ENVO_')
-GO = CurieNamespace('GO', 'http://purl.obolibrary.org/obo/GO_')
-NCBITAXON = CurieNamespace('NCBITaxon', 'http://purl.obolibrary.org/obo/NCBITaxon_')
-PMID = CurieNamespace('PMID', 'http://www.ncbi.nlm.nih.gov/pubmed/')
-UBERON = CurieNamespace('UBERON', 'http://purl.obolibrary.org/obo/UBERON_')
-COMMUNITYMECH = CurieNamespace('communitymech', 'https://w3id.org/communitymech/')
-DOI = CurieNamespace('doi', 'https://doi.org/')
-LINKML = CurieNamespace('linkml', 'https://w3id.org/linkml/')
-RDFS = CurieNamespace('rdfs', 'http://www.w3.org/2000/01/rdf-schema#')
-XSD = CurieNamespace('xsd', 'http://www.w3.org/2001/XMLSchema#')
+CHEBI = CurieNamespace("CHEBI", "http://purl.obolibrary.org/obo/CHEBI_")
+CL = CurieNamespace("CL", "http://purl.obolibrary.org/obo/CL_")
+ENVO = CurieNamespace("ENVO", "http://purl.obolibrary.org/obo/ENVO_")
+GO = CurieNamespace("GO", "http://purl.obolibrary.org/obo/GO_")
+NCBITAXON = CurieNamespace("NCBITaxon", "http://purl.obolibrary.org/obo/NCBITaxon_")
+PMID = CurieNamespace("PMID", "http://www.ncbi.nlm.nih.gov/pubmed/")
+UBERON = CurieNamespace("UBERON", "http://purl.obolibrary.org/obo/UBERON_")
+COMMUNITYMECH = CurieNamespace("communitymech", "https://w3id.org/communitymech/")
+DOI = CurieNamespace("doi", "https://doi.org/")
+LINKML = CurieNamespace("linkml", "https://w3id.org/linkml/")
+RDFS = CurieNamespace("rdfs", "http://www.w3.org/2000/01/rdf-schema#")
+XSD = CurieNamespace("xsd", "http://www.w3.org/2001/XMLSchema#")
 DEFAULT_ = COMMUNITYMECH
 
 
@@ -96,6 +62,7 @@ class Term(YAMLRoot):
     """
     An ontology term with ID and label
     """
+
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["Term"]
@@ -125,6 +92,7 @@ class EvidenceItem(YAMLRoot):
     """
     An evidence item linking a claim to a publication
     """
+
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["EvidenceItem"]
@@ -174,6 +142,7 @@ class TaxonDescriptor(YAMLRoot):
     """
     Describes an organism with NCBITaxon term
     """
+
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["TaxonDescriptor"]
@@ -207,6 +176,7 @@ class MetaboliteDescriptor(YAMLRoot):
     """
     Describes a metabolite with CHEBI term
     """
+
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["MetaboliteDescriptor"]
@@ -244,6 +214,7 @@ class BiologicalProcessDescriptor(YAMLRoot):
     """
     Describes a biological process with GO term
     """
+
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["BiologicalProcessDescriptor"]
@@ -277,6 +248,7 @@ class EnvironmentDescriptor(YAMLRoot):
     """
     Describes an environment with ENVO term
     """
+
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["EnvironmentDescriptor"]
@@ -310,6 +282,7 @@ class CultureCollectionID(YAMLRoot):
     """
     A culture collection identifier with accession number
     """
+
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["CultureCollectionID"]
@@ -347,6 +320,7 @@ class StrainDesignation(YAMLRoot):
     """
     Detailed strain-level information for reproducibility
     """
+
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["StrainDesignation"]
@@ -355,7 +329,9 @@ class StrainDesignation(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.StrainDesignation
 
     strain_name: Optional[str] = None
-    culture_collections: Optional[Union[Union[dict, CultureCollectionID], list[Union[dict, CultureCollectionID]]]] = empty_list()
+    culture_collections: Optional[
+        Union[Union[dict, CultureCollectionID], list[Union[dict, CultureCollectionID]]]
+    ] = empty_list()
     type_strain: Optional[Union[bool, Bool]] = None
     genome_accession: Optional[str] = None
     genome_url: Optional[str] = None
@@ -367,7 +343,12 @@ class StrainDesignation(YAMLRoot):
         if self.strain_name is not None and not isinstance(self.strain_name, str):
             self.strain_name = str(self.strain_name)
 
-        self._normalize_inlined_as_dict(slot_name="culture_collections", slot_type=CultureCollectionID, key_name="collection", keyed=False)
+        self._normalize_inlined_as_dict(
+            slot_name="culture_collections",
+            slot_type=CultureCollectionID,
+            key_name="collection",
+            keyed=False,
+        )
 
         if self.type_strain is not None and not isinstance(self.type_strain, Bool):
             self.type_strain = Bool(self.type_strain)
@@ -395,6 +376,7 @@ class TaxonomicComposition(YAMLRoot):
     """
     A taxon present in the community with abundance and role
     """
+
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["TaxonomicComposition"]
@@ -406,8 +388,12 @@ class TaxonomicComposition(YAMLRoot):
     strain_designation: Optional[Union[dict, StrainDesignation]] = None
     abundance_level: Optional[Union[str, "AbundanceEnum"]] = None
     abundance_value: Optional[str] = None
-    functional_role: Optional[Union[Union[str, "FunctionalRoleEnum"], list[Union[str, "FunctionalRoleEnum"]]]] = empty_list()
-    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
+    functional_role: Optional[
+        Union[Union[str, "FunctionalRoleEnum"], list[Union[str, "FunctionalRoleEnum"]]]
+    ] = empty_list()
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
+        empty_list()
+    )
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.taxon_term):
@@ -415,7 +401,9 @@ class TaxonomicComposition(YAMLRoot):
         if not isinstance(self.taxon_term, TaxonDescriptor):
             self.taxon_term = TaxonDescriptor(**as_dict(self.taxon_term))
 
-        if self.strain_designation is not None and not isinstance(self.strain_designation, StrainDesignation):
+        if self.strain_designation is not None and not isinstance(
+            self.strain_designation, StrainDesignation
+        ):
             self.strain_designation = StrainDesignation(**as_dict(self.strain_designation))
 
         if self.abundance_level is not None and not isinstance(self.abundance_level, AbundanceEnum):
@@ -425,10 +413,17 @@ class TaxonomicComposition(YAMLRoot):
             self.abundance_value = str(self.abundance_value)
 
         if not isinstance(self.functional_role, list):
-            self.functional_role = [self.functional_role] if self.functional_role is not None else []
-        self.functional_role = [v if isinstance(v, FunctionalRoleEnum) else FunctionalRoleEnum(v) for v in self.functional_role]
+            self.functional_role = (
+                [self.functional_role] if self.functional_role is not None else []
+            )
+        self.functional_role = [
+            v if isinstance(v, FunctionalRoleEnum) else FunctionalRoleEnum(v)
+            for v in self.functional_role
+        ]
 
-        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
+        self._normalize_inlined_as_dict(
+            slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False
+        )
 
         super().__post_init__(**kwargs)
 
@@ -438,6 +433,7 @@ class InteractionDownstream(YAMLRoot):
     """
     A downstream target in a causal interaction graph
     """
+
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["InteractionDownstream"]
@@ -465,6 +461,7 @@ class EcologicalInteraction(YAMLRoot):
     """
     An interaction between organisms or metabolic processes
     """
+
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["EcologicalInteraction"]
@@ -475,13 +472,23 @@ class EcologicalInteraction(YAMLRoot):
     name: str = None
     description: Optional[str] = None
     interaction_type: Optional[Union[str, "InteractionTypeEnum"]] = None
-    scope: Optional[Union[str, "InteractionScopeEnum"]] = 'PAIRWISE'
+    scope: Optional[Union[str, "InteractionScopeEnum"]] = "PAIRWISE"
     source_taxon: Optional[Union[dict, TaxonDescriptor]] = None
     target_taxon: Optional[Union[dict, TaxonDescriptor]] = None
-    metabolites: Optional[Union[Union[dict, MetaboliteDescriptor], list[Union[dict, MetaboliteDescriptor]]]] = empty_list()
-    biological_processes: Optional[Union[Union[dict, BiologicalProcessDescriptor], list[Union[dict, BiologicalProcessDescriptor]]]] = empty_list()
-    downstream: Optional[Union[Union[dict, InteractionDownstream], list[Union[dict, InteractionDownstream]]]] = empty_list()
-    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
+    metabolites: Optional[
+        Union[Union[dict, MetaboliteDescriptor], list[Union[dict, MetaboliteDescriptor]]]
+    ] = empty_list()
+    biological_processes: Optional[
+        Union[
+            Union[dict, BiologicalProcessDescriptor], list[Union[dict, BiologicalProcessDescriptor]]
+        ]
+    ] = empty_list()
+    downstream: Optional[
+        Union[Union[dict, InteractionDownstream], list[Union[dict, InteractionDownstream]]]
+    ] = empty_list()
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
+        empty_list()
+    )
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.name):
@@ -492,7 +499,9 @@ class EcologicalInteraction(YAMLRoot):
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
 
-        if self.interaction_type is not None and not isinstance(self.interaction_type, InteractionTypeEnum):
+        if self.interaction_type is not None and not isinstance(
+            self.interaction_type, InteractionTypeEnum
+        ):
             self.interaction_type = InteractionTypeEnum(self.interaction_type)
 
         if self.scope is not None and not isinstance(self.scope, InteractionScopeEnum):
@@ -504,13 +513,27 @@ class EcologicalInteraction(YAMLRoot):
         if self.target_taxon is not None and not isinstance(self.target_taxon, TaxonDescriptor):
             self.target_taxon = TaxonDescriptor(**as_dict(self.target_taxon))
 
-        self._normalize_inlined_as_dict(slot_name="metabolites", slot_type=MetaboliteDescriptor, key_name="preferred_term", keyed=False)
+        self._normalize_inlined_as_dict(
+            slot_name="metabolites",
+            slot_type=MetaboliteDescriptor,
+            key_name="preferred_term",
+            keyed=False,
+        )
 
-        self._normalize_inlined_as_dict(slot_name="biological_processes", slot_type=BiologicalProcessDescriptor, key_name="preferred_term", keyed=False)
+        self._normalize_inlined_as_dict(
+            slot_name="biological_processes",
+            slot_type=BiologicalProcessDescriptor,
+            key_name="preferred_term",
+            keyed=False,
+        )
 
-        self._normalize_inlined_as_dict(slot_name="downstream", slot_type=InteractionDownstream, key_name="target", keyed=False)
+        self._normalize_inlined_as_dict(
+            slot_name="downstream", slot_type=InteractionDownstream, key_name="target", keyed=False
+        )
 
-        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
+        self._normalize_inlined_as_dict(
+            slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False
+        )
 
         super().__post_init__(**kwargs)
 
@@ -520,6 +543,7 @@ class EnvironmentalFactor(YAMLRoot):
     """
     An environmental condition or parameter
     """
+
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["EnvironmentalFactor"]
@@ -531,7 +555,9 @@ class EnvironmentalFactor(YAMLRoot):
     value: Optional[str] = None
     unit: Optional[str] = None
     description: Optional[str] = None
-    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
+        empty_list()
+    )
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.name):
@@ -548,7 +574,9 @@ class EnvironmentalFactor(YAMLRoot):
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
 
-        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
+        self._normalize_inlined_as_dict(
+            slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False
+        )
 
         super().__post_init__(**kwargs)
 
@@ -558,6 +586,7 @@ class GrowthMediaComponent(YAMLRoot):
     """
     A component of growth media (nutrient, salt, buffer, etc.)
     """
+
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["GrowthMediaComponent"]
@@ -579,10 +608,14 @@ class GrowthMediaComponent(YAMLRoot):
         if not isinstance(self.name, str):
             self.name = str(self.name)
 
-        if self.media_ingredient_mech_id is not None and not isinstance(self.media_ingredient_mech_id, str):
+        if self.media_ingredient_mech_id is not None and not isinstance(
+            self.media_ingredient_mech_id, str
+        ):
             self.media_ingredient_mech_id = str(self.media_ingredient_mech_id)
 
-        if self.media_ingredient_mech_url is not None and not isinstance(self.media_ingredient_mech_url, str):
+        if self.media_ingredient_mech_url is not None and not isinstance(
+            self.media_ingredient_mech_url, str
+        ):
             self.media_ingredient_mech_url = str(self.media_ingredient_mech_url)
 
         if self.concentration is not None and not isinstance(self.concentration, str):
@@ -605,6 +638,7 @@ class GrowthMedia(YAMLRoot):
     """
     Growth media used for cultivation of the community or its members
     """
+
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["GrowthMedia"]
@@ -615,7 +649,9 @@ class GrowthMedia(YAMLRoot):
     name: str = None
     culturemech_id: Optional[str] = None
     culturemech_url: Optional[str] = None
-    composition: Optional[Union[Union[dict, GrowthMediaComponent], list[Union[dict, GrowthMediaComponent]]]] = empty_list()
+    composition: Optional[
+        Union[Union[dict, GrowthMediaComponent], list[Union[dict, GrowthMediaComponent]]]
+    ] = empty_list()
     ph: Optional[str] = None
     ph_range: Optional[str] = None
     temperature: Optional[str] = None
@@ -642,7 +678,9 @@ class GrowthMedia(YAMLRoot):
     vessel_type: Optional[str] = None
     preparation_notes: Optional[str] = None
     protocol_url: Optional[str] = None
-    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
+        empty_list()
+    )
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.name):
@@ -656,7 +694,9 @@ class GrowthMedia(YAMLRoot):
         if self.culturemech_url is not None and not isinstance(self.culturemech_url, str):
             self.culturemech_url = str(self.culturemech_url)
 
-        self._normalize_inlined_as_dict(slot_name="composition", slot_type=GrowthMediaComponent, key_name="name", keyed=False)
+        self._normalize_inlined_as_dict(
+            slot_name="composition", slot_type=GrowthMediaComponent, key_name="name", keyed=False
+        )
 
         if self.ph is not None and not isinstance(self.ph, str):
             self.ph = str(self.ph)
@@ -736,7 +776,9 @@ class GrowthMedia(YAMLRoot):
         if self.protocol_url is not None and not isinstance(self.protocol_url, str):
             self.protocol_url = str(self.protocol_url)
 
-        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
+        self._normalize_inlined_as_dict(
+            slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False
+        )
 
         super().__post_init__(**kwargs)
 
@@ -748,6 +790,7 @@ class RelatedMedia(YAMLRoot):
     Complements GrowthMedia (which captures media actually used for cultivation) by enabling environment-based
     discovery of potentially useful media across the CultureMech repository.
     """
+
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["RelatedMedia"]
@@ -760,7 +803,9 @@ class RelatedMedia(YAMLRoot):
     relationship_type: Optional[Union[str, "MediaRelationshipEnum"]] = None
     shared_environment_term: Optional[Union[dict, Term]] = None
     relevance_notes: Optional[str] = None
-    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
+        empty_list()
+    )
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.preferred_term):
@@ -771,16 +816,22 @@ class RelatedMedia(YAMLRoot):
         if self.culturemech_id is not None and not isinstance(self.culturemech_id, str):
             self.culturemech_id = str(self.culturemech_id)
 
-        if self.relationship_type is not None and not isinstance(self.relationship_type, MediaRelationshipEnum):
+        if self.relationship_type is not None and not isinstance(
+            self.relationship_type, MediaRelationshipEnum
+        ):
             self.relationship_type = MediaRelationshipEnum(self.relationship_type)
 
-        if self.shared_environment_term is not None and not isinstance(self.shared_environment_term, Term):
+        if self.shared_environment_term is not None and not isinstance(
+            self.shared_environment_term, Term
+        ):
             self.shared_environment_term = Term(**as_dict(self.shared_environment_term))
 
         if self.relevance_notes is not None and not isinstance(self.relevance_notes, str):
             self.relevance_notes = str(self.relevance_notes)
 
-        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
+        self._normalize_inlined_as_dict(
+            slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False
+        )
 
         super().__post_init__(**kwargs)
 
@@ -792,6 +843,7 @@ class RelatedIngredient(YAMLRoot):
     GrowthMediaComponent (which captures ingredients in actual cultivation media) by linking to environmentally
     significant compounds that may not be in any currently used medium.
     """
+
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["RelatedIngredient"]
@@ -803,7 +855,9 @@ class RelatedIngredient(YAMLRoot):
     mediaingredientmech_id: Optional[str] = None
     chebi_term: Optional[Union[dict, Term]] = None
     relevance: Optional[str] = None
-    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
+        empty_list()
+    )
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.preferred_term):
@@ -811,7 +865,9 @@ class RelatedIngredient(YAMLRoot):
         if not isinstance(self.preferred_term, str):
             self.preferred_term = str(self.preferred_term)
 
-        if self.mediaingredientmech_id is not None and not isinstance(self.mediaingredientmech_id, str):
+        if self.mediaingredientmech_id is not None and not isinstance(
+            self.mediaingredientmech_id, str
+        ):
             self.mediaingredientmech_id = str(self.mediaingredientmech_id)
 
         if self.chebi_term is not None and not isinstance(self.chebi_term, Term):
@@ -820,7 +876,9 @@ class RelatedIngredient(YAMLRoot):
         if self.relevance is not None and not isinstance(self.relevance, str):
             self.relevance = str(self.relevance)
 
-        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
+        self._normalize_inlined_as_dict(
+            slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False
+        )
 
         super().__post_init__(**kwargs)
 
@@ -830,6 +888,7 @@ class AssociatedDataset(YAMLRoot):
     """
     An omics or other dataset associated with the community
     """
+
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["AssociatedDataset"]
@@ -843,7 +902,9 @@ class AssociatedDataset(YAMLRoot):
     repository: Optional[Union[str, "DatasetRepositoryEnum"]] = None
     url: Optional[str] = None
     description: Optional[str] = None
-    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
+        empty_list()
+    )
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.name):
@@ -870,7 +931,9 @@ class AssociatedDataset(YAMLRoot):
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
 
-        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
+        self._normalize_inlined_as_dict(
+            slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False
+        )
 
         super().__post_init__(**kwargs)
 
@@ -880,6 +943,7 @@ class ExternalResource(YAMLRoot):
     """
     An external model or narrative resource linked to the community
     """
+
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["ExternalResource"]
@@ -892,7 +956,9 @@ class ExternalResource(YAMLRoot):
     resource_id: str = None
     url: str = None
     description: Optional[str] = None
-    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
+        empty_list()
+    )
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.name):
@@ -918,7 +984,9 @@ class ExternalResource(YAMLRoot):
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
 
-        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
+        self._normalize_inlined_as_dict(
+            slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False
+        )
 
         super().__post_init__(**kwargs)
 
@@ -928,6 +996,7 @@ class CommunityEngineeringDesign(YAMLRoot):
     """
     Design intent and implementation details for engineered or synthetic communities
     """
+
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["CommunityEngineeringDesign"]
@@ -943,7 +1012,9 @@ class CommunityEngineeringDesign(YAMLRoot):
     measurement_endpoints: Optional[Union[str, list[str]]] = empty_list()
     protocol_url: Optional[str] = None
     notes: Optional[str] = None
-    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
+        empty_list()
+    )
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.objective is not None and not isinstance(self.objective, str):
@@ -962,8 +1033,12 @@ class CommunityEngineeringDesign(YAMLRoot):
             self.perturbation_design = str(self.perturbation_design)
 
         if not isinstance(self.measurement_endpoints, list):
-            self.measurement_endpoints = [self.measurement_endpoints] if self.measurement_endpoints is not None else []
-        self.measurement_endpoints = [v if isinstance(v, str) else str(v) for v in self.measurement_endpoints]
+            self.measurement_endpoints = (
+                [self.measurement_endpoints] if self.measurement_endpoints is not None else []
+            )
+        self.measurement_endpoints = [
+            v if isinstance(v, str) else str(v) for v in self.measurement_endpoints
+        ]
 
         if self.protocol_url is not None and not isinstance(self.protocol_url, str):
             self.protocol_url = str(self.protocol_url)
@@ -971,7 +1046,9 @@ class CommunityEngineeringDesign(YAMLRoot):
         if self.notes is not None and not isinstance(self.notes, str):
             self.notes = str(self.notes)
 
-        self._normalize_inlined_as_dict(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False)
+        self._normalize_inlined_as_dict(
+            slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False
+        )
 
         super().__post_init__(**kwargs)
 
@@ -981,6 +1058,7 @@ class MicrobialCommunity(YAMLRoot):
     """
     A microbial community with composition and interactions
     """
+
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["MicrobialCommunity"]
@@ -996,19 +1074,41 @@ class MicrobialCommunity(YAMLRoot):
     community_category: Optional[Union[str, "CommunityCategoryEnum"]] = None
     engineering_design: Optional[Union[dict, CommunityEngineeringDesign]] = None
     environment_term: Optional[Union[dict, EnvironmentDescriptor]] = None
-    taxonomy: Optional[Union[Union[dict, TaxonomicComposition], list[Union[dict, TaxonomicComposition]]]] = empty_list()
-    ecological_interactions: Optional[Union[Union[dict, EcologicalInteraction], list[Union[dict, EcologicalInteraction]]]] = empty_list()
-    environmental_factors: Optional[Union[Union[dict, EnvironmentalFactor], list[Union[dict, EnvironmentalFactor]]]] = empty_list()
-    growth_media: Optional[Union[Union[dict, GrowthMedia], list[Union[dict, GrowthMedia]]]] = empty_list()
-    related_media: Optional[Union[Union[dict, RelatedMedia], list[Union[dict, RelatedMedia]]]] = empty_list()
-    related_ingredients: Optional[Union[Union[dict, RelatedIngredient], list[Union[dict, RelatedIngredient]]]] = empty_list()
-    associated_datasets: Optional[Union[Union[dict, AssociatedDataset], list[Union[dict, AssociatedDataset]]]] = empty_list()
-    external_resources: Optional[Union[Union[dict, ExternalResource], list[Union[dict, ExternalResource]]]] = empty_list()
-    metals_present: Optional[Union[Union[str, "MetalElementEnum"], list[Union[str, "MetalElementEnum"]]]] = empty_list()
-    rare_earth_elements_present: Optional[Union[Union[str, "RareEarthElementEnum"], list[Union[str, "RareEarthElementEnum"]]]] = empty_list()
+    taxonomy: Optional[
+        Union[Union[dict, TaxonomicComposition], list[Union[dict, TaxonomicComposition]]]
+    ] = empty_list()
+    ecological_interactions: Optional[
+        Union[Union[dict, EcologicalInteraction], list[Union[dict, EcologicalInteraction]]]
+    ] = empty_list()
+    environmental_factors: Optional[
+        Union[Union[dict, EnvironmentalFactor], list[Union[dict, EnvironmentalFactor]]]
+    ] = empty_list()
+    growth_media: Optional[Union[Union[dict, GrowthMedia], list[Union[dict, GrowthMedia]]]] = (
+        empty_list()
+    )
+    related_media: Optional[Union[Union[dict, RelatedMedia], list[Union[dict, RelatedMedia]]]] = (
+        empty_list()
+    )
+    related_ingredients: Optional[
+        Union[Union[dict, RelatedIngredient], list[Union[dict, RelatedIngredient]]]
+    ] = empty_list()
+    associated_datasets: Optional[
+        Union[Union[dict, AssociatedDataset], list[Union[dict, AssociatedDataset]]]
+    ] = empty_list()
+    external_resources: Optional[
+        Union[Union[dict, ExternalResource], list[Union[dict, ExternalResource]]]
+    ] = empty_list()
+    metals_present: Optional[
+        Union[Union[str, "MetalElementEnum"], list[Union[str, "MetalElementEnum"]]]
+    ] = empty_list()
+    rare_earth_elements_present: Optional[
+        Union[Union[str, "RareEarthElementEnum"], list[Union[str, "RareEarthElementEnum"]]]
+    ] = empty_list()
     metal_relevance: Optional[Union[str, "MetalRelevanceEnum"]] = None
     metal_notes: Optional[str] = None
-    curation_history: Optional[Union[Union[dict, "CurationEvent"], list[Union[dict, "CurationEvent"]]]] = empty_list()
+    curation_history: Optional[
+        Union[Union[dict, "CurationEvent"], list[Union[dict, "CurationEvent"]]]
+    ] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1024,58 +1124,114 @@ class MicrobialCommunity(YAMLRoot):
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
 
-        if self.ecological_state is not None and not isinstance(self.ecological_state, EcologicalStateEnum):
+        if self.ecological_state is not None and not isinstance(
+            self.ecological_state, EcologicalStateEnum
+        ):
             self.ecological_state = EcologicalStateEnum(self.ecological_state)
 
-        if self.community_origin is not None and not isinstance(self.community_origin, CommunityOriginEnum):
+        if self.community_origin is not None and not isinstance(
+            self.community_origin, CommunityOriginEnum
+        ):
             self.community_origin = CommunityOriginEnum(self.community_origin)
 
-        if self.community_category is not None and not isinstance(self.community_category, CommunityCategoryEnum):
+        if self.community_category is not None and not isinstance(
+            self.community_category, CommunityCategoryEnum
+        ):
             self.community_category = CommunityCategoryEnum(self.community_category)
 
-        if self.engineering_design is not None and not isinstance(self.engineering_design, CommunityEngineeringDesign):
+        if self.engineering_design is not None and not isinstance(
+            self.engineering_design, CommunityEngineeringDesign
+        ):
             self.engineering_design = CommunityEngineeringDesign(**as_dict(self.engineering_design))
 
-        if self.environment_term is not None and not isinstance(self.environment_term, EnvironmentDescriptor):
+        if self.environment_term is not None and not isinstance(
+            self.environment_term, EnvironmentDescriptor
+        ):
             self.environment_term = EnvironmentDescriptor(**as_dict(self.environment_term))
 
-        self._normalize_inlined_as_dict(slot_name="taxonomy", slot_type=TaxonomicComposition, key_name="taxon_term", keyed=False)
+        self._normalize_inlined_as_dict(
+            slot_name="taxonomy", slot_type=TaxonomicComposition, key_name="taxon_term", keyed=False
+        )
 
-        self._normalize_inlined_as_dict(slot_name="ecological_interactions", slot_type=EcologicalInteraction, key_name="name", keyed=False)
+        self._normalize_inlined_as_dict(
+            slot_name="ecological_interactions",
+            slot_type=EcologicalInteraction,
+            key_name="name",
+            keyed=False,
+        )
 
-        self._normalize_inlined_as_dict(slot_name="environmental_factors", slot_type=EnvironmentalFactor, key_name="name", keyed=False)
+        self._normalize_inlined_as_dict(
+            slot_name="environmental_factors",
+            slot_type=EnvironmentalFactor,
+            key_name="name",
+            keyed=False,
+        )
 
-        self._normalize_inlined_as_dict(slot_name="growth_media", slot_type=GrowthMedia, key_name="name", keyed=False)
+        self._normalize_inlined_as_dict(
+            slot_name="growth_media", slot_type=GrowthMedia, key_name="name", keyed=False
+        )
 
         if not isinstance(self.related_media, list):
             self.related_media = [self.related_media] if self.related_media is not None else []
-        self.related_media = [v if isinstance(v, RelatedMedia) else RelatedMedia(**as_dict(v)) for v in self.related_media]
+        self.related_media = [
+            v if isinstance(v, RelatedMedia) else RelatedMedia(**as_dict(v))
+            for v in self.related_media
+        ]
 
         if not isinstance(self.related_ingredients, list):
-            self.related_ingredients = [self.related_ingredients] if self.related_ingredients is not None else []
-        self.related_ingredients = [v if isinstance(v, RelatedIngredient) else RelatedIngredient(**as_dict(v)) for v in self.related_ingredients]
+            self.related_ingredients = (
+                [self.related_ingredients] if self.related_ingredients is not None else []
+            )
+        self.related_ingredients = [
+            v if isinstance(v, RelatedIngredient) else RelatedIngredient(**as_dict(v))
+            for v in self.related_ingredients
+        ]
 
-        self._normalize_inlined_as_dict(slot_name="associated_datasets", slot_type=AssociatedDataset, key_name="name", keyed=False)
+        self._normalize_inlined_as_dict(
+            slot_name="associated_datasets",
+            slot_type=AssociatedDataset,
+            key_name="name",
+            keyed=False,
+        )
 
-        self._normalize_inlined_as_dict(slot_name="external_resources", slot_type=ExternalResource, key_name="name", keyed=False)
+        self._normalize_inlined_as_dict(
+            slot_name="external_resources", slot_type=ExternalResource, key_name="name", keyed=False
+        )
 
         if not isinstance(self.metals_present, list):
             self.metals_present = [self.metals_present] if self.metals_present is not None else []
-        self.metals_present = [v if isinstance(v, MetalElementEnum) else MetalElementEnum(v) for v in self.metals_present]
+        self.metals_present = [
+            v if isinstance(v, MetalElementEnum) else MetalElementEnum(v)
+            for v in self.metals_present
+        ]
 
         if not isinstance(self.rare_earth_elements_present, list):
-            self.rare_earth_elements_present = [self.rare_earth_elements_present] if self.rare_earth_elements_present is not None else []
-        self.rare_earth_elements_present = [v if isinstance(v, RareEarthElementEnum) else RareEarthElementEnum(v) for v in self.rare_earth_elements_present]
+            self.rare_earth_elements_present = (
+                [self.rare_earth_elements_present]
+                if self.rare_earth_elements_present is not None
+                else []
+            )
+        self.rare_earth_elements_present = [
+            v if isinstance(v, RareEarthElementEnum) else RareEarthElementEnum(v)
+            for v in self.rare_earth_elements_present
+        ]
 
-        if self.metal_relevance is not None and not isinstance(self.metal_relevance, MetalRelevanceEnum):
+        if self.metal_relevance is not None and not isinstance(
+            self.metal_relevance, MetalRelevanceEnum
+        ):
             self.metal_relevance = MetalRelevanceEnum(self.metal_relevance)
 
         if self.metal_notes is not None and not isinstance(self.metal_notes, str):
             self.metal_notes = str(self.metal_notes)
 
         if not isinstance(self.curation_history, list):
-            self.curation_history = [self.curation_history] if self.curation_history is not None else []
-        self.curation_history = [v if isinstance(v, CurationEvent) else CurationEvent(**as_dict(v)) for v in self.curation_history]
+            self.curation_history = (
+                [self.curation_history] if self.curation_history is not None else []
+            )
+        self.curation_history = [
+            v if isinstance(v, CurationEvent) else CurationEvent(**as_dict(v))
+            for v in self.curation_history
+        ]
 
         super().__post_init__(**kwargs)
 
@@ -1086,6 +1242,7 @@ class CurationEvent(YAMLRoot):
     A timestamped curator action on a MicrobialCommunity. Mirrors the shape used by sibling Mech repos (CultureMech,
     MediaIngredientMech, TraitMech) so cross-repo tooling can read curation events uniformly.
     """
+
     _inherited_slots: ClassVar[list[str]] = []
 
     class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["CurationEvent"]
@@ -1131,1115 +1288,1959 @@ class EvidenceItemSupportEnum(EnumDefinitionImpl):
     the cited paper actively contradicts the claim, while WRONG_STATEMENT means the cited paper is misattributed (it
     does not address the claim).
     """
+
     SUPPORT = PermissibleValue(
         text="SUPPORT",
-        description="""The cited reference directly supports the claim; the snippet is a substring of the reference and the surrounding context endorses the interaction or property as stated.""")
+        description="""The cited reference directly supports the claim; the snippet is a substring of the reference and the surrounding context endorses the interaction or property as stated.""",
+    )
     REFUTE = PermissibleValue(
         text="REFUTE",
-        description="""The cited reference actively contradicts the claim (e.g., reports the opposite effect, or shows the proposed mechanism does not occur under the cited conditions).""")
+        description="""The cited reference actively contradicts the claim (e.g., reports the opposite effect, or shows the proposed mechanism does not occur under the cited conditions).""",
+    )
     PARTIAL = PermissibleValue(
         text="PARTIAL",
-        description="""The cited reference supports part but not all of the claim. Common cases: snippet supports the mechanism but not the specific site, taxa, or quantitative figure asserted; or the reference supports a related but weaker version of the claim.""")
+        description="""The cited reference supports part but not all of the claim. Common cases: snippet supports the mechanism but not the specific site, taxa, or quantitative figure asserted; or the reference supports a related but weaker version of the claim.""",
+    )
     NO_EVIDENCE = PermissibleValue(
         text="NO_EVIDENCE",
-        description="""The cited reference does not contain a passage that addresses the claim. Used when the paper is on-topic and a reference is required by the schema, but the curator could not locate a supporting (or contradicting) excerpt; the snippet records the closest on-topic excerpt examined. Stronger than WRONG_STATEMENT (which signals misattribution) and weaker than REFUTE.""")
+        description="""The cited reference does not contain a passage that addresses the claim. Used when the paper is on-topic and a reference is required by the schema, but the curator could not locate a supporting (or contradicting) excerpt; the snippet records the closest on-topic excerpt examined. Stronger than WRONG_STATEMENT (which signals misattribution) and weaker than REFUTE.""",
+    )
     WRONG_STATEMENT = PermissibleValue(
         text="WRONG_STATEMENT",
-        description="""The cited reference is misattributed - the paper does not address the curated claim at all (e.g., wrong DOI/PMID, paper about a different system). Distinct from REFUTE, which is reserved for references that actively contradict the claim.""")
+        description="""The cited reference is misattributed - the paper does not address the curated claim at all (e.g., wrong DOI/PMID, paper about a different system). Distinct from REFUTE, which is reserved for references that actively contradict the claim.""",
+    )
 
     _defn = EnumDefinition(
         name="EvidenceItemSupportEnum",
         description="""How the cited reference relates to the curated claim. Distinct from the validity of the claim itself: REFUTE means the cited paper actively contradicts the claim, while WRONG_STATEMENT means the cited paper is misattributed (it does not address the claim).""",
     )
 
+
 class EvidenceSourceEnum(EnumDefinitionImpl):
     """
     The provenance/source of the evidence
     """
+
     IN_VITRO = PermissibleValue(
-        text="IN_VITRO",
-        description="In vitro experiments (batch culture, bioreactor, etc.)")
+        text="IN_VITRO", description="In vitro experiments (batch culture, bioreactor, etc.)"
+    )
     IN_VIVO = PermissibleValue(
-        text="IN_VIVO",
-        description="In vivo experiments (field studies, host-associated, etc.)")
+        text="IN_VIVO", description="In vivo experiments (field studies, host-associated, etc.)"
+    )
     COMPUTATIONAL = PermissibleValue(
-        text="COMPUTATIONAL",
-        description="In silico modeling, simulation, or prediction")
-    REVIEW = PermissibleValue(
-        text="REVIEW",
-        description="Review article or meta-analysis")
-    OTHER = PermissibleValue(
-        text="OTHER",
-        description="Other evidence type")
+        text="COMPUTATIONAL", description="In silico modeling, simulation, or prediction"
+    )
+    REVIEW = PermissibleValue(text="REVIEW", description="Review article or meta-analysis")
+    OTHER = PermissibleValue(text="OTHER", description="Other evidence type")
 
     _defn = EnumDefinition(
         name="EvidenceSourceEnum",
         description="The provenance/source of the evidence",
     )
 
+
 class EcologicalStateEnum(EnumDefinitionImpl):
     """
     The ecological or health state of the community
     """
-    STABLE = PermissibleValue(
-        text="STABLE",
-        description="Stable, equilibrium community")
+
+    STABLE = PermissibleValue(text="STABLE", description="Stable, equilibrium community")
     PERTURBED = PermissibleValue(
-        text="PERTURBED",
-        description="Recently perturbed (e.g., antibiotic treatment)")
+        text="PERTURBED", description="Recently perturbed (e.g., antibiotic treatment)"
+    )
     ENGINEERED = PermissibleValue(
-        text="ENGINEERED",
-        description="Synthetic or engineered community")
-    TRANSIENT = PermissibleValue(
-        text="TRANSIENT",
-        description="Transient or developing community")
+        text="ENGINEERED", description="Synthetic or engineered community"
+    )
+    TRANSIENT = PermissibleValue(text="TRANSIENT", description="Transient or developing community")
 
     _defn = EnumDefinition(
         name="EcologicalStateEnum",
         description="The ecological or health state of the community",
     )
 
+
 class CommunityOriginEnum(EnumDefinitionImpl):
     """
     The origin or source of the community
     """
+
     NATURAL = PermissibleValue(
-        text="NATURAL",
-        description="Naturally occurring community from environment")
+        text="NATURAL", description="Naturally occurring community from environment"
+    )
     ENGINEERED = PermissibleValue(
-        text="ENGINEERED",
-        description="Deliberately engineered or synthetic community")
+        text="ENGINEERED", description="Deliberately engineered or synthetic community"
+    )
     SYNTHETIC = PermissibleValue(
-        text="SYNTHETIC",
-        description="Fully synthetic community designed in laboratory")
+        text="SYNTHETIC", description="Fully synthetic community designed in laboratory"
+    )
 
     _defn = EnumDefinition(
         name="CommunityOriginEnum",
         description="The origin or source of the community",
     )
 
+
 class MediaRelationshipEnum(EnumDefinitionImpl):
     """
     Type of relationship between a microbial community and a growth medium. Distinguishes actual cultivation media
     from environmentally related media.
     """
+
     CULTIVATION_MEDIUM = PermissibleValue(
         text="CULTIVATION_MEDIUM",
-        description="Medium actually used for cultivation of community members")
+        description="Medium actually used for cultivation of community members",
+    )
     ISOLATION_MEDIUM = PermissibleValue(
         text="ISOLATION_MEDIUM",
-        description="Medium used for initial isolation of community members from the environment")
+        description="Medium used for initial isolation of community members from the environment",
+    )
     ENVIRONMENT_ANALOG = PermissibleValue(
         text="ENVIRONMENT_ANALOG",
-        description="Medium designed to mimic the community's natural environment")
+        description="Medium designed to mimic the community's natural environment",
+    )
     REFERENCED_IN_STUDY = PermissibleValue(
         text="REFERENCED_IN_STUDY",
-        description="Medium referenced in a study of this community but not necessarily used for cultivation")
+        description="Medium referenced in a study of this community but not necessarily used for cultivation",
+    )
     SELECTIVE_ENRICHMENT = PermissibleValue(
         text="SELECTIVE_ENRICHMENT",
-        description="Medium used for selective enrichment of specific functional groups within the community")
+        description="Medium used for selective enrichment of specific functional groups within the community",
+    )
 
     _defn = EnumDefinition(
         name="MediaRelationshipEnum",
         description="""Type of relationship between a microbial community and a growth medium. Distinguishes actual cultivation media from environmentally related media.""",
     )
 
+
 class CommunityCategoryEnum(EnumDefinitionImpl):
     """
     Broad functional/ecological category of the community
     """
+
     BIOMINING = PermissibleValue(
-        text="BIOMINING",
-        description="Metal extraction and bioleaching systems")
-    AMD = PermissibleValue(
-        text="AMD",
-        description="Acid mine drainage communities")
-    SYNTROPHY = PermissibleValue(
-        text="SYNTROPHY",
-        description="Syntrophic metabolic cooperation")
+        text="BIOMINING", description="Metal extraction and bioleaching systems"
+    )
+    AMD = PermissibleValue(text="AMD", description="Acid mine drainage communities")
+    SYNTROPHY = PermissibleValue(text="SYNTROPHY", description="Syntrophic metabolic cooperation")
     PHYTOPLANKTON = PermissibleValue(
-        text="PHYTOPLANKTON",
-        description="Algae-bacteria associations")
+        text="PHYTOPLANKTON", description="Algae-bacteria associations"
+    )
     RHIZOSPHERE = PermissibleValue(
-        text="RHIZOSPHERE",
-        description="Plant root-associated communities")
+        text="RHIZOSPHERE", description="Plant root-associated communities"
+    )
     ORAL = PermissibleValue(
-        text="ORAL",
-        description="Oral microbiome and dental biofilm communities")
+        text="ORAL", description="Oral microbiome and dental biofilm communities"
+    )
     LIGNOCELLULOSE = PermissibleValue(
-        text="LIGNOCELLULOSE",
-        description="Lignocellulose degradation systems")
+        text="LIGNOCELLULOSE", description="Lignocellulose degradation systems"
+    )
     METHANOGENESIS = PermissibleValue(
-        text="METHANOGENESIS",
-        description="Methane-producing communities")
-    DIET = PermissibleValue(
-        text="DIET",
-        description="Direct interspecies electron transfer")
+        text="METHANOGENESIS", description="Methane-producing communities"
+    )
+    DIET = PermissibleValue(text="DIET", description="Direct interspecies electron transfer")
     METAL_REDUCTION = PermissibleValue(
-        text="METAL_REDUCTION",
-        description="Metal-reducing communities")
+        text="METAL_REDUCTION", description="Metal-reducing communities"
+    )
     BIOREMEDIATION = PermissibleValue(
-        text="BIOREMEDIATION",
-        description="Pollutant degradation and remediation")
+        text="BIOREMEDIATION", description="Pollutant degradation and remediation"
+    )
     CARBON_SEQUESTRATION = PermissibleValue(
-        text="CARBON_SEQUESTRATION",
-        description="Carbon fixation and storage")
+        text="CARBON_SEQUESTRATION", description="Carbon fixation and storage"
+    )
     EXTREME_ENVIRONMENT = PermissibleValue(
-        text="EXTREME_ENVIRONMENT",
-        description="Communities from extreme conditions")
+        text="EXTREME_ENVIRONMENT", description="Communities from extreme conditions"
+    )
     BIOTECHNOLOGY = PermissibleValue(
-        text="BIOTECHNOLOGY",
-        description="Industrial biotechnology applications")
-    OTHER = PermissibleValue(
-        text="OTHER",
-        description="Other or uncategorized communities")
+        text="BIOTECHNOLOGY", description="Industrial biotechnology applications"
+    )
+    OTHER = PermissibleValue(text="OTHER", description="Other or uncategorized communities")
 
     _defn = EnumDefinition(
         name="CommunityCategoryEnum",
         description="Broad functional/ecological category of the community",
     )
 
+
 class InteractionTypeEnum(EnumDefinitionImpl):
     """
     Type of ecological interaction between organisms
     """
-    MUTUALISM = PermissibleValue(
-        text="MUTUALISM",
-        description="Both organisms benefit (+/+)")
+
+    MUTUALISM = PermissibleValue(text="MUTUALISM", description="Both organisms benefit (+/+)")
     COMMENSALISM = PermissibleValue(
-        text="COMMENSALISM",
-        description="One benefits, other unaffected (+/0)")
+        text="COMMENSALISM", description="One benefits, other unaffected (+/0)"
+    )
     CROSS_FEEDING = PermissibleValue(
-        text="CROSS_FEEDING",
-        description="Metabolite exchange between organisms")
-    COMPETITION = PermissibleValue(
-        text="COMPETITION",
-        description="Both negatively affected (-/-)")
-    PREDATION = PermissibleValue(
-        text="PREDATION",
-        description="One benefits, other harmed (+/-)")
-    SYNTROPHY = PermissibleValue(
-        text="SYNTROPHY",
-        description="Obligate metabolic cooperation")
+        text="CROSS_FEEDING", description="Metabolite exchange between organisms"
+    )
+    COMPETITION = PermissibleValue(text="COMPETITION", description="Both negatively affected (-/-)")
+    PREDATION = PermissibleValue(text="PREDATION", description="One benefits, other harmed (+/-)")
+    SYNTROPHY = PermissibleValue(text="SYNTROPHY", description="Obligate metabolic cooperation")
     NICHE_PARTITIONING = PermissibleValue(
         text="NICHE_PARTITIONING",
-        description="""Strains/species occupy distinct ecological niches, reducing competition through spatial or temporal separation""")
+        description="""Strains/species occupy distinct ecological niches, reducing competition through spatial or temporal separation""",
+    )
     STRAIN_COMPETITION = PermissibleValue(
         text="STRAIN_COMPETITION",
-        description="Intraspecific competition between closely related strains of the same species")
+        description="Intraspecific competition between closely related strains of the same species",
+    )
     COLONIZATION_FACILITATION = PermissibleValue(
         text="COLONIZATION_FACILITATION",
-        description="""One organism facilitates the colonization or establishment of another through priority effects or niche modification""")
+        description="""One organism facilitates the colonization or establishment of another through priority effects or niche modification""",
+    )
 
     _defn = EnumDefinition(
         name="InteractionTypeEnum",
         description="Type of ecological interaction between organisms",
     )
 
+
 class InteractionScopeEnum(EnumDefinitionImpl):
     """
     Whether an interaction is a pairwise organism-to-organism edge or a community-level phenomenon
     """
+
     PAIRWISE = PermissibleValue(
         text="PAIRWISE",
-        description="""Standard pairwise interaction between a source organism and (usually) a target. Requires source_taxon.""")
+        description="""Standard pairwise interaction between a source organism and (usually) a target. Requires source_taxon.""",
+    )
     COMMUNITY_LEVEL = PermissibleValue(
         text="COMMUNITY_LEVEL",
-        description="""Community-wide or emergent phenomenon (e.g., division of labor, host-microbiota colonization patterns, abiotic-input-driven processes such as electrolysis-supplied H2). source_taxon may be omitted because no single organism is the source.""")
+        description="""Community-wide or emergent phenomenon (e.g., division of labor, host-microbiota colonization patterns, abiotic-input-driven processes such as electrolysis-supplied H2). source_taxon may be omitted because no single organism is the source.""",
+    )
 
     _defn = EnumDefinition(
         name="InteractionScopeEnum",
         description="Whether an interaction is a pairwise organism-to-organism edge or a community-level phenomenon",
     )
 
+
 class AbundanceEnum(EnumDefinitionImpl):
     """
     Relative abundance categories
     """
-    DOMINANT = PermissibleValue(
-        text="DOMINANT",
-        description="Greater than 1% relative abundance")
-    ABUNDANT = PermissibleValue(
-        text="ABUNDANT",
-        description="0.1-1% relative abundance")
-    COMMON = PermissibleValue(
-        text="COMMON",
-        description="0.01-0.1% relative abundance")
-    RARE = PermissibleValue(
-        text="RARE",
-        description="Less than 0.01% relative abundance")
+
+    DOMINANT = PermissibleValue(text="DOMINANT", description="Greater than 1% relative abundance")
+    ABUNDANT = PermissibleValue(text="ABUNDANT", description="0.1-1% relative abundance")
+    COMMON = PermissibleValue(text="COMMON", description="0.01-0.1% relative abundance")
+    RARE = PermissibleValue(text="RARE", description="Less than 0.01% relative abundance")
 
     _defn = EnumDefinition(
         name="AbundanceEnum",
         description="Relative abundance categories",
     )
 
+
 class FunctionalRoleEnum(EnumDefinitionImpl):
     """
     Functional role in the community
     """
+
     PRIMARY_PRODUCER = PermissibleValue(
-        text="PRIMARY_PRODUCER",
-        description="Fixes carbon (autotroph)")
+        text="PRIMARY_PRODUCER", description="Fixes carbon (autotroph)"
+    )
     PRIMARY_DEGRADER = PermissibleValue(
-        text="PRIMARY_DEGRADER",
-        description="Degrades complex substrates")
+        text="PRIMARY_DEGRADER", description="Degrades complex substrates"
+    )
     SECONDARY_FERMENTER = PermissibleValue(
-        text="SECONDARY_FERMENTER",
-        description="Ferments products from primary degraders")
+        text="SECONDARY_FERMENTER", description="Ferments products from primary degraders"
+    )
     SYNTROPHIC_PARTNER = PermissibleValue(
-        text="SYNTROPHIC_PARTNER",
-        description="Engages in syntrophic metabolism")
+        text="SYNTROPHIC_PARTNER", description="Engages in syntrophic metabolism"
+    )
     CROSS_FEEDER = PermissibleValue(
-        text="CROSS_FEEDER",
-        description="Utilizes metabolites from other taxa")
+        text="CROSS_FEEDER", description="Utilizes metabolites from other taxa"
+    )
 
     _defn = EnumDefinition(
         name="FunctionalRoleEnum",
         description="Functional role in the community",
     )
 
+
 class AtmosphereEnum(EnumDefinitionImpl):
     """
     Atmospheric/oxygen requirements for growth
     """
-    AEROBIC = PermissibleValue(
-        text="AEROBIC",
-        description="Requires oxygen for growth")
+
+    AEROBIC = PermissibleValue(text="AEROBIC", description="Requires oxygen for growth")
     ANAEROBIC = PermissibleValue(
-        text="ANAEROBIC",
-        description="Growth only in absence of oxygen (strict anaerobe)")
+        text="ANAEROBIC", description="Growth only in absence of oxygen (strict anaerobe)"
+    )
     MICROAEROBIC = PermissibleValue(
-        text="MICROAEROBIC",
-        description="Requires low oxygen levels (typically 2-10%)")
+        text="MICROAEROBIC", description="Requires low oxygen levels (typically 2-10%)"
+    )
     FACULTATIVE_ANAEROBIC = PermissibleValue(
-        text="FACULTATIVE_ANAEROBIC",
-        description="Can grow with or without oxygen")
+        text="FACULTATIVE_ANAEROBIC", description="Can grow with or without oxygen"
+    )
     FACULTATIVE_AEROBIC = PermissibleValue(
-        text="FACULTATIVE_AEROBIC",
-        description="Preferentially aerobic but can grow anaerobically")
-    CAPNOPHILIC = PermissibleValue(
-        text="CAPNOPHILIC",
-        description="Requires elevated CO2 levels")
+        text="FACULTATIVE_AEROBIC", description="Preferentially aerobic but can grow anaerobically"
+    )
+    CAPNOPHILIC = PermissibleValue(text="CAPNOPHILIC", description="Requires elevated CO2 levels")
 
     _defn = EnumDefinition(
         name="AtmosphereEnum",
         description="Atmospheric/oxygen requirements for growth",
     )
 
+
 class DatasetTypeEnum(EnumDefinitionImpl):
     """
     Type of omics or other dataset associated with a community
     """
-    METAGENOME = PermissibleValue(
-        text="METAGENOME",
-        description="Shotgun metagenomic sequencing")
-    AMPLICON_16S = PermissibleValue(
-        text="AMPLICON_16S",
-        description="16S rRNA amplicon sequencing")
+
+    METAGENOME = PermissibleValue(text="METAGENOME", description="Shotgun metagenomic sequencing")
+    AMPLICON_16S = PermissibleValue(text="AMPLICON_16S", description="16S rRNA amplicon sequencing")
     AMPLICON_ITS = PermissibleValue(
-        text="AMPLICON_ITS",
-        description="ITS amplicon sequencing (fungal)")
+        text="AMPLICON_ITS", description="ITS amplicon sequencing (fungal)"
+    )
     METATRANSCRIPTOME = PermissibleValue(
-        text="METATRANSCRIPTOME",
-        description="Metatranscriptomic sequencing")
-    METAPROTEOME = PermissibleValue(
-        text="METAPROTEOME",
-        description="Metaproteomic analysis")
+        text="METATRANSCRIPTOME", description="Metatranscriptomic sequencing"
+    )
+    METAPROTEOME = PermissibleValue(text="METAPROTEOME", description="Metaproteomic analysis")
     METABOLOMICS = PermissibleValue(
-        text="METABOLOMICS",
-        description="Metabolomics (LC-MS, GC-MS, etc.)")
-    GENOME = PermissibleValue(
-        text="GENOME",
-        description="Isolate whole genome sequencing")
+        text="METABOLOMICS", description="Metabolomics (LC-MS, GC-MS, etc.)"
+    )
+    GENOME = PermissibleValue(text="GENOME", description="Isolate whole genome sequencing")
     PHENOTYPE = PermissibleValue(
-        text="PHENOTYPE",
-        description="Phenotypic measurements (growth, imaging, etc.)")
-    OTHER = PermissibleValue(
-        text="OTHER",
-        description="Other dataset type")
+        text="PHENOTYPE", description="Phenotypic measurements (growth, imaging, etc.)"
+    )
+    OTHER = PermissibleValue(text="OTHER", description="Other dataset type")
 
     _defn = EnumDefinition(
         name="DatasetTypeEnum",
         description="Type of omics or other dataset associated with a community",
     )
 
+
 class DatasetRepositoryEnum(EnumDefinitionImpl):
     """
     Data repositories for omics and related datasets
     """
-    NCBI_SRA = PermissibleValue(
-        text="NCBI_SRA",
-        description="NCBI Sequence Read Archive")
-    NCBI_BIOPROJECT = PermissibleValue(
-        text="NCBI_BIOPROJECT",
-        description="NCBI BioProject")
-    NMDC = PermissibleValue(
-        text="NMDC",
-        description="National Microbiome Data Collaborative")
-    JGI_GOLD = PermissibleValue(
-        text="JGI_GOLD",
-        description="JGI Genomes OnLine Database")
-    JGI_IMG = PermissibleValue(
-        text="JGI_IMG",
-        description="JGI Integrated Microbial Genomes")
-    MGNIFY = PermissibleValue(
-        text="MGNIFY",
-        description="MGnify (EBI metagenomics)")
+
+    NCBI_SRA = PermissibleValue(text="NCBI_SRA", description="NCBI Sequence Read Archive")
+    NCBI_BIOPROJECT = PermissibleValue(text="NCBI_BIOPROJECT", description="NCBI BioProject")
+    NMDC = PermissibleValue(text="NMDC", description="National Microbiome Data Collaborative")
+    JGI_GOLD = PermissibleValue(text="JGI_GOLD", description="JGI Genomes OnLine Database")
+    JGI_IMG = PermissibleValue(text="JGI_IMG", description="JGI Integrated Microbial Genomes")
+    MGNIFY = PermissibleValue(text="MGNIFY", description="MGnify (EBI metagenomics)")
     METABOLOMICS_WORKBENCH = PermissibleValue(
-        text="METABOLOMICS_WORKBENCH",
-        description="Metabolomics Workbench")
-    MASSIVE = PermissibleValue(
-        text="MASSIVE",
-        description="MassIVE mass spectrometry data")
+        text="METABOLOMICS_WORKBENCH", description="Metabolomics Workbench"
+    )
+    MASSIVE = PermissibleValue(text="MASSIVE", description="MassIVE mass spectrometry data")
     GNPS = PermissibleValue(
-        text="GNPS",
-        description="Global Natural Products Social Molecular Networking")
-    FIGSHARE = PermissibleValue(
-        text="FIGSHARE",
-        description="Figshare data repository")
-    ZENODO = PermissibleValue(
-        text="ZENODO",
-        description="Zenodo data repository")
-    OTHER = PermissibleValue(
-        text="OTHER",
-        description="Other data repository")
+        text="GNPS", description="Global Natural Products Social Molecular Networking"
+    )
+    FIGSHARE = PermissibleValue(text="FIGSHARE", description="Figshare data repository")
+    ZENODO = PermissibleValue(text="ZENODO", description="Zenodo data repository")
+    OTHER = PermissibleValue(text="OTHER", description="Other data repository")
 
     _defn = EnumDefinition(
         name="DatasetRepositoryEnum",
         description="Data repositories for omics and related datasets",
     )
 
+
 class ExternalResourceRepositoryEnum(EnumDefinitionImpl):
     """
     External repositories and platforms that host community model resources
     """
-    BIOMODELS = PermissibleValue(
-        text="BIOMODELS",
-        description="BioModels database")
-    KBASE = PermissibleValue(
-        text="KBASE",
-        description="KBase Narrative platform")
-    BIGG = PermissibleValue(
-        text="BIGG",
-        description="BiGG Models")
-    VMH = PermissibleValue(
-        text="VMH",
-        description="Virtual Metabolic Human")
-    MODELSEED = PermissibleValue(
-        text="MODELSEED",
-        description="ModelSEED resources")
-    GITHUB = PermissibleValue(
-        text="GITHUB",
-        description="GitHub repository")
-    OTHER = PermissibleValue(
-        text="OTHER",
-        description="Other resource repository")
+
+    BIOMODELS = PermissibleValue(text="BIOMODELS", description="BioModels database")
+    KBASE = PermissibleValue(text="KBASE", description="KBase Narrative platform")
+    BIGG = PermissibleValue(text="BIGG", description="BiGG Models")
+    VMH = PermissibleValue(text="VMH", description="Virtual Metabolic Human")
+    MODELSEED = PermissibleValue(text="MODELSEED", description="ModelSEED resources")
+    GITHUB = PermissibleValue(text="GITHUB", description="GitHub repository")
+    OTHER = PermissibleValue(text="OTHER", description="Other resource repository")
 
     _defn = EnumDefinition(
         name="ExternalResourceRepositoryEnum",
         description="External repositories and platforms that host community model resources",
     )
 
+
 class CultureCollectionEnum(EnumDefinitionImpl):
     """
     Major microbial culture collections worldwide
     """
-    ATCC = PermissibleValue(
-        text="ATCC",
-        description="American Type Culture Collection (USA)")
+
+    ATCC = PermissibleValue(text="ATCC", description="American Type Culture Collection (USA)")
     DSM = PermissibleValue(
-        text="DSM",
-        description="Deutsche Sammlung von Mikroorganismen (DSMZ, Germany)")
-    JCM = PermissibleValue(
-        text="JCM",
-        description="Japan Collection of Microorganisms (Japan)")
-    NCTC = PermissibleValue(
-        text="NCTC",
-        description="National Collection of Type Cultures (UK)")
+        text="DSM", description="Deutsche Sammlung von Mikroorganismen (DSMZ, Germany)"
+    )
+    JCM = PermissibleValue(text="JCM", description="Japan Collection of Microorganisms (Japan)")
+    NCTC = PermissibleValue(text="NCTC", description="National Collection of Type Cultures (UK)")
     CCUG = PermissibleValue(
-        text="CCUG",
-        description="Culture Collection University of Gothenburg (Sweden)")
+        text="CCUG", description="Culture Collection University of Gothenburg (Sweden)"
+    )
     PCC = PermissibleValue(
-        text="PCC",
-        description="Pasteur Culture Collection of Cyanobacteria (France)")
+        text="PCC", description="Pasteur Culture Collection of Cyanobacteria (France)"
+    )
     NCIMB = PermissibleValue(
-        text="NCIMB",
-        description="National Collection of Industrial Marine Bacteria (UK)")
-    LMG = PermissibleValue(
-        text="LMG",
-        description="BCCM/LMG Bacteria Collection (Belgium)")
-    KCTC = PermissibleValue(
-        text="KCTC",
-        description="Korean Collection for Type Cultures (Korea)")
-    CIP = PermissibleValue(
-        text="CIP",
-        description="Collection de l'Institut Pasteur (France)")
-    NBRC = PermissibleValue(
-        text="NBRC",
-        description="NITE Biological Resource Center (Japan)")
+        text="NCIMB", description="National Collection of Industrial Marine Bacteria (UK)"
+    )
+    LMG = PermissibleValue(text="LMG", description="BCCM/LMG Bacteria Collection (Belgium)")
+    KCTC = PermissibleValue(text="KCTC", description="Korean Collection for Type Cultures (Korea)")
+    CIP = PermissibleValue(text="CIP", description="Collection de l'Institut Pasteur (France)")
+    NBRC = PermissibleValue(text="NBRC", description="NITE Biological Resource Center (Japan)")
     VKM = PermissibleValue(
-        text="VKM",
-        description="All-Russian Collection of Microorganisms (Russia)")
+        text="VKM", description="All-Russian Collection of Microorganisms (Russia)"
+    )
     CGMCC = PermissibleValue(
-        text="CGMCC",
-        description="China General Microbiological Culture Collection (China)")
+        text="CGMCC", description="China General Microbiological Culture Collection (China)"
+    )
     BCRC = PermissibleValue(
-        text="BCRC",
-        description="Bioresource Collection and Research Center (Taiwan)")
+        text="BCRC", description="Bioresource Collection and Research Center (Taiwan)"
+    )
     CBS = PermissibleValue(
-        text="CBS",
-        description="Westerdijk Fungal Biodiversity Institute (Netherlands)")
-    OTHER = PermissibleValue(
-        text="OTHER",
-        description="Other culture collection not listed")
+        text="CBS", description="Westerdijk Fungal Biodiversity Institute (Netherlands)"
+    )
+    OTHER = PermissibleValue(text="OTHER", description="Other culture collection not listed")
 
     _defn = EnumDefinition(
         name="CultureCollectionEnum",
         description="Major microbial culture collections worldwide",
     )
 
+
 class MetalElementEnum(EnumDefinitionImpl):
     """
     Metal elements relevant to microbial communities
     """
+
     COPPER = PermissibleValue(
-        text="COPPER",
-        description="Copper(2+) cation",
-        meaning=CHEBI["29036"])
-    IRON = PermissibleValue(
-        text="IRON",
-        description="Iron(2+) cation",
-        meaning=CHEBI["29033"])
-    ZINC = PermissibleValue(
-        text="ZINC",
-        description="Zinc(2+) cation",
-        meaning=CHEBI["27363"])
+        text="COPPER", description="Copper(2+) cation", meaning=CHEBI["29036"]
+    )
+    IRON = PermissibleValue(text="IRON", description="Iron(2+) cation", meaning=CHEBI["29033"])
+    ZINC = PermissibleValue(text="ZINC", description="Zinc(2+) cation", meaning=CHEBI["27363"])
     NICKEL = PermissibleValue(
-        text="NICKEL",
-        description="Nickel(2+) cation",
-        meaning=CHEBI["49786"])
+        text="NICKEL", description="Nickel(2+) cation", meaning=CHEBI["49786"]
+    )
     COBALT = PermissibleValue(
-        text="COBALT",
-        description="Cobalt(2+) cation",
-        meaning=CHEBI["48828"])
+        text="COBALT", description="Cobalt(2+) cation", meaning=CHEBI["48828"]
+    )
     VANADIUM = PermissibleValue(
-        text="VANADIUM",
-        description="Vanadium cation",
-        meaning=CHEBI["27698"])
-    URANIUM = PermissibleValue(
-        text="URANIUM",
-        description="Uranium atom",
-        meaning=CHEBI["27214"])
+        text="VANADIUM", description="Vanadium cation", meaning=CHEBI["27698"]
+    )
+    URANIUM = PermissibleValue(text="URANIUM", description="Uranium atom", meaning=CHEBI["27214"])
     CHROMIUM = PermissibleValue(
-        text="CHROMIUM",
-        description="Chromium atom",
-        meaning=CHEBI["28073"])
-    LEAD = PermissibleValue(
-        text="LEAD",
-        description="Lead(2+) cation",
-        meaning=CHEBI["25016"])
+        text="CHROMIUM", description="Chromium atom", meaning=CHEBI["28073"]
+    )
+    LEAD = PermissibleValue(text="LEAD", description="Lead(2+) cation", meaning=CHEBI["25016"])
     LITHIUM = PermissibleValue(
-        text="LITHIUM",
-        description="Lithium(1+) cation",
-        meaning=CHEBI["49713"])
-    GOLD = PermissibleValue(
-        text="GOLD",
-        description="Gold atom",
-        meaning=CHEBI["29287"])
+        text="LITHIUM", description="Lithium(1+) cation", meaning=CHEBI["49713"]
+    )
+    GOLD = PermissibleValue(text="GOLD", description="Gold atom", meaning=CHEBI["29287"])
     SILVER = PermissibleValue(
-        text="SILVER",
-        description="Silver(1+) cation",
-        meaning=CHEBI["30512"])
+        text="SILVER", description="Silver(1+) cation", meaning=CHEBI["30512"]
+    )
     PALLADIUM = PermissibleValue(
-        text="PALLADIUM",
-        description="Palladium atom",
-        meaning=CHEBI["33373"])
+        text="PALLADIUM", description="Palladium atom", meaning=CHEBI["33373"]
+    )
     GALLIUM = PermissibleValue(
-        text="GALLIUM",
-        description="Gallium(3+) cation",
-        meaning=CHEBI["49631"])
+        text="GALLIUM", description="Gallium(3+) cation", meaning=CHEBI["49631"]
+    )
     INDIUM = PermissibleValue(
-        text="INDIUM",
-        description="Indium(3+) cation",
-        meaning=CHEBI["49464"])
+        text="INDIUM", description="Indium(3+) cation", meaning=CHEBI["49464"]
+    )
     TITANIUM = PermissibleValue(
-        text="TITANIUM",
-        description="Titanium atom",
-        meaning=CHEBI["33341"])
+        text="TITANIUM", description="Titanium atom", meaning=CHEBI["33341"]
+    )
     MERCURY = PermissibleValue(
-        text="MERCURY",
-        description="Mercury(2+) cation",
-        meaning=CHEBI["16793"])
+        text="MERCURY", description="Mercury(2+) cation", meaning=CHEBI["16793"]
+    )
 
     _defn = EnumDefinition(
         name="MetalElementEnum",
         description="Metal elements relevant to microbial communities",
     )
 
+
 class RareEarthElementEnum(EnumDefinitionImpl):
     """
     Rare earth elements (lanthanides + Y, Sc)
     """
+
     LANTHANUM = PermissibleValue(
-        text="LANTHANUM",
-        description="Lanthanum(3+) cation",
-        meaning=CHEBI["32359"])
+        text="LANTHANUM", description="Lanthanum(3+) cation", meaning=CHEBI["32359"]
+    )
     CERIUM = PermissibleValue(
-        text="CERIUM",
-        description="Cerium(3+) cation",
-        meaning=CHEBI["32998"])
+        text="CERIUM", description="Cerium(3+) cation", meaning=CHEBI["32998"]
+    )
     PRASEODYMIUM = PermissibleValue(
-        text="PRASEODYMIUM",
-        description="Praseodymium(3+) cation",
-        meaning=CHEBI["49648"])
+        text="PRASEODYMIUM", description="Praseodymium(3+) cation", meaning=CHEBI["49648"]
+    )
     NEODYMIUM = PermissibleValue(
-        text="NEODYMIUM",
-        description="Neodymium(3+) cation",
-        meaning=CHEBI["33372"])
+        text="NEODYMIUM", description="Neodymium(3+) cation", meaning=CHEBI["33372"]
+    )
     SAMARIUM = PermissibleValue(
-        text="SAMARIUM",
-        description="Samarium(3+) cation",
-        meaning=CHEBI["33376"])
+        text="SAMARIUM", description="Samarium(3+) cation", meaning=CHEBI["33376"]
+    )
     EUROPIUM = PermissibleValue(
-        text="EUROPIUM",
-        description="Europium(3+) cation",
-        meaning=CHEBI["30688"])
+        text="EUROPIUM", description="Europium(3+) cation", meaning=CHEBI["30688"]
+    )
     GADOLINIUM = PermissibleValue(
-        text="GADOLINIUM",
-        description="Gadolinium(3+) cation",
-        meaning=CHEBI["33375"])
+        text="GADOLINIUM", description="Gadolinium(3+) cation", meaning=CHEBI["33375"]
+    )
     TERBIUM = PermissibleValue(
-        text="TERBIUM",
-        description="Terbium(3+) cation",
-        meaning=CHEBI["33374"])
+        text="TERBIUM", description="Terbium(3+) cation", meaning=CHEBI["33374"]
+    )
     DYSPROSIUM = PermissibleValue(
-        text="DYSPROSIUM",
-        description="Dysprosium(3+) cation",
-        meaning=CHEBI["49782"])
+        text="DYSPROSIUM", description="Dysprosium(3+) cation", meaning=CHEBI["49782"]
+    )
     HOLMIUM = PermissibleValue(
-        text="HOLMIUM",
-        description="Holmium(3+) cation",
-        meaning=CHEBI["49649"])
+        text="HOLMIUM", description="Holmium(3+) cation", meaning=CHEBI["49649"]
+    )
     ERBIUM = PermissibleValue(
-        text="ERBIUM",
-        description="Erbium(3+) cation",
-        meaning=CHEBI["49650"])
+        text="ERBIUM", description="Erbium(3+) cation", meaning=CHEBI["49650"]
+    )
     THULIUM = PermissibleValue(
-        text="THULIUM",
-        description="Thulium(3+) cation",
-        meaning=CHEBI["33377"])
+        text="THULIUM", description="Thulium(3+) cation", meaning=CHEBI["33377"]
+    )
     YTTERBIUM = PermissibleValue(
-        text="YTTERBIUM",
-        description="Ytterbium(3+) cation",
-        meaning=CHEBI["33378"])
+        text="YTTERBIUM", description="Ytterbium(3+) cation", meaning=CHEBI["33378"]
+    )
     LUTETIUM = PermissibleValue(
-        text="LUTETIUM",
-        description="Lutetium(3+) cation",
-        meaning=CHEBI["33382"])
+        text="LUTETIUM", description="Lutetium(3+) cation", meaning=CHEBI["33382"]
+    )
     YTTRIUM = PermissibleValue(
-        text="YTTRIUM",
-        description="Yttrium(3+) cation",
-        meaning=CHEBI["49976"])
+        text="YTTRIUM", description="Yttrium(3+) cation", meaning=CHEBI["49976"]
+    )
     SCANDIUM = PermissibleValue(
-        text="SCANDIUM",
-        description="Scandium(3+) cation",
-        meaning=CHEBI["33330"])
+        text="SCANDIUM", description="Scandium(3+) cation", meaning=CHEBI["33330"]
+    )
 
     _defn = EnumDefinition(
         name="RareEarthElementEnum",
         description="Rare earth elements (lanthanides + Y, Sc)",
     )
 
+
 class MetalRelevanceEnum(EnumDefinitionImpl):
     """
     Relevance of metals/REE to community function
     """
+
     PRIMARY = PermissibleValue(
-        text="PRIMARY",
-        description="Primary function involves metal/REE extraction or cycling")
+        text="PRIMARY", description="Primary function involves metal/REE extraction or cycling"
+    )
     SIGNIFICANT = PermissibleValue(
-        text="SIGNIFICANT",
-        description="Significant metal/REE metabolism but not primary function")
-    INCIDENTAL = PermissibleValue(
-        text="INCIDENTAL",
-        description="Incidental metal/REE interaction")
+        text="SIGNIFICANT", description="Significant metal/REE metabolism but not primary function"
+    )
+    INCIDENTAL = PermissibleValue(text="INCIDENTAL", description="Incidental metal/REE interaction")
     NOT_APPLICABLE = PermissibleValue(
-        text="NOT_APPLICABLE",
-        description="No significant metal/REE relevance")
+        text="NOT_APPLICABLE", description="No significant metal/REE relevance"
+    )
 
     _defn = EnumDefinition(
         name="MetalRelevanceEnum",
         description="Relevance of metals/REE to community function",
     )
 
+
 # Slots
 class slots:
     pass
 
-slots.term__id = Slot(uri=COMMUNITYMECH.id, name="term__id", curie=COMMUNITYMECH.curie('id'),
-                   model_uri=COMMUNITYMECH.term__id, domain=None, range=str)
 
-slots.term__label = Slot(uri=RDFS.label, name="term__label", curie=RDFS.curie('label'),
-                   model_uri=COMMUNITYMECH.term__label, domain=None, range=str)
-
-slots.evidenceItem__reference = Slot(uri=COMMUNITYMECH.reference, name="evidenceItem__reference", curie=COMMUNITYMECH.curie('reference'),
-                   model_uri=COMMUNITYMECH.evidenceItem__reference, domain=None, range=str,
-                   pattern=re.compile(r'^(PMID:|doi:|bioproject:).*'))
-
-slots.evidenceItem__supports = Slot(uri=COMMUNITYMECH.supports, name="evidenceItem__supports", curie=COMMUNITYMECH.curie('supports'),
-                   model_uri=COMMUNITYMECH.evidenceItem__supports, domain=None, range=Union[str, "EvidenceItemSupportEnum"])
-
-slots.evidenceItem__evidence_source = Slot(uri=COMMUNITYMECH.evidence_source, name="evidenceItem__evidence_source", curie=COMMUNITYMECH.curie('evidence_source'),
-                   model_uri=COMMUNITYMECH.evidenceItem__evidence_source, domain=None, range=Union[str, "EvidenceSourceEnum"])
-
-slots.evidenceItem__snippet = Slot(uri=COMMUNITYMECH.snippet, name="evidenceItem__snippet", curie=COMMUNITYMECH.curie('snippet'),
-                   model_uri=COMMUNITYMECH.evidenceItem__snippet, domain=None, range=str)
-
-slots.evidenceItem__explanation = Slot(uri=COMMUNITYMECH.explanation, name="evidenceItem__explanation", curie=COMMUNITYMECH.curie('explanation'),
-                   model_uri=COMMUNITYMECH.evidenceItem__explanation, domain=None, range=Optional[str])
-
-slots.evidenceItem__confidence_score = Slot(uri=COMMUNITYMECH.confidence_score, name="evidenceItem__confidence_score", curie=COMMUNITYMECH.curie('confidence_score'),
-                   model_uri=COMMUNITYMECH.evidenceItem__confidence_score, domain=None, range=Optional[float])
-
-slots.taxonDescriptor__preferred_term = Slot(uri=COMMUNITYMECH.preferred_term, name="taxonDescriptor__preferred_term", curie=COMMUNITYMECH.curie('preferred_term'),
-                   model_uri=COMMUNITYMECH.taxonDescriptor__preferred_term, domain=None, range=str)
-
-slots.taxonDescriptor__term = Slot(uri=COMMUNITYMECH.term, name="taxonDescriptor__term", curie=COMMUNITYMECH.curie('term'),
-                   model_uri=COMMUNITYMECH.taxonDescriptor__term, domain=None, range=Union[dict, Term])
-
-slots.taxonDescriptor__notes = Slot(uri=COMMUNITYMECH.notes, name="taxonDescriptor__notes", curie=COMMUNITYMECH.curie('notes'),
-                   model_uri=COMMUNITYMECH.taxonDescriptor__notes, domain=None, range=Optional[str])
-
-slots.metaboliteDescriptor__preferred_term = Slot(uri=COMMUNITYMECH.preferred_term, name="metaboliteDescriptor__preferred_term", curie=COMMUNITYMECH.curie('preferred_term'),
-                   model_uri=COMMUNITYMECH.metaboliteDescriptor__preferred_term, domain=None, range=str)
-
-slots.metaboliteDescriptor__term = Slot(uri=COMMUNITYMECH.term, name="metaboliteDescriptor__term", curie=COMMUNITYMECH.curie('term'),
-                   model_uri=COMMUNITYMECH.metaboliteDescriptor__term, domain=None, range=Union[dict, Term])
-
-slots.metaboliteDescriptor__concentration = Slot(uri=COMMUNITYMECH.concentration, name="metaboliteDescriptor__concentration", curie=COMMUNITYMECH.curie('concentration'),
-                   model_uri=COMMUNITYMECH.metaboliteDescriptor__concentration, domain=None, range=Optional[str])
-
-slots.metaboliteDescriptor__notes = Slot(uri=COMMUNITYMECH.notes, name="metaboliteDescriptor__notes", curie=COMMUNITYMECH.curie('notes'),
-                   model_uri=COMMUNITYMECH.metaboliteDescriptor__notes, domain=None, range=Optional[str])
-
-slots.biologicalProcessDescriptor__preferred_term = Slot(uri=COMMUNITYMECH.preferred_term, name="biologicalProcessDescriptor__preferred_term", curie=COMMUNITYMECH.curie('preferred_term'),
-                   model_uri=COMMUNITYMECH.biologicalProcessDescriptor__preferred_term, domain=None, range=str)
-
-slots.biologicalProcessDescriptor__term = Slot(uri=COMMUNITYMECH.term, name="biologicalProcessDescriptor__term", curie=COMMUNITYMECH.curie('term'),
-                   model_uri=COMMUNITYMECH.biologicalProcessDescriptor__term, domain=None, range=Union[dict, Term])
-
-slots.biologicalProcessDescriptor__notes = Slot(uri=COMMUNITYMECH.notes, name="biologicalProcessDescriptor__notes", curie=COMMUNITYMECH.curie('notes'),
-                   model_uri=COMMUNITYMECH.biologicalProcessDescriptor__notes, domain=None, range=Optional[str])
-
-slots.environmentDescriptor__preferred_term = Slot(uri=COMMUNITYMECH.preferred_term, name="environmentDescriptor__preferred_term", curie=COMMUNITYMECH.curie('preferred_term'),
-                   model_uri=COMMUNITYMECH.environmentDescriptor__preferred_term, domain=None, range=str)
-
-slots.environmentDescriptor__term = Slot(uri=COMMUNITYMECH.term, name="environmentDescriptor__term", curie=COMMUNITYMECH.curie('term'),
-                   model_uri=COMMUNITYMECH.environmentDescriptor__term, domain=None, range=Union[dict, Term])
-
-slots.environmentDescriptor__notes = Slot(uri=COMMUNITYMECH.notes, name="environmentDescriptor__notes", curie=COMMUNITYMECH.curie('notes'),
-                   model_uri=COMMUNITYMECH.environmentDescriptor__notes, domain=None, range=Optional[str])
-
-slots.cultureCollectionID__collection = Slot(uri=COMMUNITYMECH.collection, name="cultureCollectionID__collection", curie=COMMUNITYMECH.curie('collection'),
-                   model_uri=COMMUNITYMECH.cultureCollectionID__collection, domain=None, range=Union[str, "CultureCollectionEnum"])
-
-slots.cultureCollectionID__accession = Slot(uri=COMMUNITYMECH.accession, name="cultureCollectionID__accession", curie=COMMUNITYMECH.curie('accession'),
-                   model_uri=COMMUNITYMECH.cultureCollectionID__accession, domain=None, range=str)
-
-slots.cultureCollectionID__url = Slot(uri=COMMUNITYMECH.url, name="cultureCollectionID__url", curie=COMMUNITYMECH.curie('url'),
-                   model_uri=COMMUNITYMECH.cultureCollectionID__url, domain=None, range=Optional[str])
-
-slots.cultureCollectionID__notes = Slot(uri=COMMUNITYMECH.notes, name="cultureCollectionID__notes", curie=COMMUNITYMECH.curie('notes'),
-                   model_uri=COMMUNITYMECH.cultureCollectionID__notes, domain=None, range=Optional[str])
-
-slots.strainDesignation__strain_name = Slot(uri=COMMUNITYMECH.strain_name, name="strainDesignation__strain_name", curie=COMMUNITYMECH.curie('strain_name'),
-                   model_uri=COMMUNITYMECH.strainDesignation__strain_name, domain=None, range=Optional[str])
-
-slots.strainDesignation__culture_collections = Slot(uri=COMMUNITYMECH.culture_collections, name="strainDesignation__culture_collections", curie=COMMUNITYMECH.curie('culture_collections'),
-                   model_uri=COMMUNITYMECH.strainDesignation__culture_collections, domain=None, range=Optional[Union[Union[dict, CultureCollectionID], list[Union[dict, CultureCollectionID]]]])
-
-slots.strainDesignation__type_strain = Slot(uri=COMMUNITYMECH.type_strain, name="strainDesignation__type_strain", curie=COMMUNITYMECH.curie('type_strain'),
-                   model_uri=COMMUNITYMECH.strainDesignation__type_strain, domain=None, range=Optional[Union[bool, Bool]])
-
-slots.strainDesignation__genome_accession = Slot(uri=COMMUNITYMECH.genome_accession, name="strainDesignation__genome_accession", curie=COMMUNITYMECH.curie('genome_accession'),
-                   model_uri=COMMUNITYMECH.strainDesignation__genome_accession, domain=None, range=Optional[str])
-
-slots.strainDesignation__genome_url = Slot(uri=COMMUNITYMECH.genome_url, name="strainDesignation__genome_url", curie=COMMUNITYMECH.curie('genome_url'),
-                   model_uri=COMMUNITYMECH.strainDesignation__genome_url, domain=None, range=Optional[str])
-
-slots.strainDesignation__genetic_modification = Slot(uri=COMMUNITYMECH.genetic_modification, name="strainDesignation__genetic_modification", curie=COMMUNITYMECH.curie('genetic_modification'),
-                   model_uri=COMMUNITYMECH.strainDesignation__genetic_modification, domain=None, range=Optional[str])
-
-slots.strainDesignation__isolation_source = Slot(uri=COMMUNITYMECH.isolation_source, name="strainDesignation__isolation_source", curie=COMMUNITYMECH.curie('isolation_source'),
-                   model_uri=COMMUNITYMECH.strainDesignation__isolation_source, domain=None, range=Optional[str])
-
-slots.strainDesignation__notes = Slot(uri=COMMUNITYMECH.notes, name="strainDesignation__notes", curie=COMMUNITYMECH.curie('notes'),
-                   model_uri=COMMUNITYMECH.strainDesignation__notes, domain=None, range=Optional[str])
-
-slots.taxonomicComposition__taxon_term = Slot(uri=COMMUNITYMECH.taxon_term, name="taxonomicComposition__taxon_term", curie=COMMUNITYMECH.curie('taxon_term'),
-                   model_uri=COMMUNITYMECH.taxonomicComposition__taxon_term, domain=None, range=Union[dict, TaxonDescriptor])
-
-slots.taxonomicComposition__strain_designation = Slot(uri=COMMUNITYMECH.strain_designation, name="taxonomicComposition__strain_designation", curie=COMMUNITYMECH.curie('strain_designation'),
-                   model_uri=COMMUNITYMECH.taxonomicComposition__strain_designation, domain=None, range=Optional[Union[dict, StrainDesignation]])
-
-slots.taxonomicComposition__abundance_level = Slot(uri=COMMUNITYMECH.abundance_level, name="taxonomicComposition__abundance_level", curie=COMMUNITYMECH.curie('abundance_level'),
-                   model_uri=COMMUNITYMECH.taxonomicComposition__abundance_level, domain=None, range=Optional[Union[str, "AbundanceEnum"]])
-
-slots.taxonomicComposition__abundance_value = Slot(uri=COMMUNITYMECH.abundance_value, name="taxonomicComposition__abundance_value", curie=COMMUNITYMECH.curie('abundance_value'),
-                   model_uri=COMMUNITYMECH.taxonomicComposition__abundance_value, domain=None, range=Optional[str])
-
-slots.taxonomicComposition__functional_role = Slot(uri=COMMUNITYMECH.functional_role, name="taxonomicComposition__functional_role", curie=COMMUNITYMECH.curie('functional_role'),
-                   model_uri=COMMUNITYMECH.taxonomicComposition__functional_role, domain=None, range=Optional[Union[Union[str, "FunctionalRoleEnum"], list[Union[str, "FunctionalRoleEnum"]]]])
-
-slots.taxonomicComposition__evidence = Slot(uri=COMMUNITYMECH.evidence, name="taxonomicComposition__evidence", curie=COMMUNITYMECH.curie('evidence'),
-                   model_uri=COMMUNITYMECH.taxonomicComposition__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
-
-slots.interactionDownstream__target = Slot(uri=COMMUNITYMECH.target, name="interactionDownstream__target", curie=COMMUNITYMECH.curie('target'),
-                   model_uri=COMMUNITYMECH.interactionDownstream__target, domain=None, range=str)
-
-slots.interactionDownstream__description = Slot(uri=COMMUNITYMECH.description, name="interactionDownstream__description", curie=COMMUNITYMECH.curie('description'),
-                   model_uri=COMMUNITYMECH.interactionDownstream__description, domain=None, range=Optional[str])
-
-slots.ecologicalInteraction__name = Slot(uri=COMMUNITYMECH.name, name="ecologicalInteraction__name", curie=COMMUNITYMECH.curie('name'),
-                   model_uri=COMMUNITYMECH.ecologicalInteraction__name, domain=None, range=str)
-
-slots.ecologicalInteraction__description = Slot(uri=COMMUNITYMECH.description, name="ecologicalInteraction__description", curie=COMMUNITYMECH.curie('description'),
-                   model_uri=COMMUNITYMECH.ecologicalInteraction__description, domain=None, range=Optional[str])
-
-slots.ecologicalInteraction__interaction_type = Slot(uri=COMMUNITYMECH.interaction_type, name="ecologicalInteraction__interaction_type", curie=COMMUNITYMECH.curie('interaction_type'),
-                   model_uri=COMMUNITYMECH.ecologicalInteraction__interaction_type, domain=None, range=Optional[Union[str, "InteractionTypeEnum"]])
-
-slots.ecologicalInteraction__scope = Slot(uri=COMMUNITYMECH.scope, name="ecologicalInteraction__scope", curie=COMMUNITYMECH.curie('scope'),
-                   model_uri=COMMUNITYMECH.ecologicalInteraction__scope, domain=None, range=Optional[Union[str, "InteractionScopeEnum"]])
-
-slots.ecologicalInteraction__source_taxon = Slot(uri=COMMUNITYMECH.source_taxon, name="ecologicalInteraction__source_taxon", curie=COMMUNITYMECH.curie('source_taxon'),
-                   model_uri=COMMUNITYMECH.ecologicalInteraction__source_taxon, domain=None, range=Optional[Union[dict, TaxonDescriptor]])
-
-slots.ecologicalInteraction__target_taxon = Slot(uri=COMMUNITYMECH.target_taxon, name="ecologicalInteraction__target_taxon", curie=COMMUNITYMECH.curie('target_taxon'),
-                   model_uri=COMMUNITYMECH.ecologicalInteraction__target_taxon, domain=None, range=Optional[Union[dict, TaxonDescriptor]])
-
-slots.ecologicalInteraction__metabolites = Slot(uri=COMMUNITYMECH.metabolites, name="ecologicalInteraction__metabolites", curie=COMMUNITYMECH.curie('metabolites'),
-                   model_uri=COMMUNITYMECH.ecologicalInteraction__metabolites, domain=None, range=Optional[Union[Union[dict, MetaboliteDescriptor], list[Union[dict, MetaboliteDescriptor]]]])
-
-slots.ecologicalInteraction__biological_processes = Slot(uri=COMMUNITYMECH.biological_processes, name="ecologicalInteraction__biological_processes", curie=COMMUNITYMECH.curie('biological_processes'),
-                   model_uri=COMMUNITYMECH.ecologicalInteraction__biological_processes, domain=None, range=Optional[Union[Union[dict, BiologicalProcessDescriptor], list[Union[dict, BiologicalProcessDescriptor]]]])
-
-slots.ecologicalInteraction__downstream = Slot(uri=COMMUNITYMECH.downstream, name="ecologicalInteraction__downstream", curie=COMMUNITYMECH.curie('downstream'),
-                   model_uri=COMMUNITYMECH.ecologicalInteraction__downstream, domain=None, range=Optional[Union[Union[dict, InteractionDownstream], list[Union[dict, InteractionDownstream]]]])
-
-slots.ecologicalInteraction__evidence = Slot(uri=COMMUNITYMECH.evidence, name="ecologicalInteraction__evidence", curie=COMMUNITYMECH.curie('evidence'),
-                   model_uri=COMMUNITYMECH.ecologicalInteraction__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
-
-slots.environmentalFactor__name = Slot(uri=COMMUNITYMECH.name, name="environmentalFactor__name", curie=COMMUNITYMECH.curie('name'),
-                   model_uri=COMMUNITYMECH.environmentalFactor__name, domain=None, range=str)
-
-slots.environmentalFactor__value = Slot(uri=COMMUNITYMECH.value, name="environmentalFactor__value", curie=COMMUNITYMECH.curie('value'),
-                   model_uri=COMMUNITYMECH.environmentalFactor__value, domain=None, range=Optional[str])
-
-slots.environmentalFactor__unit = Slot(uri=COMMUNITYMECH.unit, name="environmentalFactor__unit", curie=COMMUNITYMECH.curie('unit'),
-                   model_uri=COMMUNITYMECH.environmentalFactor__unit, domain=None, range=Optional[str])
-
-slots.environmentalFactor__description = Slot(uri=COMMUNITYMECH.description, name="environmentalFactor__description", curie=COMMUNITYMECH.curie('description'),
-                   model_uri=COMMUNITYMECH.environmentalFactor__description, domain=None, range=Optional[str])
-
-slots.environmentalFactor__evidence = Slot(uri=COMMUNITYMECH.evidence, name="environmentalFactor__evidence", curie=COMMUNITYMECH.curie('evidence'),
-                   model_uri=COMMUNITYMECH.environmentalFactor__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
-
-slots.growthMediaComponent__name = Slot(uri=COMMUNITYMECH.name, name="growthMediaComponent__name", curie=COMMUNITYMECH.curie('name'),
-                   model_uri=COMMUNITYMECH.growthMediaComponent__name, domain=None, range=str)
-
-slots.growthMediaComponent__media_ingredient_mech_id = Slot(uri=COMMUNITYMECH.media_ingredient_mech_id, name="growthMediaComponent__media_ingredient_mech_id", curie=COMMUNITYMECH.curie('media_ingredient_mech_id'),
-                   model_uri=COMMUNITYMECH.growthMediaComponent__media_ingredient_mech_id, domain=None, range=Optional[str],
-                   pattern=re.compile(r'^MediaIngredientMech:\d{6}$'))
-
-slots.growthMediaComponent__media_ingredient_mech_url = Slot(uri=COMMUNITYMECH.media_ingredient_mech_url, name="growthMediaComponent__media_ingredient_mech_url", curie=COMMUNITYMECH.curie('media_ingredient_mech_url'),
-                   model_uri=COMMUNITYMECH.growthMediaComponent__media_ingredient_mech_url, domain=None, range=Optional[str])
-
-slots.growthMediaComponent__concentration = Slot(uri=COMMUNITYMECH.concentration, name="growthMediaComponent__concentration", curie=COMMUNITYMECH.curie('concentration'),
-                   model_uri=COMMUNITYMECH.growthMediaComponent__concentration, domain=None, range=Optional[str])
-
-slots.growthMediaComponent__unit = Slot(uri=COMMUNITYMECH.unit, name="growthMediaComponent__unit", curie=COMMUNITYMECH.curie('unit'),
-                   model_uri=COMMUNITYMECH.growthMediaComponent__unit, domain=None, range=Optional[str])
-
-slots.growthMediaComponent__chebi_term = Slot(uri=COMMUNITYMECH.chebi_term, name="growthMediaComponent__chebi_term", curie=COMMUNITYMECH.curie('chebi_term'),
-                   model_uri=COMMUNITYMECH.growthMediaComponent__chebi_term, domain=None, range=Optional[Union[dict, MetaboliteDescriptor]])
-
-slots.growthMediaComponent__from_source = Slot(uri=COMMUNITYMECH.from_source, name="growthMediaComponent__from_source", curie=COMMUNITYMECH.curie('from_source'),
-                   model_uri=COMMUNITYMECH.growthMediaComponent__from_source, domain=None, range=Optional[str])
-
-slots.growthMedia__name = Slot(uri=COMMUNITYMECH.name, name="growthMedia__name", curie=COMMUNITYMECH.curie('name'),
-                   model_uri=COMMUNITYMECH.growthMedia__name, domain=None, range=str)
-
-slots.growthMedia__culturemech_id = Slot(uri=COMMUNITYMECH.culturemech_id, name="growthMedia__culturemech_id", curie=COMMUNITYMECH.curie('culturemech_id'),
-                   model_uri=COMMUNITYMECH.growthMedia__culturemech_id, domain=None, range=Optional[str],
-                   pattern=re.compile(r'^CultureMech:\d{6}$'))
-
-slots.growthMedia__culturemech_url = Slot(uri=COMMUNITYMECH.culturemech_url, name="growthMedia__culturemech_url", curie=COMMUNITYMECH.curie('culturemech_url'),
-                   model_uri=COMMUNITYMECH.growthMedia__culturemech_url, domain=None, range=Optional[str])
-
-slots.growthMedia__composition = Slot(uri=COMMUNITYMECH.composition, name="growthMedia__composition", curie=COMMUNITYMECH.curie('composition'),
-                   model_uri=COMMUNITYMECH.growthMedia__composition, domain=None, range=Optional[Union[Union[dict, GrowthMediaComponent], list[Union[dict, GrowthMediaComponent]]]])
-
-slots.growthMedia__ph = Slot(uri=COMMUNITYMECH.ph, name="growthMedia__ph", curie=COMMUNITYMECH.curie('ph'),
-                   model_uri=COMMUNITYMECH.growthMedia__ph, domain=None, range=Optional[str])
-
-slots.growthMedia__ph_range = Slot(uri=COMMUNITYMECH.ph_range, name="growthMedia__ph_range", curie=COMMUNITYMECH.curie('ph_range'),
-                   model_uri=COMMUNITYMECH.growthMedia__ph_range, domain=None, range=Optional[str])
-
-slots.growthMedia__temperature = Slot(uri=COMMUNITYMECH.temperature, name="growthMedia__temperature", curie=COMMUNITYMECH.curie('temperature'),
-                   model_uri=COMMUNITYMECH.growthMedia__temperature, domain=None, range=Optional[str])
-
-slots.growthMedia__temperature_unit = Slot(uri=COMMUNITYMECH.temperature_unit, name="growthMedia__temperature_unit", curie=COMMUNITYMECH.curie('temperature_unit'),
-                   model_uri=COMMUNITYMECH.growthMedia__temperature_unit, domain=None, range=Optional[str])
-
-slots.growthMedia__temperature_range = Slot(uri=COMMUNITYMECH.temperature_range, name="growthMedia__temperature_range", curie=COMMUNITYMECH.curie('temperature_range'),
-                   model_uri=COMMUNITYMECH.growthMedia__temperature_range, domain=None, range=Optional[str])
-
-slots.growthMedia__atmosphere = Slot(uri=COMMUNITYMECH.atmosphere, name="growthMedia__atmosphere", curie=COMMUNITYMECH.curie('atmosphere'),
-                   model_uri=COMMUNITYMECH.growthMedia__atmosphere, domain=None, range=Optional[Union[str, "AtmosphereEnum"]])
-
-slots.growthMedia__headspace_gas = Slot(uri=COMMUNITYMECH.headspace_gas, name="growthMedia__headspace_gas", curie=COMMUNITYMECH.curie('headspace_gas'),
-                   model_uri=COMMUNITYMECH.growthMedia__headspace_gas, domain=None, range=Optional[str])
-
-slots.growthMedia__salinity = Slot(uri=COMMUNITYMECH.salinity, name="growthMedia__salinity", curie=COMMUNITYMECH.curie('salinity'),
-                   model_uri=COMMUNITYMECH.growthMedia__salinity, domain=None, range=Optional[str])
-
-slots.growthMedia__salinity_unit = Slot(uri=COMMUNITYMECH.salinity_unit, name="growthMedia__salinity_unit", curie=COMMUNITYMECH.curie('salinity_unit'),
-                   model_uri=COMMUNITYMECH.growthMedia__salinity_unit, domain=None, range=Optional[str])
-
-slots.growthMedia__pressure = Slot(uri=COMMUNITYMECH.pressure, name="growthMedia__pressure", curie=COMMUNITYMECH.curie('pressure'),
-                   model_uri=COMMUNITYMECH.growthMedia__pressure, domain=None, range=Optional[str])
-
-slots.growthMedia__pressure_unit = Slot(uri=COMMUNITYMECH.pressure_unit, name="growthMedia__pressure_unit", curie=COMMUNITYMECH.curie('pressure_unit'),
-                   model_uri=COMMUNITYMECH.growthMedia__pressure_unit, domain=None, range=Optional[str])
-
-slots.growthMedia__light_regime = Slot(uri=COMMUNITYMECH.light_regime, name="growthMedia__light_regime", curie=COMMUNITYMECH.curie('light_regime'),
-                   model_uri=COMMUNITYMECH.growthMedia__light_regime, domain=None, range=Optional[str])
-
-slots.growthMedia__light_intensity = Slot(uri=COMMUNITYMECH.light_intensity, name="growthMedia__light_intensity", curie=COMMUNITYMECH.curie('light_intensity'),
-                   model_uri=COMMUNITYMECH.growthMedia__light_intensity, domain=None, range=Optional[str])
-
-slots.growthMedia__light_intensity_unit = Slot(uri=COMMUNITYMECH.light_intensity_unit, name="growthMedia__light_intensity_unit", curie=COMMUNITYMECH.curie('light_intensity_unit'),
-                   model_uri=COMMUNITYMECH.growthMedia__light_intensity_unit, domain=None, range=Optional[str])
-
-slots.growthMedia__redox_potential = Slot(uri=COMMUNITYMECH.redox_potential, name="growthMedia__redox_potential", curie=COMMUNITYMECH.curie('redox_potential'),
-                   model_uri=COMMUNITYMECH.growthMedia__redox_potential, domain=None, range=Optional[str])
-
-slots.growthMedia__redox_potential_unit = Slot(uri=COMMUNITYMECH.redox_potential_unit, name="growthMedia__redox_potential_unit", curie=COMMUNITYMECH.curie('redox_potential_unit'),
-                   model_uri=COMMUNITYMECH.growthMedia__redox_potential_unit, domain=None, range=Optional[str])
-
-slots.growthMedia__inoculum_source = Slot(uri=COMMUNITYMECH.inoculum_source, name="growthMedia__inoculum_source", curie=COMMUNITYMECH.curie('inoculum_source'),
-                   model_uri=COMMUNITYMECH.growthMedia__inoculum_source, domain=None, range=Optional[str])
-
-slots.growthMedia__inoculum_size = Slot(uri=COMMUNITYMECH.inoculum_size, name="growthMedia__inoculum_size", curie=COMMUNITYMECH.curie('inoculum_size'),
-                   model_uri=COMMUNITYMECH.growthMedia__inoculum_size, domain=None, range=Optional[str])
-
-slots.growthMedia__inoculum_unit = Slot(uri=COMMUNITYMECH.inoculum_unit, name="growthMedia__inoculum_unit", curie=COMMUNITYMECH.curie('inoculum_unit'),
-                   model_uri=COMMUNITYMECH.growthMedia__inoculum_unit, domain=None, range=Optional[str])
-
-slots.growthMedia__incubation_time = Slot(uri=COMMUNITYMECH.incubation_time, name="growthMedia__incubation_time", curie=COMMUNITYMECH.curie('incubation_time'),
-                   model_uri=COMMUNITYMECH.growthMedia__incubation_time, domain=None, range=Optional[str])
-
-slots.growthMedia__incubation_time_unit = Slot(uri=COMMUNITYMECH.incubation_time_unit, name="growthMedia__incubation_time_unit", curie=COMMUNITYMECH.curie('incubation_time_unit'),
-                   model_uri=COMMUNITYMECH.growthMedia__incubation_time_unit, domain=None, range=Optional[str])
-
-slots.growthMedia__shaking_speed = Slot(uri=COMMUNITYMECH.shaking_speed, name="growthMedia__shaking_speed", curie=COMMUNITYMECH.curie('shaking_speed'),
-                   model_uri=COMMUNITYMECH.growthMedia__shaking_speed, domain=None, range=Optional[str])
-
-slots.growthMedia__shaking_speed_unit = Slot(uri=COMMUNITYMECH.shaking_speed_unit, name="growthMedia__shaking_speed_unit", curie=COMMUNITYMECH.curie('shaking_speed_unit'),
-                   model_uri=COMMUNITYMECH.growthMedia__shaking_speed_unit, domain=None, range=Optional[str])
-
-slots.growthMedia__vessel_type = Slot(uri=COMMUNITYMECH.vessel_type, name="growthMedia__vessel_type", curie=COMMUNITYMECH.curie('vessel_type'),
-                   model_uri=COMMUNITYMECH.growthMedia__vessel_type, domain=None, range=Optional[str])
-
-slots.growthMedia__preparation_notes = Slot(uri=COMMUNITYMECH.preparation_notes, name="growthMedia__preparation_notes", curie=COMMUNITYMECH.curie('preparation_notes'),
-                   model_uri=COMMUNITYMECH.growthMedia__preparation_notes, domain=None, range=Optional[str])
-
-slots.growthMedia__protocol_url = Slot(uri=COMMUNITYMECH.protocol_url, name="growthMedia__protocol_url", curie=COMMUNITYMECH.curie('protocol_url'),
-                   model_uri=COMMUNITYMECH.growthMedia__protocol_url, domain=None, range=Optional[str])
-
-slots.growthMedia__evidence = Slot(uri=COMMUNITYMECH.evidence, name="growthMedia__evidence", curie=COMMUNITYMECH.curie('evidence'),
-                   model_uri=COMMUNITYMECH.growthMedia__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
-
-slots.relatedMedia__preferred_term = Slot(uri=COMMUNITYMECH.preferred_term, name="relatedMedia__preferred_term", curie=COMMUNITYMECH.curie('preferred_term'),
-                   model_uri=COMMUNITYMECH.relatedMedia__preferred_term, domain=None, range=str)
-
-slots.relatedMedia__culturemech_id = Slot(uri=COMMUNITYMECH.culturemech_id, name="relatedMedia__culturemech_id", curie=COMMUNITYMECH.curie('culturemech_id'),
-                   model_uri=COMMUNITYMECH.relatedMedia__culturemech_id, domain=None, range=Optional[str],
-                   pattern=re.compile(r'^CultureMech:\d{6}$'))
-
-slots.relatedMedia__relationship_type = Slot(uri=COMMUNITYMECH.relationship_type, name="relatedMedia__relationship_type", curie=COMMUNITYMECH.curie('relationship_type'),
-                   model_uri=COMMUNITYMECH.relatedMedia__relationship_type, domain=None, range=Optional[Union[str, "MediaRelationshipEnum"]])
-
-slots.relatedMedia__shared_environment_term = Slot(uri=COMMUNITYMECH.shared_environment_term, name="relatedMedia__shared_environment_term", curie=COMMUNITYMECH.curie('shared_environment_term'),
-                   model_uri=COMMUNITYMECH.relatedMedia__shared_environment_term, domain=None, range=Optional[Union[dict, Term]])
-
-slots.relatedMedia__relevance_notes = Slot(uri=COMMUNITYMECH.relevance_notes, name="relatedMedia__relevance_notes", curie=COMMUNITYMECH.curie('relevance_notes'),
-                   model_uri=COMMUNITYMECH.relatedMedia__relevance_notes, domain=None, range=Optional[str])
-
-slots.relatedMedia__evidence = Slot(uri=COMMUNITYMECH.evidence, name="relatedMedia__evidence", curie=COMMUNITYMECH.curie('evidence'),
-                   model_uri=COMMUNITYMECH.relatedMedia__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
-
-slots.relatedIngredient__preferred_term = Slot(uri=COMMUNITYMECH.preferred_term, name="relatedIngredient__preferred_term", curie=COMMUNITYMECH.curie('preferred_term'),
-                   model_uri=COMMUNITYMECH.relatedIngredient__preferred_term, domain=None, range=str)
-
-slots.relatedIngredient__mediaingredientmech_id = Slot(uri=COMMUNITYMECH.mediaingredientmech_id, name="relatedIngredient__mediaingredientmech_id", curie=COMMUNITYMECH.curie('mediaingredientmech_id'),
-                   model_uri=COMMUNITYMECH.relatedIngredient__mediaingredientmech_id, domain=None, range=Optional[str],
-                   pattern=re.compile(r'^MediaIngredientMech:\d{6}$'))
-
-slots.relatedIngredient__chebi_term = Slot(uri=COMMUNITYMECH.chebi_term, name="relatedIngredient__chebi_term", curie=COMMUNITYMECH.curie('chebi_term'),
-                   model_uri=COMMUNITYMECH.relatedIngredient__chebi_term, domain=None, range=Optional[Union[dict, Term]])
-
-slots.relatedIngredient__relevance = Slot(uri=COMMUNITYMECH.relevance, name="relatedIngredient__relevance", curie=COMMUNITYMECH.curie('relevance'),
-                   model_uri=COMMUNITYMECH.relatedIngredient__relevance, domain=None, range=Optional[str])
-
-slots.relatedIngredient__evidence = Slot(uri=COMMUNITYMECH.evidence, name="relatedIngredient__evidence", curie=COMMUNITYMECH.curie('evidence'),
-                   model_uri=COMMUNITYMECH.relatedIngredient__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
-
-slots.associatedDataset__name = Slot(uri=COMMUNITYMECH.name, name="associatedDataset__name", curie=COMMUNITYMECH.curie('name'),
-                   model_uri=COMMUNITYMECH.associatedDataset__name, domain=None, range=str)
-
-slots.associatedDataset__dataset_type = Slot(uri=COMMUNITYMECH.dataset_type, name="associatedDataset__dataset_type", curie=COMMUNITYMECH.curie('dataset_type'),
-                   model_uri=COMMUNITYMECH.associatedDataset__dataset_type, domain=None, range=Union[str, "DatasetTypeEnum"])
-
-slots.associatedDataset__repository = Slot(uri=COMMUNITYMECH.repository, name="associatedDataset__repository", curie=COMMUNITYMECH.curie('repository'),
-                   model_uri=COMMUNITYMECH.associatedDataset__repository, domain=None, range=Optional[Union[str, "DatasetRepositoryEnum"]])
-
-slots.associatedDataset__accession = Slot(uri=COMMUNITYMECH.accession, name="associatedDataset__accession", curie=COMMUNITYMECH.curie('accession'),
-                   model_uri=COMMUNITYMECH.associatedDataset__accession, domain=None, range=str)
-
-slots.associatedDataset__url = Slot(uri=COMMUNITYMECH.url, name="associatedDataset__url", curie=COMMUNITYMECH.curie('url'),
-                   model_uri=COMMUNITYMECH.associatedDataset__url, domain=None, range=Optional[str])
-
-slots.associatedDataset__description = Slot(uri=COMMUNITYMECH.description, name="associatedDataset__description", curie=COMMUNITYMECH.curie('description'),
-                   model_uri=COMMUNITYMECH.associatedDataset__description, domain=None, range=Optional[str])
-
-slots.associatedDataset__evidence = Slot(uri=COMMUNITYMECH.evidence, name="associatedDataset__evidence", curie=COMMUNITYMECH.curie('evidence'),
-                   model_uri=COMMUNITYMECH.associatedDataset__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
-
-slots.externalResource__name = Slot(uri=COMMUNITYMECH.name, name="externalResource__name", curie=COMMUNITYMECH.curie('name'),
-                   model_uri=COMMUNITYMECH.externalResource__name, domain=None, range=str)
-
-slots.externalResource__repository = Slot(uri=COMMUNITYMECH.repository, name="externalResource__repository", curie=COMMUNITYMECH.curie('repository'),
-                   model_uri=COMMUNITYMECH.externalResource__repository, domain=None, range=Union[str, "ExternalResourceRepositoryEnum"])
-
-slots.externalResource__resource_id = Slot(uri=COMMUNITYMECH.resource_id, name="externalResource__resource_id", curie=COMMUNITYMECH.curie('resource_id'),
-                   model_uri=COMMUNITYMECH.externalResource__resource_id, domain=None, range=str)
-
-slots.externalResource__url = Slot(uri=COMMUNITYMECH.url, name="externalResource__url", curie=COMMUNITYMECH.curie('url'),
-                   model_uri=COMMUNITYMECH.externalResource__url, domain=None, range=str)
-
-slots.externalResource__description = Slot(uri=COMMUNITYMECH.description, name="externalResource__description", curie=COMMUNITYMECH.curie('description'),
-                   model_uri=COMMUNITYMECH.externalResource__description, domain=None, range=Optional[str])
-
-slots.externalResource__evidence = Slot(uri=COMMUNITYMECH.evidence, name="externalResource__evidence", curie=COMMUNITYMECH.curie('evidence'),
-                   model_uri=COMMUNITYMECH.externalResource__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
-
-slots.communityEngineeringDesign__objective = Slot(uri=COMMUNITYMECH.objective, name="communityEngineeringDesign__objective", curie=COMMUNITYMECH.curie('objective'),
-                   model_uri=COMMUNITYMECH.communityEngineeringDesign__objective, domain=None, range=Optional[str])
-
-slots.communityEngineeringDesign__assembly_strategy = Slot(uri=COMMUNITYMECH.assembly_strategy, name="communityEngineeringDesign__assembly_strategy", curie=COMMUNITYMECH.curie('assembly_strategy'),
-                   model_uri=COMMUNITYMECH.communityEngineeringDesign__assembly_strategy, domain=None, range=Optional[str])
-
-slots.communityEngineeringDesign__inoculation_strategy = Slot(uri=COMMUNITYMECH.inoculation_strategy, name="communityEngineeringDesign__inoculation_strategy", curie=COMMUNITYMECH.curie('inoculation_strategy'),
-                   model_uri=COMMUNITYMECH.communityEngineeringDesign__inoculation_strategy, domain=None, range=Optional[str])
-
-slots.communityEngineeringDesign__passaging_regimen = Slot(uri=COMMUNITYMECH.passaging_regimen, name="communityEngineeringDesign__passaging_regimen", curie=COMMUNITYMECH.curie('passaging_regimen'),
-                   model_uri=COMMUNITYMECH.communityEngineeringDesign__passaging_regimen, domain=None, range=Optional[str])
-
-slots.communityEngineeringDesign__perturbation_design = Slot(uri=COMMUNITYMECH.perturbation_design, name="communityEngineeringDesign__perturbation_design", curie=COMMUNITYMECH.curie('perturbation_design'),
-                   model_uri=COMMUNITYMECH.communityEngineeringDesign__perturbation_design, domain=None, range=Optional[str])
-
-slots.communityEngineeringDesign__measurement_endpoints = Slot(uri=COMMUNITYMECH.measurement_endpoints, name="communityEngineeringDesign__measurement_endpoints", curie=COMMUNITYMECH.curie('measurement_endpoints'),
-                   model_uri=COMMUNITYMECH.communityEngineeringDesign__measurement_endpoints, domain=None, range=Optional[Union[str, list[str]]])
-
-slots.communityEngineeringDesign__protocol_url = Slot(uri=COMMUNITYMECH.protocol_url, name="communityEngineeringDesign__protocol_url", curie=COMMUNITYMECH.curie('protocol_url'),
-                   model_uri=COMMUNITYMECH.communityEngineeringDesign__protocol_url, domain=None, range=Optional[str])
-
-slots.communityEngineeringDesign__notes = Slot(uri=COMMUNITYMECH.notes, name="communityEngineeringDesign__notes", curie=COMMUNITYMECH.curie('notes'),
-                   model_uri=COMMUNITYMECH.communityEngineeringDesign__notes, domain=None, range=Optional[str])
-
-slots.communityEngineeringDesign__evidence = Slot(uri=COMMUNITYMECH.evidence, name="communityEngineeringDesign__evidence", curie=COMMUNITYMECH.curie('evidence'),
-                   model_uri=COMMUNITYMECH.communityEngineeringDesign__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
-
-slots.microbialCommunity__id = Slot(uri=COMMUNITYMECH.id, name="microbialCommunity__id", curie=COMMUNITYMECH.curie('id'),
-                   model_uri=COMMUNITYMECH.microbialCommunity__id, domain=None, range=URIRef,
-                   pattern=re.compile(r'^CommunityMech:\d{6}$'))
-
-slots.microbialCommunity__name = Slot(uri=COMMUNITYMECH.name, name="microbialCommunity__name", curie=COMMUNITYMECH.curie('name'),
-                   model_uri=COMMUNITYMECH.microbialCommunity__name, domain=None, range=str)
-
-slots.microbialCommunity__description = Slot(uri=COMMUNITYMECH.description, name="microbialCommunity__description", curie=COMMUNITYMECH.curie('description'),
-                   model_uri=COMMUNITYMECH.microbialCommunity__description, domain=None, range=Optional[str])
-
-slots.microbialCommunity__ecological_state = Slot(uri=COMMUNITYMECH.ecological_state, name="microbialCommunity__ecological_state", curie=COMMUNITYMECH.curie('ecological_state'),
-                   model_uri=COMMUNITYMECH.microbialCommunity__ecological_state, domain=None, range=Optional[Union[str, "EcologicalStateEnum"]])
-
-slots.microbialCommunity__community_origin = Slot(uri=COMMUNITYMECH.community_origin, name="microbialCommunity__community_origin", curie=COMMUNITYMECH.curie('community_origin'),
-                   model_uri=COMMUNITYMECH.microbialCommunity__community_origin, domain=None, range=Optional[Union[str, "CommunityOriginEnum"]])
-
-slots.microbialCommunity__community_category = Slot(uri=COMMUNITYMECH.community_category, name="microbialCommunity__community_category", curie=COMMUNITYMECH.curie('community_category'),
-                   model_uri=COMMUNITYMECH.microbialCommunity__community_category, domain=None, range=Optional[Union[str, "CommunityCategoryEnum"]])
-
-slots.microbialCommunity__engineering_design = Slot(uri=COMMUNITYMECH.engineering_design, name="microbialCommunity__engineering_design", curie=COMMUNITYMECH.curie('engineering_design'),
-                   model_uri=COMMUNITYMECH.microbialCommunity__engineering_design, domain=None, range=Optional[Union[dict, CommunityEngineeringDesign]])
-
-slots.microbialCommunity__environment_term = Slot(uri=COMMUNITYMECH.environment_term, name="microbialCommunity__environment_term", curie=COMMUNITYMECH.curie('environment_term'),
-                   model_uri=COMMUNITYMECH.microbialCommunity__environment_term, domain=None, range=Optional[Union[dict, EnvironmentDescriptor]])
-
-slots.microbialCommunity__taxonomy = Slot(uri=COMMUNITYMECH.taxonomy, name="microbialCommunity__taxonomy", curie=COMMUNITYMECH.curie('taxonomy'),
-                   model_uri=COMMUNITYMECH.microbialCommunity__taxonomy, domain=None, range=Optional[Union[Union[dict, TaxonomicComposition], list[Union[dict, TaxonomicComposition]]]])
-
-slots.microbialCommunity__ecological_interactions = Slot(uri=COMMUNITYMECH.ecological_interactions, name="microbialCommunity__ecological_interactions", curie=COMMUNITYMECH.curie('ecological_interactions'),
-                   model_uri=COMMUNITYMECH.microbialCommunity__ecological_interactions, domain=None, range=Optional[Union[Union[dict, EcologicalInteraction], list[Union[dict, EcologicalInteraction]]]])
-
-slots.microbialCommunity__environmental_factors = Slot(uri=COMMUNITYMECH.environmental_factors, name="microbialCommunity__environmental_factors", curie=COMMUNITYMECH.curie('environmental_factors'),
-                   model_uri=COMMUNITYMECH.microbialCommunity__environmental_factors, domain=None, range=Optional[Union[Union[dict, EnvironmentalFactor], list[Union[dict, EnvironmentalFactor]]]])
-
-slots.microbialCommunity__growth_media = Slot(uri=COMMUNITYMECH.growth_media, name="microbialCommunity__growth_media", curie=COMMUNITYMECH.curie('growth_media'),
-                   model_uri=COMMUNITYMECH.microbialCommunity__growth_media, domain=None, range=Optional[Union[Union[dict, GrowthMedia], list[Union[dict, GrowthMedia]]]])
-
-slots.microbialCommunity__related_media = Slot(uri=COMMUNITYMECH.related_media, name="microbialCommunity__related_media", curie=COMMUNITYMECH.curie('related_media'),
-                   model_uri=COMMUNITYMECH.microbialCommunity__related_media, domain=None, range=Optional[Union[Union[dict, RelatedMedia], list[Union[dict, RelatedMedia]]]])
-
-slots.microbialCommunity__related_ingredients = Slot(uri=COMMUNITYMECH.related_ingredients, name="microbialCommunity__related_ingredients", curie=COMMUNITYMECH.curie('related_ingredients'),
-                   model_uri=COMMUNITYMECH.microbialCommunity__related_ingredients, domain=None, range=Optional[Union[Union[dict, RelatedIngredient], list[Union[dict, RelatedIngredient]]]])
-
-slots.microbialCommunity__associated_datasets = Slot(uri=COMMUNITYMECH.associated_datasets, name="microbialCommunity__associated_datasets", curie=COMMUNITYMECH.curie('associated_datasets'),
-                   model_uri=COMMUNITYMECH.microbialCommunity__associated_datasets, domain=None, range=Optional[Union[Union[dict, AssociatedDataset], list[Union[dict, AssociatedDataset]]]])
-
-slots.microbialCommunity__external_resources = Slot(uri=COMMUNITYMECH.external_resources, name="microbialCommunity__external_resources", curie=COMMUNITYMECH.curie('external_resources'),
-                   model_uri=COMMUNITYMECH.microbialCommunity__external_resources, domain=None, range=Optional[Union[Union[dict, ExternalResource], list[Union[dict, ExternalResource]]]])
-
-slots.microbialCommunity__metals_present = Slot(uri=COMMUNITYMECH.metals_present, name="microbialCommunity__metals_present", curie=COMMUNITYMECH.curie('metals_present'),
-                   model_uri=COMMUNITYMECH.microbialCommunity__metals_present, domain=None, range=Optional[Union[Union[str, "MetalElementEnum"], list[Union[str, "MetalElementEnum"]]]])
-
-slots.microbialCommunity__rare_earth_elements_present = Slot(uri=COMMUNITYMECH.rare_earth_elements_present, name="microbialCommunity__rare_earth_elements_present", curie=COMMUNITYMECH.curie('rare_earth_elements_present'),
-                   model_uri=COMMUNITYMECH.microbialCommunity__rare_earth_elements_present, domain=None, range=Optional[Union[Union[str, "RareEarthElementEnum"], list[Union[str, "RareEarthElementEnum"]]]])
-
-slots.microbialCommunity__metal_relevance = Slot(uri=COMMUNITYMECH.metal_relevance, name="microbialCommunity__metal_relevance", curie=COMMUNITYMECH.curie('metal_relevance'),
-                   model_uri=COMMUNITYMECH.microbialCommunity__metal_relevance, domain=None, range=Optional[Union[str, "MetalRelevanceEnum"]])
-
-slots.microbialCommunity__metal_notes = Slot(uri=COMMUNITYMECH.metal_notes, name="microbialCommunity__metal_notes", curie=COMMUNITYMECH.curie('metal_notes'),
-                   model_uri=COMMUNITYMECH.microbialCommunity__metal_notes, domain=None, range=Optional[str])
-
-slots.microbialCommunity__curation_history = Slot(uri=COMMUNITYMECH.curation_history, name="microbialCommunity__curation_history", curie=COMMUNITYMECH.curie('curation_history'),
-                   model_uri=COMMUNITYMECH.microbialCommunity__curation_history, domain=None, range=Optional[Union[Union[dict, CurationEvent], list[Union[dict, CurationEvent]]]])
-
-slots.curationEvent__timestamp = Slot(uri=COMMUNITYMECH.timestamp, name="curationEvent__timestamp", curie=COMMUNITYMECH.curie('timestamp'),
-                   model_uri=COMMUNITYMECH.curationEvent__timestamp, domain=None, range=Union[str, XSDDateTime])
-
-slots.curationEvent__curator = Slot(uri=COMMUNITYMECH.curator, name="curationEvent__curator", curie=COMMUNITYMECH.curie('curator'),
-                   model_uri=COMMUNITYMECH.curationEvent__curator, domain=None, range=str)
-
-slots.curationEvent__action = Slot(uri=COMMUNITYMECH.action, name="curationEvent__action", curie=COMMUNITYMECH.curie('action'),
-                   model_uri=COMMUNITYMECH.curationEvent__action, domain=None, range=str,
-                   pattern=re.compile(r'^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'))
-
-slots.curationEvent__changes = Slot(uri=COMMUNITYMECH.changes, name="curationEvent__changes", curie=COMMUNITYMECH.curie('changes'),
-                   model_uri=COMMUNITYMECH.curationEvent__changes, domain=None, range=Optional[str])
-
-slots.curationEvent__llm_assisted = Slot(uri=COMMUNITYMECH.llm_assisted, name="curationEvent__llm_assisted", curie=COMMUNITYMECH.curie('llm_assisted'),
-                   model_uri=COMMUNITYMECH.curationEvent__llm_assisted, domain=None, range=Optional[Union[bool, Bool]])
-
+slots.term__id = Slot(
+    uri=COMMUNITYMECH.id,
+    name="term__id",
+    curie=COMMUNITYMECH.curie("id"),
+    model_uri=COMMUNITYMECH.term__id,
+    domain=None,
+    range=str,
+)
+
+slots.term__label = Slot(
+    uri=RDFS.label,
+    name="term__label",
+    curie=RDFS.curie("label"),
+    model_uri=COMMUNITYMECH.term__label,
+    domain=None,
+    range=str,
+)
+
+slots.evidenceItem__reference = Slot(
+    uri=COMMUNITYMECH.reference,
+    name="evidenceItem__reference",
+    curie=COMMUNITYMECH.curie("reference"),
+    model_uri=COMMUNITYMECH.evidenceItem__reference,
+    domain=None,
+    range=str,
+    pattern=re.compile(r"^(PMID:|doi:|bioproject:).*"),
+)
+
+slots.evidenceItem__supports = Slot(
+    uri=COMMUNITYMECH.supports,
+    name="evidenceItem__supports",
+    curie=COMMUNITYMECH.curie("supports"),
+    model_uri=COMMUNITYMECH.evidenceItem__supports,
+    domain=None,
+    range=Union[str, "EvidenceItemSupportEnum"],
+)
+
+slots.evidenceItem__evidence_source = Slot(
+    uri=COMMUNITYMECH.evidence_source,
+    name="evidenceItem__evidence_source",
+    curie=COMMUNITYMECH.curie("evidence_source"),
+    model_uri=COMMUNITYMECH.evidenceItem__evidence_source,
+    domain=None,
+    range=Union[str, "EvidenceSourceEnum"],
+)
+
+slots.evidenceItem__snippet = Slot(
+    uri=COMMUNITYMECH.snippet,
+    name="evidenceItem__snippet",
+    curie=COMMUNITYMECH.curie("snippet"),
+    model_uri=COMMUNITYMECH.evidenceItem__snippet,
+    domain=None,
+    range=str,
+)
+
+slots.evidenceItem__explanation = Slot(
+    uri=COMMUNITYMECH.explanation,
+    name="evidenceItem__explanation",
+    curie=COMMUNITYMECH.curie("explanation"),
+    model_uri=COMMUNITYMECH.evidenceItem__explanation,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.evidenceItem__confidence_score = Slot(
+    uri=COMMUNITYMECH.confidence_score,
+    name="evidenceItem__confidence_score",
+    curie=COMMUNITYMECH.curie("confidence_score"),
+    model_uri=COMMUNITYMECH.evidenceItem__confidence_score,
+    domain=None,
+    range=Optional[float],
+)
+
+slots.taxonDescriptor__preferred_term = Slot(
+    uri=COMMUNITYMECH.preferred_term,
+    name="taxonDescriptor__preferred_term",
+    curie=COMMUNITYMECH.curie("preferred_term"),
+    model_uri=COMMUNITYMECH.taxonDescriptor__preferred_term,
+    domain=None,
+    range=str,
+)
+
+slots.taxonDescriptor__term = Slot(
+    uri=COMMUNITYMECH.term,
+    name="taxonDescriptor__term",
+    curie=COMMUNITYMECH.curie("term"),
+    model_uri=COMMUNITYMECH.taxonDescriptor__term,
+    domain=None,
+    range=Union[dict, Term],
+)
+
+slots.taxonDescriptor__notes = Slot(
+    uri=COMMUNITYMECH.notes,
+    name="taxonDescriptor__notes",
+    curie=COMMUNITYMECH.curie("notes"),
+    model_uri=COMMUNITYMECH.taxonDescriptor__notes,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.metaboliteDescriptor__preferred_term = Slot(
+    uri=COMMUNITYMECH.preferred_term,
+    name="metaboliteDescriptor__preferred_term",
+    curie=COMMUNITYMECH.curie("preferred_term"),
+    model_uri=COMMUNITYMECH.metaboliteDescriptor__preferred_term,
+    domain=None,
+    range=str,
+)
+
+slots.metaboliteDescriptor__term = Slot(
+    uri=COMMUNITYMECH.term,
+    name="metaboliteDescriptor__term",
+    curie=COMMUNITYMECH.curie("term"),
+    model_uri=COMMUNITYMECH.metaboliteDescriptor__term,
+    domain=None,
+    range=Union[dict, Term],
+)
+
+slots.metaboliteDescriptor__concentration = Slot(
+    uri=COMMUNITYMECH.concentration,
+    name="metaboliteDescriptor__concentration",
+    curie=COMMUNITYMECH.curie("concentration"),
+    model_uri=COMMUNITYMECH.metaboliteDescriptor__concentration,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.metaboliteDescriptor__notes = Slot(
+    uri=COMMUNITYMECH.notes,
+    name="metaboliteDescriptor__notes",
+    curie=COMMUNITYMECH.curie("notes"),
+    model_uri=COMMUNITYMECH.metaboliteDescriptor__notes,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.biologicalProcessDescriptor__preferred_term = Slot(
+    uri=COMMUNITYMECH.preferred_term,
+    name="biologicalProcessDescriptor__preferred_term",
+    curie=COMMUNITYMECH.curie("preferred_term"),
+    model_uri=COMMUNITYMECH.biologicalProcessDescriptor__preferred_term,
+    domain=None,
+    range=str,
+)
+
+slots.biologicalProcessDescriptor__term = Slot(
+    uri=COMMUNITYMECH.term,
+    name="biologicalProcessDescriptor__term",
+    curie=COMMUNITYMECH.curie("term"),
+    model_uri=COMMUNITYMECH.biologicalProcessDescriptor__term,
+    domain=None,
+    range=Union[dict, Term],
+)
+
+slots.biologicalProcessDescriptor__notes = Slot(
+    uri=COMMUNITYMECH.notes,
+    name="biologicalProcessDescriptor__notes",
+    curie=COMMUNITYMECH.curie("notes"),
+    model_uri=COMMUNITYMECH.biologicalProcessDescriptor__notes,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.environmentDescriptor__preferred_term = Slot(
+    uri=COMMUNITYMECH.preferred_term,
+    name="environmentDescriptor__preferred_term",
+    curie=COMMUNITYMECH.curie("preferred_term"),
+    model_uri=COMMUNITYMECH.environmentDescriptor__preferred_term,
+    domain=None,
+    range=str,
+)
+
+slots.environmentDescriptor__term = Slot(
+    uri=COMMUNITYMECH.term,
+    name="environmentDescriptor__term",
+    curie=COMMUNITYMECH.curie("term"),
+    model_uri=COMMUNITYMECH.environmentDescriptor__term,
+    domain=None,
+    range=Union[dict, Term],
+)
+
+slots.environmentDescriptor__notes = Slot(
+    uri=COMMUNITYMECH.notes,
+    name="environmentDescriptor__notes",
+    curie=COMMUNITYMECH.curie("notes"),
+    model_uri=COMMUNITYMECH.environmentDescriptor__notes,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.cultureCollectionID__collection = Slot(
+    uri=COMMUNITYMECH.collection,
+    name="cultureCollectionID__collection",
+    curie=COMMUNITYMECH.curie("collection"),
+    model_uri=COMMUNITYMECH.cultureCollectionID__collection,
+    domain=None,
+    range=Union[str, "CultureCollectionEnum"],
+)
+
+slots.cultureCollectionID__accession = Slot(
+    uri=COMMUNITYMECH.accession,
+    name="cultureCollectionID__accession",
+    curie=COMMUNITYMECH.curie("accession"),
+    model_uri=COMMUNITYMECH.cultureCollectionID__accession,
+    domain=None,
+    range=str,
+)
+
+slots.cultureCollectionID__url = Slot(
+    uri=COMMUNITYMECH.url,
+    name="cultureCollectionID__url",
+    curie=COMMUNITYMECH.curie("url"),
+    model_uri=COMMUNITYMECH.cultureCollectionID__url,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.cultureCollectionID__notes = Slot(
+    uri=COMMUNITYMECH.notes,
+    name="cultureCollectionID__notes",
+    curie=COMMUNITYMECH.curie("notes"),
+    model_uri=COMMUNITYMECH.cultureCollectionID__notes,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.strainDesignation__strain_name = Slot(
+    uri=COMMUNITYMECH.strain_name,
+    name="strainDesignation__strain_name",
+    curie=COMMUNITYMECH.curie("strain_name"),
+    model_uri=COMMUNITYMECH.strainDesignation__strain_name,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.strainDesignation__culture_collections = Slot(
+    uri=COMMUNITYMECH.culture_collections,
+    name="strainDesignation__culture_collections",
+    curie=COMMUNITYMECH.curie("culture_collections"),
+    model_uri=COMMUNITYMECH.strainDesignation__culture_collections,
+    domain=None,
+    range=Optional[Union[Union[dict, CultureCollectionID], list[Union[dict, CultureCollectionID]]]],
+)
+
+slots.strainDesignation__type_strain = Slot(
+    uri=COMMUNITYMECH.type_strain,
+    name="strainDesignation__type_strain",
+    curie=COMMUNITYMECH.curie("type_strain"),
+    model_uri=COMMUNITYMECH.strainDesignation__type_strain,
+    domain=None,
+    range=Optional[Union[bool, Bool]],
+)
+
+slots.strainDesignation__genome_accession = Slot(
+    uri=COMMUNITYMECH.genome_accession,
+    name="strainDesignation__genome_accession",
+    curie=COMMUNITYMECH.curie("genome_accession"),
+    model_uri=COMMUNITYMECH.strainDesignation__genome_accession,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.strainDesignation__genome_url = Slot(
+    uri=COMMUNITYMECH.genome_url,
+    name="strainDesignation__genome_url",
+    curie=COMMUNITYMECH.curie("genome_url"),
+    model_uri=COMMUNITYMECH.strainDesignation__genome_url,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.strainDesignation__genetic_modification = Slot(
+    uri=COMMUNITYMECH.genetic_modification,
+    name="strainDesignation__genetic_modification",
+    curie=COMMUNITYMECH.curie("genetic_modification"),
+    model_uri=COMMUNITYMECH.strainDesignation__genetic_modification,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.strainDesignation__isolation_source = Slot(
+    uri=COMMUNITYMECH.isolation_source,
+    name="strainDesignation__isolation_source",
+    curie=COMMUNITYMECH.curie("isolation_source"),
+    model_uri=COMMUNITYMECH.strainDesignation__isolation_source,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.strainDesignation__notes = Slot(
+    uri=COMMUNITYMECH.notes,
+    name="strainDesignation__notes",
+    curie=COMMUNITYMECH.curie("notes"),
+    model_uri=COMMUNITYMECH.strainDesignation__notes,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.taxonomicComposition__taxon_term = Slot(
+    uri=COMMUNITYMECH.taxon_term,
+    name="taxonomicComposition__taxon_term",
+    curie=COMMUNITYMECH.curie("taxon_term"),
+    model_uri=COMMUNITYMECH.taxonomicComposition__taxon_term,
+    domain=None,
+    range=Union[dict, TaxonDescriptor],
+)
+
+slots.taxonomicComposition__strain_designation = Slot(
+    uri=COMMUNITYMECH.strain_designation,
+    name="taxonomicComposition__strain_designation",
+    curie=COMMUNITYMECH.curie("strain_designation"),
+    model_uri=COMMUNITYMECH.taxonomicComposition__strain_designation,
+    domain=None,
+    range=Optional[Union[dict, StrainDesignation]],
+)
+
+slots.taxonomicComposition__abundance_level = Slot(
+    uri=COMMUNITYMECH.abundance_level,
+    name="taxonomicComposition__abundance_level",
+    curie=COMMUNITYMECH.curie("abundance_level"),
+    model_uri=COMMUNITYMECH.taxonomicComposition__abundance_level,
+    domain=None,
+    range=Optional[Union[str, "AbundanceEnum"]],
+)
+
+slots.taxonomicComposition__abundance_value = Slot(
+    uri=COMMUNITYMECH.abundance_value,
+    name="taxonomicComposition__abundance_value",
+    curie=COMMUNITYMECH.curie("abundance_value"),
+    model_uri=COMMUNITYMECH.taxonomicComposition__abundance_value,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.taxonomicComposition__functional_role = Slot(
+    uri=COMMUNITYMECH.functional_role,
+    name="taxonomicComposition__functional_role",
+    curie=COMMUNITYMECH.curie("functional_role"),
+    model_uri=COMMUNITYMECH.taxonomicComposition__functional_role,
+    domain=None,
+    range=Optional[Union[Union[str, "FunctionalRoleEnum"], list[Union[str, "FunctionalRoleEnum"]]]],
+)
+
+slots.taxonomicComposition__evidence = Slot(
+    uri=COMMUNITYMECH.evidence,
+    name="taxonomicComposition__evidence",
+    curie=COMMUNITYMECH.curie("evidence"),
+    model_uri=COMMUNITYMECH.taxonomicComposition__evidence,
+    domain=None,
+    range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
+)
+
+slots.interactionDownstream__target = Slot(
+    uri=COMMUNITYMECH.target,
+    name="interactionDownstream__target",
+    curie=COMMUNITYMECH.curie("target"),
+    model_uri=COMMUNITYMECH.interactionDownstream__target,
+    domain=None,
+    range=str,
+)
+
+slots.interactionDownstream__description = Slot(
+    uri=COMMUNITYMECH.description,
+    name="interactionDownstream__description",
+    curie=COMMUNITYMECH.curie("description"),
+    model_uri=COMMUNITYMECH.interactionDownstream__description,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.ecologicalInteraction__name = Slot(
+    uri=COMMUNITYMECH.name,
+    name="ecologicalInteraction__name",
+    curie=COMMUNITYMECH.curie("name"),
+    model_uri=COMMUNITYMECH.ecologicalInteraction__name,
+    domain=None,
+    range=str,
+)
+
+slots.ecologicalInteraction__description = Slot(
+    uri=COMMUNITYMECH.description,
+    name="ecologicalInteraction__description",
+    curie=COMMUNITYMECH.curie("description"),
+    model_uri=COMMUNITYMECH.ecologicalInteraction__description,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.ecologicalInteraction__interaction_type = Slot(
+    uri=COMMUNITYMECH.interaction_type,
+    name="ecologicalInteraction__interaction_type",
+    curie=COMMUNITYMECH.curie("interaction_type"),
+    model_uri=COMMUNITYMECH.ecologicalInteraction__interaction_type,
+    domain=None,
+    range=Optional[Union[str, "InteractionTypeEnum"]],
+)
+
+slots.ecologicalInteraction__scope = Slot(
+    uri=COMMUNITYMECH.scope,
+    name="ecologicalInteraction__scope",
+    curie=COMMUNITYMECH.curie("scope"),
+    model_uri=COMMUNITYMECH.ecologicalInteraction__scope,
+    domain=None,
+    range=Optional[Union[str, "InteractionScopeEnum"]],
+)
+
+slots.ecologicalInteraction__source_taxon = Slot(
+    uri=COMMUNITYMECH.source_taxon,
+    name="ecologicalInteraction__source_taxon",
+    curie=COMMUNITYMECH.curie("source_taxon"),
+    model_uri=COMMUNITYMECH.ecologicalInteraction__source_taxon,
+    domain=None,
+    range=Optional[Union[dict, TaxonDescriptor]],
+)
+
+slots.ecologicalInteraction__target_taxon = Slot(
+    uri=COMMUNITYMECH.target_taxon,
+    name="ecologicalInteraction__target_taxon",
+    curie=COMMUNITYMECH.curie("target_taxon"),
+    model_uri=COMMUNITYMECH.ecologicalInteraction__target_taxon,
+    domain=None,
+    range=Optional[Union[dict, TaxonDescriptor]],
+)
+
+slots.ecologicalInteraction__metabolites = Slot(
+    uri=COMMUNITYMECH.metabolites,
+    name="ecologicalInteraction__metabolites",
+    curie=COMMUNITYMECH.curie("metabolites"),
+    model_uri=COMMUNITYMECH.ecologicalInteraction__metabolites,
+    domain=None,
+    range=Optional[
+        Union[Union[dict, MetaboliteDescriptor], list[Union[dict, MetaboliteDescriptor]]]
+    ],
+)
+
+slots.ecologicalInteraction__biological_processes = Slot(
+    uri=COMMUNITYMECH.biological_processes,
+    name="ecologicalInteraction__biological_processes",
+    curie=COMMUNITYMECH.curie("biological_processes"),
+    model_uri=COMMUNITYMECH.ecologicalInteraction__biological_processes,
+    domain=None,
+    range=Optional[
+        Union[
+            Union[dict, BiologicalProcessDescriptor], list[Union[dict, BiologicalProcessDescriptor]]
+        ]
+    ],
+)
+
+slots.ecologicalInteraction__downstream = Slot(
+    uri=COMMUNITYMECH.downstream,
+    name="ecologicalInteraction__downstream",
+    curie=COMMUNITYMECH.curie("downstream"),
+    model_uri=COMMUNITYMECH.ecologicalInteraction__downstream,
+    domain=None,
+    range=Optional[
+        Union[Union[dict, InteractionDownstream], list[Union[dict, InteractionDownstream]]]
+    ],
+)
+
+slots.ecologicalInteraction__evidence = Slot(
+    uri=COMMUNITYMECH.evidence,
+    name="ecologicalInteraction__evidence",
+    curie=COMMUNITYMECH.curie("evidence"),
+    model_uri=COMMUNITYMECH.ecologicalInteraction__evidence,
+    domain=None,
+    range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
+)
+
+slots.environmentalFactor__name = Slot(
+    uri=COMMUNITYMECH.name,
+    name="environmentalFactor__name",
+    curie=COMMUNITYMECH.curie("name"),
+    model_uri=COMMUNITYMECH.environmentalFactor__name,
+    domain=None,
+    range=str,
+)
+
+slots.environmentalFactor__value = Slot(
+    uri=COMMUNITYMECH.value,
+    name="environmentalFactor__value",
+    curie=COMMUNITYMECH.curie("value"),
+    model_uri=COMMUNITYMECH.environmentalFactor__value,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.environmentalFactor__unit = Slot(
+    uri=COMMUNITYMECH.unit,
+    name="environmentalFactor__unit",
+    curie=COMMUNITYMECH.curie("unit"),
+    model_uri=COMMUNITYMECH.environmentalFactor__unit,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.environmentalFactor__description = Slot(
+    uri=COMMUNITYMECH.description,
+    name="environmentalFactor__description",
+    curie=COMMUNITYMECH.curie("description"),
+    model_uri=COMMUNITYMECH.environmentalFactor__description,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.environmentalFactor__evidence = Slot(
+    uri=COMMUNITYMECH.evidence,
+    name="environmentalFactor__evidence",
+    curie=COMMUNITYMECH.curie("evidence"),
+    model_uri=COMMUNITYMECH.environmentalFactor__evidence,
+    domain=None,
+    range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
+)
+
+slots.growthMediaComponent__name = Slot(
+    uri=COMMUNITYMECH.name,
+    name="growthMediaComponent__name",
+    curie=COMMUNITYMECH.curie("name"),
+    model_uri=COMMUNITYMECH.growthMediaComponent__name,
+    domain=None,
+    range=str,
+)
+
+slots.growthMediaComponent__media_ingredient_mech_id = Slot(
+    uri=COMMUNITYMECH.media_ingredient_mech_id,
+    name="growthMediaComponent__media_ingredient_mech_id",
+    curie=COMMUNITYMECH.curie("media_ingredient_mech_id"),
+    model_uri=COMMUNITYMECH.growthMediaComponent__media_ingredient_mech_id,
+    domain=None,
+    range=Optional[str],
+    pattern=re.compile(r"^MediaIngredientMech:\d{6}$"),
+)
+
+slots.growthMediaComponent__media_ingredient_mech_url = Slot(
+    uri=COMMUNITYMECH.media_ingredient_mech_url,
+    name="growthMediaComponent__media_ingredient_mech_url",
+    curie=COMMUNITYMECH.curie("media_ingredient_mech_url"),
+    model_uri=COMMUNITYMECH.growthMediaComponent__media_ingredient_mech_url,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMediaComponent__concentration = Slot(
+    uri=COMMUNITYMECH.concentration,
+    name="growthMediaComponent__concentration",
+    curie=COMMUNITYMECH.curie("concentration"),
+    model_uri=COMMUNITYMECH.growthMediaComponent__concentration,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMediaComponent__unit = Slot(
+    uri=COMMUNITYMECH.unit,
+    name="growthMediaComponent__unit",
+    curie=COMMUNITYMECH.curie("unit"),
+    model_uri=COMMUNITYMECH.growthMediaComponent__unit,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMediaComponent__chebi_term = Slot(
+    uri=COMMUNITYMECH.chebi_term,
+    name="growthMediaComponent__chebi_term",
+    curie=COMMUNITYMECH.curie("chebi_term"),
+    model_uri=COMMUNITYMECH.growthMediaComponent__chebi_term,
+    domain=None,
+    range=Optional[Union[dict, MetaboliteDescriptor]],
+)
+
+slots.growthMediaComponent__from_source = Slot(
+    uri=COMMUNITYMECH.from_source,
+    name="growthMediaComponent__from_source",
+    curie=COMMUNITYMECH.curie("from_source"),
+    model_uri=COMMUNITYMECH.growthMediaComponent__from_source,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__name = Slot(
+    uri=COMMUNITYMECH.name,
+    name="growthMedia__name",
+    curie=COMMUNITYMECH.curie("name"),
+    model_uri=COMMUNITYMECH.growthMedia__name,
+    domain=None,
+    range=str,
+)
+
+slots.growthMedia__culturemech_id = Slot(
+    uri=COMMUNITYMECH.culturemech_id,
+    name="growthMedia__culturemech_id",
+    curie=COMMUNITYMECH.curie("culturemech_id"),
+    model_uri=COMMUNITYMECH.growthMedia__culturemech_id,
+    domain=None,
+    range=Optional[str],
+    pattern=re.compile(r"^CultureMech:\d{6}$"),
+)
+
+slots.growthMedia__culturemech_url = Slot(
+    uri=COMMUNITYMECH.culturemech_url,
+    name="growthMedia__culturemech_url",
+    curie=COMMUNITYMECH.curie("culturemech_url"),
+    model_uri=COMMUNITYMECH.growthMedia__culturemech_url,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__composition = Slot(
+    uri=COMMUNITYMECH.composition,
+    name="growthMedia__composition",
+    curie=COMMUNITYMECH.curie("composition"),
+    model_uri=COMMUNITYMECH.growthMedia__composition,
+    domain=None,
+    range=Optional[
+        Union[Union[dict, GrowthMediaComponent], list[Union[dict, GrowthMediaComponent]]]
+    ],
+)
+
+slots.growthMedia__ph = Slot(
+    uri=COMMUNITYMECH.ph,
+    name="growthMedia__ph",
+    curie=COMMUNITYMECH.curie("ph"),
+    model_uri=COMMUNITYMECH.growthMedia__ph,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__ph_range = Slot(
+    uri=COMMUNITYMECH.ph_range,
+    name="growthMedia__ph_range",
+    curie=COMMUNITYMECH.curie("ph_range"),
+    model_uri=COMMUNITYMECH.growthMedia__ph_range,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__temperature = Slot(
+    uri=COMMUNITYMECH.temperature,
+    name="growthMedia__temperature",
+    curie=COMMUNITYMECH.curie("temperature"),
+    model_uri=COMMUNITYMECH.growthMedia__temperature,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__temperature_unit = Slot(
+    uri=COMMUNITYMECH.temperature_unit,
+    name="growthMedia__temperature_unit",
+    curie=COMMUNITYMECH.curie("temperature_unit"),
+    model_uri=COMMUNITYMECH.growthMedia__temperature_unit,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__temperature_range = Slot(
+    uri=COMMUNITYMECH.temperature_range,
+    name="growthMedia__temperature_range",
+    curie=COMMUNITYMECH.curie("temperature_range"),
+    model_uri=COMMUNITYMECH.growthMedia__temperature_range,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__atmosphere = Slot(
+    uri=COMMUNITYMECH.atmosphere,
+    name="growthMedia__atmosphere",
+    curie=COMMUNITYMECH.curie("atmosphere"),
+    model_uri=COMMUNITYMECH.growthMedia__atmosphere,
+    domain=None,
+    range=Optional[Union[str, "AtmosphereEnum"]],
+)
+
+slots.growthMedia__headspace_gas = Slot(
+    uri=COMMUNITYMECH.headspace_gas,
+    name="growthMedia__headspace_gas",
+    curie=COMMUNITYMECH.curie("headspace_gas"),
+    model_uri=COMMUNITYMECH.growthMedia__headspace_gas,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__salinity = Slot(
+    uri=COMMUNITYMECH.salinity,
+    name="growthMedia__salinity",
+    curie=COMMUNITYMECH.curie("salinity"),
+    model_uri=COMMUNITYMECH.growthMedia__salinity,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__salinity_unit = Slot(
+    uri=COMMUNITYMECH.salinity_unit,
+    name="growthMedia__salinity_unit",
+    curie=COMMUNITYMECH.curie("salinity_unit"),
+    model_uri=COMMUNITYMECH.growthMedia__salinity_unit,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__pressure = Slot(
+    uri=COMMUNITYMECH.pressure,
+    name="growthMedia__pressure",
+    curie=COMMUNITYMECH.curie("pressure"),
+    model_uri=COMMUNITYMECH.growthMedia__pressure,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__pressure_unit = Slot(
+    uri=COMMUNITYMECH.pressure_unit,
+    name="growthMedia__pressure_unit",
+    curie=COMMUNITYMECH.curie("pressure_unit"),
+    model_uri=COMMUNITYMECH.growthMedia__pressure_unit,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__light_regime = Slot(
+    uri=COMMUNITYMECH.light_regime,
+    name="growthMedia__light_regime",
+    curie=COMMUNITYMECH.curie("light_regime"),
+    model_uri=COMMUNITYMECH.growthMedia__light_regime,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__light_intensity = Slot(
+    uri=COMMUNITYMECH.light_intensity,
+    name="growthMedia__light_intensity",
+    curie=COMMUNITYMECH.curie("light_intensity"),
+    model_uri=COMMUNITYMECH.growthMedia__light_intensity,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__light_intensity_unit = Slot(
+    uri=COMMUNITYMECH.light_intensity_unit,
+    name="growthMedia__light_intensity_unit",
+    curie=COMMUNITYMECH.curie("light_intensity_unit"),
+    model_uri=COMMUNITYMECH.growthMedia__light_intensity_unit,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__redox_potential = Slot(
+    uri=COMMUNITYMECH.redox_potential,
+    name="growthMedia__redox_potential",
+    curie=COMMUNITYMECH.curie("redox_potential"),
+    model_uri=COMMUNITYMECH.growthMedia__redox_potential,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__redox_potential_unit = Slot(
+    uri=COMMUNITYMECH.redox_potential_unit,
+    name="growthMedia__redox_potential_unit",
+    curie=COMMUNITYMECH.curie("redox_potential_unit"),
+    model_uri=COMMUNITYMECH.growthMedia__redox_potential_unit,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__inoculum_source = Slot(
+    uri=COMMUNITYMECH.inoculum_source,
+    name="growthMedia__inoculum_source",
+    curie=COMMUNITYMECH.curie("inoculum_source"),
+    model_uri=COMMUNITYMECH.growthMedia__inoculum_source,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__inoculum_size = Slot(
+    uri=COMMUNITYMECH.inoculum_size,
+    name="growthMedia__inoculum_size",
+    curie=COMMUNITYMECH.curie("inoculum_size"),
+    model_uri=COMMUNITYMECH.growthMedia__inoculum_size,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__inoculum_unit = Slot(
+    uri=COMMUNITYMECH.inoculum_unit,
+    name="growthMedia__inoculum_unit",
+    curie=COMMUNITYMECH.curie("inoculum_unit"),
+    model_uri=COMMUNITYMECH.growthMedia__inoculum_unit,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__incubation_time = Slot(
+    uri=COMMUNITYMECH.incubation_time,
+    name="growthMedia__incubation_time",
+    curie=COMMUNITYMECH.curie("incubation_time"),
+    model_uri=COMMUNITYMECH.growthMedia__incubation_time,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__incubation_time_unit = Slot(
+    uri=COMMUNITYMECH.incubation_time_unit,
+    name="growthMedia__incubation_time_unit",
+    curie=COMMUNITYMECH.curie("incubation_time_unit"),
+    model_uri=COMMUNITYMECH.growthMedia__incubation_time_unit,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__shaking_speed = Slot(
+    uri=COMMUNITYMECH.shaking_speed,
+    name="growthMedia__shaking_speed",
+    curie=COMMUNITYMECH.curie("shaking_speed"),
+    model_uri=COMMUNITYMECH.growthMedia__shaking_speed,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__shaking_speed_unit = Slot(
+    uri=COMMUNITYMECH.shaking_speed_unit,
+    name="growthMedia__shaking_speed_unit",
+    curie=COMMUNITYMECH.curie("shaking_speed_unit"),
+    model_uri=COMMUNITYMECH.growthMedia__shaking_speed_unit,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__vessel_type = Slot(
+    uri=COMMUNITYMECH.vessel_type,
+    name="growthMedia__vessel_type",
+    curie=COMMUNITYMECH.curie("vessel_type"),
+    model_uri=COMMUNITYMECH.growthMedia__vessel_type,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__preparation_notes = Slot(
+    uri=COMMUNITYMECH.preparation_notes,
+    name="growthMedia__preparation_notes",
+    curie=COMMUNITYMECH.curie("preparation_notes"),
+    model_uri=COMMUNITYMECH.growthMedia__preparation_notes,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__protocol_url = Slot(
+    uri=COMMUNITYMECH.protocol_url,
+    name="growthMedia__protocol_url",
+    curie=COMMUNITYMECH.curie("protocol_url"),
+    model_uri=COMMUNITYMECH.growthMedia__protocol_url,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.growthMedia__evidence = Slot(
+    uri=COMMUNITYMECH.evidence,
+    name="growthMedia__evidence",
+    curie=COMMUNITYMECH.curie("evidence"),
+    model_uri=COMMUNITYMECH.growthMedia__evidence,
+    domain=None,
+    range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
+)
+
+slots.relatedMedia__preferred_term = Slot(
+    uri=COMMUNITYMECH.preferred_term,
+    name="relatedMedia__preferred_term",
+    curie=COMMUNITYMECH.curie("preferred_term"),
+    model_uri=COMMUNITYMECH.relatedMedia__preferred_term,
+    domain=None,
+    range=str,
+)
+
+slots.relatedMedia__culturemech_id = Slot(
+    uri=COMMUNITYMECH.culturemech_id,
+    name="relatedMedia__culturemech_id",
+    curie=COMMUNITYMECH.curie("culturemech_id"),
+    model_uri=COMMUNITYMECH.relatedMedia__culturemech_id,
+    domain=None,
+    range=Optional[str],
+    pattern=re.compile(r"^CultureMech:\d{6}$"),
+)
+
+slots.relatedMedia__relationship_type = Slot(
+    uri=COMMUNITYMECH.relationship_type,
+    name="relatedMedia__relationship_type",
+    curie=COMMUNITYMECH.curie("relationship_type"),
+    model_uri=COMMUNITYMECH.relatedMedia__relationship_type,
+    domain=None,
+    range=Optional[Union[str, "MediaRelationshipEnum"]],
+)
+
+slots.relatedMedia__shared_environment_term = Slot(
+    uri=COMMUNITYMECH.shared_environment_term,
+    name="relatedMedia__shared_environment_term",
+    curie=COMMUNITYMECH.curie("shared_environment_term"),
+    model_uri=COMMUNITYMECH.relatedMedia__shared_environment_term,
+    domain=None,
+    range=Optional[Union[dict, Term]],
+)
+
+slots.relatedMedia__relevance_notes = Slot(
+    uri=COMMUNITYMECH.relevance_notes,
+    name="relatedMedia__relevance_notes",
+    curie=COMMUNITYMECH.curie("relevance_notes"),
+    model_uri=COMMUNITYMECH.relatedMedia__relevance_notes,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.relatedMedia__evidence = Slot(
+    uri=COMMUNITYMECH.evidence,
+    name="relatedMedia__evidence",
+    curie=COMMUNITYMECH.curie("evidence"),
+    model_uri=COMMUNITYMECH.relatedMedia__evidence,
+    domain=None,
+    range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
+)
+
+slots.relatedIngredient__preferred_term = Slot(
+    uri=COMMUNITYMECH.preferred_term,
+    name="relatedIngredient__preferred_term",
+    curie=COMMUNITYMECH.curie("preferred_term"),
+    model_uri=COMMUNITYMECH.relatedIngredient__preferred_term,
+    domain=None,
+    range=str,
+)
+
+slots.relatedIngredient__mediaingredientmech_id = Slot(
+    uri=COMMUNITYMECH.mediaingredientmech_id,
+    name="relatedIngredient__mediaingredientmech_id",
+    curie=COMMUNITYMECH.curie("mediaingredientmech_id"),
+    model_uri=COMMUNITYMECH.relatedIngredient__mediaingredientmech_id,
+    domain=None,
+    range=Optional[str],
+    pattern=re.compile(r"^MediaIngredientMech:\d{6}$"),
+)
+
+slots.relatedIngredient__chebi_term = Slot(
+    uri=COMMUNITYMECH.chebi_term,
+    name="relatedIngredient__chebi_term",
+    curie=COMMUNITYMECH.curie("chebi_term"),
+    model_uri=COMMUNITYMECH.relatedIngredient__chebi_term,
+    domain=None,
+    range=Optional[Union[dict, Term]],
+)
+
+slots.relatedIngredient__relevance = Slot(
+    uri=COMMUNITYMECH.relevance,
+    name="relatedIngredient__relevance",
+    curie=COMMUNITYMECH.curie("relevance"),
+    model_uri=COMMUNITYMECH.relatedIngredient__relevance,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.relatedIngredient__evidence = Slot(
+    uri=COMMUNITYMECH.evidence,
+    name="relatedIngredient__evidence",
+    curie=COMMUNITYMECH.curie("evidence"),
+    model_uri=COMMUNITYMECH.relatedIngredient__evidence,
+    domain=None,
+    range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
+)
+
+slots.associatedDataset__name = Slot(
+    uri=COMMUNITYMECH.name,
+    name="associatedDataset__name",
+    curie=COMMUNITYMECH.curie("name"),
+    model_uri=COMMUNITYMECH.associatedDataset__name,
+    domain=None,
+    range=str,
+)
+
+slots.associatedDataset__dataset_type = Slot(
+    uri=COMMUNITYMECH.dataset_type,
+    name="associatedDataset__dataset_type",
+    curie=COMMUNITYMECH.curie("dataset_type"),
+    model_uri=COMMUNITYMECH.associatedDataset__dataset_type,
+    domain=None,
+    range=Union[str, "DatasetTypeEnum"],
+)
+
+slots.associatedDataset__repository = Slot(
+    uri=COMMUNITYMECH.repository,
+    name="associatedDataset__repository",
+    curie=COMMUNITYMECH.curie("repository"),
+    model_uri=COMMUNITYMECH.associatedDataset__repository,
+    domain=None,
+    range=Optional[Union[str, "DatasetRepositoryEnum"]],
+)
+
+slots.associatedDataset__accession = Slot(
+    uri=COMMUNITYMECH.accession,
+    name="associatedDataset__accession",
+    curie=COMMUNITYMECH.curie("accession"),
+    model_uri=COMMUNITYMECH.associatedDataset__accession,
+    domain=None,
+    range=str,
+)
+
+slots.associatedDataset__url = Slot(
+    uri=COMMUNITYMECH.url,
+    name="associatedDataset__url",
+    curie=COMMUNITYMECH.curie("url"),
+    model_uri=COMMUNITYMECH.associatedDataset__url,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.associatedDataset__description = Slot(
+    uri=COMMUNITYMECH.description,
+    name="associatedDataset__description",
+    curie=COMMUNITYMECH.curie("description"),
+    model_uri=COMMUNITYMECH.associatedDataset__description,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.associatedDataset__evidence = Slot(
+    uri=COMMUNITYMECH.evidence,
+    name="associatedDataset__evidence",
+    curie=COMMUNITYMECH.curie("evidence"),
+    model_uri=COMMUNITYMECH.associatedDataset__evidence,
+    domain=None,
+    range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
+)
+
+slots.externalResource__name = Slot(
+    uri=COMMUNITYMECH.name,
+    name="externalResource__name",
+    curie=COMMUNITYMECH.curie("name"),
+    model_uri=COMMUNITYMECH.externalResource__name,
+    domain=None,
+    range=str,
+)
+
+slots.externalResource__repository = Slot(
+    uri=COMMUNITYMECH.repository,
+    name="externalResource__repository",
+    curie=COMMUNITYMECH.curie("repository"),
+    model_uri=COMMUNITYMECH.externalResource__repository,
+    domain=None,
+    range=Union[str, "ExternalResourceRepositoryEnum"],
+)
+
+slots.externalResource__resource_id = Slot(
+    uri=COMMUNITYMECH.resource_id,
+    name="externalResource__resource_id",
+    curie=COMMUNITYMECH.curie("resource_id"),
+    model_uri=COMMUNITYMECH.externalResource__resource_id,
+    domain=None,
+    range=str,
+)
+
+slots.externalResource__url = Slot(
+    uri=COMMUNITYMECH.url,
+    name="externalResource__url",
+    curie=COMMUNITYMECH.curie("url"),
+    model_uri=COMMUNITYMECH.externalResource__url,
+    domain=None,
+    range=str,
+)
+
+slots.externalResource__description = Slot(
+    uri=COMMUNITYMECH.description,
+    name="externalResource__description",
+    curie=COMMUNITYMECH.curie("description"),
+    model_uri=COMMUNITYMECH.externalResource__description,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.externalResource__evidence = Slot(
+    uri=COMMUNITYMECH.evidence,
+    name="externalResource__evidence",
+    curie=COMMUNITYMECH.curie("evidence"),
+    model_uri=COMMUNITYMECH.externalResource__evidence,
+    domain=None,
+    range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
+)
+
+slots.communityEngineeringDesign__objective = Slot(
+    uri=COMMUNITYMECH.objective,
+    name="communityEngineeringDesign__objective",
+    curie=COMMUNITYMECH.curie("objective"),
+    model_uri=COMMUNITYMECH.communityEngineeringDesign__objective,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.communityEngineeringDesign__assembly_strategy = Slot(
+    uri=COMMUNITYMECH.assembly_strategy,
+    name="communityEngineeringDesign__assembly_strategy",
+    curie=COMMUNITYMECH.curie("assembly_strategy"),
+    model_uri=COMMUNITYMECH.communityEngineeringDesign__assembly_strategy,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.communityEngineeringDesign__inoculation_strategy = Slot(
+    uri=COMMUNITYMECH.inoculation_strategy,
+    name="communityEngineeringDesign__inoculation_strategy",
+    curie=COMMUNITYMECH.curie("inoculation_strategy"),
+    model_uri=COMMUNITYMECH.communityEngineeringDesign__inoculation_strategy,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.communityEngineeringDesign__passaging_regimen = Slot(
+    uri=COMMUNITYMECH.passaging_regimen,
+    name="communityEngineeringDesign__passaging_regimen",
+    curie=COMMUNITYMECH.curie("passaging_regimen"),
+    model_uri=COMMUNITYMECH.communityEngineeringDesign__passaging_regimen,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.communityEngineeringDesign__perturbation_design = Slot(
+    uri=COMMUNITYMECH.perturbation_design,
+    name="communityEngineeringDesign__perturbation_design",
+    curie=COMMUNITYMECH.curie("perturbation_design"),
+    model_uri=COMMUNITYMECH.communityEngineeringDesign__perturbation_design,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.communityEngineeringDesign__measurement_endpoints = Slot(
+    uri=COMMUNITYMECH.measurement_endpoints,
+    name="communityEngineeringDesign__measurement_endpoints",
+    curie=COMMUNITYMECH.curie("measurement_endpoints"),
+    model_uri=COMMUNITYMECH.communityEngineeringDesign__measurement_endpoints,
+    domain=None,
+    range=Optional[Union[str, list[str]]],
+)
+
+slots.communityEngineeringDesign__protocol_url = Slot(
+    uri=COMMUNITYMECH.protocol_url,
+    name="communityEngineeringDesign__protocol_url",
+    curie=COMMUNITYMECH.curie("protocol_url"),
+    model_uri=COMMUNITYMECH.communityEngineeringDesign__protocol_url,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.communityEngineeringDesign__notes = Slot(
+    uri=COMMUNITYMECH.notes,
+    name="communityEngineeringDesign__notes",
+    curie=COMMUNITYMECH.curie("notes"),
+    model_uri=COMMUNITYMECH.communityEngineeringDesign__notes,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.communityEngineeringDesign__evidence = Slot(
+    uri=COMMUNITYMECH.evidence,
+    name="communityEngineeringDesign__evidence",
+    curie=COMMUNITYMECH.curie("evidence"),
+    model_uri=COMMUNITYMECH.communityEngineeringDesign__evidence,
+    domain=None,
+    range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
+)
+
+slots.microbialCommunity__id = Slot(
+    uri=COMMUNITYMECH.id,
+    name="microbialCommunity__id",
+    curie=COMMUNITYMECH.curie("id"),
+    model_uri=COMMUNITYMECH.microbialCommunity__id,
+    domain=None,
+    range=URIRef,
+    pattern=re.compile(r"^CommunityMech:\d{6}$"),
+)
+
+slots.microbialCommunity__name = Slot(
+    uri=COMMUNITYMECH.name,
+    name="microbialCommunity__name",
+    curie=COMMUNITYMECH.curie("name"),
+    model_uri=COMMUNITYMECH.microbialCommunity__name,
+    domain=None,
+    range=str,
+)
+
+slots.microbialCommunity__description = Slot(
+    uri=COMMUNITYMECH.description,
+    name="microbialCommunity__description",
+    curie=COMMUNITYMECH.curie("description"),
+    model_uri=COMMUNITYMECH.microbialCommunity__description,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.microbialCommunity__ecological_state = Slot(
+    uri=COMMUNITYMECH.ecological_state,
+    name="microbialCommunity__ecological_state",
+    curie=COMMUNITYMECH.curie("ecological_state"),
+    model_uri=COMMUNITYMECH.microbialCommunity__ecological_state,
+    domain=None,
+    range=Optional[Union[str, "EcologicalStateEnum"]],
+)
+
+slots.microbialCommunity__community_origin = Slot(
+    uri=COMMUNITYMECH.community_origin,
+    name="microbialCommunity__community_origin",
+    curie=COMMUNITYMECH.curie("community_origin"),
+    model_uri=COMMUNITYMECH.microbialCommunity__community_origin,
+    domain=None,
+    range=Optional[Union[str, "CommunityOriginEnum"]],
+)
+
+slots.microbialCommunity__community_category = Slot(
+    uri=COMMUNITYMECH.community_category,
+    name="microbialCommunity__community_category",
+    curie=COMMUNITYMECH.curie("community_category"),
+    model_uri=COMMUNITYMECH.microbialCommunity__community_category,
+    domain=None,
+    range=Optional[Union[str, "CommunityCategoryEnum"]],
+)
+
+slots.microbialCommunity__engineering_design = Slot(
+    uri=COMMUNITYMECH.engineering_design,
+    name="microbialCommunity__engineering_design",
+    curie=COMMUNITYMECH.curie("engineering_design"),
+    model_uri=COMMUNITYMECH.microbialCommunity__engineering_design,
+    domain=None,
+    range=Optional[Union[dict, CommunityEngineeringDesign]],
+)
+
+slots.microbialCommunity__environment_term = Slot(
+    uri=COMMUNITYMECH.environment_term,
+    name="microbialCommunity__environment_term",
+    curie=COMMUNITYMECH.curie("environment_term"),
+    model_uri=COMMUNITYMECH.microbialCommunity__environment_term,
+    domain=None,
+    range=Optional[Union[dict, EnvironmentDescriptor]],
+)
+
+slots.microbialCommunity__taxonomy = Slot(
+    uri=COMMUNITYMECH.taxonomy,
+    name="microbialCommunity__taxonomy",
+    curie=COMMUNITYMECH.curie("taxonomy"),
+    model_uri=COMMUNITYMECH.microbialCommunity__taxonomy,
+    domain=None,
+    range=Optional[
+        Union[Union[dict, TaxonomicComposition], list[Union[dict, TaxonomicComposition]]]
+    ],
+)
+
+slots.microbialCommunity__ecological_interactions = Slot(
+    uri=COMMUNITYMECH.ecological_interactions,
+    name="microbialCommunity__ecological_interactions",
+    curie=COMMUNITYMECH.curie("ecological_interactions"),
+    model_uri=COMMUNITYMECH.microbialCommunity__ecological_interactions,
+    domain=None,
+    range=Optional[
+        Union[Union[dict, EcologicalInteraction], list[Union[dict, EcologicalInteraction]]]
+    ],
+)
+
+slots.microbialCommunity__environmental_factors = Slot(
+    uri=COMMUNITYMECH.environmental_factors,
+    name="microbialCommunity__environmental_factors",
+    curie=COMMUNITYMECH.curie("environmental_factors"),
+    model_uri=COMMUNITYMECH.microbialCommunity__environmental_factors,
+    domain=None,
+    range=Optional[Union[Union[dict, EnvironmentalFactor], list[Union[dict, EnvironmentalFactor]]]],
+)
+
+slots.microbialCommunity__growth_media = Slot(
+    uri=COMMUNITYMECH.growth_media,
+    name="microbialCommunity__growth_media",
+    curie=COMMUNITYMECH.curie("growth_media"),
+    model_uri=COMMUNITYMECH.microbialCommunity__growth_media,
+    domain=None,
+    range=Optional[Union[Union[dict, GrowthMedia], list[Union[dict, GrowthMedia]]]],
+)
+
+slots.microbialCommunity__related_media = Slot(
+    uri=COMMUNITYMECH.related_media,
+    name="microbialCommunity__related_media",
+    curie=COMMUNITYMECH.curie("related_media"),
+    model_uri=COMMUNITYMECH.microbialCommunity__related_media,
+    domain=None,
+    range=Optional[Union[Union[dict, RelatedMedia], list[Union[dict, RelatedMedia]]]],
+)
+
+slots.microbialCommunity__related_ingredients = Slot(
+    uri=COMMUNITYMECH.related_ingredients,
+    name="microbialCommunity__related_ingredients",
+    curie=COMMUNITYMECH.curie("related_ingredients"),
+    model_uri=COMMUNITYMECH.microbialCommunity__related_ingredients,
+    domain=None,
+    range=Optional[Union[Union[dict, RelatedIngredient], list[Union[dict, RelatedIngredient]]]],
+)
+
+slots.microbialCommunity__associated_datasets = Slot(
+    uri=COMMUNITYMECH.associated_datasets,
+    name="microbialCommunity__associated_datasets",
+    curie=COMMUNITYMECH.curie("associated_datasets"),
+    model_uri=COMMUNITYMECH.microbialCommunity__associated_datasets,
+    domain=None,
+    range=Optional[Union[Union[dict, AssociatedDataset], list[Union[dict, AssociatedDataset]]]],
+)
+
+slots.microbialCommunity__external_resources = Slot(
+    uri=COMMUNITYMECH.external_resources,
+    name="microbialCommunity__external_resources",
+    curie=COMMUNITYMECH.curie("external_resources"),
+    model_uri=COMMUNITYMECH.microbialCommunity__external_resources,
+    domain=None,
+    range=Optional[Union[Union[dict, ExternalResource], list[Union[dict, ExternalResource]]]],
+)
+
+slots.microbialCommunity__metals_present = Slot(
+    uri=COMMUNITYMECH.metals_present,
+    name="microbialCommunity__metals_present",
+    curie=COMMUNITYMECH.curie("metals_present"),
+    model_uri=COMMUNITYMECH.microbialCommunity__metals_present,
+    domain=None,
+    range=Optional[Union[Union[str, "MetalElementEnum"], list[Union[str, "MetalElementEnum"]]]],
+)
+
+slots.microbialCommunity__rare_earth_elements_present = Slot(
+    uri=COMMUNITYMECH.rare_earth_elements_present,
+    name="microbialCommunity__rare_earth_elements_present",
+    curie=COMMUNITYMECH.curie("rare_earth_elements_present"),
+    model_uri=COMMUNITYMECH.microbialCommunity__rare_earth_elements_present,
+    domain=None,
+    range=Optional[
+        Union[Union[str, "RareEarthElementEnum"], list[Union[str, "RareEarthElementEnum"]]]
+    ],
+)
+
+slots.microbialCommunity__metal_relevance = Slot(
+    uri=COMMUNITYMECH.metal_relevance,
+    name="microbialCommunity__metal_relevance",
+    curie=COMMUNITYMECH.curie("metal_relevance"),
+    model_uri=COMMUNITYMECH.microbialCommunity__metal_relevance,
+    domain=None,
+    range=Optional[Union[str, "MetalRelevanceEnum"]],
+)
+
+slots.microbialCommunity__metal_notes = Slot(
+    uri=COMMUNITYMECH.metal_notes,
+    name="microbialCommunity__metal_notes",
+    curie=COMMUNITYMECH.curie("metal_notes"),
+    model_uri=COMMUNITYMECH.microbialCommunity__metal_notes,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.microbialCommunity__curation_history = Slot(
+    uri=COMMUNITYMECH.curation_history,
+    name="microbialCommunity__curation_history",
+    curie=COMMUNITYMECH.curie("curation_history"),
+    model_uri=COMMUNITYMECH.microbialCommunity__curation_history,
+    domain=None,
+    range=Optional[Union[Union[dict, CurationEvent], list[Union[dict, CurationEvent]]]],
+)
+
+slots.curationEvent__timestamp = Slot(
+    uri=COMMUNITYMECH.timestamp,
+    name="curationEvent__timestamp",
+    curie=COMMUNITYMECH.curie("timestamp"),
+    model_uri=COMMUNITYMECH.curationEvent__timestamp,
+    domain=None,
+    range=Union[str, XSDDateTime],
+)
+
+slots.curationEvent__curator = Slot(
+    uri=COMMUNITYMECH.curator,
+    name="curationEvent__curator",
+    curie=COMMUNITYMECH.curie("curator"),
+    model_uri=COMMUNITYMECH.curationEvent__curator,
+    domain=None,
+    range=str,
+)
+
+slots.curationEvent__action = Slot(
+    uri=COMMUNITYMECH.action,
+    name="curationEvent__action",
+    curie=COMMUNITYMECH.curie("action"),
+    model_uri=COMMUNITYMECH.curationEvent__action,
+    domain=None,
+    range=str,
+    pattern=re.compile(r"^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
+)
+
+slots.curationEvent__changes = Slot(
+    uri=COMMUNITYMECH.changes,
+    name="curationEvent__changes",
+    curie=COMMUNITYMECH.curie("changes"),
+    model_uri=COMMUNITYMECH.curationEvent__changes,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.curationEvent__llm_assisted = Slot(
+    uri=COMMUNITYMECH.llm_assisted,
+    name="curationEvent__llm_assisted",
+    curie=COMMUNITYMECH.curie("llm_assisted"),
+    model_uri=COMMUNITYMECH.curationEvent__llm_assisted,
+    domain=None,
+    range=Optional[Union[bool, Bool]],
+)

--- a/src/communitymech/literature.py
+++ b/src/communitymech/literature.py
@@ -125,8 +125,9 @@ def parse_first_author_from_medline(text: str) -> str | None:
             # "Author information:" within the next few lines, or be the last
             # name-like line — heuristic, but collective-only papers are rare.
             return first_token_clean
-        if _AUTHOR_TOKEN_RE.match(first_token_clean):
-            return _AUTHOR_TOKEN_RE.match(first_token_clean).group(1)
+        author_match = _AUTHOR_TOKEN_RE.match(first_token_clean)
+        if author_match:
+            return author_match.group(1)
     return None
 
 

--- a/src/communitymech/llm/anthropic_client.py
+++ b/src/communitymech/llm/anthropic_client.py
@@ -174,11 +174,15 @@ class AnthropicClient(LLMClient):
                 self.total_input_tokens += response.usage.input_tokens
                 self.total_output_tokens += response.usage.output_tokens
 
-            # Extract text response
+            # Extract text response. The first content block is only a
+            # TextBlock for normal completions; other block types (tool use,
+            # thinking, …) have no `.text`, so guard rather than assume.
             if not response.content or len(response.content) == 0:
                 raise ValueError("Empty response from API")
 
-            response_text = response.content[0].text
+            response_text = getattr(response.content[0], "text", None)
+            if response_text is None:
+                raise ValueError("Expected a text block in API response")
 
             # Parse YAML from response
             suggestion = self._parse_yaml_response(response_text)

--- a/src/communitymech/validation/write_validated.py
+++ b/src/communitymech/validation/write_validated.py
@@ -40,9 +40,9 @@ from threading import Lock
 from typing import Any
 
 import yaml
-from linkml.validator import Validator
-from linkml.validator.plugins import JsonschemaValidationPlugin
-from linkml.validator.report import Severity, ValidationResult
+from linkml.validator import Validator  # type: ignore[import-untyped]
+from linkml.validator.plugins import JsonschemaValidationPlugin  # type: ignore[import-untyped]
+from linkml.validator.report import Severity, ValidationResult  # type: ignore[import-untyped]
 
 DEFAULT_SCHEMA_PATH = Path(__file__).resolve().parents[1] / "schema" / "communitymech.yaml"
 DEFAULT_TARGET_CLASS = "MicrobialCommunity"

--- a/tests/test_citation_author.py
+++ b/tests/test_citation_author.py
@@ -37,9 +37,9 @@ REAL_CASES = {
 }
 
 
-@pytest.mark.parametrize("pmid,expected,year,wrong", [
-    (p, e, y, w) for p, (e, y, w) in REAL_CASES.items()
-])
+@pytest.mark.parametrize(
+    "pmid,expected,year,wrong", [(p, e, y, w) for p, (e, y, w) in REAL_CASES.items()]
+)
 def test_first_author_from_real_medline_cache(pmid, expected, year, wrong):
     cache_file = CACHE_DIR / f"PMID_{pmid}.txt"
     if not cache_file.exists():
@@ -86,9 +86,10 @@ def test_collective_author_preserved():
 
 
 def test_author_string_path_multi_author():
-    assert format_citation(
-        "J. 2020 Feb;...", author_string="Luo DL, Huang SY, Dai CC"
-    ) == "(Luo et al. 2020)"
+    assert (
+        format_citation("J. 2020 Feb;...", author_string="Luo DL, Huang SY, Dai CC")
+        == "(Luo et al. 2020)"
+    )
 
 
 def test_format_citation_no_year():
@@ -109,7 +110,7 @@ def test_validate_citation_author_gate(tmp_path):
     )
     assert fetcher.validate_citation_author("999", "Luo") is True
     assert fetcher.validate_citation_author("999", "luo") is True  # case-insensitive
-    assert fetcher.validate_citation_author("999", "Yu") is False   # the bug
+    assert fetcher.validate_citation_author("999", "Yu") is False  # the bug
     # Unparseable / missing -> fail closed.
     assert fetcher.validate_citation_author("absent", "Anyone") is False
 

--- a/tests/test_id_label_empty_adapter.py
+++ b/tests/test_id_label_empty_adapter.py
@@ -54,6 +54,7 @@ _NO_SUCH_TABLE = Exception("(sqlite3.OperationalError) no such table: node")
 
 # -- _is_uninitialized_stub: the positive empty-stub check ------------------
 
+
 def test_stub_true_for_zero_byte_file(tmp_path):
     p = tmp_path / "micro.db"
     p.touch()  # 0 bytes
@@ -86,6 +87,7 @@ def test_stub_false_when_no_engine():
 
 # -- _is_empty: combines the probe with the positive stub check -------------
 
+
 def test_empty_when_no_entities():
     assert mod.AdapterPool._is_empty(_Adapter(items=[]), "x") is True
 
@@ -96,7 +98,7 @@ def test_empty_when_probe_raises_and_db_is_zero_byte(tmp_path):
     assert mod.AdapterPool._is_empty(_Adapter(exc=_NO_SUCH_TABLE, db=str(p)), "micro") is True
 
 
-def test_NOT_empty_when_probe_raises_but_db_has_tables(tmp_path):
+def test_not_empty_when_probe_raises_but_db_has_tables(tmp_path):
     # THE REGRESSION GUARD: partially-migrated live db (tables present, one
     # missing) raises "no such table" yet must NOT be masked as empty.
     p = tmp_path / "chebi.db"
@@ -107,7 +109,7 @@ def test_NOT_empty_when_probe_raises_but_db_has_tables(tmp_path):
     assert mod.AdapterPool._is_empty(_Adapter(exc=_NO_SUCH_TABLE, db=str(p)), "chebi") is False
 
 
-def test_NOT_empty_on_no_such_table_without_resolvable_db():
+def test_not_empty_on_no_such_table_without_resolvable_db():
     # error text alone is never enough — no path to confirm a stub → not empty.
     assert mod.AdapterPool._is_empty(_Adapter(exc=_NO_SUCH_TABLE), "chebi") is False
 
@@ -115,13 +117,14 @@ def test_NOT_empty_on_no_such_table_without_resolvable_db():
 def test_empty_vs_nonempty_with_arbitrary_error(tmp_path):
     p = tmp_path / "x.db"
     p.touch()  # 0-byte stub still wins regardless of error text
-    assert mod.AdapterPool._is_empty(_Adapter(exc=Exception("disk I/O error"), db=str(p)), "x") is True
+    err = Exception("disk I/O error")
+    assert mod.AdapterPool._is_empty(_Adapter(exc=err, db=str(p)), "x") is True
     con = sqlite3.connect(str(p))  # now give it a table
     con.execute("CREATE TABLE t (x)")
     con.commit()
     con.close()
     # non-stub db + arbitrary probe error → stays non-empty (not masked)
-    assert mod.AdapterPool._is_empty(_Adapter(exc=Exception("disk I/O error"), db=str(p)), "x") is False
+    assert mod.AdapterPool._is_empty(_Adapter(exc=err, db=str(p)), "x") is False
 
 
 def test_populated_adapter_not_empty():

--- a/tests/test_id_label_unknown_prefix.py
+++ b/tests/test_id_label_unknown_prefix.py
@@ -51,7 +51,8 @@ def test_typoed_prefix_fails_enforce(tmp_path, monkeypatch):
 def test_ignored_and_prefixless_pass_enforce(tmp_path, monkeypatch):
     # cas:/MIM: are explicitly ignored; UNMAPPED_1 has no CURIE prefix at all.
     cfg = _setup(
-        tmp_path, monkeypatch,
+        tmp_path,
+        monkeypatch,
         "cas:50-00-0\tformaldehyde\nMIM:000123\tfoo\nUNMAPPED_1\tmystery\n",
     )
     assert mod.run(cfg, report_path=None) == 0

--- a/tests/test_literature_fetcher.py
+++ b/tests/test_literature_fetcher.py
@@ -93,9 +93,7 @@ def test_pubmed_abstract_writes_uppercase_cache(fetcher):
     abstract must be written uppercase to be discoverable on case-sensitive
     filesystems (Linux/CI).
     """
-    with patch.object(
-        fetcher.session, "get", return_value=_mock_text_response("fresh abstract")
-    ):
+    with patch.object(fetcher.session, "get", return_value=_mock_text_response("fresh abstract")):
         result = fetcher.fetch_pubmed_abstract("87654321")
     assert result == "fresh abstract"
     # The abstract is cached under the uppercase, validator-visible name.

--- a/tests/test_optional_binding_obligation.py
+++ b/tests/test_optional_binding_obligation.py
@@ -17,6 +17,7 @@ optional slot into a de-facto required slot. This test pins that contract:
 The test shells out to ``linkml-term-validator validate-data --labels`` (the
 same gate ``just validate`` uses) and is skipped when that CLI is unavailable.
 """
+
 from __future__ import annotations
 
 import shutil


### PR DESCRIPTION
## Problem

`just lint` (black --check + ruff + mypy) was never wired into CI, so style/type debt accumulated unnoticed. On `main` it currently reports **black: 6 files, ruff: 4 errors, mypy: 15 errors**.

## Fix

**mypy (15 → 0):**
- `literature.py` — reuse the regex `Match` object instead of calling `.match()` a second time (the re-run could be `None` → `union-attr`).
- `llm/anthropic_client.py` — guard `response.content[0].text`; only `TextBlock` carries `.text`, other block types (tool-use/thinking/…) don't. Raises a clear error if the first block isn't text.
- `validation/write_validated.py` — `# type: ignore[import-untyped]` on the untyped `linkml.validator` imports (`ignore_missing_imports` doesn't cover `import-untyped` across mypy versions).

**ruff (4 → 0)** in `tests/test_id_label_empty_adapter.py` — rename two `test_NOT_*` functions to lowercase (N802) and shorten two long asserts (E501).

**black** — format the auto-generated datamodel + a few test files. `just gen-python` now pipes the generated datamodel through black, so `black --check src/` stays green after every regen without a manual `just format`.

**CI** — new `.github/workflows/lint.yaml` runs black/ruff/mypy on PRs touching Python or deps.

## Notes
- No behavior change. The datamodel diff is pure black formatting (generation timestamp unchanged — not regenerated).
- `references_cache/*` and other unrelated working-tree files were intentionally left out.

## Test plan
- [x] `just lint` → black/ruff/mypy all clean
- [x] `uv run pytest tests/ -q --no-cov` → **183 passed, 7 deselected**
- [x] `just validate-strict` → 265 files, **0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)