### PR TITLE
Restore exceptions allow-list in shared id-label validator (#134)

### DIFF
--- a/conf/id_label_targets.yaml
+++ b/conf/id_label_targets.yaml
@@ -54,13 +54,10 @@ targets:
     # cycle because the ontology has no clean replacement (true terminal
     # obsoletes, MF-vs-BP context mismatches, taxa absent from the current
     # OAK snapshot). Each entry includes a one-line `reason` for review.
-    #
-    # NOT ENFORCED by the current shared validator: the byte-identical script
-    # ported in PR #132 dropped the `exceptions`/OK_EXCEPTION mechanism, so
-    # these entries are inert and surface as MISMATCH/ID_NOT_FOUND findings in
-    # report mode. Retained as triage documentation; restoring an enforcement
-    # path is tracked in issue #134 (must be resolved before `validate-products`
-    # is switched to a blocking gate).
+    # Matching pairs are accepted as OK_EXCEPTION (non-error). The match is
+    # EXACT on (id, label), so a different wrong label on the same id still
+    # fails as MISMATCH — the allow-list can't mask drift it didn't accept.
+    # (Enforcement restored in the shared validator per issue #134.)
     exceptions:
       # --- CHEBI (11) ---
       - { id: "CHEBI:33104", label: "chromium(III) hydroxide", reason: "no clean CHEBI term; needs minting" }
@@ -105,9 +102,8 @@ targets:
       - [id, name]
     # Residuals that flow into the KGX export from the community YAMLs, plus
     # one exporter-side label choice ("mercury(2+) cation") that diverges
-    # from OAK canonical by design.
-    # NOT ENFORCED by the current shared validator — see communities_yaml note
-    # above and issue #134.
+    # from OAK canonical by design. Accepted as OK_EXCEPTION (see communities_yaml
+    # note above; enforcement restored per issue #134).
     exceptions:
       - { id: "CHEBI:16793", label: "mercury(2+) cation", reason: "exporter-side label (kgx_export.py line 82) uses the +cation suffix; OAK canonical is mercury(2+)" }
       - { id: "ENVO:00000274", label: "soda lake", reason: "see communities_yaml exception" }

--- a/scripts/.validate_id_label_correspondence.sha256
+++ b/scripts/.validate_id_label_correspondence.sha256
@@ -1,1 +1,1 @@
-706987057cd83610ac62e6c82b55383ee529e34d299af3fa74fe2639deef8f6f  scripts/validate_id_label_correspondence.py
+142bbe1ed020d64554e6787e0adf126003a4179e8b74198b226dd6097263542a  scripts/validate_id_label_correspondence.py

--- a/scripts/validate_id_label_correspondence.py
+++ b/scripts/validate_id_label_correspondence.py
@@ -26,6 +26,13 @@ repos already use, and classifies the pair:
     OK_ID_ONLY          id resolves; label match WAIVED for this slot (the slot
                         carries a curator-intended formula/common name, e.g.
                         CHEBI:15377 "Distilled water" — see ``label_waived_keys``)
+    OK_EXCEPTION        the exact (id, label) pair is on the target's
+                        ``exceptions`` allow-list — a curator-accepted residual
+                        (obsolete-no-successor, no clean term yet, or id absent
+                        from the current ontology snapshot) carrying a documented
+                        ``reason``. Overrides MISMATCH / ID_NOT_FOUND only; the
+                        match is exact, so a different wrong label on the same id
+                        still fails as MISMATCH.
     MISMATCH            label is neither canonical nor an accepted synonym  (ERROR)
     ID_NOT_FOUND        id has an adapter but is absent from the ontology   (ERROR)
     EMPTY_LABEL         id present, label blank                             (ERROR)
@@ -119,10 +126,23 @@ _ERROR_VERDICTS = {
     "UNKNOWN_PREFIX",
 }
 
+# Path segments under which a `term`/`chebi_term` label-waiver does NOT apply:
+# organism (NCBITaxon) and environment (ENVO) groundings must carry the canonical
+# ontology label. Everywhere else a waived key is an INGREDIENT grounding whose
+# label is a curator formula/common-name (CHEBI "NaCl", FOODON "Yeast extract",
+# UBERON "Calf brains") and stays waived regardless of ontology.
+_CANONICAL_LABEL_CONTEXTS = (
+    "target_organisms",
+    "source_environment",
+)
+
 # Verdicts that are accepted (do NOT get recorded as findings and never fail
 # enforce). OK_ID_ONLY is a pass: the id resolved and the slot's label was
-# intentionally waived (curator-intended formula/common name).
-_OK_VERDICTS = {"OK_CANONICAL", "OK_SYNONYM", "OK_ID_ONLY"}
+# intentionally waived (curator-intended formula/common name). OK_EXCEPTION is a
+# pass: the exact (id, label) pair is on the target's ``exceptions`` allow-list —
+# a curator-accepted residual (obsolete-no-successor, no clean term yet, id
+# absent from the current ontology snapshot) with a documented ``reason``.
+_OK_VERDICTS = {"OK_CANONICAL", "OK_SYNONYM", "OK_ID_ONLY", "OK_EXCEPTION"}
 # Benign skips: not OK (still surfaced in the report) but never fail enforce.
 _SKIP_VERDICTS = {"SKIPPED_NO_ADAPTER", "SKIPPED_EMPTY_ADAPTER"}
 
@@ -381,8 +401,11 @@ def _read_tabular_rows(
     if not body:
         return [], [], []
     lines = [text for _, text in body]
-    # body[0] is the header; data rows begin at the next physical line.
-    data_line_numbers = [phys for phys, _ in body[1:]]
+    # body[0] is the header; data rows begin at the next physical line. Exclude
+    # truly-empty lines: csv.DictReader skips them (yields no row), so counting
+    # them here would shift every subsequent locator one line early. An
+    # all-whitespace line is NOT skipped by DictReader, so it stays counted.
+    data_line_numbers = [phys for phys, text in body[1:] if text.rstrip("\r\n") != ""]
     reader = csv.DictReader(lines, delimiter=delim)
     return list(reader.fieldnames or []), list(reader), data_line_numbers
 
@@ -459,7 +482,21 @@ def _walk_yaml(
                 if isinstance(curie, str) and curie.strip():
                     label = node.get(label_key)
                     label = label if isinstance(label, str) else ""
-                    yield f"{path}.{id_key}", curie.strip(), (label or "").strip(), waived, None
+                    cur = curie.strip()
+                    # Scope the label waiver to INGREDIENT groundings by context.
+                    # The waiver exists for curator formula/common-name labels on
+                    # ingredient terms (CHEBI "NaCl", FOODON "Yeast extract",
+                    # UBERON "Calf brains"). The `term` key is reused on organism
+                    # (target_organisms) and environment (source_environment)
+                    # blocks, whose labels MUST stay canonical (per the skill
+                    # spec) — so a `term`/`chebi_term` waiver does NOT apply when
+                    # the term sits in an organism/environment context, even
+                    # though the key name matches. Keying on context (not the id
+                    # prefix) keeps curator ingredient labels of every ontology
+                    # waived while still canonical-checking taxon/environment.
+                    in_canonical_ctx = any(seg in path for seg in _CANONICAL_LABEL_CONTEXTS)
+                    effective_waived = waived and not in_canonical_ctx
+                    yield f"{path}.{id_key}", cur, (label or "").strip(), effective_waived, None
         for k, v in node.items():
             # Skip excluded grounding blocks entirely (no checks at all).
             if k in exclude_keys:
@@ -499,6 +536,27 @@ def iter_yaml(
     )
 
 
+# -- exceptions allow-list ------------------------------------------------
+
+def load_exceptions(target: dict[str, Any]) -> set[tuple[str, str]]:
+    """Return the (curie, normalized_label) pairs the target accepts as-is.
+
+    The ``exceptions`` field on a target is a list of mappings, each with at
+    least ``id`` and ``label``. Optional ``reason`` is documentation only;
+    pairs are matched on (id, normalized(label)) so a missing or alternative
+    casing for ``reason`` doesn't affect matching. A target with no
+    ``exceptions`` key yields an empty set (no-op), so repos that don't use the
+    allow-list are unaffected.
+    """
+    out: set[tuple[str, str]] = set()
+    for entry in target.get("exceptions") or []:
+        curie = str(entry.get("id", "")).strip()
+        label = str(entry.get("label", ""))
+        if curie:
+            out.add((curie, normalize(label)))
+    return out
+
+
 # -- driver ---------------------------------------------------------------
 
 def load_config(config_path: Path) -> dict[str, Any]:
@@ -531,6 +589,7 @@ def run(config_path: Path, report_path: Path | None) -> int:
         pairs = target.get("pairs", [])
         exclude_keys = frozenset(target.get("exclude_keys", []) or [])
         label_waived_keys = frozenset(target.get("label_waived_keys", []) or [])
+        exceptions = load_exceptions(target)
         required = bool(target.get("required", False))
         globs = target.get("glob")
         glob_list = globs if isinstance(globs, list) else [globs]
@@ -600,6 +659,19 @@ def run(config_path: Path, report_path: Path | None) -> int:
                             scope=scope, lookup_curie=lookup_curie,
                             label_waived=label_waived,
                         )
+                # Curator-accepted residual: an EXACT (id, label) pair on the
+                # target's ``exceptions`` allow-list is accepted as OK_EXCEPTION
+                # (non-error, documented ``reason``). Applies ONLY to label/id
+                # residuals (MISMATCH / ID_NOT_FOUND) — never to structural
+                # errors (UNKNOWN_PREFIX, ADAPTER_ERROR, MISSING_COLUMN,
+                # MISSING_GLOB, EMPTY_LABEL), which signal real defects rather
+                # than a knowingly-accepted label. The match is exact, so a
+                # different wrong label on the same id still fails as MISMATCH.
+                if rec["verdict"] in ("MISMATCH", "ID_NOT_FOUND") and (
+                    curie,
+                    normalize(label),
+                ) in exceptions:
+                    rec["verdict"] = "OK_EXCEPTION"
                 counts[rec["verdict"]] = counts.get(rec["verdict"], 0) + 1
                 if rec["verdict"] not in _OK_VERDICTS | _SKIP_VERDICTS:
                     findings.append({
@@ -616,6 +688,7 @@ def run(config_path: Path, report_path: Path | None) -> int:
         "OK_CANONICAL",
         "OK_SYNONYM",
         "OK_ID_ONLY",
+        "OK_EXCEPTION",
         "MISMATCH",
         "ID_NOT_FOUND",
         "EMPTY_LABEL",

--- a/tests/test_id_label_exceptions.py
+++ b/tests/test_id_label_exceptions.py
@@ -1,0 +1,103 @@
+"""Tests for the id-label validator's ``exceptions`` allow-list (OK_EXCEPTION).
+
+A curator-accepted residual — an exact ``(id, label)`` pair the ontology
+disagrees with because the canonical term is wrong/obsolete/unminted, or the id
+is absent from the current snapshot — is listed under a target's ``exceptions``
+and accepted as ``OK_EXCEPTION`` (non-error). The match is EXACT, so:
+
+* a residual on the list overrides MISMATCH and ID_NOT_FOUND → enforce passes;
+* a DIFFERENT wrong label on the same id is NOT on the list → still MISMATCH
+  (the allow-list can't mask drift it didn't explicitly accept);
+* with no ``exceptions`` configured the residual fails as before.
+
+Driven through ``run()`` end-to-end with a fake adapter + temp config, so no
+real OAK adapter / network is touched.
+"""
+
+import importlib.util
+import textwrap
+from pathlib import Path
+
+_spec = importlib.util.spec_from_file_location(
+    "validate_id_label_correspondence",
+    Path(__file__).parent.parent / "scripts" / "validate_id_label_correspondence.py",
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+class _Adapter:
+    """Fake OAK adapter: CHEBI:33104 resolves to a canonical label that differs
+    from the curator's; everything else is absent (label() -> None)."""
+
+    _LABELS = {"CHEBI:33104": "chromium hydroxide"}
+
+    def label(self, curie):
+        return self._LABELS.get(curie)
+
+    def entities(self):
+        return iter(self._LABELS)
+
+    def entity_alias_map(self, curie):
+        return {}
+
+
+def _setup(tmp_path, monkeypatch, body_yaml, exceptions_block):
+    import oaklib
+
+    monkeypatch.setattr(oaklib, "get_adapter", lambda sel: _Adapter())
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+    (tmp_path / "f.yaml").write_text(body_yaml)
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(textwrap.dedent("""
+            adapters: {CHEBI: 'sqlite:obo:chebi'}
+            ignored_prefixes: []
+            synonym_scope: exact
+            targets:
+              - name: t
+                kind: yaml
+                glob: f.yaml
+                policy: canonical
+                pairs: [[id, label]]
+                exceptions:
+            """) + exceptions_block)
+    return cfg
+
+
+_EXC = "      - { id: 'CHEBI:33104', label: 'chromium(III) hydroxide', reason: 'no clean term' }\n"
+
+
+def test_residual_on_allowlist_passes_enforce(tmp_path, monkeypatch):
+    # id resolves but canonical != curator label; pair IS on the allow-list.
+    cfg = _setup(
+        tmp_path, monkeypatch, "x:\n  id: CHEBI:33104\n  label: chromium(III) hydroxide\n", _EXC
+    )
+    assert mod.run(cfg, report_path=None) == 0
+
+
+def test_different_wrong_label_same_id_still_fails(tmp_path, monkeypatch):
+    # same id, a DIFFERENT label that is NOT on the list -> must still MISMATCH.
+    cfg = _setup(tmp_path, monkeypatch, "x:\n  id: CHEBI:33104\n  label: totally wrong\n", _EXC)
+    assert mod.run(cfg, report_path=None) == 2
+
+
+def test_absent_id_on_allowlist_passes_enforce(tmp_path, monkeypatch):
+    # id absent from the snapshot (ID_NOT_FOUND) but on the list -> OK_EXCEPTION.
+    exc = "      - { id: 'CHEBI:99999', label: 'absent thing', reason: 'absent from snapshot' }\n"
+    cfg = _setup(tmp_path, monkeypatch, "x:\n  id: CHEBI:99999\n  label: absent thing\n", exc)
+    assert mod.run(cfg, report_path=None) == 0
+
+
+def test_no_exceptions_residual_fails(tmp_path, monkeypatch):
+    cfg = _setup(
+        tmp_path,
+        monkeypatch,
+        "x:\n  id: CHEBI:33104\n  label: chromium(III) hydroxide\n",
+        "      []\n",
+    )
+    assert mod.run(cfg, report_path=None) == 2
+
+
+def test_ok_exception_is_not_an_error_verdict():
+    assert "OK_EXCEPTION" not in mod._ERROR_VERDICTS
+    assert "OK_EXCEPTION" in mod._OK_VERDICTS


### PR DESCRIPTION
Implements the #134 decision (signed off): restore the per-`(id,label)` `exceptions` / `OK_EXCEPTION` mechanism that the 0ea8e15 port dropped, and re-unify the vendored validator to **byte-identical across all three Mech repos**.

## What changed
- **Restored exceptions allow-list**: an EXACT `(id, normalized-label)` pair on a target's `exceptions:` list is accepted as `OK_EXCEPTION` (non-error), overriding `MISMATCH`/`ID_NOT_FOUND`. This lets CommunityMech's 34 curator-accepted residuals pass enforce again.
- **Anti-masking guarantees** (honoring 0ea8e15):
  - exact match only — a *different* wrong label on the same id still fails `MISMATCH`;
  - applies only to label/id residuals, never to structural errors (`UNKNOWN_PREFIX`, `ADAPTER_ERROR`, `MISSING_COLUMN`, `MISSING_GLOB`, `EMPTY_LABEL`).
- **Byte-identical re-sync**: canonical script = CultureMech's context-based label-waiver superset + the restored allow-list (both no-ops where unused). All three repos now carry sha `142bbe1e…` and matching pins. Companion PRs: CultureMech + MediaIngredientMech `sync/id-label-validator-restore-exceptions`.
- `conf/id_label_targets.yaml`: the 34 exceptions are enforced again (reverted the temporary "NOT ENFORCED" note).
- `tests/test_id_label_exceptions.py`: 5 end-to-end tests.

## Validation
- [x] `tests/test_id_label_exceptions.py` 5/5; validator tests 22/22
- [x] full suite **188 passed**
- [x] `just lint` clean; `just verify-validator-pin` OK
- [x] same script + test pass in CultureMech and MIM

Closes #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)