### PR TITLE
Backfill related_ingredients in 8 more communities (#30)

### DIFF
--- a/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
+++ b/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
@@ -160,6 +160,49 @@ environmental_factors:
     evidence_source: IN_VITRO
     snippet: TCE and perchloroethene (PCE) reductive dechlorination
     explanation: Supports the chlorinated electron acceptors.
+related_ingredients:
+- preferred_term: acetylene
+  chebi_term:
+    id: CHEBI:27518
+    label: acetylene
+  relevance: >
+    Acetylene (C2H2) is supplied as the sole electron donor and organic carbon
+    source for the enrichment and arises in situ as an abiotic degradation
+    product of TCE.
+  evidence:
+  - reference: PMID:33531396
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: acetylene (C2H2) is a product of abiotic degradation of
+    explanation: Names acetylene (C2H2) as the substrate central to the
+      enrichment.
+- preferred_term: trichloroethene
+  chebi_term:
+    id: CHEBI:16602
+    label: trichloroethene
+  relevance: >
+    Trichloroethene (TCE) is the chlorinated electron acceptor reductively
+    dechlorinated by the enrichment community.
+  evidence:
+  - reference: PMID:33531396
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: multiple microbial processes including TCE dechlorination
+    explanation: Names TCE as the substrate undergoing reductive dechlorination.
+- preferred_term: tetrachloroethene
+  chebi_term:
+    id: CHEBI:17300
+    label: tetrachloroethene
+  relevance: >
+    Perchloroethene (PCE), i.e. tetrachloroethene, is reductively dechlorinated
+    by the groundwater enrichment alongside TCE.
+  evidence:
+  - reference: PMID:33531396
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: perchloroethene (PCE) reductive dechlorination by a microbial community enriched
+    explanation: Names perchloroethene (PCE) as a substrate reductively
+      dechlorinated by the enrichment.
 growth_media: []
 external_resources:
 - name: Primary publication for the acetylene TCE-dechlorination community

--- a/kb/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.yaml
+++ b/kb/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.yaml
@@ -91,6 +91,99 @@ taxonomy:
     evidence_source: IN_VITRO
     snippet: Clostridium kluyveri monocultures in batch operated stirred-tank bioreactors
     explanation: Supports C. kluyveri as the chain-elongating organism whose CO sensitivity and process role were studied.
+related_ingredients:
+- preferred_term: carbon monoxide
+  chebi_term:
+    id: CHEBI:17245
+    label: carbon monoxide
+  relevance: >
+    CO is the primary gaseous carbon/energy feedstock fed to the coculture; its
+    fermentation drives autotrophic growth and the downstream conversion to
+    longer-chain alcohols.
+  evidence:
+  - reference: PMID:37110426
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: 1-Butanol and 1-Hexanol from CO
+    explanation: Names CO as the gaseous feedstock converted by the synthetic clostridial coculture.
+- preferred_term: carbon dioxide
+  chebi_term:
+    id: CHEBI:16526
+    label: carbon dioxide
+  relevance: >
+    CO2 is co-fed with CO in the continuous gassing regime that sustains the
+    autotrophic acetogenic partner.
+  evidence:
+  - reference: PMID:34669248
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: continuous CO/CO2 -gassing
+    explanation: Names CO2 as part of the continuous gas supply to the coculture.
+- preferred_term: acetate
+  chebi_term:
+    id: CHEBI:30089
+    label: acetate
+  relevance: >
+    Acetate is one of the main C2 products of acetogenic syngas fermentation
+    that feeds the chain-elongation partner.
+  evidence:
+  - reference: PMID:34669248
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: produce mainly acetate and
+    explanation: Names acetate as a primary product of syngas fermentation in this system.
+- preferred_term: ethanol
+  chebi_term:
+    id: CHEBI:16236
+    label: ethanol
+  relevance: >
+    Ethanol is a main C2 product of the acetogenic partner and a substrate for
+    chain elongation by C. kluyveri.
+  evidence:
+  - reference: PMID:34669248
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: ethanol efficiently
+    explanation: Names ethanol as a primary product of syngas fermentation.
+- preferred_term: 1-butanol
+  chebi_term:
+    id: CHEBI:28885
+    label: butan-1-ol
+  relevance: >
+    Butanol is a longer-chain alcohol product whose final concentration
+    increased threefold in coculture relative to C. carboxidivorans monoculture.
+  evidence:
+  - reference: PMID:34669248
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the corresponding alcohols butanol and hexanol
+    explanation: Names butanol as an alcohol produced by acid reduction in the coculture.
+- preferred_term: 1-hexanol
+  chebi_term:
+    id: CHEBI:87393
+    label: hexan-1-ol
+  relevance: >
+    Hexanol is a target medium-chain alcohol whose production was enabled by the
+    coculture but not the acetogen monoculture.
+  evidence:
+  - reference: PMID:34669248
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the corresponding alcohols butanol and hexanol
+    explanation: Names hexanol as an alcohol produced by acid reduction in the coculture.
+- preferred_term: sulfide
+  chebi_term:
+    id: CHEBI:26822
+    label: sulfide
+  relevance: >
+    Continuous sulfide supply increased autotrophic growth and ethanol formation
+    by C. carboxidivorans under low-CO conditions in the continuous cascade.
+  evidence:
+  - reference: PMID:37110426
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: continuous supply of sulfide led to
+    explanation: Names sulfide as a supplement improving autotrophic growth and ethanol formation.
 ecological_interactions:
 - name: Acetogen-Chain Elongator Product Coupling
   description: >

--- a/kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml
+++ b/kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml
@@ -423,6 +423,118 @@ associated_datasets:
     evidence_source: COMPUTATIONAL
     snippet: Genome-based metabolic reconstruction highlights metabolic versatility of Methylophilaceae
     explanation: Links Methylophilaceae genomic evidence to the curated methylotroph guild.
+related_ingredients:
+- preferred_term: methane
+  chebi_term:
+    id: CHEBI:16183
+    label: methane
+  relevance: >
+    Methane is the selective carbon and energy substrate supplied to the Lake
+    Washington sediment microcosms and the primary carbon source oxidized by the
+    methanotrophic members of the methane-cycling community.
+  evidence:
+  - reference: PMID:25755930
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: methane supplied to lake sediment microbial
+    explanation: Methane is the substrate fed to the lake sediment community.
+  - reference: PMID:32655999
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: oxidize methane as their primary carbon
+    explanation: Methanotrophs in the modeled community oxidize methane as their primary carbon source.
+- preferred_term: dioxygen
+  chebi_term:
+    id: CHEBI:15379
+    label: dioxygen
+  relevance: >
+    Oxygen tension is the controlled environmental variable that structures which
+    methanotroph and methylotroph genera dominate the methane-fed microcosms.
+  evidence:
+  - reference: PMID:25755930
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: different oxygen tensions
+    explanation: Oxygen was varied across microcosms as a key factor in community composition.
+- preferred_term: methanol
+  chebi_term:
+    id: CHEBI:17790
+    label: methanol
+  relevance: >
+    Methanol is a one-carbon intermediate of methylotrophy; Lake Washington
+    Methylophilaceae ecotypes carry methanol dehydrogenase substrate-oxidation
+    systems.
+  evidence:
+  - reference: PMID:25058595
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: MxaFI-type methanol dehydrogenase
+    explanation: Methylophilaceae ecotypes possess methanol dehydrogenase oxidation systems.
+- preferred_term: formaldehyde
+  chebi_term:
+    id: CHEBI:16842
+    label: formaldehyde
+  relevance: >
+    Formaldehyde is a central one-carbon intermediate whose excretion and transfer
+    between community members is predicted by the genome-scale community model.
+  evidence:
+  - reference: PMID:32655999
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: excretion of formaldehyde
+    explanation: The community model predicts formaldehyde excretion among community members.
+- preferred_term: carbon dioxide
+  chebi_term:
+    id: CHEBI:16526
+    label: carbon dioxide
+  relevance: >
+    Carbon dioxide is a predicted excreted product of the methane-cycling community
+    in the genome-scale metabolic model.
+  evidence:
+  - reference: PMID:32655999
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: and carbon di-oxide in the community
+    explanation: The community model predicts carbon dioxide excretion (text spells it "carbon di-oxide").
+- preferred_term: methylamine
+  chebi_term:
+    id: CHEBI:16830
+    label: methylamine
+  relevance: >
+    Methylamine is a methylotrophy substrate oxidized by Lake Washington
+    Methylophilaceae ecotypes, which encode methylamine dehydrogenase.
+  evidence:
+  - reference: PMID:25058595
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: methylamine dehydrogenase versus N-methylglutamate pathway
+    explanation: Methylophilaceae ecotypes possess methylamine dehydrogenase oxidation systems.
+- preferred_term: pyruvate
+  chebi_term:
+    id: CHEBI:15361
+    label: pyruvate
+  relevance: >
+    Pyruvate metabolism is one of the internal metabolic pathways that varied
+    across conditions in the genome-scale community model of the methanotrophs.
+  evidence:
+  - reference: PMID:32655999
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: pyruvate metabolism, and the TCA cycle
+    explanation: Pyruvate metabolism is a modeled pathway shifting across conditions.
+- preferred_term: nitrate
+  chebi_term:
+    id: CHEBI:17632
+    label: nitrate
+  relevance: >
+    Nitrate reduction is part of the nitrogen-metabolism versatility of Lake
+    Washington Methylophilaceae ecotypes, which vary in denitrification potential.
+  evidence:
+  - reference: PMID:25058595
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: nitrate reduction
+    explanation: Methylophilaceae ecotypes differ in assimilatory versus respiratory nitrate reduction.
 metal_relevance: NOT_APPLICABLE
 metal_notes: >
   No metal or rare earth element processing role is curated for this

--- a/kb/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.yaml
+++ b/kb/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.yaml
@@ -210,6 +210,95 @@ growth_media:
     evidence_source: IN_VITRO
     snippet: under a CH4:O2 or air atmosphere
     explanation: Supports the headspace conditions for the PHBV accumulation stage.
+related_ingredients:
+- preferred_term: poly(3-hydroxybutyrate-co-3-hydroxyvalerate)
+  relevance: >
+    PHBV is the target biopolymer produced by the coculture from methane and
+    volatile fatty acid cosubstrates.
+  evidence:
+  - reference: PMID:38516398
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: synthesize poly(3-hydroxybutyrate-co-3-hydroxyvalerate) (PHBV)
+    explanation: Names PHBV as the polymer synthesized by the coculture.
+- preferred_term: methane
+  chebi_term:
+    id: CHEBI:16183
+    label: methane
+  relevance: >
+    Methane is the primary gaseous feedstock supplied to the methanotroph for
+    growth and PHBV accumulation.
+  evidence:
+  - reference: PMID:38516398
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: previously grown on methane
+    explanation: Names methane as the growth substrate for the cultures.
+- preferred_term: oxygen
+  chebi_term:
+    id: CHEBI:15379
+    label: dioxygen
+  relevance: >
+    Oxygen is supplied as part of the CH4:O2 headspace used for methanotrophic
+    growth and the PHBV accumulation tests.
+  evidence:
+  - reference: PMID:38516398
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: under a CH4:O2
+    explanation: Names oxygen (O2) as a component of the CH4:O2 atmosphere.
+- preferred_term: valeric acid
+  chebi_term:
+    id: CHEBI:17418
+    label: valeric acid
+  relevance: >
+    Valeric acid was supplied alone as a cosubstrate and promoted PHBV
+    accumulation in the coculture.
+  evidence:
+  - reference: PMID:38516398
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: enriched with valeric acid
+    explanation: Names valeric acid as a medium cosubstrate.
+- preferred_term: acetic acid
+  chebi_term:
+    id: CHEBI:15366
+    label: acetic acid
+  relevance: >
+    Acetic acid was a component of the mixed VFA cosubstrate fed to the
+    coculture for PHBV accumulation.
+  evidence:
+  - reference: PMID:38516398
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: acetic, propionic, butyric, and valeric acids
+    explanation: Names acetic acid in the mixed VFA cosubstrate.
+- preferred_term: propionic acid
+  chebi_term:
+    id: CHEBI:30768
+    label: propionic acid
+  relevance: >
+    Propionic acid was a component of the mixed VFA cosubstrate fed to the
+    coculture for PHBV accumulation.
+  evidence:
+  - reference: PMID:38516398
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: acetic, propionic, butyric, and valeric acids
+    explanation: Names propionic acid in the mixed VFA cosubstrate.
+- preferred_term: butyric acid
+  chebi_term:
+    id: CHEBI:30772
+    label: butyric acid
+  relevance: >
+    Butyric acid was a component of the mixed VFA cosubstrate fed to the
+    coculture for PHBV accumulation.
+  evidence:
+  - reference: PMID:38516398
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: acetic, propionic, butyric, and valeric acids
+    explanation: Names butyric acid in the mixed VFA cosubstrate.
 external_resources:
 - name: Exact-system PHBV primary publication
   repository: OTHER

--- a/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
+++ b/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
@@ -563,6 +563,36 @@ environmental_factors:
     snippet: The "Cave of Crystals" (aka 'Naica') in Chihuahua Mexico is a natural unique subterranean
       ecosystem which mainly consists of crystals made of calcium sulfate
     explanation: Highlights astrobiology significance
+related_ingredients:
+- preferred_term: calcium sulfate
+  chebi_term:
+    id: CHEBI:31346
+    label: calcium sulfate
+  relevance: >
+    The Naica crystal cave system is composed of giant selenite crystals made of
+    calcium sulfate, which defines the mineralogical matrix of this deep-subsurface
+    thermophilic habitat.
+  evidence:
+  - reference: PMID:23640690
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: subterranean ecosystem which mainly consists of crystals made of calcium
+      sulfate
+    explanation: Reference names calcium sulfate as the crystal-forming mineral of the Naica cave.
+- preferred_term: gypsum
+  chebi_term:
+    id: CHEBI:48838
+    label: gypsum
+  relevance: >
+    The giant Naica crystals are gypsum (calcium sulfate dihydrate), formed in
+    cavities filled by low-salinity hydrothermal water and potentially trapping
+    microorganisms in fluid inclusions.
+  evidence:
+  - reference: doi:10.3389/fmicb.2013.00037
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: The Naica Mine in northern Mexico is famous for its giant gypsum crystals
+    explanation: Reference names gypsum as the crystal-forming mineral of the Naica system.
 metals_present:
 - IRON
 metal_relevance: SIGNIFICANT

--- a/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
+++ b/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
@@ -212,3 +212,55 @@ rare_earth_elements_present: []
 metal_relevance: NOT_APPLICABLE
 metal_notes: No metal or rare earth element processing role is curated for this
   thiocyanate bioremediation community.
+related_ingredients:
+- preferred_term: thiocyanate
+  chebi_term:
+    id: CHEBI:18022
+    label: thiocyanate
+  relevance: >
+    Thiocyanate (SCN-) is the primary contaminant substrate driving selection in
+    this bioreactor community and is degraded by the dominant strains.
+  evidence:
+  - reference: PMID:33897653
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Thiocyanate (SCN-) contamination threatens aquatic ecosystems
+    explanation: Names thiocyanate as the contaminant substrate of the community.
+- preferred_term: cyanate
+  chebi_term:
+    id: CHEBI:29195
+    label: cyanate
+  relevance: >
+    Cyanate is the intermediate product released during SCN- breakdown and is
+    further degraded by cyanate hydratase.
+  evidence:
+  - reference: PMID:33897653
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: degrade product cyanate to ammonia and CO2 via cyanate
+    explanation: Names cyanate as the intermediate degraded via cyanate hydratase.
+- preferred_term: ammonia
+  chebi_term:
+    id: CHEBI:16134
+    label: ammonia
+  relevance: >
+    Ammonia is a product of cyanate degradation by the Afipia variant.
+  evidence:
+  - reference: PMID:33897653
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: degrade product cyanate to ammonia and CO2 via cyanate
+    explanation: Names ammonia as a product of cyanate degradation.
+- preferred_term: carbon dioxide
+  chebi_term:
+    id: CHEBI:16526
+    label: carbon dioxide
+  relevance: >
+    Carbon dioxide is produced from cyanate degradation and subsequently fixed
+    by the autotrophic Afipia variant via the Calvin-Benson-Bassham cycle.
+  evidence:
+  - reference: PMID:33897653
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: degrade product cyanate to ammonia and CO2 via cyanate
+    explanation: Names CO2 as a product of cyanate degradation.

--- a/kb/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.yaml
+++ b/kb/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.yaml
@@ -272,6 +272,21 @@ associated_datasets:
     evidence_source: IN_VITRO
     snippet: Tunable population dynamics in a synthetic filamentous coculture
     explanation: Lists the primary publication for this exact synthetic filamentous coculture.
+related_ingredients:
+- preferred_term: cellulose
+  chebi_term:
+    id: CHEBI:18246
+    label: (1->4)-beta-D-glucan
+  relevance: >
+    alpha-Cellulose was supplied as the sole carbon source, forcing the
+    noncellulolytic S. coelicolor to depend on hydrolysate sugars released by
+    T. reesei cellulases acting on the cellulose substrate.
+  evidence:
+  - reference: PMID:36314761
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: α-cellulose as a carbon source
+    explanation: Names cellulose as the designed carbon source for the coculture.
 metal_relevance: NOT_APPLICABLE
 metal_notes: >
   No metal or rare earth element processing role is curated for this

--- a/kb/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.yaml
+++ b/kb/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.yaml
@@ -9,6 +9,35 @@ description: >
   increase for both organisms, supporting the bidirectional vitamin-dependent
   mutualism predicted from metagenome-informed abundance correlation networks
   of mine-tailings-derived consortia grown under dozens of conditions.
+related_ingredients:
+- preferred_term: thiamine
+  chebi_term:
+    id: CHEBI:18385
+    label: thiamine(1+)
+  relevance: >
+    Thiamine (vitamin B1) is the vitamin produced at high levels by the
+    Variovorax hub and cross-fed to correlated thiamine auxotrophs, anchoring
+    one direction of the validated vitamin mutualism.
+  evidence:
+  - reference: PMID:37553333
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: high levels of thiamine production, up to 100 mg/L
+    explanation: Quantifies thiamine production by Variovorax in minimal media.
+- preferred_term: pantothenate
+  chebi_term:
+    id: CHEBI:7916
+    label: pantothenic acid
+  relevance: >
+    Pantothenate (vitamin B5) is the B-vitamin produced by the Cryptococcus
+    yeast and required for growth of Variovorax, supplying the reciprocal
+    direction of the bidirectional vitamin cross-feeding mutualism.
+  evidence:
+  - reference: PMID:37553333
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the B-vitamin pantothenate
+    explanation: Names pantothenate as the B-vitamin produced by the Cryptococcus yeast.
 ecological_state: ENGINEERED
 community_origin: SYNTHETIC
 community_category: BIOTECHNOLOGY


### PR DESCRIPTION
Continues the #30 `related_ingredients` backfill — **34 CHEBI-grounded ingredients across 8 communities**, strict no-fabrication protocol.

| File | # |
|---|---|
| Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture | 7 |
| Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture | 7 |
| Lake_Washington_Methane_Oxygen_Methylotroph_Community | 8 |
| Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community | 4 |
| Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment | 3 |
| Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm | 2 |
| Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture | 1 |
| Naica_Deep_Subsurface_Thermophilic | 2 |

## Protocol (enforced + independently verified)
- CHEBI ids OAK-verified, canonical labels exact → **34/34 labels canonical** (PHBV kept as preferred_term only, no clean CHEBI term).
- Every `snippet` is a verbatim contiguous substring of a cited+cached reference (full-text `.md` preferred) → **35/35 snippets exact**.
- Compounds not named in the cited+cached text were omitted (no fabrication).

## Validation
- [x] `linkml-validate` all 8 → exit 0
- [x] 34/34 labels canonical; 35/35 snippets exact
- [x] additions-only (463 insertions)

Adoption: 173 → **181 / 265**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)