### PR TITLE
Record id-label residual triage: validate-terms-all blocked upstream

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -27,6 +27,27 @@ from the OAK snapshot). Enabling it as blocking requires one of:
   - teach the LinkML gate to consume a shared waiver (a feature the vendored
     Engine-B script already has but linkml-term-validator does not).
 
+**Triage 2026-06-17 (option 2 attempt):** re-checked all 34 residuals against the
+CURRENT OAK snapshot (`/tmp/triage.py`). Finding is sharper (and worse) than
+"needs minting": every residual id resolves to an UNRELATED entity in the current
+build, and broad `runoak search` finds NO repoint target for the intended label —
+i.e. the compound/environment is genuinely absent from ChEBI/ENVO, and the
+placeholder id is semantically wrong. Examples: CHEBI:33104 "chromium(III)
+hydroxide"→*hydridoarsenic*; CHEBI:34818 "humic acid"→*Leucomycin A8*; CHEBI:38292
+"uranyl(2+)"→*nido-undecaborane*; CHEBI:89981 "yeast extract"→*LPS with O-antigen*;
+ENVO:00000274 "soda lake"→*continental rise*; ENVO:01001442 "phyllosphere"→
+*agriculture*; NCBITaxon:3050471 "Stenotrophomonas goyi"→*unclassified
+Dissulfuribacter*. Only near-repoint found: sodium metasilicate (CHEBI:86154) →
+CHEBI:60720 "sodium silicate" (a generalization, label changes; not applied).
+**Conclusion: option 2 is genuinely upstream-blocked** — I cannot mint
+ChEBI/ENVO/GO/NCBITaxon terms. validate-terms-all stays deferred. The real fixes
+are external: (a) submit the ~9 CHEBI + 3 ENVO + 2 NCBITaxon compounds/taxa as
+term requests (ROBOT template / OBO issue), (b) repoint the ~12 obsolete GO ids to
+current terms where a curator accepts a replacement, then (c) drop resolved
+entries from `exceptions:`. The `exceptions` allow-list keeps `validate-products`
+green meanwhile, but note these groundings are semantically wrong in the KGX
+export (the id ≠ the labelled compound) — a data-quality item worth tracking.
+
 ## 2. Cross-repository environmental linking (issue #30)
 
 Open issue: enhance environment/isolation-source links between CommunityMech,


### PR DESCRIPTION
**Option 2** of the plan ("mint/clean the 34 residuals so validate-terms-all can go blocking") — triage result.

Re-checked all 34 curator-accepted `exceptions` residuals against the **current OAK snapshot**. The finding is sharper than the old "needs minting" reasons suggest: **every residual id resolves to an unrelated entity** in the current ChEBI/ENVO/NCBITaxon build, and broad `runoak search` finds **no repoint target** for the intended label — the compound/environment is genuinely absent from the ontology, and the placeholder id is semantically wrong.

Examples:
- `CHEBI:33104` "chromium(III) hydroxide" → *hydridoarsenic(2.) (triplet)*
- `CHEBI:34818` "humic acid" → *Leucomycin A8*
- `CHEBI:89981` "yeast extract" → *LPS with O-antigen*
- `ENVO:00000274` "soda lake" → *continental rise*
- `NCBITaxon:3050471` "Stenotrophomonas goyi" → *unclassified Dissulfuribacter*

Only near-repoint: sodium metasilicate (`CHEBI:86154`) → `CHEBI:60720` "sodium silicate" (a generalization that changes the label; not applied).

## Conclusion
`validate-terms-all` **cannot** be made a blocking gate now — minting ChEBI/ENVO/GO/NCBITaxon terms is an external OBO process I can't perform. Documented in `NEXT_TASKS.md` item 1: the real fix path (term requests for ~9 CHEBI + 3 ENVO + 2 NCBITaxon; GO obsolete repoints), and the **data-quality caveat** that these groundings carry the wrong id in the KGX export (worth tracking separately).

Doc-only; no code/data change. `validate-products` stays green via the `exceptions` allow-list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)