### PR TITLE
Backfill Cable Bacteria related_ingredients via re-fetched abstract (#30)

### DIFF
--- a/kb/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.yaml
+++ b/kb/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.yaml
@@ -196,6 +196,59 @@ environmental_factors:
     evidence_source: IN_VITRO
     snippet: oxic-anoxic interfaces in aquifer sediments
     explanation: Supports the redox-interface setting for cable-bacteria activity.
+related_ingredients:
+- preferred_term: sulfide
+  chebi_term:
+    id: CHEBI:15138
+    label: sulfide(2-)
+  relevance: >
+    Free sulfide in the reduced sediment is the electron donor that cable bacteria oxidize,
+    harvesting electrons that are conducted to oxygen near the surface.
+  evidence:
+  - reference: PMID:25416774
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: harvesting electrons from free sulfide
+    explanation: Names sulfide as the electron-donor substrate for cable-bacteria oxidation.
+- preferred_term: dioxygen
+  chebi_term:
+    id: CHEBI:15379
+    label: dioxygen
+  relevance: >
+    Oxygen near the sediment-water interface is the terminal electron acceptor for long-distance
+    electron transfer, spatially separated from sulfide at depth.
+  evidence:
+  - reference: PMID:27058505
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: spatial separation of oxygen and sulfide
+    explanation: Names oxygen as the acceptor separated from sulfide across the redox interface.
+- preferred_term: sulfate
+  chebi_term:
+    id: CHEBI:16189
+    label: sulfate
+  relevance: >
+    Cable-bacteria long-distance electron transfer drives direct recycling of sulfate over
+    centimeter distances at oxic-anoxic interfaces.
+  evidence:
+  - reference: PMID:27058505
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: direct recycling of sulfate by electron transfer
+    explanation: Names sulfate as the product recycled by cable-bacteria electron transfer.
+- preferred_term: iron sulfide
+  chebi_term:
+    id: CHEBI:75896
+    label: iron sulfides
+  relevance: >
+    Aquifer sediment was amended with iron sulfide as a reduced sulfur source supporting
+    sulfur-oxidizing cable-bacteria activity in the incubations.
+  evidence:
+  - reference: PMID:27058505
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: amended with iron sulfide
+    explanation: Names iron sulfide as the amended reduced-sulfur source in the sediment incubation.
 associated_datasets:
 - name: Cable bacteria photosynthetic biofilm sediment article
   dataset_type: PHENOTYPE

--- a/references_cache/PMID_27058505.md
+++ b/references_cache/PMID_27058505.md
@@ -20,3 +20,25 @@ Key snippets used in curated records:
 - "hydrocarbon-contaminated aquifer"
 - "identified by sequencing of 16S rRNA genes"
 - "belonging to the Desulfobulbaceae"
+
+Full abstract (re-fetched 2026-06-14 via communitymech.literature):
+
+The biodegradation of organic pollutants in aquifers is often restricted to the 
+fringes of contaminant plumes where steep countergradients of electron donors 
+and acceptors are separated by limited dispersive mixing. However, long-distance 
+electron transfer (LDET) by filamentous 'cable bacteria' has recently been 
+discovered in marine sediments to couple spatially separated redox half 
+reactions over centimeter scales. Here we provide primary evidence that such 
+sulfur-oxidizing cable bacteria can also be found at oxic-anoxic interfaces in 
+aquifer sediments, where they provide a means for the direct recycling of 
+sulfate by electron transfer over 1-2-cm distance. Sediments were taken from a 
+hydrocarbon-contaminated aquifer, amended with iron sulfide and saturated with 
+water, leaving the sediment surface exposed to air. Steep geochemical gradients 
+developed in the upper 3 cm, showing a spatial separation of oxygen and sulfide 
+by 9 mm together with a pH profile characteristic for sulfur oxidation by LDET. 
+Bacterial filaments, which were highly abundant in the suboxic zone, were 
+identified by sequencing of 16S rRNA genes and fluorescence in situ 
+hybridization (FISH) as cable bacteria belonging to the Desulfobulbaceae. The 
+detection of similar Desulfobulbaceae at the oxic-anoxic interface of fresh 
+sediment cores taken at a contaminated aquifer suggests that LDET may indeed be 
+active at the capillary fringe in situ.


### PR DESCRIPTION
Part **(b)** — re-fetch fuller abstracts for high-value un-backfillable files.

Screened the un-backfilled set for references cached only as stubs/missing, then re-fetched 4 PMIDs via `communitymech.literature`:

| PMID | File | Outcome |
|---|---|---|
| 27058505 | Cable_Bacteria_Photosynthetic_Biofilm_Sediment | **Unlocked** — full abstract has sulfur/oxygen chemistry |
| 38228683 | CeMbio | No chemistry (behaviour paper) |
| 34135464 | PMI_Variovorax | No chemistry (phenotypic-variation paper) |
| 19395564 | Yogurt | No chemistry (in-silico HGT/genomics paper) |

For the one that unlocked, I folded the full abstract into `references_cache/PMID_27058505.md` (the validator's primary cache, previously a stub) and added **4 CHEBI-grounded ingredients** to the cable-bacteria community: sulfide, dioxygen, sulfate, iron sulfide. The other 3 are confirmed genuinely un-backfillable (re-fetch verified no hidden chemistry); scratch fetches discarded, no changes.

## Validation
- [x] 4/4 labels OAK-canonical; 4/4 snippets verbatim substrings of the cited+cached refs
- [x] `linkml-validate` → exit 0

Adoption: 181 → **182 / 265**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)