### PR TITLE
Render datasets + knowledge-gap discussions per community (claw#7 Phase 1)

### DIFF
--- a/docs/communities/ANME_SRB_Marine_Methane_Seep_Consortium.html
+++ b/docs/communities/ANME_SRB_Marine_Methane_Seep_Consortium.html
@@ -724,7 +724,7 @@
                             <br><span class="dataset-description">Comparative genomic analysis of ANME genomes reconstructed from environmental metagenomes and flow-sorted syntrophic consortia.</span>
                             
                         </td>
-                        <td><span class="role-badge">METAGENOME</span></td>
+                        <td><span class="role-badge">METAGENOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Aalborg_East_Full_Scale_EBPR_Community.html
+++ b/docs/communities/Aalborg_East_Full_Scale_EBPR_Community.html
@@ -862,7 +862,7 @@
                             <br><span class="dataset-description">Nonredundant contigs from the Aalborg East full-scale EBPR activated sludge metagenome.</span>
                             
                         </td>
-                        <td><span class="role-badge">METAGENOME</span></td>
+                        <td><span class="role-badge">METAGENOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.html
+++ b/docs/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.html
@@ -790,7 +790,7 @@
                             <br><span class="dataset-description">Draft genome assemblies for the eight ASF members, including AQFQ00000000.1, AQFR00000000.1, AQFS00000000.1, AYGZ00000000.1, AQFT00000000.1, AYJP00000000.1, AQFU00000000.1, and AQFV00000000.1.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Anammox_Granule_Metabolic_Interaction_Community.html
+++ b/docs/communities/Anammox_Granule_Metabolic_Interaction_Community.html
@@ -841,7 +841,7 @@
                             <br><span class="dataset-description">Open-access article reporting genome-centric metagenomics, metatranscriptomics, and metabolic network reconstruction for a laboratory anammox granule community.</span>
                             
                         </td>
-                        <td><span class="role-badge">METATRANSCRIPTOME</span></td>
+                        <td><span class="role-badge">METATRANSCRIPTOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.html
+++ b/docs/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.html
@@ -828,7 +828,7 @@
                             <br><span class="dataset-description">GEO accessions deposited with the PNAS study for transcriptional profiling data from the gnotobiotic model.</span>
                             
                         </td>
-                        <td><span class="role-badge">METATRANSCRIPTOME</span></td>
+                        <td><span class="role-badge">METATRANSCRIPTOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             
@@ -844,7 +844,7 @@
                             <br><span class="dataset-description">NCBI BioProject for the E. rectale ATCC 33656 genome sequenced in the same study.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             

--- a/docs/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.html
+++ b/docs/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.html
@@ -782,7 +782,7 @@
                             <br><span class="dataset-description">M. smithii gene sequence accession reported with the gnotobiotic mutualism study.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.html
+++ b/docs/communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.html
@@ -765,7 +765,7 @@
                             <br><span class="dataset-description">NCBI BioProject for the Buchnera aphidicola BCc genome from Cinara cedri.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             
@@ -781,7 +781,7 @@
                             <br><span class="dataset-description">NCBI BioProject for Serratia symbiotica from Cinara cedri.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             

--- a/docs/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.html
+++ b/docs/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.html
@@ -803,7 +803,7 @@
                             <br><span class="dataset-description">Genome project for C. saccharolyticus DSM 8903, one member of the coculture.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             
@@ -819,7 +819,7 @@
                             <br><span class="dataset-description">Genome project for the strain reported as C. kristjanssonii DSM 12137.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             

--- a/docs/communities/CeMbio_Caenorhabditis_Elegans_Microbiome.html
+++ b/docs/communities/CeMbio_Caenorhabditis_Elegans_Microbiome.html
@@ -854,7 +854,7 @@
                             <br><span class="dataset-description">European Nucleotide Archive genome sequencing data for the CeMbio bacterial strains.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.html
+++ b/docs/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.html
@@ -762,7 +762,7 @@
                             <br><span class="dataset-description">Genome sequence for the central bacterium in Chlorochromatium aggregatum.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             
@@ -778,7 +778,7 @@
                             <br><span class="dataset-description">Genome sequence for the green sulfur bacterial epibiont.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.html
+++ b/docs/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.html
@@ -764,7 +764,7 @@
                             <br><span class="dataset-description">Genome project for the C. thermocellum ATCC 27405 strain used in the coculture study.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             
@@ -780,7 +780,7 @@
                             <br><span class="dataset-description">Genome project for C. bescii DSM 6725, the second strain in the coculture study.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             

--- a/docs/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.html
+++ b/docs/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.html
@@ -832,7 +832,7 @@
 </span>
                             
                         </td>
-                        <td><span class="role-badge">METATRANSCRIPTOME</span></td>
+                        <td><span class="role-badge">METATRANSCRIPTOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.html
+++ b/docs/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.html
@@ -825,7 +825,7 @@
                             <br><span class="dataset-description">NCBI BioProject for the complete genome of the C. phytofermentans ISDg member.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             
@@ -841,7 +841,7 @@
                             <br><span class="dataset-description">Reference genome assembly for the E. coli K-12 MG1655 member.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.html
+++ b/docs/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.html
@@ -884,7 +884,7 @@
                             <br><span class="dataset-description">SRA BioProject for the tripartite consortium metatranscriptome data from the two-shaking-speed study.</span>
                             
                         </td>
-                        <td><span class="role-badge">METATRANSCRIPTOME</span></td>
+                        <td><span class="role-badge">METATRANSCRIPTOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             
@@ -900,7 +900,7 @@
                             <br><span class="dataset-description">JGI/MycoCosm genome resource for the Coniochaeta sp. 2T2.1 fungal member.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             
@@ -916,7 +916,7 @@
                             <br><span class="dataset-description">Draft genome assembly for the w15 bacterial member originally reported as S. multivorum.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             
@@ -932,7 +932,7 @@
                             <br><span class="dataset-description">Draft genome assembly for the C. freundii so4 bacterial member.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.html
+++ b/docs/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.html
@@ -928,7 +928,7 @@
                             <br><span class="dataset-description">Genome-resolved stable-isotope-probing study reconstructing hydrocarbon-degradation pathways from DWH sea-surface and deep-plume enrichment communities.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.html
+++ b/docs/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.html
@@ -859,7 +859,7 @@
                             <br><span class="dataset-description">GEO microarray dataset for strain 195 grown in isolation, DvH/195 coculture, and related triculture conditions.</span>
                             
                         </td>
-                        <td><span class="role-badge">METATRANSCRIPTOME</span></td>
+                        <td><span class="role-badge">METATRANSCRIPTOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.html
+++ b/docs/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.html
@@ -908,7 +908,7 @@
                             <br><span class="dataset-description">GEO dataset for Dhc195 transcriptomic responses in defined DvH, PfR7, and triculture conditions.</span>
                             
                         </td>
-                        <td><span class="role-badge">METATRANSCRIPTOME</span></td>
+                        <td><span class="role-badge">METATRANSCRIPTOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.html
+++ b/docs/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.html
@@ -810,7 +810,7 @@
                             <br><span class="dataset-description">Genome project for D. mccartyi 195, the TCE-dechlorinating partner in the coculture.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             
@@ -826,7 +826,7 @@
                             <br><span class="dataset-description">Genome project containing the SFB93 acetylene-fermenting partner.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             

--- a/docs/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.html
+++ b/docs/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.html
@@ -838,7 +838,7 @@
                             <br><span class="dataset-description">NCBI BioProject for the complete genome of D. mccartyi 195, the dechlorinating partner in the coculture.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             
@@ -854,7 +854,7 @@
                             <br><span class="dataset-description">NCBI BioProject for S. wolfei subsp. wolfei strain Goettingen G311, the butyrate-fermenting syntrophic partner.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             

--- a/docs/communities/ENIGMA_Denitrifying_SynCom.html
+++ b/docs/communities/ENIGMA_Denitrifying_SynCom.html
@@ -720,7 +720,7 @@
                             <br><span class="dataset-description">Raw sequencing data for transcriptomics analysis of monoculture and SynCom contexts.</span>
                             
                         </td>
-                        <td><span class="role-badge">METATRANSCRIPTOME</span></td>
+                        <td><span class="role-badge">METATRANSCRIPTOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             
@@ -736,7 +736,7 @@
                             <br><span class="dataset-description">Mass spectrometry proteomics data deposited through PRIDE/ProteomeXchange.</span>
                             
                         </td>
-                        <td><span class="role-badge">METAPROTEOME</span></td>
+                        <td><span class="role-badge">METAPROTEOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             
@@ -752,7 +752,7 @@
                             <br><span class="dataset-description">Genome resource used for R12-specific transcript quantification and modeling.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             
@@ -768,7 +768,7 @@
                             <br><span class="dataset-description">Genome resource used for 3H11-specific transcript quantification and modeling.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             

--- a/docs/communities/East_River_Floodplain_Core_Microbiome.html
+++ b/docs/communities/East_River_Floodplain_Core_Microbiome.html
@@ -825,7 +825,7 @@
                             <br><span class="dataset-description">Umbrella BioProject for East River floodplain metagenome and metatranscriptome datasets.</span>
                             
                         </td>
-                        <td><span class="role-badge">METAGENOME</span></td>
+                        <td><span class="role-badge">METAGENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             
@@ -841,7 +841,7 @@
                             <br><span class="dataset-description">ESS-DIVE data package containing representative genomes and environmental metadata for East River floodplain microbiome analyses.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/East_River_Hillslope_Riparian_Transect_Community.html
+++ b/docs/communities/East_River_Hillslope_Riparian_Transect_Community.html
@@ -932,7 +932,7 @@
                             <br><span class="dataset-description">NCBI BioProject record for a DOE JGI East River watershed hillslope metagenome sample associated with groundwater sediment microbial communities from the East River, Colorado.</span>
                             
                         </td>
-                        <td><span class="role-badge">METAGENOME</span></td>
+                        <td><span class="role-badge">METAGENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             

--- a/docs/communities/EcoFAB_Ring_Trial_SynCom17.html
+++ b/docs/communities/EcoFAB_Ring_Trial_SynCom17.html
@@ -1974,7 +1974,7 @@
                             <br><span class="dataset-description">Annotated whole genome sequences for all 17 SynCom bacterial isolates, searchable by isolate name or GOLD Project ID.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>JGI_IMG</td>
                         <td>
                             

--- a/docs/communities/GLBRC_Populus_Variovorax_SynCom28.html
+++ b/docs/communities/GLBRC_Populus_Variovorax_SynCom28.html
@@ -1864,7 +1864,7 @@
                             <br><span class="dataset-description">Strain-resolved metagenomic sequencing reads for rhizosphere and endosphere colonization analyses.</span>
                             
                         </td>
-                        <td><span class="role-badge">METAGENOME</span></td>
+                        <td><span class="role-badge">METAGENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             

--- a/docs/communities/GLBRC_UFMP_Fermentation_Community.html
+++ b/docs/communities/GLBRC_UFMP_Fermentation_Community.html
@@ -1089,7 +1089,7 @@
 </span>
                             
                         </td>
-                        <td><span class="role-badge">METAGENOME</span></td>
+                        <td><span class="role-badge">METAGENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             

--- a/docs/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.html
+++ b/docs/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.html
@@ -945,7 +945,7 @@
                             <br><span class="dataset-description">Raw mass spectra for the metaproteomics study of the high-solids switchgrass microbiome.</span>
                             
                         </td>
-                        <td><span class="role-badge">METAPROTEOME</span></td>
+                        <td><span class="role-badge">METAPROTEOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             
@@ -961,7 +961,7 @@
                             <br><span class="dataset-description">ProteomeXchange record for the metaproteomics data from the high-solids switchgrass microbiome.</span>
                             
                         </td>
-                        <td><span class="role-badge">METAPROTEOME</span></td>
+                        <td><span class="role-badge">METAPROTEOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.html
+++ b/docs/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.html
@@ -1135,7 +1135,7 @@
 </span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/MSC2_Model_Soil_Consortium.html
+++ b/docs/communities/MSC2_Model_Soil_Consortium.html
@@ -775,7 +775,7 @@
                             <br><span class="dataset-description">BioProject containing the eight isolate genome assemblies used for MSC-2.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             
@@ -791,7 +791,7 @@
                             <br><span class="dataset-description">PNNL DataHub record linking the MSC-2 isolate genome assemblies and accessions.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             
@@ -823,7 +823,7 @@
                             <br><span class="dataset-description">Metatranscriptomic data from MSC-2 chitin growth assays.</span>
                             
                         </td>
-                        <td><span class="role-badge">METATRANSCRIPTOME</span></td>
+                        <td><span class="role-badge">METATRANSCRIPTOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Mercury_SFA_EFPC_Sediment_Community.html
+++ b/docs/communities/Mercury_SFA_EFPC_Sediment_Community.html
@@ -1106,7 +1106,7 @@
 </span>
                             
                         </td>
-                        <td><span class="role-badge">METAGENOME</span></td>
+                        <td><span class="role-badge">METAGENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             

--- a/docs/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.html
+++ b/docs/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.html
@@ -756,7 +756,7 @@
                             <br><span class="dataset-description">NCBI genome assembly for the M. marinum S8 methanotroph.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             
@@ -772,7 +772,7 @@
                             <br><span class="dataset-description">NCBI genome assembly for the C. necator NBRC 102504 partner.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.html
+++ b/docs/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.html
@@ -762,7 +762,7 @@
                             <br><span class="dataset-description">BioProject for the complete genome of the Gela4 methylotrophic partner used in the coculture.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             
@@ -778,7 +778,7 @@
                             <br><span class="dataset-description">DDBJ Sequence Read Archive RNA-seq dataset comparing Gela4 pure culture and methane-fed Gela4/S8 coculture conditions.</span>
                             
                         </td>
-                        <td><span class="role-badge">METATRANSCRIPTOME</span></td>
+                        <td><span class="role-badge">METATRANSCRIPTOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Mushroom_Spring_Hot_Spring_Phototrophic_Mat_Community.html
+++ b/docs/communities/Mushroom_Spring_Hot_Spring_Phototrophic_Mat_Community.html
@@ -962,7 +962,7 @@
 </span>
                             
                         </td>
-                        <td><span class="role-badge">METATRANSCRIPTOME</span></td>
+                        <td><span class="role-badge">METATRANSCRIPTOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             
@@ -979,7 +979,7 @@
 </span>
                             
                         </td>
-                        <td><span class="role-badge">METAGENOME</span></td>
+                        <td><span class="role-badge">METAGENOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/OMM12_Gnotobiotic_Mouse_Gut_Community.html
+++ b/docs/communities/OMM12_Gnotobiotic_Mouse_Gut_Community.html
@@ -649,7 +649,7 @@
                             <br><span class="dataset-description">Genome announcement reporting high-quality whole-genome sequences for the Oligo-MM12 strains.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.html
+++ b/docs/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.html
@@ -887,7 +887,7 @@
                             <br><span class="dataset-description">GEO series for strand-specific RNA-seq comparing P. thermopropionicum and M. conradii monocultures with the syntrophic coculture.</span>
                             
                         </td>
-                        <td><span class="role-badge">METATRANSCRIPTOME</span></td>
+                        <td><span class="role-badge">METATRANSCRIPTOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.html
+++ b/docs/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.html
@@ -1012,7 +1012,7 @@
                             <br><span class="dataset-description">DOE JGI Genome Portal project for raw reads, trimmed reads, assemblies, and quality-control reports from &#34;Seasonal Sulfur Cycling as a Control on Methane Flux in Carbon-Rich Prairie Pothole Sediment Ecosystems.&#34;</span>
                             
                         </td>
-                        <td><span class="role-badge">METAGENOME</span></td>
+                        <td><span class="role-badge">METAGENOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/SIHUMIx_Human_Intestinal_Model_Community.html
+++ b/docs/communities/SIHUMIx_Human_Intestinal_Model_Community.html
@@ -968,7 +968,7 @@
                             <br><span class="dataset-description">Multi-omics study identifying community-relevant small proteins in SIHUMIx.</span>
                             
                         </td>
-                        <td><span class="role-badge">METAPROTEOME</span></td>
+                        <td><span class="role-badge">METAPROTEOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/SPRUCE_Peatland_Methane_Cycling_Community.html
+++ b/docs/communities/SPRUCE_Peatland_Methane_Cycling_Community.html
@@ -735,7 +735,7 @@
                             <br><span class="dataset-description">Public NCBI BioProject ranges containing raw metagenomic sequences from SPRUCE peat samples.</span>
                             
                         </td>
-                        <td><span class="role-badge">METAGENOME</span></td>
+                        <td><span class="role-badge">METAGENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             
@@ -751,7 +751,7 @@
                             <br><span class="dataset-description">NCBI BioProject containing metagenome-assembled genomes analyzed for the SPRUCE peat microbial community.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             
@@ -767,7 +767,7 @@
                             <br><span class="dataset-description">Mass spectrometry proteomics datasets associated with the SPRUCE warming metagenome study.</span>
                             
                         </td>
-                        <td><span class="role-badge">METAPROTEOME</span></td>
+                        <td><span class="role-badge">METAPROTEOMICS</span></td>
                         <td>MASSIVE</td>
                         <td>
                             

--- a/docs/communities/Saccharomyces_Chlamydomonas_Fungal_Algal_Mutualism.html
+++ b/docs/communities/Saccharomyces_Chlamydomonas_Fungal_Algal_Mutualism.html
@@ -783,7 +783,7 @@
                             <br><span class="dataset-description">Raw sequencing data for the later exact-composition S. cerevisiae-C. reinhardtii experimental-evolution study.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             

--- a/docs/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.html
+++ b/docs/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.html
@@ -824,7 +824,7 @@
                             <br><span class="dataset-description">GEO Series for transcriptomic measurements from the multispecies exoelectrogenic biofilm community in bioelectrochemical systems.</span>
                             
                         </td>
-                        <td><span class="role-badge">METATRANSCRIPTOME</span></td>
+                        <td><span class="role-badge">METATRANSCRIPTOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.html
+++ b/docs/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.html
@@ -931,7 +931,7 @@
                             <br><span class="dataset-description">ProteomeXchange/iProX dataset associated with the S. elongatus cscB and P. putida cscRABY synthetic coculture multi-omics study.</span>
                             
                         </td>
-                        <td><span class="role-badge">METAPROTEOME</span></td>
+                        <td><span class="role-badge">METAPROTEOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.html
+++ b/docs/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.html
@@ -854,7 +854,7 @@
                             <br><span class="dataset-description">Genome assembly for S. gentianae DSM 8423/HQG1, the benzoate-degrading bacterial species.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             
@@ -870,7 +870,7 @@
                             <br><span class="dataset-description">JGI IMG genome resource for S. gentianae DSM 8423.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>JGI_IMG</td>
                         <td>
                             

--- a/docs/communities/THOR_Rhizosphere_Model_Community.html
+++ b/docs/communities/THOR_Rhizosphere_Model_Community.html
@@ -804,7 +804,7 @@
                             <br><span class="dataset-description">Comparative metatranscriptomics study of THOR pairwise and full-community interactions.</span>
                             
                         </td>
-                        <td><span class="role-badge">METATRANSCRIPTOME</span></td>
+                        <td><span class="role-badge">METATRANSCRIPTOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/TYQ1_Nematode_Biocontrol_SynCom.html
+++ b/docs/communities/TYQ1_Nematode_Biocontrol_SynCom.html
@@ -1010,7 +1010,7 @@
                             <br><span class="dataset-description">Transcriptomic data for understanding gene expression in TYQ1-centered SynCom during nematode biocontrol.</span>
                             
                         </td>
-                        <td><span class="role-badge">METATRANSCRIPTOME</span></td>
+                        <td><span class="role-badge">METATRANSCRIPTOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             

--- a/docs/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.html
+++ b/docs/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.html
@@ -827,7 +827,7 @@
                             <br><span class="dataset-description">Public RNA-seq data associated with pairwise T. pseudonana coculture experiments.</span>
                             
                         </td>
-                        <td><span class="role-badge">METATRANSCRIPTOME</span></td>
+                        <td><span class="role-badge">METATRANSCRIPTOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             

--- a/docs/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.html
+++ b/docs/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.html
@@ -880,7 +880,7 @@
                             <br><span class="dataset-description">Genome sequencing project for T. phaeum DSM 12270 strain PB, the bacterial member of this syntrophic coculture.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             

--- a/docs/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.html
+++ b/docs/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.html
@@ -849,7 +849,7 @@
                             <br><span class="dataset-description">Genome project for T. maritima MSB8, the fermentative bacterial member.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             
@@ -865,7 +865,7 @@
                             <br><span class="dataset-description">Genome project for M. jannaschii DSM 2661, the methanogenic archaeal member.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             

--- a/docs/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.html
+++ b/docs/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.html
@@ -866,7 +866,7 @@
                             <br><span class="dataset-description">Genome assembly for T. flocculiformis ES5/DSM 23957, the fermentative strain added to the coculture.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             
@@ -882,7 +882,7 @@
                             <br><span class="dataset-description">JGI IMG genome resource for T. flocculiformis DSM 23957.</span>
                             
                         </td>
-                        <td><span class="role-badge">GENOME</span></td>
+                        <td><span class="role-badge">GENOMICS</span></td>
                         <td>JGI_IMG</td>
                         <td>
                             

--- a/docs/communities/Trichodesmium_Alteromonas_Marine_Consortium.html
+++ b/docs/communities/Trichodesmium_Alteromonas_Marine_Consortium.html
@@ -816,7 +816,7 @@
                             <br><span class="dataset-description">Publication reporting metatranscriptome sequencing of Trichodesmium colonies from the North Pacific Subtropical Gyre.</span>
                             
                         </td>
-                        <td><span class="role-badge">METATRANSCRIPTOME</span></td>
+                        <td><span class="role-badge">METATRANSCRIPTOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.html
+++ b/docs/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.html
@@ -910,7 +910,7 @@
                             <br><span class="dataset-description">NCBI BioProject for metagenome data from the wetland soil incubation treated with sulfate and oxygen.</span>
                             
                         </td>
-                        <td><span class="role-badge">METAGENOME</span></td>
+                        <td><span class="role-badge">METAGENOMICS</span></td>
                         <td>NCBI_BIOPROJECT</td>
                         <td>
                             
@@ -926,7 +926,7 @@
                             <br><span class="dataset-description">ProteomeXchange/PRIDE dataset linked to the wetland soil incubation treated with sulfate and oxygen.</span>
                             
                         </td>
-                        <td><span class="role-badge">METAPROTEOME</span></td>
+                        <td><span class="role-badge">METAPROTEOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/docs/communities/Yogurt_TwoSpecies_Starter_Culture.html
+++ b/docs/communities/Yogurt_TwoSpecies_Starter_Culture.html
@@ -939,7 +939,7 @@
                             <br><span class="dataset-description">Transcriptomic and proteomic analysis of S. thermophilus LMG 18311 cocultured in milk with L. delbrueckii subsp. bulgaricus ATCC 11842.</span>
                             
                         </td>
-                        <td><span class="role-badge">METATRANSCRIPTOME</span></td>
+                        <td><span class="role-badge">METATRANSCRIPTOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             
@@ -955,7 +955,7 @@
                             <br><span class="dataset-description">Mixed-culture transcriptome study of S. thermophilus CNRZ1066 and L. bulgaricus ATCC BAA-365 during batch mixed-culture growth in milk.</span>
                             
                         </td>
-                        <td><span class="role-badge">METATRANSCRIPTOME</span></td>
+                        <td><span class="role-badge">METATRANSCRIPTOMICS</span></td>
                         <td>OTHER</td>
                         <td>
                             

--- a/src/communitymech/templates/community.html
+++ b/src/communitymech/templates/community.html
@@ -608,7 +608,7 @@
                     {% for ds in community.associated_datasets %}
                     <tr>
                         <td>
-                            <strong>{{ ds.name }}</strong>
+                            <strong>{{ ds.title or ds.accession }}</strong>
                             {% if ds.description %}
                             <br><span class="dataset-description">{{ ds.description }}</span>
                             {% endif %}
@@ -628,6 +628,58 @@
             </table>
         </section>
         {% endif %}
+        {%- if community.discussions %}
+        <section id="discussions">
+            <h2>Knowledge gaps &amp; discussions <span class="muted">({{ community.discussions|length }})</span></h2>
+            {% for d in community.discussions %}
+            <div class="discussion">
+                <h3>
+                    {% if d.kind %}<span class="role-badge">{{ d.kind }}</span>{% endif %}
+                    {% if d.status %}<span class="role-badge">{{ d.status }}</span>{% endif %}
+                    {{ d.prompt }}
+                </h3>
+                {% if d.rationale %}<p class="prewrap">{{ d.rationale }}</p>{% endif %}
+                {% if d.attaches_to %}
+                <p class="muted small">Attaches to: {% for a in d.attaches_to %}<code>{{ a }}</code>{% if not loop.last %}, {% endif %}{% endfor %}</p>
+                {% endif %}
+                {% if d.proposed_experiments %}
+                <details>
+                    <summary class="muted small">{{ d.proposed_experiments|length }} proposed experiment(s)</summary>
+                    {% for exp in d.proposed_experiments %}
+                    <div class="experiment">
+                        <strong>{{ exp.name or exp.experiment_id or 'Experiment ' ~ loop.index }}</strong>
+                        {% if exp.approach %}<br><span class="small">Approach: {{ exp.approach }}</span>{% endif %}
+                        {% if exp.decision_criterion %}<br><span class="small">Decision: {{ exp.decision_criterion }}</span>{% endif %}
+                    </div>
+                    {% endfor %}
+                </details>
+                {% endif %}
+                {% if d.evidence %}
+                <details class="evidence-list">
+                    <summary class="muted small">{{ d.evidence|length }} evidence item(s)</summary>
+                    {% for ev in d.evidence %}
+                    <div class="evidence">
+                        <div class="evidence-head">
+                            {% if ev.evidence_source %}<span class="badge small">{{ ev.evidence_source }}</span>{% endif %}
+                            {% if ev.supports %}<span class="badge small">{{ ev.supports }}</span>{% endif %}
+                            {% if ev.reference %}
+                                {% set ref = ev.reference %}
+                                {% if ref.startswith('PMID:') %}
+                                <a href="https://pubmed.ncbi.nlm.nih.gov/{{ ref|replace('PMID:','') }}/" rel="nofollow noreferrer">{{ ref }}</a>
+                                {% else %}{{ ref }}{% endif %}
+                            {% endif %}
+                        </div>
+                        {% if ev.snippet %}<p class="snippet small prewrap">{{ ev.snippet }}</p>{% endif %}
+                        {% if ev.explanation %}<p class="muted small prewrap">{{ ev.explanation }}</p>{% endif %}
+                    </div>
+                    {% endfor %}
+                </details>
+                {% endif %}
+                {% if d.resolution_note %}<p class="small"><em>Resolution:</em> {{ d.resolution_note }}</p>{% endif %}
+            </div>
+            {% endfor %}
+        </section>
+        {%- endif %}
 
         <!-- Environmental Factors -->
         {% if community.external_resources %}


### PR DESCRIPTION
Surfaces the new shared sections in per-community HTML. Fixes the Associated Datasets table for the migrated `Dataset` shape (`ds.name`→`ds.title`; 50 dataset-bearing pages re-rendered) and adds a **Knowledge gaps & discussions** section (kind/status, prompt, rationale, `attaches_to`, proposed experiments, SupportingReference evidence). Trim-guarded so discussion-less communities are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)