### PR TITLE
CI: enforce id↔label correspondence (Phase 2, blocking)

### DIFF
--- a/.github/workflows/label-correspondence.yaml
+++ b/.github/workflows/label-correspondence.yaml
@@ -1,9 +1,19 @@
 name: label-correspondence
 
-# Phase 1 (report-only): generate the id↔label drift report and upload it as an
-# artifact. Does NOT fail the build — it surfaces existing label drift for
-# triage. Phase 2 will switch to the blocking gates (`just validate-terms-all`
-# + `just validate-products`).
+# Phase 2 (enforcing): `just validate-products` is now a BLOCKING gate — an
+# id↔label MISMATCH / ID_NOT_FOUND / UNKNOWN_PREFIX in the community YAMLs or
+# KGX products fails the build. Curator-accepted residuals stay green via the
+# `exceptions:` allow-list in conf/id_label_targets.yaml (OK_EXCEPTION; restored
+# in issue #134). The drift report (reports/label_drift.tsv) is still generated
+# and uploaded as an artifact for triage, even when the gate passes.
+#
+# NOT enabled here: `just validate-terms-all` (the LinkML-native binding gate).
+# linkml-term-validator has no exceptions mechanism, so it fails on the 34
+# curator-accepted residuals that `validate-products` accepts (e.g. obsolete
+# GO:0055114, CHEBI mislabels needing minting, taxa absent from the OAK
+# snapshot). Enabling it as blocking is deferred until those residuals are
+# minted/cleaned (see NEXT_TASKS.md and the chebi-mislabels backlog) or the
+# vendored validator grows a shared waiver the LinkML tool can consume.
 
 on:
   pull_request:
@@ -34,7 +44,7 @@ jobs:
       - name: Verify validator pin
         run: sha256sum -c scripts/.validate_id_label_correspondence.sha256
 
-  label-drift-report:
+  label-correspondence:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -58,7 +68,9 @@ jobs:
           path: ~/.data/oaklib
           key: oaklib-${{ runner.os }}-v1
 
-      - name: Generate id↔label drift report (non-blocking)
+      # Always generate + upload the drift report first, so the triage artifact
+      # exists even when the enforce step below fails the build.
+      - name: Generate id↔label drift report
         run: just report-label-drift
 
       - name: Upload drift report
@@ -68,3 +80,9 @@ jobs:
           name: label-drift-report-${{ github.run_id }}
           path: reports/label_drift.tsv
           if-no-files-found: warn
+
+      # Phase 2 blocking gate: fail on any id↔label error-class verdict
+      # (MISMATCH / ID_NOT_FOUND / UNKNOWN_PREFIX / ADAPTER_ERROR /
+      # MISSING_COLUMN). Curator-accepted residuals pass as OK_EXCEPTION.
+      - name: Enforce id↔label correspondence
+        run: just validate-products

--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -9,16 +9,23 @@ Last reconciled: 2026-06-14.
 
 ## 1. Phase-2 id↔label enforcement rollout (report-only → blocking)
 
-The id↔label validator is vendored and in sync (byte-identical `.py` with
-MIM/CultureMech; `just verify-validator-pin` passes), and the `exceptions` /
-`OK_EXCEPTION` enforcement path is restored (issue #134). But the gate is still
-**Phase-1 report-only**: `.github/workflows/label-correspondence.yaml` runs
-`just report-label-drift`, not the blocking `just validate-products`.
+**`validate-products` is now a BLOCKING gate** (done 2026-06-14):
+`.github/workflows/label-correspondence.yaml` still generates + uploads the
+drift report, then runs `just validate-products` as a failing step. Verified
+locally: 5362 OK_CANONICAL, 184 OK_EXCEPTION, 0 errors (exit 0). The 34
+curator-accepted residuals in `conf/id_label_targets.yaml` (`exceptions:`) all
+resolve as OK_EXCEPTION (184 pair-instances across files).
 
-- Triage `reports/label_drift.tsv`; confirm the curator-accepted residuals in
-  `conf/id_label_targets.yaml` (`exceptions:`) still resolve as OK_EXCEPTION.
-- Then switch CI to `just validate-products` (blocking) and add
-  `validate-terms-all` for the community YAMLs.
+**Deferred — `validate-terms-all` as a blocking gate.** linkml-term-validator
+(`--labels`) has NO exceptions mechanism, so it fails on exactly those residuals
+(confirmed: it errors on obsolete `GO:0055114` "oxidation-reduction process",
+and would also flag the CHEBI mislabels needing minting and the taxa absent
+from the OAK snapshot). Enabling it as blocking requires one of:
+  - mint/clean the 34 residuals (see chebi-mislabels backlog — 11 CHEBI need
+    minted terms; obsolete GO terms; 2 absent NCBITaxon), then drop them from
+    `exceptions:`; or
+  - teach the LinkML gate to consume a shared waiver (a feature the vendored
+    Engine-B script already has but linkml-term-validator does not).
 
 ## 2. Cross-repository environmental linking (issue #30)
 


### PR DESCRIPTION
Flips `label-correspondence.yaml` from **report-only → blocking**, completing the Phase-2 rollout that #134 unblocked.

## What changed
- The workflow still generates and uploads `reports/label_drift.tsv` (triage artifact, `if: always()`), then runs **`just validate-products` as a blocking step**.
- Curator-accepted residuals stay green via the `exceptions:` / `OK_EXCEPTION` allow-list restored in #134.

## Verified locally
```
id↔label correspondence summary:
  OK_CANONICAL: 5362
  OK_EXCEPTION: 184      # 34 distinct residuals × occurrences across files
  SKIPPED_NO_ADAPTER: 530
✅ All id↔label pairs correspond.   (exit 0)
```

## Why `validate-terms-all` is NOT enabled
`linkml-term-validator --labels` has **no exceptions mechanism**, so it fails on exactly the residuals `validate-products` accepts — confirmed:
```
❌ WARN: Label mismatch for 'GO:0055114': expected 'obsolete oxidation-reduction process', got 'oxidation-reduction process'  (exit 1)
```
Enabling it as a blocking gate is deferred until the 34 residuals are minted/cleaned (chebi-mislabels backlog) or the LinkML gate can consume a shared waiver. Documented in the workflow header and `NEXT_TASKS.md`.

## Test plan
- [x] `just validate-products` → exit 0 locally
- [ ] CI: the new blocking `Enforce id↔label correspondence` step passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)