### PR TITLE
Backfill related_ingredients in 8 more communities (#30)

### DIFF
--- a/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
+++ b/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
@@ -254,6 +254,156 @@ ecological_interactions:
     snippet: the time-windows of yeast and Acetobacter growth align well with the beneficial or inhibitory
       range of lactate and acetate concentration
     explanation: Shows temporal alignment of K. exigua growth with beneficial lactate concentrations.
+related_ingredients:
+- preferred_term: lactose
+  chebi_term:
+    id: CHEBI:17716
+    label: lactose
+  relevance: >
+    Lactose is the primary milk sugar fermented by the kefir community; about half of the
+    initial lactose remains unused, with metabolism shifting from homofermentative to
+    heterofermentative during early fermentation.
+  evidence:
+  - reference: PMID:33398099
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: lactose metabolism shifted from homofermentative to heterofermentative
+    explanation: Identifies lactose as the fermented milk substrate of the kefir community.
+  - reference: PMID:33398099
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: about half of the initial lactose was left unused
+    explanation: Confirms lactose as the bulk fermentation substrate, only partially consumed.
+- preferred_term: glucose
+  chebi_term:
+    id: CHEBI:17234
+    label: glucose
+  relevance: >
+    Glucose is one of the sugars supplied in isolation media (M17) used to recover kefir
+    bacterial isolates from the community.
+  evidence:
+  - reference: PMID:33398099
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: M17 supplemented with lactose and glucose
+    explanation: Names glucose as a carbohydrate substrate used for kefir isolate cultivation.
+- preferred_term: lactate
+  chebi_term:
+    id: CHEBI:24996
+    label: lactate
+  relevance: >
+    Lactate is a major fermentation product that mediates cross-feeding in the kefir community,
+    boosting growth of L. kefiranofaciens roughly three-fold and supporting Acetobacter and yeast.
+  evidence:
+  - reference: PMID:33398099
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: lactate considerably boosted (circa three-fold) the growth of L. kefiranofaciens
+    explanation: Demonstrates lactate as a key cross-fed fermentation product.
+- preferred_term: acetate
+  chebi_term:
+    id: CHEBI:30089
+    label: acetate
+  relevance: >
+    Acetate is one of the major fermentation products tested for its impact on kefir community
+    member growth alongside lactate and ethanol.
+  evidence:
+  - reference: PMID:33398099
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: lactate, acetate, and ethanol (EtOH)
+    explanation: Lists acetate as a major fermentation product affecting community growth.
+- preferred_term: ethanol
+  chebi_term:
+    id: CHEBI:16236
+    label: ethanol
+  relevance: >
+    Ethanol is one of the main fermentation products evaluated for its effect on the growth of
+    kefir community members.
+  evidence:
+  - reference: PMID:33398099
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: supplemented with lactate, acetate, or ethanol
+    explanation: Names ethanol as a main fermentation product tested in kefir whey supplementation.
+- preferred_term: citrate
+  chebi_term:
+    id: CHEBI:30769
+    label: citric acid
+  relevance: >
+    Citrate depletion in early fermentation, driven by citrate-utilizing L. lactis and
+    L. mesenteroides, is linked to the onset of proteolysis and amino acid accumulation.
+  evidence:
+  - reference: PMID:33398099
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: depletion of citrate
+    explanation: Identifies citrate consumption as an early metabolic function in kefir fermentation.
+- preferred_term: aspartate
+  chebi_term:
+    id: CHEBI:22660
+    label: aspartic acid
+  relevance: >
+    Aspartate is limiting during kefir fermentation, rapidly consumed early on, and boosts
+    Acetobacter growth in milk whey; it is also cross-fed between L. lactis and A. fabarum.
+  evidence:
+  - reference: PMID:33398099
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Aspartate, on the other hand, is limiting during kefir fermentation and indeed boosts the growth of Acetobacter
+    explanation: Establishes aspartate as a limiting, growth-promoting metabolite for Acetobacter.
+- preferred_term: glutamate
+  chebi_term:
+    id: CHEBI:18237
+    label: glutamic acid
+  relevance: >
+    Glutamate concentrations remain at initial levels during fermentation, and it serves as the
+    precursor from which L. lactis produces GABA.
+  evidence:
+  - reference: PMID:33398099
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: recently reported to be produced by L. lactis from glutamate
+    explanation: Names glutamate as the metabolic precursor for GABA production by L. lactis.
+- preferred_term: proline
+  chebi_term:
+    id: CHEBI:26271
+    label: proline
+  relevance: >
+    Proline accumulates in large quantities during kefir fermentation and is among the amino
+    acids cross-fed between L. lactis and A. fabarum.
+  evidence:
+  - reference: PMID:33398099
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Aspartate, proline, glycine, and GABA are cross-fed between L. lactis and A. fabarum
+    explanation: Identifies proline as a cross-fed amino acid between L. lactis and A. fabarum.
+- preferred_term: glycine
+  chebi_term:
+    id: CHEBI:15428
+    label: glycine
+  relevance: >
+    Glycine is cross-fed between L. lactis and A. fabarum, being consumed in conditioned media
+    while also exerting an inhibitory effect.
+  evidence:
+  - reference: PMID:33398099
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Aspartate, proline, glycine, and GABA are cross-fed between L. lactis and A. fabarum
+    explanation: Identifies glycine as a cross-fed amino acid in the kefir community.
+- preferred_term: GABA
+  chebi_term:
+    id: CHEBI:16865
+    label: gamma-aminobutyric acid
+  relevance: >
+    GABA (4-aminobutyric acid) is produced by L. lactis from glutamate and cross-fed between
+    L. lactis and A. fabarum during kefir fermentation.
+  evidence:
+  - reference: PMID:33398099
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Aspartate, proline, glycine, and GABA are cross-fed between L. lactis and A. fabarum
+    explanation: Identifies GABA as a cross-fed metabolite between L. lactis and A. fabarum.
 associated_datasets:
 - name: BioModels model file
   dataset_type: OTHER

--- a/kb/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.yaml
+++ b/kb/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.yaml
@@ -319,6 +319,47 @@ external_resources:
   resource_id: doi:10.1016/j.ijhydene.2008.07.092
   url: https://doi.org/10.1016/j.ijhydene.2008.07.092
   description: Earlier publication evaluating C. saccharolyticus and C. kristjanssonii in coculture during mixed-sugar hydrogen production.
+related_ingredients:
+- preferred_term: glucose
+  chebi_term:
+    id: CHEBI:17234
+    label: glucose
+  relevance: >
+    Glucose is one of the two model lignocellulosic hydrolysate sugars fed to the
+    coculture and was also used as the sole growth-limiting substrate to test stable
+    coexistence; the maximum hydrogen yield was reported per mole of glucose.
+  evidence:
+  - reference: PMID:21192828
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: glucose was used as the sole growth-limiting
+    explanation: Names glucose as a fermentation substrate for the coculture.
+- preferred_term: xylose
+  chebi_term:
+    id: CHEBI:18222
+    label: xylose
+  relevance: >
+    Xylose is the second lignocellulosic hydrolysate sugar supplied with glucose as
+    the carbon and energy source for hydrogen production by the coculture.
+  evidence:
+  - reference: PMID:21192828
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: from glucose and xylose in a continuous-flow
+    explanation: Names xylose as a co-fed fermentation substrate.
+- preferred_term: hydrogen
+  chebi_term:
+    id: CHEBI:18276
+    label: dihydrogen
+  relevance: >
+    Dihydrogen is the target fermentation product; the coculture produced H2 from
+    glucose and xylose at yields exceeding those of either pure culture.
+  evidence:
+  - reference: PMID:21192828
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: combined in a co-culture for H2 production
+    explanation: Names hydrogen as the fermentation product of the coculture.
 metals_present: []
 rare_earth_elements_present: []
 metal_relevance: NOT_APPLICABLE

--- a/kb/communities/Chlamydomonas_Bacterial_H2_Consortium.yaml
+++ b/kb/communities/Chlamydomonas_Bacterial_H2_Consortium.yaml
@@ -91,6 +91,124 @@ taxonomy:
     evidence_source: IN_VITRO
     snippet: A naturally occurring multispecies bacterial community composed of Bacillus cereus and two
       novel bacteria (Microbacterium forte sp. nov. and Stenotrop
+related_ingredients:
+- preferred_term: dihydrogen
+  chebi_term:
+    id: CHEBI:18276
+    label: dihydrogen
+  relevance: >
+    Hydrogen (H2) is the target product of this alga-bacteria consortium, with the
+    bacterial community sustaining algal H2 production up to 313 mL H2/L over 17 days.
+  evidence:
+  - reference: PMID:38159768
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: sustain algal hydrogen production up to 313
+    explanation: Names hydrogen as the sustained product of the consortium.
+- preferred_term: mannitol
+  chebi_term:
+    id: CHEBI:16899
+    label: D-mannitol
+  relevance: >
+    Mannitol is supplied in the growth medium as the carbon substrate that the bacterial
+    community consumes to promote and sustain algal hydrogen production.
+  evidence:
+  - reference: PMID:38159768
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: 'When incubated in mannitol- and'
+    explanation: Identifies mannitol as a supplied medium substrate for the consortium.
+- preferred_term: acetic acid
+  chebi_term:
+    id: CHEBI:15366
+    label: acetic acid
+  relevance: >
+    Microbacterium forte releases acetic acid (0.15 mM/day) to the alga as part of the
+    mutualistic exchange that complements algal nutrition.
+  evidence:
+  - reference: PMID:38159768
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: 'and acetic acid '
+    explanation: Bacterium releases acetic acid for the alga.
+- preferred_term: ammonium
+  chebi_term:
+    id: CHEBI:28938
+    label: ammonium
+  relevance: >
+    The bacterium releases ammonium (0.19 mM/day) to the alga, complementing algal
+    nitrogen nutrition in the mutualistic association.
+  evidence:
+  - reference: PMID:38159768
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: nutrient deficiencies of the bacterium, while the bacterium released ammonium
+    explanation: Bacterium releases ammonium for the alga.
+- preferred_term: biotin
+  chebi_term:
+    id: CHEBI:15956
+    label: biotin
+  relevance: >
+    Microbacterium forte is auxotrophic for biotin, which the alga supplies to complement
+    the bacterium's nutrient deficiencies in the mutualism.
+  evidence:
+  - reference: PMID:38159768
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: forte sp. nov. have revealed that this bacterium is auxotroph for biotin and
+    explanation: Names biotin as an auxotrophy of the bacterium.
+- preferred_term: thiamine
+  chebi_term:
+    id: CHEBI:26948
+    label: vitamin B1
+  relevance: >
+    Microbacterium forte is auxotrophic for thiamine (vitamin B1), one of the nutrient
+    deficiencies complemented by the alga in the mutualistic association.
+  evidence:
+  - reference: PMID:38159768
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: thiamine and unable to use sulfate as sulfur source
+    explanation: Names thiamine as an auxotrophy of the bacterium.
+- preferred_term: sulfate
+  chebi_term:
+    id: CHEBI:16189
+    label: sulfate
+  relevance: >
+    Microbacterium forte is unable to use sulfate as a sulfur source, instead requiring
+    reduced sulfur compounds, which shapes the consortium's nutrient exchange.
+  evidence:
+  - reference: PMID:38159768
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: unable to use sulfate as sulfur source
+    explanation: Bacterium cannot use sulfate as sulfur source.
+- preferred_term: cysteine
+  chebi_term:
+    id: CHEBI:15356
+    label: cysteine
+  relevance: >
+    Microbacterium forte requires reduced-sulfur forms such as cysteine, supplied through
+    the mutualistic association with the alga.
+  evidence:
+  - reference: PMID:38159768
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: such as cysteine and methionine.
+    explanation: Names cysteine as a required reduced-sulfur form.
+- preferred_term: methionine
+  chebi_term:
+    id: CHEBI:16811
+    label: methionine
+  relevance: >
+    Microbacterium forte requires reduced-sulfur forms such as methionine as its sulfur
+    source within the consortium.
+  evidence:
+  - reference: PMID:38159768
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: such as cysteine and methionine.
+    explanation: Names methionine as a required reduced-sulfur form.
 ecological_interactions:
 - name: Photosynthetic Hydrogen Production
   interaction_type: COMMENSALISM

--- a/kb/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.yaml
+++ b/kb/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.yaml
@@ -81,6 +81,138 @@ taxonomy:
     evidence_source: IN_VITRO
     snippet: Thermoanaerobacterium thermosaccharolyticum GD17
     explanation: Supports T. thermosaccharolyticum GD17 as a member of the exact coculture.
+related_ingredients:
+- preferred_term: cellulose
+  chebi_term:
+    id: CHEBI:18246
+    label: (1->4)-beta-D-glucan
+  relevance: >
+    Cellulose is the primary lignocellulosic substrate of the coculture; the
+    cellulolytic partner C. thermocellum JN4 degrades it to release fermentable
+    sugars for the consortium.
+  evidence:
+  - reference: PMID:31551972
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: can efficiently degrade cellulose
+    explanation: Cellulose is the degradable substrate of the coculture.
+- preferred_term: cellobiose
+  chebi_term:
+    id: CHEBI:17057
+    label: cellobiose
+  relevance: >
+    Cellobiose is released from cellulose during degradation and is a key
+    fermentable sugar competed for by GD17.
+  evidence:
+  - reference: PMID:31551972
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: more cellobiose or glucose released from
+    explanation: Cellobiose is released from lignocellulose during degradation.
+- preferred_term: glucose
+  chebi_term:
+    id: CHEBI:17234
+    label: glucose
+  relevance: >
+    Glucose is released during cellulose degradation and is rapidly consumed by
+    GD17, giving it a competitive metabolic advantage over JN4.
+  evidence:
+  - reference: PMID:31551972
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: more cellobiose or glucose released from
+    explanation: Glucose is released from lignocellulose during degradation.
+- preferred_term: xylose
+  chebi_term:
+    id: CHEBI:18222
+    label: xylose
+  relevance: >
+    GD17 can digest hemicellulose to xylose, a potential benefit it provides to
+    the coculture when grown on natural substrates such as corncob.
+  evidence:
+  - reference: PMID:31551972
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: may also benefit C. thermocellum JN4 by digesting hemicellulose to xylose
+    explanation: GD17 digests hemicellulose to xylose.
+- preferred_term: lactate
+  chebi_term:
+    id: CHEBI:24996
+    label: lactate
+  relevance: >
+    Lactate is one of the end products of cellulose and sugar fermentation in
+    the coculture, with enhanced formation relative to JN4 monoculture.
+  evidence:
+  - reference: PMID:31551972
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: conversion of glucose or cellobiose to the end-products lactate, acetate and ethanol
+    explanation: Lactate is an end product of sugar conversion in the coculture.
+- preferred_term: acetate
+  chebi_term:
+    id: CHEBI:30089
+    label: acetate
+  relevance: >
+    Acetate is one of the fermentation end products formed from glucose and
+    cellobiose conversion in the coculture.
+  evidence:
+  - reference: PMID:31551972
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: conversion of glucose or cellobiose to the end-products lactate, acetate and ethanol
+    explanation: Acetate is an end product of sugar conversion in the coculture.
+- preferred_term: ethanol
+  chebi_term:
+    id: CHEBI:16236
+    label: ethanol
+  relevance: >
+    Ethanol is a principal cellulosic biofuel product of the coculture, formed
+    from glucose and cellobiose conversion and enhanced relative to monoculture.
+  evidence:
+  - reference: PMID:31551972
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: conversion of glucose or cellobiose to the end-products lactate, acetate and ethanol
+    explanation: Ethanol is an end product of sugar conversion in the coculture.
+- preferred_term: dihydrogen
+  chebi_term:
+    id: CHEBI:18276
+    label: dihydrogen
+  relevance: >
+    Hydrogen (H2) is a cellulosic biofuel product whose production improves in
+    the coculture over JN4 monoculture, attributed mainly to GD17.
+  evidence:
+  - reference: PMID:27538932
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: produces H2 at a rate 4-12-fold higher than C. thermocellum
+    explanation: GD17 produces H2 at a higher rate, driving coculture H2 improvement.
+- preferred_term: dextrin
+  chebi_term:
+    id: CHEBI:28675
+    label: dextrin
+  relevance: >
+    Dextrin was used as a GD17-selective stimulant to rebalance the consortium
+    and modulate cellulose degradation.
+  evidence:
+  - reference: PMID:31551972
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "two potential stimulants for T. thermosaccharolyticum GD17 were selected: dextrin and sucrose"
+    explanation: Dextrin is a selective stimulant for GD17 used to tune the consortium.
+- preferred_term: sucrose
+  chebi_term:
+    id: CHEBI:17992
+    label: sucrose
+  relevance: >
+    Sucrose was used as a GD17-selective stimulant to rebalance the consortium
+    and modulate cellulose degradation.
+  evidence:
+  - reference: PMID:31551972
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "two potential stimulants for T. thermosaccharolyticum GD17 were selected: dextrin and sucrose"
+    explanation: Sucrose is a selective stimulant for GD17 used to tune the consortium.
 ecological_interactions:
 - name: Cellulosic Biofuel Efficiency Enhancement
   description: Coculturing C. thermocellum JN4 with T. thermosaccharolyticum GD17 improves overall

--- a/kb/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.yaml
@@ -339,6 +339,139 @@ external_resources:
   url: https://doi.org/10.3389/fmicb.2016.01795
   description: Follow-up publication measuring S. wolfei membrane complexes and gene expression
     in syntrophic growth with D. mccartyi strain 195.
+related_ingredients:
+- preferred_term: trichloroethene
+  chebi_term:
+    id: CHEBI:16602
+    label: trichloroethene
+  relevance: >
+    Chlorinated electron acceptor that D. mccartyi 195 reductively dechlorinates
+    in the syntrophic coculture, the central substrate of the TCE-dechlorination system.
+  evidence:
+  - reference: PMID:25576615
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: trichloroethene (TCE) as an electron acceptor
+    explanation: Names TCE as the electron acceptor in the coculture.
+  - reference: PMID:24015929
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: trichloroethene (TCE)
+    explanation: Names TCE as the substrate in the exact-composition isotope study.
+- preferred_term: butyrate
+  chebi_term:
+    id: CHEBI:17968
+    label: butyrate
+  relevance: >
+    Fermentable fatty-acid electron donor and carbon source oxidized by S. wolfei
+    to fuel interspecies hydrogen transfer that supports dechlorination.
+  evidence:
+  - reference: PMID:25576615
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: using butyrate as an electron donor and
+    explanation: Names butyrate as the electron donor and carbon source.
+  - reference: doi:10.3389/fmicb.2016.01795
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: crotonate-grown and butyrate grown
+    explanation: Names butyrate as a growth substrate for S. wolfei.
+- preferred_term: dihydrogen
+  chebi_term:
+    id: CHEBI:18276
+    label: dihydrogen
+  relevance: >
+    Interspecies electron carrier produced by S. wolfei butyrate fermentation and
+    consumed by D. mccartyi 195 for reductive dechlorination.
+  evidence:
+  - reference: PMID:25576615
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Aqueous H2 concentrations ranged from 24 to 180 nM
+    explanation: Reports the aqueous hydrogen concentration during dechlorination.
+  - reference: doi:10.3389/fmicb.2016.01795
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: production of hydrogen and/or formate from the high potential electron donor,
+    explanation: Names hydrogen as a product of syntrophic butyrate metabolism.
+- preferred_term: carbon monoxide
+  chebi_term:
+    id: CHEBI:17245
+    label: carbon monoxide
+  relevance: >
+    Trace metabolite measured in the coculture, lower than in strain 195 isolation,
+    reflecting altered metabolism during syntrophic growth.
+  evidence:
+  - reference: PMID:25576615
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Carbon monoxide in the coculture was around
+    explanation: Reports carbon monoxide measured in the coculture.
+- preferred_term: chloroethene
+  chebi_term:
+    id: CHEBI:28509
+    label: chloroethene
+  relevance: >
+    Vinyl chloride, a less-chlorinated dechlorination intermediate; elevated exposure
+    was one tested growth condition for Dhc195 in the isotope-fractionation study.
+  evidence:
+  - reference: PMID:24015929
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: elevated vinyl chloride exposure
+    explanation: Names vinyl chloride as a tested condition for Dhc195.
+- preferred_term: cobalamin
+  chebi_term:
+    id: CHEBI:30411
+    label: cobalamin
+  relevance: >
+    Vitamin B12 cofactor required by Dehalococcoides; its trace availability was a
+    tested suboptimal growth condition affecting isotope fractionation.
+  evidence:
+  - reference: PMID:24015929
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: trace vitamin B12 availability
+    explanation: Names vitamin B12 as a tested cofactor-limiting condition.
+- preferred_term: formate
+  chebi_term:
+    id: CHEBI:15740
+    label: formate
+  relevance: >
+    Alternative interspecies electron carrier from syntrophic butyrate metabolism;
+    notably, the D. mccartyi coculture proceeds exclusively by hydrogen transfer.
+  evidence:
+  - reference: doi:10.3389/fmicb.2016.01795
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: production of hydrogen and/or formate from the high potential electron donor,
+    explanation: Names formate as a possible product of syntrophic butyrate metabolism.
+- preferred_term: butyryl-CoA
+  chebi_term:
+    id: CHEBI:15517
+    label: butyryl-CoA
+  relevance: >
+    High-potential electron donor intermediate of butyrate metabolism whose oxidation
+    to hydrogen requires reverse electron transfer in S. wolfei.
+  evidence:
+  - reference: doi:10.3389/fmicb.2016.01795
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: butyryl-CoA. Such redox reactions can occur only with energy input by a process
+    explanation: Names butyryl-CoA as the high-potential electron donor in butyrate metabolism.
+- preferred_term: crotonate
+  chebi_term:
+    id: CHEBI:35899
+    label: crotonate
+  relevance: >
+    Alternative non-syntrophic growth substrate for S. wolfei used as a comparison
+    condition that does not require reverse electron transfer.
+  evidence:
+  - reference: doi:10.3389/fmicb.2016.01795
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: crotonate-grown and butyrate grown
+    explanation: Names crotonate as a comparison growth substrate for S. wolfei.
 metals_present: []
 rare_earth_elements_present: []
 metal_relevance: NOT_APPLICABLE

--- a/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
+++ b/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
@@ -422,6 +422,119 @@ ecological_interactions:
 
       '
     explanation: Actinobacteriota produce lactic acid consumed by Firmicutes chain elongators
+related_ingredients:
+- preferred_term: lactose
+  chebi_term:
+    id: CHEBI:17716
+    label: lactose
+  relevance: >
+    Primary fermentable sugar in ultra-filtered milk permeate; degraded by
+    Actinobacteriota via the Leloir pathway and bifid shunt and used by some
+    Firmicutes as a chain-elongation growth substrate.
+  evidence:
+  - reference: PMID:37324413
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: 'members of the Actinobacteriota phylum are important in the degradation of lactose, via
+      the Leloir pathway and the bifid shunt, and the production of acetic, lactic, and succinic acids'
+    explanation: Lactose is the substrate degraded by Actinobacteriota members
+- preferred_term: acetic acid
+  chebi_term:
+    id: CHEBI:15366
+    label: acetic acid
+  relevance: >
+    Short-chain fermentation product of lactose degradation by Actinobacteriota
+    via the Leloir pathway and bifid shunt.
+  evidence:
+  - reference: PMID:37324413
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: 'members of the Actinobacteriota phylum are important in the degradation of lactose, via
+      the Leloir pathway and the bifid shunt, and the production of acetic, lactic, and succinic acids'
+    explanation: Acetic acid is named as a production product of Actinobacteriota
+- preferred_term: lactic acid
+  chebi_term:
+    id: CHEBI:422
+    label: (S)-lactic acid
+  relevance: >
+    Produced by Actinobacteriota from lactose and consumed by Firmicutes as an
+    electron donor and carbon source for chain elongation, forming the core
+    cross-feeding link in the community.
+  evidence:
+  - reference: PMID:37324413
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: 'with different microbes using either lactose, ethanol, or lactic acid as the growth substrate'
+    explanation: Lactic acid is named as a growth substrate for chain elongation
+- preferred_term: succinic acid
+  chebi_term:
+    id: CHEBI:30031
+    label: succinate(2-)
+  relevance: >
+    Organic acid produced during lactose degradation by Actinobacteriota members
+    of the community.
+  evidence:
+  - reference: PMID:37324413
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: 'members of the Actinobacteriota phylum are important in the degradation of lactose, via
+      the Leloir pathway and the bifid shunt, and the production of acetic, lactic, and succinic acids'
+    explanation: Succinic acid is named as a production product of Actinobacteriota
+- preferred_term: ethanol
+  chebi_term:
+    id: CHEBI:16236
+    label: ethanol
+  relevance: >
+    Alternative growth substrate used by some Firmicutes for chain-elongation-mediated
+    production of medium-chain fatty acids.
+  evidence:
+  - reference: PMID:37324413
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: 'with different microbes using either lactose, ethanol, or lactic acid as the growth substrate'
+    explanation: Ethanol is named as a growth substrate for chain elongation
+- preferred_term: butyric acid
+  chebi_term:
+    id: CHEBI:30772
+    label: butyric acid
+  relevance: >
+    C4 medium-chain fatty acid produced by Firmicutes via chain elongation
+    (reverse beta-oxidation).
+  evidence:
+  - reference: PMID:37324413
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: 'members of the Firmicutes phylum contribute to the chain-elongation-mediated production
+      of butyric, hexanoic, and octanoic acids'
+    explanation: Butyric acid is named as a chain-elongation product of Firmicutes
+- preferred_term: hexanoic acid
+  chebi_term:
+    id: CHEBI:30776
+    label: hexanoic acid
+  relevance: >
+    C6 medium-chain fatty acid produced by Firmicutes via chain elongation
+    (reverse beta-oxidation).
+  evidence:
+  - reference: PMID:37324413
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: 'members of the Firmicutes phylum contribute to the chain-elongation-mediated production
+      of butyric, hexanoic, and octanoic acids'
+    explanation: Hexanoic acid is named as a chain-elongation product of Firmicutes
+- preferred_term: octanoic acid
+  chebi_term:
+    id: CHEBI:28837
+    label: octanoic acid
+  relevance: >
+    C8 medium-chain fatty acid produced by Firmicutes via chain elongation
+    (reverse beta-oxidation).
+  evidence:
+  - reference: PMID:37324413
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: 'members of the Firmicutes phylum contribute to the chain-elongation-mediated production
+      of butyric, hexanoic, and octanoic acids'
+    explanation: Octanoic acid is named as a chain-elongation product of Firmicutes
 environmental_factors:
 - name: Temperature
   value: '35'

--- a/kb/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.yaml
+++ b/kb/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.yaml
@@ -89,6 +89,137 @@ taxonomy:
     evidence_source: IN_VITRO
     snippet: oxygen supplied by the extremophilic microalga Galdieria sp. RTK37.1
     explanation: Supports assigning Galdieria sp. RTK37.1 as the oxygen-supplying primary producer.
+related_ingredients:
+- preferred_term: methane
+  chebi_term:
+    id: CHEBI:16183
+    label: methane
+  relevance: >
+    Methane is the primary carbon and energy feedstock oxidized by Methylacidiphilum sp. RTK17.1
+    and the gas whose valorisation defines the purpose of this methanotroph-microalga coculture.
+  evidence:
+  - reference: PMID:41888821
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: methane (CH₄) and carbon dioxide (CO₂) valorisation
+    explanation: Names methane as a feed gas valorised by the coculture.
+  - reference: PMID:33841379
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: variety of substrates including methane, methanol, and hydrogen for growth
+    explanation: Names methane among growth substrates of the methanotroph partner.
+- preferred_term: carbon dioxide
+  chebi_term:
+    id: CHEBI:16526
+    label: carbon dioxide
+  relevance: >
+    Carbon dioxide is both a methane-oxidation product of the methanotroph and the inorganic carbon
+    valorised and fixed by the Galdieria partner, central to the coculture's carbon assimilation.
+  evidence:
+  - reference: PMID:41888821
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: methane (CH₄) and carbon dioxide (CO₂) valorisation
+    explanation: Names carbon dioxide as a feed gas valorised by the coculture.
+  - reference: PMID:33841379
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: oxidizing methane to carbon dioxide via methanol
+    explanation: Names carbon dioxide as the terminal product of methane oxidation.
+- preferred_term: oxygen
+  chebi_term:
+    id: CHEBI:15379
+    label: dioxygen
+  relevance: >
+    Dioxygen supplied photosynthetically by Galdieria sustains aerobic methane oxidation by the
+    methanotroph; oxygen partitioning is the critical factor that shifts the interaction between
+    mutualism and competition.
+  evidence:
+  - reference: PMID:41888821
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: oxygen supplied by the extremophilic microalga Galdieria sp. RTK37.1
+    explanation: Names oxygen as the algal-supplied resource driving the interaction.
+  - reference: PMID:41888821
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: oxygen availability is a critical factor
+    explanation: Identifies oxygen availability as the central limiting factor.
+- preferred_term: methanol
+  chebi_term:
+    id: CHEBI:17790
+    label: methanol
+  relevance: >
+    Methanol is the first oxidation intermediate of methane in Methylacidiphilum sp. RTK17.1 and a
+    standalone growth substrate, relevant to the methanotroph's central carbon metabolism.
+  evidence:
+  - reference: PMID:33841379
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: oxidizing methane to carbon dioxide via methanol
+    explanation: Names methanol as an intermediate in methane oxidation.
+  - reference: PMID:33841379
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: variety of substrates including methane, methanol, and hydrogen for growth
+    explanation: Names methanol among growth substrates of the methanotroph.
+- preferred_term: formate
+  chebi_term:
+    id: CHEBI:15740
+    label: formate
+  relevance: >
+    Formate is the downstream intermediate of methanol oxidation in Methylacidiphilum sp. RTK17.1,
+    whose terminal oxidation by formate dehydrogenase yields reducing equivalents for the cell.
+  evidence:
+  - reference: PMID:33841379
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: formate as the only source of reducing
+    explanation: Names formate as a source of reducing equivalents in the methanotroph.
+- preferred_term: formic acid
+  chebi_term:
+    id: CHEBI:30751
+    label: formic acid
+  relevance: >
+    Formic acid is the protonated form of formate that diffuses into the acidophilic methanotroph and
+    was demonstrated as a sole energy/carbon source under chemostat growth in this strain.
+  evidence:
+  - reference: PMID:33841379
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: stable growth on formic acid
+    explanation: Names formic acid as a demonstrated growth substrate of the methanotroph.
+  - reference: PMID:33841379
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the addition of 1 mM formic acid
+    explanation: Names formic acid in the dose-dependent physiological characterization.
+- preferred_term: hydrogen
+  chebi_term:
+    id: CHEBI:18276
+    label: dihydrogen
+  relevance: >
+    Dihydrogen is named as one of the substrates supporting growth of the verrucomicrobial
+    thermoacidophilic methanotroph, reflecting its metabolic flexibility in this coculture partner.
+  evidence:
+  - reference: PMID:33841379
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: variety of substrates including methane, methanol, and hydrogen for growth
+    explanation: Names hydrogen among growth substrates of the methanotroph.
+- preferred_term: coproporphyrin III
+  chebi_term:
+    id: CHEBI:27609
+    label: coproporphyrin III
+  relevance: >
+    Coproporphyrin III is excreted by Galdieria under oxygen-limited chlorosis, serving as a
+    diagnostic marker of the competition phenotype when methanotroph abundance is elevated.
+  evidence:
+  - reference: PMID:41888821
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: excreted coproporphyrin III
+    explanation: Names coproporphyrin III as the compound excreted during chlorosis.
 ecological_interactions:
 - name: Low-Oxygen Algal O2 Support for Methane Oxidation
   description: Under low-oxygen conditions, Galdieria sp. RTK37.1 supplies oxygen that benefits

--- a/kb/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.yaml
+++ b/kb/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.yaml
@@ -84,6 +84,33 @@ taxonomy:
     evidence_source: IN_VITRO
     snippet: metabolizes soluble saccharides into desired products
     explanation: Supports E. coli as the soluble-saccharide-consuming fermentation partner.
+related_ingredients:
+- preferred_term: isobutanol
+  chebi_term:
+    id: CHEBI:46645
+    label: isobutanol
+  relevance: >
+    Isobutanol (2-methylpropan-1-ol) is the target biofuel product of the consortium,
+    produced by the E. coli partner from saccharides released by fungal cellulose hydrolysis.
+  evidence:
+  - reference: PMID:23959872
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: direct production of isobutanol from cellulosic biomass
+    explanation: Names isobutanol as the consortium's target biofuel product.
+- preferred_term: cellulose
+  chebi_term:
+    id: CHEBI:18246
+    label: (1->4)-beta-D-glucan
+  relevance: >
+    Microcrystalline cellulose is the cellulosic feedstock hydrolyzed by Trichoderma reesei
+    cellulases into soluble saccharides for downstream isobutanol fermentation.
+  evidence:
+  - reference: PMID:23959872
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: microcrystalline cellulose
+    explanation: Names microcrystalline cellulose as the model cellulosic substrate.
 ecological_interactions:
 - name: Fungal Cellulase Hydrolysis
   description: Trichoderma reesei secretes cellulase enzymes that hydrolyze lignocellulosic


### PR DESCRIPTION
Continues the #30 `related_ingredients` backfill — **60 CHEBI-grounded ingredients across 8 communities**, strict no-fabrication protocol.

| File | # |
|---|---|
| Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture | 8 |
| Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture | 3 |
| Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture | 9 |
| Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture | 10 |
| Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture | 2 |
| BioModels_MODEL2204300001_Kefir_Community_Model | 11 |
| Chlamydomonas_Bacterial_H2_Consortium | 9 |
| GLBRC_UFMP_Fermentation_Community | 8 |

## Protocol (enforced + independently verified)
- CHEBI ids OAK-verified, canonical labels exact → **60/60 labels canonical**.
- Every `snippet` is a verbatim contiguous substring of a reference **already cited in the file** and **cached** (full-text `.md`) → **69/69 snippets exact**.
- Compounds not named in the cited+cached text were omitted (no fabrication).

## Validation
- [x] `linkml-validate` all 8 → exit 0
- [x] 60/60 labels canonical; 69/69 snippets exact substrings
- [x] additions-only (845 insertions)

Adoption: 149 → **157 / 265**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)