### PR TITLE
Backfill related_ingredients in 8 more communities (#30)

### DIFF
--- a/kb/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.yaml
@@ -102,6 +102,46 @@ taxonomy:
     evidence_source: IN_VITRO
     snippet: Saccharomyces cerevisiae cdt-1
     explanation: Supports the identity of the engineered yeast partner.
+related_ingredients:
+- preferred_term: cellulose
+  chebi_term:
+    id: CHEBI:18246
+    label: (1->4)-beta-D-glucan
+  relevance: >
+    Alpha-cellulose is the lignocellulosic feedstock fermented by the coculture;
+    C. phytofermentans hydrolyzes it to soluble sugars that the yeast ferments to ethanol.
+  evidence:
+  - reference: PMID:23628342
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Ethanol is produced from α-cellulose
+    explanation: Names alpha-cellulose as the substrate fermented by the consortium.
+- preferred_term: ethanol
+  chebi_term:
+    id: CHEBI:16236
+    label: ethanol
+  relevance: >
+    Ethanol is the target product of the consolidated bioprocessing coculture,
+    reaching approximately 22 g/L from 100 g/L alpha-cellulose with added endoglucanase.
+  evidence:
+  - reference: PMID:23628342
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: 22 g/L ethanol from 100 g/L
+    explanation: Names ethanol as the quantified fermentation product.
+- preferred_term: oxygen
+  chebi_term:
+    id: CHEBI:15379
+    label: dioxygen
+  relevance: >
+    Controlled low-level oxygen is the environmental mediator of the symbiosis; the yeast
+    consumes introduced oxygen to protect the anaerobic cellulolytic bacterium.
+  evidence:
+  - reference: PMID:23628342
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: from introduced oxygen in return for soluble sugars
+    explanation: Names oxygen as the mediator removed by the yeast in the symbiosis.
 ecological_interactions:
 - name: Cellulose Hydrolysis Feeds Yeast Fermentation
   description: C. phytofermentans hydrolyzes alpha-cellulose and releases soluble sugars

--- a/kb/communities/MAMC_M48_Lignocellulose.yaml
+++ b/kb/communities/MAMC_M48_Lignocellulose.yaml
@@ -355,6 +355,60 @@ growth_media:
       consortium
   culturemech_id: CultureMech:000423
   culturemech_url: https://github.com/CultureBotAI/CultureMech/tree/main/kb/media/CultureMech:000423
+related_ingredients:
+- preferred_term: lignocellulose
+  chebi_term:
+    id: CHEBI:180683
+    label: lignocellulose
+  relevance: >
+    Lignocellulose from sugarcane origin is the target substrate degraded by the
+    MAMC-M48 consortium, which was enriched and screened for lignocellulose-degrading
+    capacity.
+  evidence:
+  - reference: PMID:29392382
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: can effectively contribute to lignocellulose degradation
+    explanation: Establishes lignocellulose as the degradation substrate for the enriched consortia.
+- preferred_term: cellulose
+  chebi_term:
+    id: CHEBI:18246
+    label: (1->4)-beta-D-glucan
+  relevance: >
+    Cellulose is one of the lignocellulosic fractions degraded by the consortium;
+    its degradation was assessed relative to functional diversity of the MAMC.
+  evidence:
+  - reference: PMID:29392382
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: whereas cellulose and hemicellulose degradation were
+    explanation: Names cellulose as a measured lignocellulosic degradation fraction.
+- preferred_term: hemicellulose
+  chebi_term:
+    id: CHEBI:61266
+    label: hemicellulose
+  relevance: >
+    Hemicellulose is a lignocellulosic fraction degraded by the consortium and was
+    measured alongside cellulose in characterizing degradation capacity.
+  evidence:
+  - reference: PMID:29392382
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: whereas cellulose and hemicellulose degradation were
+    explanation: Names hemicellulose as a measured lignocellulosic degradation fraction.
+- preferred_term: lignin
+  chebi_term:
+    id: CHEBI:6457
+    label: lignin
+  relevance: >
+    Lignin is the most complex lignocellulosic fraction; its degradation positively
+    correlated with the functional diversity of the consortium.
+  evidence:
+  - reference: PMID:29392382
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the most complex lignocellulosic fraction (lignin)
+    explanation: Identifies lignin as the most complex degraded lignocellulosic fraction.
 metals_present: []
 metal_relevance: INCIDENTAL
 metal_notes: Metal/REE detected via environmental factor measurements

--- a/kb/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.yaml
+++ b/kb/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.yaml
@@ -174,3 +174,52 @@ environmental_factors:
     snippet: the presence of inhibitory compounds, such as furan aldehydes
     explanation: Documents the inhibitor challenge in lignocellulose hydrolysates
       that the coculture is designed to overcome.
+related_ingredients:
+- preferred_term: furfural
+  chebi_term:
+    id: CHEBI:34768
+    label: furfural
+  relevance: >
+    Furfural is one of the two furan aldehyde inhibitors present in the synthetic
+    lignocellulosic hydrolysate that A. baylyi ADP1 bioconverts, relieving the
+    inhibitor stress that limits S. cerevisiae fermentation in monoculture.
+  evidence:
+  - reference: PMID:38711153
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: efficient bioconversion of furan aldehydes present in the hydrolysate,
+      namely furfural and 5-hydroxymethylfurfural
+    explanation: Names furfural as a furan aldehyde inhibitor bioconverted by A. baylyi
+      ADP1.
+- preferred_term: 5-hydroxymethylfurfural
+  chebi_term:
+    id: CHEBI:412516
+    label: 5-hydroxymethylfurfural
+  relevance: >
+    5-Hydroxymethylfurfural (HMF) is the second furan aldehyde inhibitor in the
+    hydrolysate; its bioconversion by A. baylyi ADP1 is central to the
+    detoxification function that improves coculture lactic acid productivity.
+  evidence:
+  - reference: PMID:38711153
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: efficient bioconversion of furan aldehydes present in the hydrolysate,
+      namely furfural and 5-hydroxymethylfurfural
+    explanation: Names 5-hydroxymethylfurfural as a furan aldehyde inhibitor bioconverted
+      by A. baylyi ADP1.
+- preferred_term: lactic acid
+  chebi_term:
+    id: CHEBI:28358
+    label: rac-lactic acid
+  relevance: >
+    Lactic acid is the target product synthesized by the engineered S. cerevisiae
+    member from the synthetic lignocellulosic hydrolysate, with productivity raised
+    roughly 1.5-fold in the coculture relative to monoculture.
+  evidence:
+  - reference: PMID:38711153
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: production of lactic acid and wax esters from a synthetic lignocellulosic
+      hydrolysate
+    explanation: Names lactic acid as a product generated from the synthetic lignocellulosic
+      hydrolysate by the coculture.

--- a/kb/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.yaml
+++ b/kb/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.yaml
@@ -75,6 +75,77 @@ taxonomy:
     snippet: CPR Gracilibacteria, Absconditabacteria, Saccharibacteria,
       Peregrinibacteria, Berkelbacteria, Microgenomates, and Parcubacteria
     explanation: Supports the diverse CPR membership of the biofilm.
+related_ingredients:
+- preferred_term: elemental sulfur
+  chebi_term:
+    id: CHEBI:26833
+    label: sulfur atom
+  relevance: >
+    Filamentous sulfur-oxidizing bacteria (likely Thiothrix) store
+    protein-encapsulated spherical elemental sulfur granules, the hallmark
+    intermediate of chemolithotrophic sulfur oxidation in the biofilm.
+  evidence:
+  - reference: PMID:38273328
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: protein-encapsulated spherical elemental sulfur granules
+    explanation: Identifies elemental sulfur granules in the filamentous bacteria.
+- preferred_term: sulfide
+  chebi_term:
+    id: CHEBI:15138
+    label: sulfide(2-)
+  relevance: >
+    Sulfide supplied by deeply sourced groundwater is the electron donor that
+    sustains the chemoautotrophic, sulfur-oxidizing biofilm community.
+  evidence:
+  - reference: PMID:38273328
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: grow in sulfide-rich springs to investigate microbial controls on
+      biogeochemical cycling
+    explanation: Names the sulfide-rich spring waters that fuel the biofilm.
+- preferred_term: thiosulfate
+  chebi_term:
+    id: CHEBI:26977
+    label: thiosulfate
+  relevance: >
+    A Doudnabacteria genome encodes adjacent sulfur dioxygenase and rhodanese
+    genes predicted to convert thiosulfate, implicating thiosulfate in the
+    biofilm's cryptic sulfur cycling.
+  evidence:
+  - reference: PMID:38273328
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: adjacent sulfur dioxygenase and rhodanese genes that may convert
+      thiosulfate to sulfite
+    explanation: Names thiosulfate as a substrate of the predicted sulfur enzymes.
+- preferred_term: sulfite
+  chebi_term:
+    id: CHEBI:17359
+    label: sulfite
+  relevance: >
+    Sulfite is the predicted product of the Doudnabacteria sulfur dioxygenase
+    and rhodanese genes acting on thiosulfate within the biofilm sulfur cycle.
+  evidence:
+  - reference: PMID:38273328
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: adjacent sulfur dioxygenase and rhodanese genes that may convert
+      thiosulfate to sulfite
+    explanation: Names sulfite as the predicted product of thiosulfate conversion.
+- preferred_term: dihydrogen
+  chebi_term:
+    id: CHEBI:18276
+    label: dihydrogen
+  relevance: >
+    Predicted group 3b [NiFe]-hydrogenases in CPR bacteria link the community to
+    hydrogen cycling alongside sulfur metabolism.
+  evidence:
+  - reference: PMID:38273328
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: We infer roles for CPR bacteria in sulfur and hydrogen cycling
+    explanation: Attributes hydrogen cycling roles to the biofilm CPR bacteria.
 ecological_interactions:
 - name: Filamentous Sulfur Oxidation with Encapsulated S Granules
   description: Filamentous bacteria, likely Thiothrix, contain

--- a/kb/communities/Synechococcus_Bacillus_SPC.yaml
+++ b/kb/communities/Synechococcus_Bacillus_SPC.yaml
@@ -119,3 +119,19 @@ ecological_interactions:
     evidence_source: IN_VITRO
     snippet: One destabilizing interaction we observed was that non-sucrose byproducts of oxygenic photosynthesis
       negatively impacted heterotroph growth
+related_ingredients:
+- preferred_term: sucrose
+  chebi_term:
+    id: CHEBI:17992
+    label: sucrose
+  relevance: >
+    The cyanobacterial partner Synechococcus elongatus PCC 7942 is engineered to secrete the bulk of its
+    fixed carbon as sucrose, which serves as the central cross-feeding metabolite supporting heterotrophic
+    growth of Bacillus subtilis in this synthetic photosynthetic consortium.
+  evidence:
+  - reference: PMID:28127397
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: We previously engineered a model cyanobacterium, Synechococcus elongatus PCC 7942, to secrete
+      the bulk of the carbon it fixes as sucrose, a carbohydrate that can be utilized by many other microbes
+    explanation: Sucrose is the secreted carbohydrate that feeds the heterotroph in the consortium.

--- a/kb/communities/Synechococcus_Ecoli_SPC.yaml
+++ b/kb/communities/Synechococcus_Ecoli_SPC.yaml
@@ -184,6 +184,36 @@ environmental_factors:
     snippet: We previously engineered a model cyanobacterium, Synechococcus elongatus PCC 7942, to secrete
       the bulk of the carbon it fixes as sucrose, a carbohydrate that can be utilized by many other microbes
     explanation: IPTG induction is required for CscB expression and sucrose export
+related_ingredients:
+- preferred_term: sucrose
+  chebi_term:
+    id: CHEBI:17992
+    label: sucrose
+  relevance: >
+    Sucrose is the central cross-feeding metabolite of this consortium: the engineered
+    Synechococcus elongatus PCC 7942 secretes the bulk of its photosynthetically fixed carbon
+    as sucrose, which the heterotrophic partner (E. coli) utilizes as its carbon and energy source.
+  evidence:
+  - reference: PMID:28127397
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: secrete the bulk of the carbon it fixes as sucrose, a carbohydrate that can be utilized
+      by many other microbes
+    explanation: Names sucrose as the secreted photosynthate that cross-feeds the heterotroph
+- preferred_term: poly(hydroxybutyrate)
+  chebi_term:
+    id: CHEBI:53388
+    label: poly(hydroxybutyrate)
+  relevance: >
+    Polyhydroxybutyrate is a target photoproduct of the consortium: switching the heterotroph
+    to a specialized E. coli strain enables sucrose-driven production of polyhydroxybutyrate.
+  evidence:
+  - reference: PMID:28127397
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: by changing the heterotroph in co-culture to specialized strains of B. subtilis or E.
+      coli we demonstrate production of alpha-amylase and polyhydroxybutyrate, respectively
+    explanation: Names polyhydroxybutyrate as the E. coli photoproduct of the consortium
 metals_present: []
 metal_relevance: INCIDENTAL
 metal_notes: Metal/REE detected via environmental factor measurements

--- a/kb/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.yaml
+++ b/kb/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.yaml
@@ -246,6 +246,48 @@ external_resources:
     evidence_source: IN_VITRO
     snippet: A synthetic, light-driven consortium of cyanobacteria and heterotrophic bacteria enables stable polyhydroxybutyrate production
     explanation: Supports the primary article as the source for this curated community.
+related_ingredients:
+- preferred_term: sucrose
+  chebi_term:
+    id: CHEBI:17992
+    label: sucrose
+  relevance: >
+    Sucrose is the photosynthetically derived carbohydrate exported by the engineered S. elongatus
+    CscB cyanobacterium and is the organic carbon source that directly supports H. boliviensis growth
+    and PHB accumulation in the coculture.
+  evidence:
+  - reference: PMID:29061492
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: sucrose secreted by S. elongatus CscB directly supports the bacterium Halomonas
+    explanation: Names sucrose as the cross-fed carbohydrate supporting the heterotroph.
+- preferred_term: poly(3-hydroxybutyrate)
+  chebi_term:
+    id: CHEBI:53389
+    label: poly(3-hydroxybutyrate)
+  relevance: >
+    Poly(3-hydroxybutyrate) (PHB) is the bioplastic precursor accumulated by H. boliviensis from
+    cyanobacterial sucrose, representing the higher-value bioproduct target of this light-driven
+    coculture.
+  evidence:
+  - reference: PMID:29061492
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: natural producer of the bioplastic precursor, PHB
+    explanation: Names PHB as the bioplastic precursor produced by H. boliviensis.
+- preferred_term: alginic acid
+  chebi_term:
+    id: CHEBI:17548
+    label: alginic acid
+  relevance: >
+    Alginate is used to encapsulate S. elongatus CscB, a coculture format that enhances sucrose-export
+    rates and improves co-culture stability.
+  evidence:
+  - reference: PMID:29061492
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: alginate encapsulation of S. elongatus CscB enhances sucrose-export
+    explanation: Names alginate as the encapsulation material for the cyanobacterial partner.
 metals_present: []
 rare_earth_elements_present: []
 metal_relevance: NOT_APPLICABLE

--- a/kb/communities/Synechococcus_Yarrowia_SPC.yaml
+++ b/kb/communities/Synechococcus_Yarrowia_SPC.yaml
@@ -129,3 +129,17 @@ ecological_interactions:
     snippet: Stability and productivity of autotroph/heterotroph co-cultures was dependent on heterotroph
       sucrose utilization, as well as other species-independent interactions that we observed across all
       dyads
+related_ingredients:
+- preferred_term: sucrose
+  chebi_term:
+    id: CHEBI:17992
+    label: sucrose
+  relevance: >
+    Sucrose is the central cross-feeding metabolite of this consortium: the engineered cyanobacterium
+    secretes the bulk of its fixed carbon as sucrose, which the heterotrophic partner utilizes for growth.
+  evidence:
+  - reference: PMID:28127397
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: carbon it fixes as sucrose, a carbohydrate that can be utilized by many other
+    explanation: Abstract identifies sucrose as the secreted fixed-carbon source feeding heterotrophs.


### PR DESCRIPTION
Continues the #30 `related_ingredients` backfill — **22 CHEBI-grounded ingredients across 8 communities**, strict no-fabrication protocol. This is the thinner tail (abstract-only caches), so several files correctly yield only 1–3 entries.

| File | # |
|---|---|
| Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture | 3 |
| Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture | 3 |
| Synechococcus_Halomonas_Light_Driven_PHB_Coculture | 3 |
| MAMC_M48_Lignocellulose | 4 |
| Synechococcus_Bacillus_SPC | 1 |
| Synechococcus_Ecoli_SPC | 2 |
| Synechococcus_Yarrowia_SPC | 1 |
| Sulfide_Spring_Autotrophic_CPR_Biofilm | 5 |

## Protocol (enforced + independently verified)
- CHEBI ids OAK-verified, canonical labels exact → **22/22 labels canonical**.
- Every `snippet` is a verbatim contiguous substring of a cited+cached reference (full-text `.md` preferred) → **22/22 snippets exact**.
- Compounds not named in the cited+cached text were omitted (no fabrication).

## Validation
- [x] `linkml-validate` all 8 → exit 0
- [x] 22/22 labels canonical; 22/22 snippets exact
- [x] additions-only (316 insertions)

Adoption: 165 → **173 / 265**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)