### PR TITLE
skills: sharpen manage-identifiers description

### DIFF
--- a/.claude/skills/manage-identifiers/skill.md
+++ b/.claude/skills/manage-identifiers/skill.md
@@ -1,6 +1,6 @@
 ---
 name: manage-identifiers
-description: Generic identifier management for X-Mech repositories - finding highest IDs, minting new IDs, and adding records with proper ID placement
+description: Use this skill to manage CommunityMech record identifiers — find the highest existing CommunityMech id, mint the next id, and insert new community records with correct id placement. Use when adding or importing community records, or reconciling id collisions.
 category: workflow
 requires_database: false
 requires_internet: false


### PR DESCRIPTION
Per [author-skills guidance](https://ai4curation.io/aidocs/how-tos/author-skills/): replaced the placeholder "Generic identifier management for X-Mech repositories" with a CommunityMech-specific "Use when…" description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)