### PR TITLE
Backfill related_ingredients in 7 more communities (#30)

### DIFF
--- a/kb/communities/Aalborg_East_Full_Scale_EBPR_Community.yaml
+++ b/kb/communities/Aalborg_East_Full_Scale_EBPR_Community.yaml
@@ -120,6 +120,36 @@ taxonomy:
     snippet: bacteria providing substrate to the PAOs, such as fermenters, and bacteria involved in hydrolysis
       of macromolecules
     explanation: Supports a functionally important flanking bacterial community around PAOs.
+related_ingredients:
+- preferred_term: phosphate
+  chebi_term:
+    id: CHEBI:18367
+    label: phosphate(3-)
+  relevance: >
+    Phosphate is the target nutrient removed from wastewater by the EBPR process,
+    and the community metagenome was enriched for phosphate metabolism genes.
+  evidence:
+  - reference: PMID:22170425
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: The genetic potential for community function showed enrichment of genes involved in phosphate
+      metabolism and biofilm formation, reflecting the selective pressure of the EBPR process.
+    explanation: Phosphate metabolism is a selected functional potential of the EBPR community.
+- preferred_term: polyphosphate
+  chebi_term:
+    id: CHEBI:16838
+    label: polyphosphate
+  relevance: >
+    Polyphosphate is the intracellular phosphorus storage polymer accumulated by the
+    polyphosphate accumulating organisms (PAOs) that drive enhanced biological phosphorus removal.
+  evidence:
+  - reference: PMID:22170425
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: The organisms facilitating EBPR are called polyphosphate accumulating organisms (PAOs) and
+      the most important PAOs have been identified using culture independent methods as Candidatus Accumulibacter
+      phosphatis and the actinobacterial genus Tetrasphaera.
+    explanation: Identifies the PAOs that accumulate polyphosphate as central to the EBPR community.
 ecological_interactions:
 - name: PAO Phosphate Storage Under EBPR Selection
   description: EBPR process cycling selects for bacteria that accumulate and use intracellular polyphosphate,

--- a/kb/communities/Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community.yaml
+++ b/kb/communities/Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community.yaml
@@ -124,6 +124,48 @@ ecological_interactions:
       bacteria may represent an adaptation to membrane curvature stress
       induced by their small cell sizes
     explanation: Supports the curated lysolipid-curvature-adaptation hypothesis.
+related_ingredients:
+- preferred_term: carbon dioxide
+  chebi_term:
+    id: CHEBI:16526
+    label: carbon dioxide
+  relevance: >
+    CO2 is the keystone substrate of this deep biosphere: bacterial and archaeal
+    CO2 fixation in the CO2-rich aquifer supplies the organic carbon pool that
+    sustains the community, including CPR bacteria.
+  evidence:
+  - reference: PMID:32203118
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: CO2 fixation ongoing in the deep subsurface provides organic carbon
+    explanation: CO2 fixation is the autotrophic carbon source for the community.
+- preferred_term: lipid
+  chebi_term:
+    id: CHEBI:18059
+    label: lipid
+  relevance: >
+    Membrane lipids are central to this community: CPR bacteria lack complete
+    lipid biosynthesis pathways yet retain regular lipid membranes, implying
+    lipid redistribution from other community members.
+  evidence:
+  - reference: PMID:32203118
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: CPR bacteria lack complete lipid biosynthesis pathways
+    explanation: CPR membrane lipids are sourced from partner community members.
+- preferred_term: fatty acid
+  chebi_term:
+    id: CHEBI:35366
+    label: fatty acid
+  relevance: >
+    Non-CPR community members adapt to high in situ pressure by increasing
+    fatty acid unsaturation in their membrane lipids.
+  evidence:
+  - reference: PMID:32203118
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: increasing fatty acid unsaturation
+    explanation: Fatty acid unsaturation is a pressure-adaptation of partner lipids.
 environmental_factors:
 - name: Aquifer chemistry
   value: CO2-rich Colorado Plateau aquifers

--- a/kb/communities/Early_Dental_Biofilm_FiveSpecies.yaml
+++ b/kb/communities/Early_Dental_Biofilm_FiveSpecies.yaml
@@ -112,6 +112,24 @@ taxonomy:
       mitis, Streptococcus downei and Actinomyces naeslundii were employed in
       the model.
     explanation: Documents Actinomyces naeslundii as a member of the five-species model.
+related_ingredients:
+- preferred_term: glucose
+  chebi_term:
+    id: CHEBI:17234
+    label: glucose
+  relevance: >
+    Glucose supplied in salivary solutions is the carbohydrate substrate that
+    drives anaerobic glycolysis in this five-species biofilm, generating the
+    acidic extracellular microenvironments central to the caries model.
+  evidence:
+  - reference: PMID:21966490
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      We employed the pH-sensitive ratiometric probe C-SNARF-4 to perform
+      real-time microscopic analyses of the biofilm pH in response to salivary
+      solutions containing glucose.
+    explanation: Names glucose as the carbohydrate challenge fueling biofilm acidogenesis.
 environmental_factors:
 - name: Glucose challenge
   description: >-

--- a/kb/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.yaml
+++ b/kb/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.yaml
@@ -162,6 +162,72 @@ environmental_factors:
       reconstructed genomes, from diverse animal-associated and natural
       environments
     explanation: Supports the curated multi-habitat genome set.
+related_ingredients:
+- preferred_term: dihydrogen
+  chebi_term:
+    id: CHEBI:18276
+    label: dihydrogen
+  relevance: >
+    Hydrogen is a substrate for Rnf complex-dependent acetogenesis in
+    groundwater-associated Elusimicrobia.
+  evidence:
+  - reference: PMID:32681159
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: hydrogen and carbon dioxide as the substrates
+    explanation: Names hydrogen as a substrate of Rnf-dependent acetogenesis.
+- preferred_term: carbon dioxide
+  chebi_term:
+    id: CHEBI:16526
+    label: carbon dioxide
+  relevance: >
+    Carbon dioxide is co-substrate with hydrogen for Rnf complex-dependent
+    acetogenesis in groundwater-associated Elusimicrobia.
+  evidence:
+  - reference: PMID:32681159
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: hydrogen and carbon dioxide as the substrates
+    explanation: Names carbon dioxide as a substrate of Rnf-dependent acetogenesis.
+- preferred_term: nitrate
+  chebi_term:
+    id: CHEBI:17632
+    label: nitrate
+  relevance: >
+    Nitrate serves as a terminal electron acceptor for nitrate/nitrite-dependent
+    respiration in groundwater-associated Elusimicrobia.
+  evidence:
+  - reference: PMID:32681159
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: oxygen or nitrate/nitrite-dependent respiration
+    explanation: Names nitrate as an electron acceptor for respiration.
+- preferred_term: nitrite
+  chebi_term:
+    id: CHEBI:16301
+    label: nitrite
+  relevance: >
+    Nitrite serves as a terminal electron acceptor for nitrate/nitrite-dependent
+    respiration in groundwater-associated Elusimicrobia.
+  evidence:
+  - reference: PMID:32681159
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: oxygen or nitrate/nitrite-dependent respiration
+    explanation: Names nitrite as an electron acceptor for respiration.
+- preferred_term: dioxygen
+  chebi_term:
+    id: CHEBI:15379
+    label: dioxygen
+  relevance: >
+    Oxygen serves as a terminal electron acceptor for aerobic respiration in
+    groundwater-associated Elusimicrobia.
+  evidence:
+  - reference: PMID:32681159
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: oxygen or nitrate/nitrite-dependent respiration
+    explanation: Names oxygen as an electron acceptor for respiration.
 growth_media: []
 external_resources:
 - name: Primary publication for the groundwater Elusimicrobia community

--- a/kb/communities/Lac_Pavin_Stratified_Lake_Community.yaml
+++ b/kb/communities/Lac_Pavin_Stratified_Lake_Community.yaml
@@ -134,6 +134,49 @@ environmental_factors:
     snippet: the distribution of microbial lineages along an oxygen gradient in
       Lac Pavin
     explanation: Supports the curated oxygen gradient as a structuring factor.
+related_ingredients:
+- preferred_term: methane
+  chebi_term:
+    id: CHEBI:16183
+    label: methane
+  relevance: >
+    Methane is the central carbon currency of the Lac Pavin methane cycle, with
+    its oxidation spatially separated from production by diverse sediment
+    methanogens across the lake's depth gradient.
+  evidence:
+  - reference: PMID:36694212
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: the oxidation of methane and its byproducts is
+    explanation: Abstract names methane oxidation as a key process in the community.
+- preferred_term: carbon dioxide
+  chebi_term:
+    id: CHEBI:16526
+    label: carbon dioxide
+  relevance: >
+    CO2 fixation pathways are enriched along the oxygen gradient, with distinct
+    C1 and CO2 fixation strategies partitioned between the oxic interface and the
+    anoxic zone/sediments.
+  evidence:
+  - reference: PMID:36694212
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: enrichment of distinct C1 and CO2 fixation pathways in the
+    explanation: Abstract names CO2 fixation pathways as enriched in the community.
+- preferred_term: oxygen
+  chebi_term:
+    id: CHEBI:15379
+    label: dioxygen
+  relevance: >
+    Dissolved oxygen forms the dominant geochemical gradient in the permanently
+    stratified water column, structuring the metabolic strategies of non-CPR
+    bacteria and archaea from the oxic interface to the anoxic sediments.
+  evidence:
+  - reference: PMID:36694212
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: oxygen gradient in Lac Pavin
+    explanation: Abstract names the oxygen gradient as the structuring geochemical factor.
 growth_media: []
 external_resources:
 - name: Primary publication for the Lac Pavin stratified lake community

--- a/kb/communities/SMutans_VParvula_ASC_Biofilm.yaml
+++ b/kb/communities/SMutans_VParvula_ASC_Biofilm.yaml
@@ -127,3 +127,21 @@ ecological_interactions:
       virulence of S. mutans when being co-infected and augmented the
       progression, quantity, and severity of dental caries.
     explanation: Supports Veillonella parvula as a synergistic pathobiont in adult severe caries.
+related_ingredients:
+- preferred_term: hydrogen peroxide
+  chebi_term:
+    id: CHEBI:16240
+    label: hydrogen peroxide
+  relevance: >
+    Hydrogen peroxide is the oxidative stress agent the dual-species biofilm must
+    tolerate; coculture with V. parvula enhances S. mutans hydrogen peroxide
+    detoxification, contributing to biofilm virulence.
+  evidence:
+  - reference: PMID:39345197
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      In vitro experiments found that V. parvula can effectively promote S.
+      mutans mature biofilm formation with enhanced acid resistance, hydrogen
+      peroxide detoxicity, and biofilm virulence.
+    explanation: Names hydrogen peroxide as the oxidative stress compound detoxified in the coculture.

--- a/kb/communities/Trichoderma_Lactate_Platform.yaml
+++ b/kb/communities/Trichoderma_Lactate_Platform.yaml
@@ -210,6 +210,34 @@ environmental_factors:
     food chain
 
     '
+related_ingredients:
+- preferred_term: lactate
+  chebi_term:
+    id: CHEBI:24996
+    label: lactate
+  relevance: >
+    Lactate is the central metabolic intermediate of the platform: lignocellulosic
+    carbohydrates are funneled to lactate by the lactic acid bacteria before downstream
+    conversion to short-chain fatty acids.
+  evidence:
+  - reference: PMID:32855308
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: lactate as a central intermediate in engineered food chains
+    explanation: Abstract names lactate as the central intermediate funneled from lignocellulosic carbohydrates.
+- preferred_term: butyric acid
+  chebi_term:
+    id: CHEBI:30772
+    label: butyric acid
+  relevance: >
+    Butyric acid is the primary short-chain fatty acid product of the consortium,
+    produced from the lactate platform at 196 kg per metric ton of beechwood.
+  evidence:
+  - reference: PMID:32855308
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: kilograms of butyric acid per metric ton of beechwood
+    explanation: Abstract reports butyric acid as the consortium's main SCFA product yield.
 metals_present: []
 metal_relevance: INCIDENTAL
 metal_notes: Metal/REE detected via environmental factor measurements


### PR DESCRIPTION
Continues the #30 backfill — **17 CHEBI-grounded ingredients across 7 communities**, strict no-fabrication protocol. Thin tail, so most files yield 1–5 entries; one attempted file (Shewanella_Geobacter exoelectrogenic) named no compounds and was correctly skipped.

| File | # |
|---|---|
| Trichoderma_Lactate_Platform | 2 |
| Aalborg_East_Full_Scale_EBPR_Community | 2 |
| Early_Dental_Biofilm_FiveSpecies | 1 |
| SMutans_VParvula_ASC_Biofilm | 1 |
| Groundwater_Elusimicrobia_Diverse_Metabolisms | 5 |
| Lac_Pavin_Stratified_Lake_Community | 3 |
| Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community | 3 |

## Verification
- [x] 17/17 labels OAK-canonical; 17/17 snippets exact substrings of cited+cached refs
- [x] `linkml-validate` all 7 → exit 0
- [x] **`just validate-products` (now the blocking CI gate) → exit 0** (5379 OK_CANONICAL, 184 OK_EXCEPTION, 0 errors)

First backfill batch under the new Phase-2 blocking id↔label gate. Adoption: 182 → **189 / 265**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)