### PR TITLE
Backfill first related_media entries by ENVO match (#30)

### DIFF
--- a/kb/communities/Geobacter_Methanosaeta_DIET.yaml
+++ b/kb/communities/Geobacter_Methanosaeta_DIET.yaml
@@ -330,6 +330,28 @@ related_ingredients:
     evidence_source: IN_VITRO
     snippet: stoichiometrically converted ethanol to methane
     explanation: Anchors methane as the end product of the coculture's electron flow.
+related_media:
+- preferred_term: modified_dsm_120_medium_for_diet_coculture
+  culturemech_id: CultureMech:015434
+  relationship_type: ENVIRONMENT_ANALOG
+  shared_environment_term:
+    id: ENVO:00002007
+    label: sediment
+  relevance_notes: >
+    CultureMech medium built for DIET cocultures and tagged with the same source
+    environment (ENVO:00002007 sediment) as this community; an environment-analog
+    medium for cultivating this sediment DIET consortium. Linkage basis is the
+    shared ENVO term (CultureMech source_environment, backfilled from CommunityMech).
+- preferred_term: modified_freshwater_medium_for_diet_coculture
+  culturemech_id: CultureMech:015435
+  relationship_type: ENVIRONMENT_ANALOG
+  shared_environment_term:
+    id: ENVO:00002007
+    label: sediment
+  relevance_notes: >
+    CultureMech freshwater medium for DIET cocultures sharing the sediment source
+    environment (ENVO:00002007); environment-analog medium for this sediment DIET
+    consortium. Linkage basis is the shared ENVO term.
 metals_present: []
 metal_relevance: SIGNIFICANT
 metal_notes: Metal/REE detected via environmental factor measurements; Metal/REE detected

--- a/kb/communities/Geobacter_Methanosarcina_DIET.yaml
+++ b/kb/communities/Geobacter_Methanosarcina_DIET.yaml
@@ -387,6 +387,28 @@ related_ingredients:
     snippet: using either H2 or electrons derived from DIET for CO2 reduction
     explanation: States that DIET-derived electrons drive CO2 reduction, anchoring
       carbon dioxide as the electron-accepting substrate for methanogenesis.
+related_media:
+- preferred_term: modified_dsm_120_medium_for_diet_coculture
+  culturemech_id: CultureMech:015434
+  relationship_type: ENVIRONMENT_ANALOG
+  shared_environment_term:
+    id: ENVO:00002007
+    label: sediment
+  relevance_notes: >
+    CultureMech medium built for DIET cocultures and tagged with the same source
+    environment (ENVO:00002007 sediment) as this community; an environment-analog
+    medium for cultivating this sediment DIET consortium. Linkage basis is the
+    shared ENVO term (CultureMech source_environment, backfilled from CommunityMech).
+- preferred_term: modified_freshwater_medium_for_diet_coculture
+  culturemech_id: CultureMech:015435
+  relationship_type: ENVIRONMENT_ANALOG
+  shared_environment_term:
+    id: ENVO:00002007
+    label: sediment
+  relevance_notes: >
+    CultureMech freshwater medium for DIET cocultures sharing the sediment source
+    environment (ENVO:00002007); environment-analog medium for this sediment DIET
+    consortium. Linkage basis is the shared ENVO term.
 metals_present: []
 metal_relevance: SIGNIFICANT
 metal_notes: Metal/REE detected via environmental factor measurements; Metal/REE detected

--- a/kb/communities/SF356_Cellulose_Degrader.yaml
+++ b/kb/communities/SF356_Cellulose_Degrader.yaml
@@ -435,3 +435,16 @@ related_ingredients:
       Clostridium sp. strain FG4
     explanation: Names excess acetic acid produced by FG4 as the negative interaction inhibiting
       cellulose degradation in SF356.
+related_media:
+- preferred_term: pcs_fp_medium_for_thermophilic_cellulose_degradation
+  culturemech_id: CultureMech:015439
+  relationship_type: ENVIRONMENT_ANALOG
+  shared_environment_term:
+    id: ENVO:00002170
+    label: compost
+  relevance_notes: >
+    CultureMech medium for thermophilic cellulose degradation tagged with the same
+    source environment (ENVO:00002170 compost) as this community; an environment-analog
+    medium for this compost-derived thermophilic cellulose-degrading consortium.
+    Linkage basis is the shared ENVO term (CultureMech source_environment, backfilled
+    from CommunityMech).


### PR DESCRIPTION
First `related_media` entries (field was **0/265**), now unblocked by CultureMech#2 (`source_environment`, merged).

Links 3 communities to CultureMech media sharing their `source_environment` ENVO term:

| Community | ENVO | CultureMech media |
|---|---|---|
| Geobacter_Methanosaeta_DIET | ENVO:00002007 sediment | `:015434`, `:015435` (DIET coculture media) |
| Geobacter_Methanosarcina_DIET | ENVO:00002007 sediment | `:015434`, `:015435` |
| SF356_Cellulose_Degrader | ENVO:00002170 compost | `:015439` (thermophilic cellulose) |

- `relationship_type: ENVIRONMENT_ANALOG`; `shared_environment_term` carries the matched ENVO id + canonical label.
- No fabricated evidence: the link **is** the shared ENVO term (documented in `relevance_notes`). Noted transparently that CultureMech's `source_environment` was itself backfilled from CommunityMech.
- **Scoped to specific matches only** — the other sediment communities aren't DIET systems, and coarse buckets (laboratory environment, generic LB/TSB-under-rhizosphere) are deliberately left unlinked as noise (see #30 thread).

## Validation
- [x] `linkml-validate` all 3 → exit 0
- [x] shared_environment_term labels == OAK canonical (sediment, compost)
- [x] additions-only (57 insertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)