### PR TITLE
Wire knowledge-gap scan recipe + config (claw#7 Item 2)

### DIFF
--- a/conf/kgscan_config.yaml
+++ b/conf/kgscan_config.yaml
@@ -1,0 +1,10 @@
+# CommunityMech knowledge-gap scan config — drives kg_microbe_kgscan (in culturebotai-claw).
+# Europe PMC (free) per-record gap-signal search over community records.
+repo_name: CommunityMech
+record_glob: ../kb/communities/*.yaml
+name_fields: [name]
+synonym_field: synonyms
+id_field: id
+discussions_field: discussions
+topic_context_terms: ["microbial community", "microbiome", "consortium", "syntrophy", "co-culture"]
+min_score: 8

--- a/justfile
+++ b/justfile
@@ -199,6 +199,14 @@ gen-qc-dashboard:
     PYTHONPATH=../../culturebotai-claw/src /opt/homebrew/bin/python3.13 \
       -m kg_microbe_qc --config conf/qc_config.yaml --output dashboard
 
+# Knowledge-gap scan (Europe PMC, free) via shared kg_microbe_kgscan in claw.
+# Dry-run by default → reports/knowledge_gap_scan.{json,md}. Pass `--apply`
+# (and e.g. --limit/--min-score) to seed Discussion(kind=KNOWLEDGE_GAP).
+# Nested repo → PYTHONPATH is ../../culturebotai-claw/src.
+knowledge-gap-scan *args:
+    PYTHONPATH=../../culturebotai-claw/src /opt/homebrew/bin/python3.13 \
+      -m kg_microbe_kgscan --config conf/kgscan_config.yaml {{args}}
+
 # Generate all HTML (communities + UMAP)
 gen-all: gen-html gen-umap
     @echo "✅ All HTML pages regenerated"


### PR DESCRIPTION
Adds `conf/kgscan_config.yaml` + a `knowledge-gap-scan` recipe (shared `kg_microbe_kgscan`, free Europe PMC; nested-repo PYTHONPATH `../../culturebotai-claw/src`). Initial seed found 0 strong gaps — community labels are long specific phrases that phrase-match Europe PMC poorly — so no records are auto-written here; recipe is wired for triage/tuning. Consistent with the TraitMech/MIM wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)