### PR TITLE
Backfill related_ingredients: marine/photosym/fermentation cohort (#30)

### DIFF
--- a/kb/communities/Kombucha_KMC_IMBG1_Fermentation_Community.yaml
+++ b/kb/communities/Kombucha_KMC_IMBG1_Fermentation_Community.yaml
@@ -207,4 +207,31 @@ associated_datasets:
     evidence_source: IN_VITRO
     snippet: submitted to the GenBank database under an accession numbers KF908872-KF90879
     explanation: Supports the associated GenBank sequence-accession range reported by the study.
+related_ingredients:
+- preferred_term: sucrose
+  chebi_term:
+    id: CHEBI:17992
+    label: sucrose
+  relevance: >
+    Sucrose is the primary fermentable carbon source added to the black-tea substrate that sustains
+    the KMC-IMBG1 yeast and acetobacterial community.
+  evidence:
+  - reference: PMID:26061774
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: black tea (Lipton, 1.2%, w/v) extract with sucrose (3.0%, w/v)
+    explanation: Names sucrose as the sweetener added to the black-tea fermentation medium.
+- preferred_term: cellulose
+  chebi_term:
+    id: CHEBI:18246
+    label: (1->4)-beta-D-glucan
+  relevance: >
+    Cellulose is produced by the acetobacterial members and forms the surface pellicle that physically
+    structures the kombucha community.
+  evidence:
+  - reference: doi:10.1186/s13568-015-0124-5
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: cellulose-based pellicles created by the cellulose-producing bacteria
+    explanation: Names cellulose as the pellicle material produced by community bacteria.
 metal_relevance: NOT_APPLICABLE

--- a/kb/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.yaml
+++ b/kb/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.yaml
@@ -238,6 +238,72 @@ environmental_factors:
     evidence_source: IN_VITRO
     snippet: from air, water, phosphate, trace metals, and sunlight
     explanation: Supports trace metals as reported inorganic inputs.
+related_ingredients:
+- preferred_term: sucrose
+  chebi_term:
+    id: CHEBI:17992
+    label: sucrose
+  relevance: >
+    Sucrose is the cross-fed carbon currency: engineered cscB S. elongatus exports sucrose, and the
+    coculture cannot grow without a sucrose-exporting S. elongatus partner.
+  evidence:
+  - reference: PMID:27232890
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: sucrose-exporting S. elongatus
+    explanation: Names sucrose export by S. elongatus as required for coculture growth.
+- preferred_term: polyhydroxybutyrate
+  chebi_term:
+    id: CHEBI:53389
+    label: poly(3-hydroxybutyrate)
+  relevance: >
+    Polyhydroxybutyrate (PHB) is the industrially relevant biopolymer the designed coculture was shown
+    to produce from simple inorganic inputs and light.
+  evidence:
+  - reference: PMID:27232890
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: polyhydroxybutyrate (PHB) and alginate
+    explanation: Names polyhydroxybutyrate as an industrially relevant product of the system.
+- preferred_term: alginate
+  chebi_term:
+    id: CHEBI:58187
+    label: alginate
+  relevance: >
+    Alginate is named as a second industrially relevant biopolymer the coculture has the potential to
+    produce alongside PHB.
+  evidence:
+  - reference: PMID:27232890
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: polyhydroxybutyrate (PHB) and alginate
+    explanation: Names alginate as a potential industrially relevant product of the coculture.
+- preferred_term: glutamate
+  chebi_term:
+    id: CHEBI:18237
+    label: glutamic acid
+  relevance: >
+    Glutamate was supplied in the initial coculture studies that established the cross-feeding model
+    between S. elongatus and A. vinelandii.
+  evidence:
+  - reference: PMID:27232890
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: media with glutamate
+    explanation: Names glutamate as a medium component in the initial cross-feeding studies.
+- preferred_term: phosphate
+  chebi_term:
+    id: CHEBI:18367
+    label: phosphate(3-)
+  relevance: >
+    Phosphate is one of the simple inorganic inputs from which the coculture concept was designed to
+    drive chemical photoproduction.
+  evidence:
+  - reference: PMID:27232890
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: from air, water, phosphate, trace
+    explanation: Names phosphate among the simple inorganic inputs for photoproduction.
 growth_media:
 - name: Light-driven Synechococcus-Azotobacter coculture
   composition:

--- a/kb/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.yaml
+++ b/kb/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.yaml
@@ -232,5 +232,20 @@ associated_datasets:
   url: https://doi.org/10.1186/s13068-017-0736-x
   description: Open-access study reporting growth, sucrose use, ROS, biomass, and lipid measurements for
     S. elongatus-yeast artificial lichen cocultures.
+related_ingredients:
+- preferred_term: sucrose
+  chebi_term:
+    id: CHEBI:17992
+    label: sucrose
+  relevance: >
+    Sucrose is the central exchanged metabolite of this synthetic lichen coculture: engineered
+    cscB+ Synechococcus elongatus secretes it as photosynthate and Rhodotorula glutinis consumes it
+    as its carbon source for growth and lipid production.
+  evidence:
+  - reference: doi:10.1186/s13068-017-0736-x
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: sucrose-secreting cyanobacterium Synechococcus elongatus
+    explanation: Names sucrose as the metabolite secreted by the engineered cyanobacterial partner.
 metal_relevance: NOT_APPLICABLE
 


### PR DESCRIPTION
Cohort sweep across the user's requested marine/aquatic + gut/rhizosphere groups. **8 CHEBI-grounded ingredients across 3 communities**:

| File | # |
|---|---|
| Synechococcus_Azotobacter_Photoproduction_Mutualism | 5 |
| Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture | 1 |
| Kombucha_KMC_IMBG1_Fermentation_Community | 2 |

**Five other files were attempted and correctly added nothing** (no fabrication): `Pseudonitzschia_Sulfitobacter` (cited ref is a species-description/taxonomy paper), `Maize_Root_Simplified` / `Lotus_LjSC3` (community-ecology abstracts, no metabolites), `Infant_Gut_DNA_Phage_Succession` (phage survey). `Cheese_Rind` + `Kombucha` are limited by stub caches — their full texts (e.g. Wolfe 2014 lactate/amino-acid metabolism) would yield more and are good candidates for a future abstract re-fetch.

## Verification
- [x] 8/8 labels OAK-canonical; 8/8 snippets exact substrings
- [x] `linkml-validate` all 3 → exit 0
- [x] `just validate-products` (blocking gate) → exit 0 (5448 OK_CANONICAL)

Adoption: 204 → **207 / 265**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)