### PR TITLE
Schema: add electron-transfer roles to FunctionalRoleEnum

### DIFF
--- a/kb/taxa/Geobacter_sulfurreducens.yaml
+++ b/kb/taxa/Geobacter_sulfurreducens.yaml
@@ -18,7 +18,7 @@ genes:
   - id: GO:0009055
     label: electron transfer activity
   supports_roles:
-  - SYNTROPHIC_PARTNER
+  - ELECTRON_DONOR
   supports_interaction: >
     Conductive pili (e-pili) mediate long-range extracellular and direct
     interspecies electron transfer (DIET) to partner methanogens and to
@@ -32,7 +32,7 @@ genes:
   - id: GO:0009055
     label: electron transfer activity
   supports_roles:
-  - SYNTROPHIC_PARTNER
+  - ELECTRON_DONOR
   supports_interaction: >
     Cytochrome filament/decoration required for extracellular electron transfer
     to Fe(III) oxides and for direct interspecies electron transfer to partners.
@@ -45,7 +45,7 @@ genes:
   - id: GO:0009055
     label: electron transfer activity
   supports_roles:
-  - SYNTROPHIC_PARTNER
+  - ELECTRON_DONOR
   supports_interaction: >
     Cytochrome essential for high-density current production at electrodes
     (extracellular electron transfer to anodes).

--- a/kb/taxa/Shewanella_oneidensis_MR1.yaml
+++ b/kb/taxa/Shewanella_oneidensis_MR1.yaml
@@ -18,7 +18,7 @@ genes:
   - id: GO:0009055
     label: electron transfer activity
   supports_roles:
-  - SYNTROPHIC_PARTNER
+  - ELECTRON_DONOR
   supports_interaction: >
     Terminal reductase of the Mtr extracellular electron transfer pathway; transfers
     electrons to extracellular acceptors (e.g. Fe(III)/Mn(IV) oxides, electrodes),
@@ -29,7 +29,7 @@ genes:
   product: Outer-membrane beta-barrel that embeds the MtrA/MtrC cytochrome module
   genome: GCF_000146165.2
   supports_roles:
-  - SYNTROPHIC_PARTNER
+  - ELECTRON_DONOR
   supports_interaction: >
     Forms the outer-membrane conduit of the MtrCAB porin-cytochrome complex enabling
     electron egress to extracellular acceptors.
@@ -42,7 +42,7 @@ genes:
   - id: GO:0009055
     label: electron transfer activity
   supports_roles:
-  - SYNTROPHIC_PARTNER
+  - ELECTRON_DONOR
   supports_interaction: >
     Conducts electrons across the outer membrane within the MtrCAB complex during
     extracellular electron transfer.
@@ -55,7 +55,7 @@ genes:
   - id: GO:0009055
     label: electron transfer activity
   supports_roles:
-  - SYNTROPHIC_PARTNER
+  - ELECTRON_DONOR
   supports_interaction: >
     Branch point that delivers electrons from the menaquinone pool to periplasmic
     and outer-membrane cytochromes for extracellular electron transfer.

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-06-17T20:06:08
+# Generation date: 2026-06-17T20:26:35
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech
@@ -1756,6 +1756,22 @@ class FunctionalRoleEnum(EnumDefinitionImpl):
     )
     CROSS_FEEDER = PermissibleValue(
         text="CROSS_FEEDER", description="Utilizes metabolites from other taxa"
+    )
+    ELECTRON_DONOR = PermissibleValue(
+        text="ELECTRON_DONOR",
+        description="""Donates electrons in interspecies or extracellular electron transfer (e.g. the electron-donating partner in DIET).""",
+    )
+    ELECTRON_ACCEPTOR = PermissibleValue(
+        text="ELECTRON_ACCEPTOR",
+        description="""Accepts electrons in interspecies or extracellular electron transfer (e.g. the electron-accepting methanogen in DIET).""",
+    )
+    ELECTROGEN = PermissibleValue(
+        text="ELECTROGEN",
+        description="""Exoelectrogen; transfers electrons to an extracellular solid acceptor such as an anode or a metal (Fe/Mn) oxide.""",
+    )
+    ELECTROTROPH = PermissibleValue(
+        text="ELECTROTROPH",
+        description="""Takes up electrons from an extracellular donor such as a cathode (electrotrophy / extracellular electron uptake).""",
     )
 
     _defn = EnumDefinition(

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -225,6 +225,22 @@ enums:
         description: Engages in syntrophic metabolism
       CROSS_FEEDER:
         description: Utilizes metabolites from other taxa
+      ELECTRON_DONOR:
+        description: >-
+          Donates electrons in interspecies or extracellular electron transfer
+          (e.g. the electron-donating partner in DIET).
+      ELECTRON_ACCEPTOR:
+        description: >-
+          Accepts electrons in interspecies or extracellular electron transfer
+          (e.g. the electron-accepting methanogen in DIET).
+      ELECTROGEN:
+        description: >-
+          Exoelectrogen; transfers electrons to an extracellular solid acceptor
+          such as an anode or a metal (Fe/Mn) oxide.
+      ELECTROTROPH:
+        description: >-
+          Takes up electrons from an extracellular donor such as a cathode
+          (electrotrophy / extracellular electron uptake).
 
   AtmosphereEnum:
     description: Atmospheric/oxygen requirements for growth


### PR DESCRIPTION
Adds four electron-transfer values to `FunctionalRoleEnum` (the prior five couldn't express EET/DIET roles):

- `ELECTRON_DONOR` / `ELECTRON_ACCEPTOR` — interspecies / extracellular electron transfer (e.g. DIET donor and acceptor)
- `ELECTROGEN` — exoelectrogen → solid acceptor (anode, Fe/Mn oxide)
- `ELECTROTROPH` — electron uptake from a cathode

Updates the two example `kb/taxa/` records to use the precise `ELECTRON_DONOR` role on their EET genes (was `SYNTROPHIC_PARTNER`).

## Verification
- [x] `just gen-python` (datamodel regenerated, enum present)
- [x] `just validate-taxa`, `just validate-products` (0 errors), `just lint`, taxon tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)