### PR TITLE
Schema: cultivation hardware setup (instrument + mode) + standardized vocab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,9 @@ src/communitymech/
 kb/communities/                  # curated community YAML files (root class MicrobialCommunity)
 kb/taxa/                          # reusable per-taxon gene records (root class CommonTaxon);
                                   #   referenced from taxonomy[].common_taxon; `just validate-taxa`
+vocab/                            # controlled-vocabulary staging files (e.g. cultivation_terms.yaml):
+                                  #   definitions/synonyms/ontology-mapping for METPO proposals;
+                                  #   kept in sync with the schema enums by tests/
 conf/oak_config.yaml             # OAK ontology adapter config (NCBITaxon, ENVO, CHEBI, GO)
 references_cache/                # Cached PubMed abstracts (committed for reproducibility)
 scripts/                         # Utility scripts for curation (not part of package)

--- a/kb/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.yaml
+++ b/kb/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.yaml
@@ -36,6 +36,16 @@ engineering_design:
     evidence_source: IN_VITRO
     snippet: consequence of the applied anode potential
     explanation: Supports anode potential as the experimental perturbation.
+cultivation_setup:
+- system_type: BIOELECTROCHEMICAL_SYSTEM
+  instrument_detail: Anode-associated bioelectrochemical reactor with a poised working electrode.
+  electrode_detail: Applied anode (working-electrode) potential was varied across the study.
+  evidence:
+  - reference: PMID:28087529
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: consequence of the applied anode potential
+    explanation: Anchors the anode-poised bioelectrochemical setup used to grow the biofilm.
 environment_term:
   preferred_term: anode-associated bioelectrochemical reactor biofilm
   term:

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-06-17T20:26:35
+# Generation date: 2026-06-19T17:47:32
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech
@@ -22,8 +22,8 @@ from linkml_runtime.utils.slot import Slot
 from linkml_runtime.utils.yamlutils import YAMLRoot, extended_float, extended_int, extended_str
 from rdflib import Namespace, URIRef
 
-from linkml_runtime.linkml_model.types import Boolean, Datetime, Float, String
-from linkml_runtime.utils.metamodelcore import Bool, XSDDateTime
+from linkml_runtime.linkml_model.types import Boolean, Date, Datetime, Float, Integer, String, Uri
+from linkml_runtime.utils.metamodelcore import Bool, URI, XSDDate, XSDDateTime
 
 metamodel_version = "1.7.0"
 version = None
@@ -34,11 +34,13 @@ CL = CurieNamespace("CL", "http://purl.obolibrary.org/obo/CL_")
 ENVO = CurieNamespace("ENVO", "http://purl.obolibrary.org/obo/ENVO_")
 GO = CurieNamespace("GO", "http://purl.obolibrary.org/obo/GO_")
 NCBITAXON = CurieNamespace("NCBITaxon", "http://purl.obolibrary.org/obo/NCBITaxon_")
+OBI = CurieNamespace("OBI", "http://purl.obolibrary.org/obo/OBI_")
 PMID = CurieNamespace("PMID", "http://www.ncbi.nlm.nih.gov/pubmed/")
 UBERON = CurieNamespace("UBERON", "http://purl.obolibrary.org/obo/UBERON_")
 COMMUNITYMECH = CurieNamespace("communitymech", "https://w3id.org/communitymech/")
 DOI = CurieNamespace("doi", "https://doi.org/")
 LINKML = CurieNamespace("linkml", "https://w3id.org/linkml/")
+MECH_SHARED = CurieNamespace("mech_shared", "https://w3id.org/kg-microbe/mech-shared/")
 RDFS = CurieNamespace("rdfs", "http://www.w3.org/2000/01/rdf-schema#")
 XSD = CurieNamespace("xsd", "http://www.w3.org/2001/XMLSchema#")
 DEFAULT_ = COMMUNITYMECH
@@ -912,61 +914,6 @@ class RelatedIngredient(YAMLRoot):
 
 
 @dataclass(repr=False)
-class AssociatedDataset(YAMLRoot):
-    """
-    An omics or other dataset associated with the community
-    """
-
-    _inherited_slots: ClassVar[list[str]] = []
-
-    class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["AssociatedDataset"]
-    class_class_curie: ClassVar[str] = "communitymech:AssociatedDataset"
-    class_name: ClassVar[str] = "AssociatedDataset"
-    class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.AssociatedDataset
-
-    name: str = None
-    dataset_type: Union[str, "DatasetTypeEnum"] = None
-    accession: str = None
-    repository: Optional[Union[str, "DatasetRepositoryEnum"]] = None
-    url: Optional[str] = None
-    description: Optional[str] = None
-    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
-        empty_list()
-    )
-
-    def __post_init__(self, *_: str, **kwargs: Any):
-        if self._is_empty(self.name):
-            self.MissingRequiredField("name")
-        if not isinstance(self.name, str):
-            self.name = str(self.name)
-
-        if self._is_empty(self.dataset_type):
-            self.MissingRequiredField("dataset_type")
-        if not isinstance(self.dataset_type, DatasetTypeEnum):
-            self.dataset_type = DatasetTypeEnum(self.dataset_type)
-
-        if self._is_empty(self.accession):
-            self.MissingRequiredField("accession")
-        if not isinstance(self.accession, str):
-            self.accession = str(self.accession)
-
-        if self.repository is not None and not isinstance(self.repository, DatasetRepositoryEnum):
-            self.repository = DatasetRepositoryEnum(self.repository)
-
-        if self.url is not None and not isinstance(self.url, str):
-            self.url = str(self.url)
-
-        if self.description is not None and not isinstance(self.description, str):
-            self.description = str(self.description)
-
-        self._normalize_inlined_as_dict(
-            slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False
-        )
-
-        super().__post_init__(**kwargs)
-
-
-@dataclass(repr=False)
 class ExternalResource(YAMLRoot):
     """
     An external model or narrative resource linked to the community
@@ -1082,6 +1029,137 @@ class CommunityEngineeringDesign(YAMLRoot):
 
 
 @dataclass(repr=False)
+class CultivationSetup(YAMLRoot):
+    """
+    Hardware/instrumentation and cultivation mode used to grow or sustain the community. Optional — not all
+    communities have a defined setup. Captures both the system (e.g. stirred-tank bioreactor, photobioreactor,
+    microbial fuel cell) and the operating approach (batch, fed-batch, continuous, …). Complements GrowthMedia (medium
+    composition/conditions); the controlled cultivation_mode/system_type values are the preferred standardized home
+    for vessel/reactor information going forward (vs the legacy free-text GrowthMedia.vessel_type).
+    """
+
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["CultivationSetup"]
+    class_class_curie: ClassVar[str] = "communitymech:CultivationSetup"
+    class_name: ClassVar[str] = "CultivationSetup"
+    class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.CultivationSetup
+
+    cultivation_mode: Optional[Union[str, "CultivationModeEnum"]] = None
+    system_type: Optional[Union[str, "CultivationSystemEnum"]] = None
+    instrument_detail: Optional[str] = None
+    manufacturer_model: Optional[str] = None
+    working_volume: Optional[float] = None
+    working_volume_unit: Optional[str] = None
+    operating_temperature: Optional[float] = None
+    operating_temperature_unit: Optional[str] = None
+    feed_or_dilution_rate: Optional[float] = None
+    feed_or_dilution_rate_unit: Optional[str] = None
+    retention_time: Optional[float] = None
+    retention_time_unit: Optional[str] = None
+    retention_time_type: Optional[str] = None
+    applied_potential: Optional[float] = None
+    applied_potential_unit: Optional[str] = None
+    electrode_detail: Optional[str] = None
+    ph_controlled: Optional[Union[bool, Bool]] = None
+    do_controlled: Optional[Union[bool, Bool]] = None
+    temperature_controlled: Optional[Union[bool, Bool]] = None
+    controls_notes: Optional[str] = None
+    protocol_url: Optional[str] = None
+    notes: Optional[str] = None
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
+        empty_list()
+    )
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self.cultivation_mode is not None and not isinstance(
+            self.cultivation_mode, CultivationModeEnum
+        ):
+            self.cultivation_mode = CultivationModeEnum(self.cultivation_mode)
+
+        if self.system_type is not None and not isinstance(self.system_type, CultivationSystemEnum):
+            self.system_type = CultivationSystemEnum(self.system_type)
+
+        if self.instrument_detail is not None and not isinstance(self.instrument_detail, str):
+            self.instrument_detail = str(self.instrument_detail)
+
+        if self.manufacturer_model is not None and not isinstance(self.manufacturer_model, str):
+            self.manufacturer_model = str(self.manufacturer_model)
+
+        if self.working_volume is not None and not isinstance(self.working_volume, float):
+            self.working_volume = float(self.working_volume)
+
+        if self.working_volume_unit is not None and not isinstance(self.working_volume_unit, str):
+            self.working_volume_unit = str(self.working_volume_unit)
+
+        if self.operating_temperature is not None and not isinstance(
+            self.operating_temperature, float
+        ):
+            self.operating_temperature = float(self.operating_temperature)
+
+        if self.operating_temperature_unit is not None and not isinstance(
+            self.operating_temperature_unit, str
+        ):
+            self.operating_temperature_unit = str(self.operating_temperature_unit)
+
+        if self.feed_or_dilution_rate is not None and not isinstance(
+            self.feed_or_dilution_rate, float
+        ):
+            self.feed_or_dilution_rate = float(self.feed_or_dilution_rate)
+
+        if self.feed_or_dilution_rate_unit is not None and not isinstance(
+            self.feed_or_dilution_rate_unit, str
+        ):
+            self.feed_or_dilution_rate_unit = str(self.feed_or_dilution_rate_unit)
+
+        if self.retention_time is not None and not isinstance(self.retention_time, float):
+            self.retention_time = float(self.retention_time)
+
+        if self.retention_time_unit is not None and not isinstance(self.retention_time_unit, str):
+            self.retention_time_unit = str(self.retention_time_unit)
+
+        if self.retention_time_type is not None and not isinstance(self.retention_time_type, str):
+            self.retention_time_type = str(self.retention_time_type)
+
+        if self.applied_potential is not None and not isinstance(self.applied_potential, float):
+            self.applied_potential = float(self.applied_potential)
+
+        if self.applied_potential_unit is not None and not isinstance(
+            self.applied_potential_unit, str
+        ):
+            self.applied_potential_unit = str(self.applied_potential_unit)
+
+        if self.electrode_detail is not None and not isinstance(self.electrode_detail, str):
+            self.electrode_detail = str(self.electrode_detail)
+
+        if self.ph_controlled is not None and not isinstance(self.ph_controlled, Bool):
+            self.ph_controlled = Bool(self.ph_controlled)
+
+        if self.do_controlled is not None and not isinstance(self.do_controlled, Bool):
+            self.do_controlled = Bool(self.do_controlled)
+
+        if self.temperature_controlled is not None and not isinstance(
+            self.temperature_controlled, Bool
+        ):
+            self.temperature_controlled = Bool(self.temperature_controlled)
+
+        if self.controls_notes is not None and not isinstance(self.controls_notes, str):
+            self.controls_notes = str(self.controls_notes)
+
+        if self.protocol_url is not None and not isinstance(self.protocol_url, str):
+            self.protocol_url = str(self.protocol_url)
+
+        if self.notes is not None and not isinstance(self.notes, str):
+            self.notes = str(self.notes)
+
+        self._normalize_inlined_as_dict(
+            slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False
+        )
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
 class MicrobialCommunity(YAMLRoot):
     """
     A microbial community with composition and interactions
@@ -1114,15 +1192,18 @@ class MicrobialCommunity(YAMLRoot):
     growth_media: Optional[Union[Union[dict, GrowthMedia], list[Union[dict, GrowthMedia]]]] = (
         empty_list()
     )
+    cultivation_setup: Optional[
+        Union[Union[dict, CultivationSetup], list[Union[dict, CultivationSetup]]]
+    ] = empty_list()
     related_media: Optional[Union[Union[dict, RelatedMedia], list[Union[dict, RelatedMedia]]]] = (
         empty_list()
     )
     related_ingredients: Optional[
         Union[Union[dict, RelatedIngredient], list[Union[dict, RelatedIngredient]]]
     ] = empty_list()
-    associated_datasets: Optional[
-        Union[Union[dict, AssociatedDataset], list[Union[dict, AssociatedDataset]]]
-    ] = empty_list()
+    associated_datasets: Optional[Union[Union[dict, "Dataset"], list[Union[dict, "Dataset"]]]] = (
+        empty_list()
+    )
     external_resources: Optional[
         Union[Union[dict, ExternalResource], list[Union[dict, ExternalResource]]]
     ] = empty_list()
@@ -1199,6 +1280,15 @@ class MicrobialCommunity(YAMLRoot):
             slot_name="growth_media", slot_type=GrowthMedia, key_name="name", keyed=False
         )
 
+        if not isinstance(self.cultivation_setup, list):
+            self.cultivation_setup = (
+                [self.cultivation_setup] if self.cultivation_setup is not None else []
+            )
+        self.cultivation_setup = [
+            v if isinstance(v, CultivationSetup) else CultivationSetup(**as_dict(v))
+            for v in self.cultivation_setup
+        ]
+
         if not isinstance(self.related_media, list):
             self.related_media = [self.related_media] if self.related_media is not None else []
         self.related_media = [
@@ -1215,12 +1305,13 @@ class MicrobialCommunity(YAMLRoot):
             for v in self.related_ingredients
         ]
 
-        self._normalize_inlined_as_dict(
-            slot_name="associated_datasets",
-            slot_type=AssociatedDataset,
-            key_name="name",
-            keyed=False,
-        )
+        if not isinstance(self.associated_datasets, list):
+            self.associated_datasets = (
+                [self.associated_datasets] if self.associated_datasets is not None else []
+            )
+        self.associated_datasets = [
+            v if isinstance(v, Dataset) else Dataset(**as_dict(v)) for v in self.associated_datasets
+        ]
 
         self._normalize_inlined_as_dict(
             slot_name="external_resources", slot_type=ExternalResource, key_name="name", keyed=False
@@ -1482,6 +1573,297 @@ class GeneAnnotation(YAMLRoot):
         self.evidence = [
             v if isinstance(v, EvidenceItem) else EvidenceItem(**as_dict(v)) for v in self.evidence
         ]
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class SupportingReference(YAMLRoot):
+    """
+    A lightweight literature/database citation supporting a Discussion or Dataset. Self-contained (so this module has
+    no dependency on each repo's EvidenceItem); carries a verbatim `snippet` so the same anti-hallucination
+    snippet-vs-cached-abstract check the Mechs already run can validate it.
+    """
+
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = MECH_SHARED["SupportingReference"]
+    class_class_curie: ClassVar[str] = "mech_shared:SupportingReference"
+    class_name: ClassVar[str] = "SupportingReference"
+    class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.SupportingReference
+
+    reference: str = None
+    reference_title: Optional[str] = None
+    supports: Optional[Union[str, "SupportLevelEnum"]] = None
+    evidence_source: Optional[str] = None
+    snippet: Optional[str] = None
+    explanation: Optional[str] = None
+    notes: Optional[str] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.reference):
+            self.MissingRequiredField("reference")
+        if not isinstance(self.reference, str):
+            self.reference = str(self.reference)
+
+        if self.reference_title is not None and not isinstance(self.reference_title, str):
+            self.reference_title = str(self.reference_title)
+
+        if self.supports is not None and not isinstance(self.supports, SupportLevelEnum):
+            self.supports = SupportLevelEnum(self.supports)
+
+        if self.evidence_source is not None and not isinstance(self.evidence_source, str):
+            self.evidence_source = str(self.evidence_source)
+
+        if self.snippet is not None and not isinstance(self.snippet, str):
+            self.snippet = str(self.snippet)
+
+        if self.explanation is not None and not isinstance(self.explanation, str):
+            self.explanation = str(self.explanation)
+
+        if self.notes is not None and not isinstance(self.notes, str):
+            self.notes = str(self.notes)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class Discussion(YAMLRoot):
+    """
+    A thread-like record of an open question, controversy, curation todo, emerging hypothesis, knowledge gap, or
+    interpretation debate attached to a record or one of its sub-objects. Captures the discourse / knowledge-gap layer
+    of curation. External thread links (GitHub issues, forum posts) are cited via the `evidence` block, not a separate
+    slot.
+    """
+
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = MECH_SHARED["Discussion"]
+    class_class_curie: ClassVar[str] = "mech_shared:Discussion"
+    class_name: ClassVar[str] = "Discussion"
+    class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.Discussion
+
+    discussion_id: str = None
+    prompt: str = None
+    kind: Optional[Union[str, "DiscussionKindEnum"]] = None
+    status: Optional[Union[str, "DiscussionStatusEnum"]] = None
+    attaches_to: Optional[Union[str, list[str]]] = empty_list()
+    rationale: Optional[str] = None
+    proposed_experiments: Optional[
+        Union[Union[dict, "ProposedExperiment"], list[Union[dict, "ProposedExperiment"]]]
+    ] = empty_list()
+    evidence: Optional[
+        Union[Union[dict, SupportingReference], list[Union[dict, SupportingReference]]]
+    ] = empty_list()
+    posed_by: Optional[str] = None
+    posed_date: Optional[Union[str, XSDDate]] = None
+    resolved_date: Optional[Union[str, XSDDate]] = None
+    resolution_note: Optional[str] = None
+    notes: Optional[str] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.discussion_id):
+            self.MissingRequiredField("discussion_id")
+        if not isinstance(self.discussion_id, str):
+            self.discussion_id = str(self.discussion_id)
+
+        if self._is_empty(self.prompt):
+            self.MissingRequiredField("prompt")
+        if not isinstance(self.prompt, str):
+            self.prompt = str(self.prompt)
+
+        if self.kind is not None and not isinstance(self.kind, DiscussionKindEnum):
+            self.kind = DiscussionKindEnum(self.kind)
+
+        if self.status is not None and not isinstance(self.status, DiscussionStatusEnum):
+            self.status = DiscussionStatusEnum(self.status)
+
+        if not isinstance(self.attaches_to, list):
+            self.attaches_to = [self.attaches_to] if self.attaches_to is not None else []
+        self.attaches_to = [v if isinstance(v, str) else str(v) for v in self.attaches_to]
+
+        if self.rationale is not None and not isinstance(self.rationale, str):
+            self.rationale = str(self.rationale)
+
+        if not isinstance(self.proposed_experiments, list):
+            self.proposed_experiments = (
+                [self.proposed_experiments] if self.proposed_experiments is not None else []
+            )
+        self.proposed_experiments = [
+            v if isinstance(v, ProposedExperiment) else ProposedExperiment(**as_dict(v))
+            for v in self.proposed_experiments
+        ]
+
+        if not isinstance(self.evidence, list):
+            self.evidence = [self.evidence] if self.evidence is not None else []
+        self.evidence = [
+            v if isinstance(v, SupportingReference) else SupportingReference(**as_dict(v))
+            for v in self.evidence
+        ]
+
+        if self.posed_by is not None and not isinstance(self.posed_by, str):
+            self.posed_by = str(self.posed_by)
+
+        if self.posed_date is not None and not isinstance(self.posed_date, XSDDate):
+            self.posed_date = XSDDate(self.posed_date)
+
+        if self.resolved_date is not None and not isinstance(self.resolved_date, XSDDate):
+            self.resolved_date = XSDDate(self.resolved_date)
+
+        if self.resolution_note is not None and not isinstance(self.resolution_note, str):
+            self.resolution_note = str(self.resolution_note)
+
+        if self.notes is not None and not isinstance(self.notes, str):
+            self.notes = str(self.notes)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class ProposedExperiment(YAMLRoot):
+    """
+    A lightweight, domain-neutral sketch of an experiment or analysis that could resolve a knowledge gap. Records the
+    idea and how its outcome would decide the gap; intentionally simpler than a full study design.
+    """
+
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = MECH_SHARED["ProposedExperiment"]
+    class_class_curie: ClassVar[str] = "mech_shared:ProposedExperiment"
+    class_name: ClassVar[str] = "ProposedExperiment"
+    class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.ProposedExperiment
+
+    experiment_id: Optional[str] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
+    approach: Optional[str] = None
+    model_systems: Optional[Union[str, list[str]]] = empty_list()
+    perturbations: Optional[Union[str, list[str]]] = empty_list()
+    readouts: Optional[Union[str, list[str]]] = empty_list()
+    decision_criterion: Optional[str] = None
+    would_support: Optional[str] = None
+    would_refute: Optional[str] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self.experiment_id is not None and not isinstance(self.experiment_id, str):
+            self.experiment_id = str(self.experiment_id)
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
+        if self.approach is not None and not isinstance(self.approach, str):
+            self.approach = str(self.approach)
+
+        if not isinstance(self.model_systems, list):
+            self.model_systems = [self.model_systems] if self.model_systems is not None else []
+        self.model_systems = [v if isinstance(v, str) else str(v) for v in self.model_systems]
+
+        if not isinstance(self.perturbations, list):
+            self.perturbations = [self.perturbations] if self.perturbations is not None else []
+        self.perturbations = [v if isinstance(v, str) else str(v) for v in self.perturbations]
+
+        if not isinstance(self.readouts, list):
+            self.readouts = [self.readouts] if self.readouts is not None else []
+        self.readouts = [v if isinstance(v, str) else str(v) for v in self.readouts]
+
+        if self.decision_criterion is not None and not isinstance(self.decision_criterion, str):
+            self.decision_criterion = str(self.decision_criterion)
+
+        if self.would_support is not None and not isinstance(self.would_support, str):
+            self.would_support = str(self.would_support)
+
+        if self.would_refute is not None and not isinstance(self.would_refute, str):
+            self.would_refute = str(self.would_refute)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class Dataset(YAMLRoot):
+    """
+    A reference to a publicly available dataset (omics, sequence, phenotype) relevant to this record. A lightweight
+    repository-accession reference, not a full Datasheets-for-Datasets / DCAT description.
+    """
+
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = MECH_SHARED["Dataset"]
+    class_class_curie: ClassVar[str] = "mech_shared:Dataset"
+    class_name: ClassVar[str] = "Dataset"
+    class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.Dataset
+
+    accession: Optional[str] = None
+    title: Optional[str] = None
+    description: Optional[str] = None
+    organism: Optional[str] = None
+    dataset_type: Optional[Union[str, "DatasetTypeEnum"]] = None
+    repository: Optional[Union[str, "DatasetRepositoryEnum"]] = None
+    sample_types: Optional[Union[str, list[str]]] = empty_list()
+    sample_count: Optional[int] = None
+    conditions: Optional[Union[str, list[str]]] = empty_list()
+    platform: Optional[str] = None
+    url: Optional[Union[str, URI]] = None
+    publication: Optional[str] = None
+    findings: Optional[str] = None
+    evidence: Optional[
+        Union[Union[dict, SupportingReference], list[Union[dict, SupportingReference]]]
+    ] = empty_list()
+    notes: Optional[str] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self.accession is not None and not isinstance(self.accession, str):
+            self.accession = str(self.accession)
+
+        if self.title is not None and not isinstance(self.title, str):
+            self.title = str(self.title)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
+        if self.organism is not None and not isinstance(self.organism, str):
+            self.organism = str(self.organism)
+
+        if self.dataset_type is not None and not isinstance(self.dataset_type, DatasetTypeEnum):
+            self.dataset_type = DatasetTypeEnum(self.dataset_type)
+
+        if self.repository is not None and not isinstance(self.repository, DatasetRepositoryEnum):
+            self.repository = DatasetRepositoryEnum(self.repository)
+
+        if not isinstance(self.sample_types, list):
+            self.sample_types = [self.sample_types] if self.sample_types is not None else []
+        self.sample_types = [v if isinstance(v, str) else str(v) for v in self.sample_types]
+
+        if self.sample_count is not None and not isinstance(self.sample_count, int):
+            self.sample_count = int(self.sample_count)
+
+        if not isinstance(self.conditions, list):
+            self.conditions = [self.conditions] if self.conditions is not None else []
+        self.conditions = [v if isinstance(v, str) else str(v) for v in self.conditions]
+
+        if self.platform is not None and not isinstance(self.platform, str):
+            self.platform = str(self.platform)
+
+        if self.url is not None and not isinstance(self.url, URI):
+            self.url = URI(self.url)
+
+        if self.publication is not None and not isinstance(self.publication, str):
+            self.publication = str(self.publication)
+
+        if self.findings is not None and not isinstance(self.findings, str):
+            self.findings = str(self.findings)
+
+        if not isinstance(self.evidence, list):
+            self.evidence = [self.evidence] if self.evidence is not None else []
+        self.evidence = [
+            v if isinstance(v, SupportingReference) else SupportingReference(**as_dict(v))
+            for v in self.evidence
+        ]
+
+        if self.notes is not None and not isinstance(self.notes, str):
+            self.notes = str(self.notes)
 
         super().__post_init__(**kwargs)
 
@@ -1806,63 +2188,6 @@ class AtmosphereEnum(EnumDefinitionImpl):
     )
 
 
-class DatasetTypeEnum(EnumDefinitionImpl):
-    """
-    Type of omics or other dataset associated with a community
-    """
-
-    METAGENOME = PermissibleValue(text="METAGENOME", description="Shotgun metagenomic sequencing")
-    AMPLICON_16S = PermissibleValue(text="AMPLICON_16S", description="16S rRNA amplicon sequencing")
-    AMPLICON_ITS = PermissibleValue(
-        text="AMPLICON_ITS", description="ITS amplicon sequencing (fungal)"
-    )
-    METATRANSCRIPTOME = PermissibleValue(
-        text="METATRANSCRIPTOME", description="Metatranscriptomic sequencing"
-    )
-    METAPROTEOME = PermissibleValue(text="METAPROTEOME", description="Metaproteomic analysis")
-    METABOLOMICS = PermissibleValue(
-        text="METABOLOMICS", description="Metabolomics (LC-MS, GC-MS, etc.)"
-    )
-    GENOME = PermissibleValue(text="GENOME", description="Isolate whole genome sequencing")
-    PHENOTYPE = PermissibleValue(
-        text="PHENOTYPE", description="Phenotypic measurements (growth, imaging, etc.)"
-    )
-    OTHER = PermissibleValue(text="OTHER", description="Other dataset type")
-
-    _defn = EnumDefinition(
-        name="DatasetTypeEnum",
-        description="Type of omics or other dataset associated with a community",
-    )
-
-
-class DatasetRepositoryEnum(EnumDefinitionImpl):
-    """
-    Data repositories for omics and related datasets
-    """
-
-    NCBI_SRA = PermissibleValue(text="NCBI_SRA", description="NCBI Sequence Read Archive")
-    NCBI_BIOPROJECT = PermissibleValue(text="NCBI_BIOPROJECT", description="NCBI BioProject")
-    NMDC = PermissibleValue(text="NMDC", description="National Microbiome Data Collaborative")
-    JGI_GOLD = PermissibleValue(text="JGI_GOLD", description="JGI Genomes OnLine Database")
-    JGI_IMG = PermissibleValue(text="JGI_IMG", description="JGI Integrated Microbial Genomes")
-    MGNIFY = PermissibleValue(text="MGNIFY", description="MGnify (EBI metagenomics)")
-    METABOLOMICS_WORKBENCH = PermissibleValue(
-        text="METABOLOMICS_WORKBENCH", description="Metabolomics Workbench"
-    )
-    MASSIVE = PermissibleValue(text="MASSIVE", description="MassIVE mass spectrometry data")
-    GNPS = PermissibleValue(
-        text="GNPS", description="Global Natural Products Social Molecular Networking"
-    )
-    FIGSHARE = PermissibleValue(text="FIGSHARE", description="Figshare data repository")
-    ZENODO = PermissibleValue(text="ZENODO", description="Zenodo data repository")
-    OTHER = PermissibleValue(text="OTHER", description="Other data repository")
-
-    _defn = EnumDefinition(
-        name="DatasetRepositoryEnum",
-        description="Data repositories for omics and related datasets",
-    )
-
-
 class ExternalResourceRepositoryEnum(EnumDefinitionImpl):
     """
     External repositories and platforms that host community model resources
@@ -2058,6 +2383,327 @@ class MetalRelevanceEnum(EnumDefinitionImpl):
     _defn = EnumDefinition(
         name="MetalRelevanceEnum",
         description="Relevance of metals/REE to community function",
+    )
+
+
+class CultivationModeEnum(EnumDefinitionImpl):
+    """
+    Operating mode / approach used to cultivate the community. Standardized terms maintained in
+    vocab/cultivation_terms.yaml (kept in sync by tests/test_cultivation_vocab_sync.py) and staged for a METPO
+    proposal.
+    """
+
+    BATCH = PermissibleValue(
+        text="BATCH",
+        description="Closed culture with no nutrient addition or removal after inoculation.",
+    )
+    FED_BATCH = PermissibleValue(
+        text="FED_BATCH",
+        description="Nutrients fed during the run, with no removal of culture broth.",
+    )
+    CONTINUOUS = PermissibleValue(
+        text="CONTINUOUS",
+        description="Fresh medium added and culture withdrawn continuously, typically at steady state.",
+    )
+    SEMI_CONTINUOUS = PermissibleValue(
+        text="SEMI_CONTINUOUS",
+        description="Periodic partial harvest and replacement of medium (draw-and-fill).",
+    )
+    CHEMOSTAT = PermissibleValue(
+        text="CHEMOSTAT",
+        description="""Continuous culture held at steady state by a fixed dilution rate and a growth-limiting nutrient.""",
+    )
+    TURBIDOSTAT = PermissibleValue(
+        text="TURBIDOSTAT",
+        description="Continuous culture controlled to hold constant turbidity / cell density.",
+    )
+    PERFUSION = PermissibleValue(
+        text="PERFUSION",
+        description="""Continuous medium exchange with biomass retention (cells retained while spent medium is removed).""",
+    )
+    SEQUENCING_BATCH = PermissibleValue(
+        text="SEQUENCING_BATCH",
+        description="Repeated fill / react / settle / draw cycles in a single vessel.",
+    )
+    RETENTOSTAT = PermissibleValue(
+        text="RETENTOSTAT",
+        description="Continuous culture with complete biomass retention, approaching near-zero growth rate.",
+    )
+    OTHER = PermissibleValue(
+        text="OTHER", description="Other cultivation mode not covered by the listed values."
+    )
+
+    _defn = EnumDefinition(
+        name="CultivationModeEnum",
+        description="""Operating mode / approach used to cultivate the community. Standardized terms maintained in vocab/cultivation_terms.yaml (kept in sync by tests/test_cultivation_vocab_sync.py) and staged for a METPO proposal.""",
+    )
+
+
+class CultivationSystemEnum(EnumDefinitionImpl):
+    """
+    Instrumentation / vessel system used to grow the community. Standardized terms maintained in
+    vocab/cultivation_terms.yaml (kept in sync by tests/test_cultivation_vocab_sync.py) and staged for a METPO
+    proposal.
+    """
+
+    STIRRED_TANK_BIOREACTOR = PermissibleValue(
+        text="STIRRED_TANK_BIOREACTOR", description="Mechanically stirred tank reactor (CSTR-type)."
+    )
+    PHOTOBIOREACTOR = PermissibleValue(
+        text="PHOTOBIOREACTOR",
+        description="Light-driven reactor for cultivating phototrophic organisms.",
+    )
+    MICROBIAL_FUEL_CELL = PermissibleValue(
+        text="MICROBIAL_FUEL_CELL",
+        description="Bioelectrochemical system that generates electric current from microbial metabolism.",
+    )
+    BIOELECTROCHEMICAL_SYSTEM = PermissibleValue(
+        text="BIOELECTROCHEMICAL_SYSTEM",
+        description="""Electrode-coupled reactor (broader than a microbial fuel cell), e.g. microbial electrolysis or electrosynthesis cells.""",
+    )
+    CHEMOSTAT_VESSEL = PermissibleValue(
+        text="CHEMOSTAT_VESSEL",
+        description="A vessel configured for chemostat (dilution-rate-controlled) continuous culture.",
+    )
+    MEMBRANE_BIOREACTOR = PermissibleValue(
+        text="MEMBRANE_BIOREACTOR",
+        description="Reactor coupling cultivation with a membrane for biomass/liquid separation.",
+    )
+    SERUM_BOTTLE = PermissibleValue(
+        text="SERUM_BOTTLE",
+        description="Sealed serum bottle, commonly used for anaerobic cultivation.",
+    )
+    FLASK = PermissibleValue(text="FLASK", description="Erlenmeyer / shake flask.")
+    GAS_LIFT_REACTOR = PermissibleValue(
+        text="GAS_LIFT_REACTOR", description="Pneumatically mixed reactor (airlift / gas-lift)."
+    )
+    PACKED_BED_REACTOR = PermissibleValue(
+        text="PACKED_BED_REACTOR",
+        description="Reactor with a fixed packed support matrix for biofilm growth.",
+    )
+    MICROFLUIDIC_DEVICE = PermissibleValue(
+        text="MICROFLUIDIC_DEVICE", description="Microfluidic cultivation chip / device."
+    )
+    HOLLOW_FIBER_REACTOR = PermissibleValue(
+        text="HOLLOW_FIBER_REACTOR", description="Hollow-fiber membrane cultivation system."
+    )
+    BIOREACTOR_UNSPECIFIED = PermissibleValue(
+        text="BIOREACTOR_UNSPECIFIED",
+        description="Bioreactor of unspecified type.",
+        meaning=OBI["0001046"],
+    )
+    OTHER = PermissibleValue(
+        text="OTHER", description="Other cultivation system not covered by the listed values."
+    )
+
+    _defn = EnumDefinition(
+        name="CultivationSystemEnum",
+        description="""Instrumentation / vessel system used to grow the community. Standardized terms maintained in vocab/cultivation_terms.yaml (kept in sync by tests/test_cultivation_vocab_sync.py) and staged for a METPO proposal.""",
+    )
+
+
+class DiscussionKindEnum(EnumDefinitionImpl):
+    """
+    Kind of unresolved / in-progress item captured by a Discussion. Knowledge gaps are represented as a discussion
+    kind so they reuse the shared pointer, evidence, and lifecycle machinery, while optional proposed experiments
+    capture how a gap could be resolved.
+    """
+
+    OPEN_QUESTION = PermissibleValue(
+        text="OPEN_QUESTION",
+        description="An unresolved scientific question posed by curators or experts.",
+    )
+    KNOWLEDGE_GAP = PermissibleValue(
+        text="KNOWLEDGE_GAP",
+        description="""A missing causal, evidentiary, model-system, or measurement assertion whose resolution would materially improve the record.""",
+    )
+    CONTROVERSY = PermissibleValue(
+        text="CONTROVERSY",
+        description="A live disagreement or competing interpretation between published positions.",
+    )
+    CURATION_TODO = PermissibleValue(
+        text="CURATION_TODO",
+        description='A curation task captured inline (e.g. "ingredient needs CHEBI refinement").',
+    )
+    EMERGING_HYPOTHESIS = PermissibleValue(
+        text="EMERGING_HYPOTHESIS",
+        description="A recently reported hypothesis under active discussion in the community.",
+    )
+    INTERPRETATION = PermissibleValue(
+        text="INTERPRETATION",
+        description="A discussion about how to interpret existing evidence or model an edge.",
+    )
+    HUMAN_MODEL_MISMATCH = PermissibleValue(
+        text="HUMAN_MODEL_MISMATCH",
+        description="""A gap where evidence exists in one system but its fidelity to the target context is uncertain (e.g. an in-vitro/model result whose transfer to the in-situ or host-associated setting is unverified).""",
+    )
+
+    _defn = EnumDefinition(
+        name="DiscussionKindEnum",
+        description="""Kind of unresolved / in-progress item captured by a Discussion. Knowledge gaps are represented as a discussion kind so they reuse the shared pointer, evidence, and lifecycle machinery, while optional proposed experiments capture how a gap could be resolved.""",
+    )
+
+
+class DiscussionStatusEnum(EnumDefinitionImpl):
+    """
+    Lifecycle status for a Discussion.
+    """
+
+    OPEN = PermissibleValue(text="OPEN", description="Posed but not yet under active discussion.")
+    UNDER_DISCUSSION = PermissibleValue(
+        text="UNDER_DISCUSSION",
+        description="Actively being discussed in one or more linked venues.",
+    )
+    RESOLVED = PermissibleValue(
+        text="RESOLVED", description="Closed with a documented resolution; kept for provenance."
+    )
+    ARCHIVED = PermissibleValue(
+        text="ARCHIVED",
+        description="No longer active and not resolved (deferred, stale, or superseded).",
+    )
+
+    _defn = EnumDefinition(
+        name="DiscussionStatusEnum",
+        description="Lifecycle status for a Discussion.",
+    )
+
+
+class SupportLevelEnum(EnumDefinitionImpl):
+    """
+    How a SupportingReference bears on the claim it is attached to (mirrors the supports semantics already used in the
+    Mech EvidenceItem models).
+    """
+
+    SUPPORT = PermissibleValue(text="SUPPORT", description="The source supports the claim.")
+    REFUTE = PermissibleValue(text="REFUTE", description="The source contradicts the claim.")
+    PARTIAL = PermissibleValue(
+        text="PARTIAL",
+        description="The source partially supports the claim or supports it with caveats.",
+    )
+    NO_EVIDENCE = PermissibleValue(
+        text="NO_EVIDENCE",
+        description="The source is relevant context but does not directly bear on the claim.",
+    )
+    WRONG_STATEMENT = PermissibleValue(
+        text="WRONG_STATEMENT",
+        description="The cited statement was found to be incorrect (kept for provenance).",
+    )
+
+    _defn = EnumDefinition(
+        name="SupportLevelEnum",
+        description="""How a SupportingReference bears on the claim it is attached to (mirrors the supports semantics already used in the Mech EvidenceItem models).""",
+    )
+
+
+class DatasetTypeEnum(EnumDefinitionImpl):
+    """
+    Type of dataset or data resource. Canonical UNION of CultureMech's and CommunityMech's enums plus microbial
+    additions. Migration map (old → this): CultureMech values carry over unchanged; CommunityMech GENOME→GENOMICS,
+    METAGENOME→METAGENOMICS, METATRANSCRIPTOME→METATRANSCRIPTOMICS, METAPROTEOME→METAPROTEOMICS (AMPLICON_16S /
+    AMPLICON_ITS / METABOLOMICS / PHENOTYPE / MULTI_OMICS / OTHER are unchanged).
+    """
+
+    GENOMICS = PermissibleValue(
+        text="GENOMICS",
+        description="Isolate / single-organism genome data. (CultureMech GENOMICS; CommunityMech GENOME)",
+    )
+    METAGENOMICS = PermissibleValue(
+        text="METAGENOMICS", description="Shotgun metagenome sequencing. (CommunityMech METAGENOME)"
+    )
+    AMPLICON_16S = PermissibleValue(
+        text="AMPLICON_16S", description="16S rRNA marker-gene amplicon sequencing."
+    )
+    AMPLICON_ITS = PermissibleValue(
+        text="AMPLICON_ITS", description="ITS marker-gene amplicon sequencing."
+    )
+    AMPLICON_OTHER = PermissibleValue(
+        text="AMPLICON_OTHER",
+        description="Marker-gene amplicon sequencing other than 16S/ITS (e.g. 18S, rpoB).",
+    )
+    TRANSCRIPTOMICS = PermissibleValue(
+        text="TRANSCRIPTOMICS", description="Single-organism RNA sequencing / expression."
+    )
+    METATRANSCRIPTOMICS = PermissibleValue(
+        text="METATRANSCRIPTOMICS",
+        description="Community-level RNA sequencing. (CommunityMech METATRANSCRIPTOME)",
+    )
+    PROTEOMICS = PermissibleValue(
+        text="PROTEOMICS", description="Single-organism protein expression profiling."
+    )
+    METAPROTEOMICS = PermissibleValue(
+        text="METAPROTEOMICS",
+        description="Community-level proteomics. (CommunityMech METAPROTEOME)",
+    )
+    METABOLOMICS = PermissibleValue(text="METABOLOMICS", description="Metabolite profiling.")
+    FLUXOMICS = PermissibleValue(text="FLUXOMICS", description="Metabolic flux profiling.")
+    PHENOMICS = PermissibleValue(
+        text="PHENOMICS", description="High-throughput phenotype profiling."
+    )
+    PHENOTYPE = PermissibleValue(
+        text="PHENOTYPE",
+        description="Phenotype / trait measurement collection (e.g. growth, biochemical).",
+    )
+    MULTI_OMICS = PermissibleValue(
+        text="MULTI_OMICS", description="Integrated multi-omics profiling."
+    )
+    OTHER = PermissibleValue(text="OTHER", description="A dataset type not covered by the above.")
+
+    _defn = EnumDefinition(
+        name="DatasetTypeEnum",
+        description="""Type of dataset or data resource. Canonical UNION of CultureMech's and CommunityMech's enums plus microbial additions. Migration map (old → this): CultureMech values carry over unchanged; CommunityMech GENOME→GENOMICS, METAGENOME→METAGENOMICS, METATRANSCRIPTOME→METATRANSCRIPTOMICS, METAPROTEOME→METAPROTEOMICS (AMPLICON_16S / AMPLICON_ITS / METABOLOMICS / PHENOTYPE / MULTI_OMICS / OTHER are unchanged).""",
+    )
+
+
+class DatasetRepositoryEnum(EnumDefinitionImpl):
+    """
+    Public repository hosting the dataset. Superset of CommunityMech's enum (all values preserved) plus common
+    additions; CultureMech datasets have no repository field today and migrate with repository unset / OTHER.
+    """
+
+    NCBI_SRA = PermissibleValue(text="NCBI_SRA", description="NCBI Sequence Read Archive.")
+    NCBI_BIOPROJECT = PermissibleValue(text="NCBI_BIOPROJECT", description="NCBI BioProject.")
+    NCBI_GEO = PermissibleValue(text="NCBI_GEO", description="NCBI Gene Expression Omnibus.")
+    NCBI_ASSEMBLY = PermissibleValue(
+        text="NCBI_ASSEMBLY", description="NCBI Assembly (genome assemblies)."
+    )
+    ENA = PermissibleValue(text="ENA", description="European Nucleotide Archive.")
+    ARRAYEXPRESS = PermissibleValue(
+        text="ARRAYEXPRESS", description="EBI ArrayExpress / BioStudies."
+    )
+    MGNIFY = PermissibleValue(text="MGNIFY", description="EBI MGnify metagenomics resource.")
+    JGI_GOLD = PermissibleValue(text="JGI_GOLD", description="JGI Genomes OnLine Database.")
+    JGI_IMG = PermissibleValue(
+        text="JGI_IMG", description="JGI Integrated Microbial Genomes & Microbiomes."
+    )
+    NMDC = PermissibleValue(text="NMDC", description="National Microbiome Data Collaborative.")
+    METABOLOMICS_WORKBENCH = PermissibleValue(
+        text="METABOLOMICS_WORKBENCH", description="NIH Metabolomics Workbench."
+    )
+    METABOLIGHTS = PermissibleValue(
+        text="METABOLIGHTS", description="EBI MetaboLights metabolomics repository."
+    )
+    MASSIVE = PermissibleValue(text="MASSIVE", description="MassIVE mass-spectrometry repository.")
+    GNPS = PermissibleValue(
+        text="GNPS", description="Global Natural Products Social Molecular Networking."
+    )
+    PRIDE = PermissibleValue(text="PRIDE", description="EBI PRIDE proteomics repository.")
+    DBGAP = PermissibleValue(text="DBGAP", description="NCBI database of Genotypes and Phenotypes.")
+    GTEX = PermissibleValue(text="GTEX", description="Genotype-Tissue Expression project.")
+    FIGSHARE = PermissibleValue(
+        text="FIGSHARE", description="Figshare general-purpose research data archive."
+    )
+    ZENODO = PermissibleValue(
+        text="ZENODO", description="Zenodo general-purpose research data archive."
+    )
+    BIOMODELS = PermissibleValue(
+        text="BIOMODELS", description="EBI BioModels repository of computational models."
+    )
+    KBASE = PermissibleValue(text="KBASE", description="DOE Systems Biology Knowledgebase (KBase).")
+    OTHER = PermissibleValue(text="OTHER", description="A repository not covered by the above.")
+
+    _defn = EnumDefinition(
+        name="DatasetRepositoryEnum",
+        description="""Public repository hosting the dataset. Superset of CommunityMech's enum (all values preserved) plus common additions; CultureMech datasets have no repository field today and migrate with repository unset / OTHER.""",
     )
 
 
@@ -3072,69 +3718,6 @@ slots.relatedIngredient__evidence = Slot(
     range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
 )
 
-slots.associatedDataset__name = Slot(
-    uri=COMMUNITYMECH.name,
-    name="associatedDataset__name",
-    curie=COMMUNITYMECH.curie("name"),
-    model_uri=COMMUNITYMECH.associatedDataset__name,
-    domain=None,
-    range=str,
-)
-
-slots.associatedDataset__dataset_type = Slot(
-    uri=COMMUNITYMECH.dataset_type,
-    name="associatedDataset__dataset_type",
-    curie=COMMUNITYMECH.curie("dataset_type"),
-    model_uri=COMMUNITYMECH.associatedDataset__dataset_type,
-    domain=None,
-    range=Union[str, "DatasetTypeEnum"],
-)
-
-slots.associatedDataset__repository = Slot(
-    uri=COMMUNITYMECH.repository,
-    name="associatedDataset__repository",
-    curie=COMMUNITYMECH.curie("repository"),
-    model_uri=COMMUNITYMECH.associatedDataset__repository,
-    domain=None,
-    range=Optional[Union[str, "DatasetRepositoryEnum"]],
-)
-
-slots.associatedDataset__accession = Slot(
-    uri=COMMUNITYMECH.accession,
-    name="associatedDataset__accession",
-    curie=COMMUNITYMECH.curie("accession"),
-    model_uri=COMMUNITYMECH.associatedDataset__accession,
-    domain=None,
-    range=str,
-)
-
-slots.associatedDataset__url = Slot(
-    uri=COMMUNITYMECH.url,
-    name="associatedDataset__url",
-    curie=COMMUNITYMECH.curie("url"),
-    model_uri=COMMUNITYMECH.associatedDataset__url,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.associatedDataset__description = Slot(
-    uri=COMMUNITYMECH.description,
-    name="associatedDataset__description",
-    curie=COMMUNITYMECH.curie("description"),
-    model_uri=COMMUNITYMECH.associatedDataset__description,
-    domain=None,
-    range=Optional[str],
-)
-
-slots.associatedDataset__evidence = Slot(
-    uri=COMMUNITYMECH.evidence,
-    name="associatedDataset__evidence",
-    curie=COMMUNITYMECH.curie("evidence"),
-    model_uri=COMMUNITYMECH.associatedDataset__evidence,
-    domain=None,
-    range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
-)
-
 slots.externalResource__name = Slot(
     uri=COMMUNITYMECH.name,
     name="externalResource__name",
@@ -3270,6 +3853,213 @@ slots.communityEngineeringDesign__evidence = Slot(
     range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
 )
 
+slots.cultivationSetup__cultivation_mode = Slot(
+    uri=COMMUNITYMECH.cultivation_mode,
+    name="cultivationSetup__cultivation_mode",
+    curie=COMMUNITYMECH.curie("cultivation_mode"),
+    model_uri=COMMUNITYMECH.cultivationSetup__cultivation_mode,
+    domain=None,
+    range=Optional[Union[str, "CultivationModeEnum"]],
+)
+
+slots.cultivationSetup__system_type = Slot(
+    uri=COMMUNITYMECH.system_type,
+    name="cultivationSetup__system_type",
+    curie=COMMUNITYMECH.curie("system_type"),
+    model_uri=COMMUNITYMECH.cultivationSetup__system_type,
+    domain=None,
+    range=Optional[Union[str, "CultivationSystemEnum"]],
+)
+
+slots.cultivationSetup__instrument_detail = Slot(
+    uri=COMMUNITYMECH.instrument_detail,
+    name="cultivationSetup__instrument_detail",
+    curie=COMMUNITYMECH.curie("instrument_detail"),
+    model_uri=COMMUNITYMECH.cultivationSetup__instrument_detail,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.cultivationSetup__manufacturer_model = Slot(
+    uri=COMMUNITYMECH.manufacturer_model,
+    name="cultivationSetup__manufacturer_model",
+    curie=COMMUNITYMECH.curie("manufacturer_model"),
+    model_uri=COMMUNITYMECH.cultivationSetup__manufacturer_model,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.cultivationSetup__working_volume = Slot(
+    uri=COMMUNITYMECH.working_volume,
+    name="cultivationSetup__working_volume",
+    curie=COMMUNITYMECH.curie("working_volume"),
+    model_uri=COMMUNITYMECH.cultivationSetup__working_volume,
+    domain=None,
+    range=Optional[float],
+)
+
+slots.cultivationSetup__working_volume_unit = Slot(
+    uri=COMMUNITYMECH.working_volume_unit,
+    name="cultivationSetup__working_volume_unit",
+    curie=COMMUNITYMECH.curie("working_volume_unit"),
+    model_uri=COMMUNITYMECH.cultivationSetup__working_volume_unit,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.cultivationSetup__operating_temperature = Slot(
+    uri=COMMUNITYMECH.operating_temperature,
+    name="cultivationSetup__operating_temperature",
+    curie=COMMUNITYMECH.curie("operating_temperature"),
+    model_uri=COMMUNITYMECH.cultivationSetup__operating_temperature,
+    domain=None,
+    range=Optional[float],
+)
+
+slots.cultivationSetup__operating_temperature_unit = Slot(
+    uri=COMMUNITYMECH.operating_temperature_unit,
+    name="cultivationSetup__operating_temperature_unit",
+    curie=COMMUNITYMECH.curie("operating_temperature_unit"),
+    model_uri=COMMUNITYMECH.cultivationSetup__operating_temperature_unit,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.cultivationSetup__feed_or_dilution_rate = Slot(
+    uri=COMMUNITYMECH.feed_or_dilution_rate,
+    name="cultivationSetup__feed_or_dilution_rate",
+    curie=COMMUNITYMECH.curie("feed_or_dilution_rate"),
+    model_uri=COMMUNITYMECH.cultivationSetup__feed_or_dilution_rate,
+    domain=None,
+    range=Optional[float],
+)
+
+slots.cultivationSetup__feed_or_dilution_rate_unit = Slot(
+    uri=COMMUNITYMECH.feed_or_dilution_rate_unit,
+    name="cultivationSetup__feed_or_dilution_rate_unit",
+    curie=COMMUNITYMECH.curie("feed_or_dilution_rate_unit"),
+    model_uri=COMMUNITYMECH.cultivationSetup__feed_or_dilution_rate_unit,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.cultivationSetup__retention_time = Slot(
+    uri=COMMUNITYMECH.retention_time,
+    name="cultivationSetup__retention_time",
+    curie=COMMUNITYMECH.curie("retention_time"),
+    model_uri=COMMUNITYMECH.cultivationSetup__retention_time,
+    domain=None,
+    range=Optional[float],
+)
+
+slots.cultivationSetup__retention_time_unit = Slot(
+    uri=COMMUNITYMECH.retention_time_unit,
+    name="cultivationSetup__retention_time_unit",
+    curie=COMMUNITYMECH.curie("retention_time_unit"),
+    model_uri=COMMUNITYMECH.cultivationSetup__retention_time_unit,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.cultivationSetup__retention_time_type = Slot(
+    uri=COMMUNITYMECH.retention_time_type,
+    name="cultivationSetup__retention_time_type",
+    curie=COMMUNITYMECH.curie("retention_time_type"),
+    model_uri=COMMUNITYMECH.cultivationSetup__retention_time_type,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.cultivationSetup__applied_potential = Slot(
+    uri=COMMUNITYMECH.applied_potential,
+    name="cultivationSetup__applied_potential",
+    curie=COMMUNITYMECH.curie("applied_potential"),
+    model_uri=COMMUNITYMECH.cultivationSetup__applied_potential,
+    domain=None,
+    range=Optional[float],
+)
+
+slots.cultivationSetup__applied_potential_unit = Slot(
+    uri=COMMUNITYMECH.applied_potential_unit,
+    name="cultivationSetup__applied_potential_unit",
+    curie=COMMUNITYMECH.curie("applied_potential_unit"),
+    model_uri=COMMUNITYMECH.cultivationSetup__applied_potential_unit,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.cultivationSetup__electrode_detail = Slot(
+    uri=COMMUNITYMECH.electrode_detail,
+    name="cultivationSetup__electrode_detail",
+    curie=COMMUNITYMECH.curie("electrode_detail"),
+    model_uri=COMMUNITYMECH.cultivationSetup__electrode_detail,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.cultivationSetup__ph_controlled = Slot(
+    uri=COMMUNITYMECH.ph_controlled,
+    name="cultivationSetup__ph_controlled",
+    curie=COMMUNITYMECH.curie("ph_controlled"),
+    model_uri=COMMUNITYMECH.cultivationSetup__ph_controlled,
+    domain=None,
+    range=Optional[Union[bool, Bool]],
+)
+
+slots.cultivationSetup__do_controlled = Slot(
+    uri=COMMUNITYMECH.do_controlled,
+    name="cultivationSetup__do_controlled",
+    curie=COMMUNITYMECH.curie("do_controlled"),
+    model_uri=COMMUNITYMECH.cultivationSetup__do_controlled,
+    domain=None,
+    range=Optional[Union[bool, Bool]],
+)
+
+slots.cultivationSetup__temperature_controlled = Slot(
+    uri=COMMUNITYMECH.temperature_controlled,
+    name="cultivationSetup__temperature_controlled",
+    curie=COMMUNITYMECH.curie("temperature_controlled"),
+    model_uri=COMMUNITYMECH.cultivationSetup__temperature_controlled,
+    domain=None,
+    range=Optional[Union[bool, Bool]],
+)
+
+slots.cultivationSetup__controls_notes = Slot(
+    uri=COMMUNITYMECH.controls_notes,
+    name="cultivationSetup__controls_notes",
+    curie=COMMUNITYMECH.curie("controls_notes"),
+    model_uri=COMMUNITYMECH.cultivationSetup__controls_notes,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.cultivationSetup__protocol_url = Slot(
+    uri=COMMUNITYMECH.protocol_url,
+    name="cultivationSetup__protocol_url",
+    curie=COMMUNITYMECH.curie("protocol_url"),
+    model_uri=COMMUNITYMECH.cultivationSetup__protocol_url,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.cultivationSetup__notes = Slot(
+    uri=COMMUNITYMECH.notes,
+    name="cultivationSetup__notes",
+    curie=COMMUNITYMECH.curie("notes"),
+    model_uri=COMMUNITYMECH.cultivationSetup__notes,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.cultivationSetup__evidence = Slot(
+    uri=COMMUNITYMECH.evidence,
+    name="cultivationSetup__evidence",
+    curie=COMMUNITYMECH.curie("evidence"),
+    model_uri=COMMUNITYMECH.cultivationSetup__evidence,
+    domain=None,
+    range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
+)
+
 slots.microbialCommunity__id = Slot(
     uri=COMMUNITYMECH.id,
     name="microbialCommunity__id",
@@ -3383,6 +4173,15 @@ slots.microbialCommunity__growth_media = Slot(
     range=Optional[Union[Union[dict, GrowthMedia], list[Union[dict, GrowthMedia]]]],
 )
 
+slots.microbialCommunity__cultivation_setup = Slot(
+    uri=COMMUNITYMECH.cultivation_setup,
+    name="microbialCommunity__cultivation_setup",
+    curie=COMMUNITYMECH.curie("cultivation_setup"),
+    model_uri=COMMUNITYMECH.microbialCommunity__cultivation_setup,
+    domain=None,
+    range=Optional[Union[Union[dict, CultivationSetup], list[Union[dict, CultivationSetup]]]],
+)
+
 slots.microbialCommunity__related_media = Slot(
     uri=COMMUNITYMECH.related_media,
     name="microbialCommunity__related_media",
@@ -3407,7 +4206,7 @@ slots.microbialCommunity__associated_datasets = Slot(
     curie=COMMUNITYMECH.curie("associated_datasets"),
     model_uri=COMMUNITYMECH.microbialCommunity__associated_datasets,
     domain=None,
-    range=Optional[Union[Union[dict, AssociatedDataset], list[Union[dict, AssociatedDataset]]]],
+    range=Optional[Union[Union[dict, Dataset], list[Union[dict, Dataset]]]],
 )
 
 slots.microbialCommunity__external_resources = Slot(
@@ -3694,4 +4493,409 @@ slots.geneAnnotation__evidence = Slot(
     model_uri=COMMUNITYMECH.geneAnnotation__evidence,
     domain=None,
     range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
+)
+
+slots.supportingReference__reference = Slot(
+    uri=MECH_SHARED.reference,
+    name="supportingReference__reference",
+    curie=MECH_SHARED.curie("reference"),
+    model_uri=COMMUNITYMECH.supportingReference__reference,
+    domain=None,
+    range=str,
+)
+
+slots.supportingReference__reference_title = Slot(
+    uri=MECH_SHARED.reference_title,
+    name="supportingReference__reference_title",
+    curie=MECH_SHARED.curie("reference_title"),
+    model_uri=COMMUNITYMECH.supportingReference__reference_title,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.supportingReference__supports = Slot(
+    uri=MECH_SHARED.supports,
+    name="supportingReference__supports",
+    curie=MECH_SHARED.curie("supports"),
+    model_uri=COMMUNITYMECH.supportingReference__supports,
+    domain=None,
+    range=Optional[Union[str, "SupportLevelEnum"]],
+)
+
+slots.supportingReference__evidence_source = Slot(
+    uri=MECH_SHARED.evidence_source,
+    name="supportingReference__evidence_source",
+    curie=MECH_SHARED.curie("evidence_source"),
+    model_uri=COMMUNITYMECH.supportingReference__evidence_source,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.supportingReference__snippet = Slot(
+    uri=MECH_SHARED.snippet,
+    name="supportingReference__snippet",
+    curie=MECH_SHARED.curie("snippet"),
+    model_uri=COMMUNITYMECH.supportingReference__snippet,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.supportingReference__explanation = Slot(
+    uri=MECH_SHARED.explanation,
+    name="supportingReference__explanation",
+    curie=MECH_SHARED.curie("explanation"),
+    model_uri=COMMUNITYMECH.supportingReference__explanation,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.supportingReference__notes = Slot(
+    uri=MECH_SHARED.notes,
+    name="supportingReference__notes",
+    curie=MECH_SHARED.curie("notes"),
+    model_uri=COMMUNITYMECH.supportingReference__notes,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.discussion__discussion_id = Slot(
+    uri=MECH_SHARED.discussion_id,
+    name="discussion__discussion_id",
+    curie=MECH_SHARED.curie("discussion_id"),
+    model_uri=COMMUNITYMECH.discussion__discussion_id,
+    domain=None,
+    range=str,
+)
+
+slots.discussion__prompt = Slot(
+    uri=MECH_SHARED.prompt,
+    name="discussion__prompt",
+    curie=MECH_SHARED.curie("prompt"),
+    model_uri=COMMUNITYMECH.discussion__prompt,
+    domain=None,
+    range=str,
+)
+
+slots.discussion__kind = Slot(
+    uri=MECH_SHARED.kind,
+    name="discussion__kind",
+    curie=MECH_SHARED.curie("kind"),
+    model_uri=COMMUNITYMECH.discussion__kind,
+    domain=None,
+    range=Optional[Union[str, "DiscussionKindEnum"]],
+)
+
+slots.discussion__status = Slot(
+    uri=MECH_SHARED.status,
+    name="discussion__status",
+    curie=MECH_SHARED.curie("status"),
+    model_uri=COMMUNITYMECH.discussion__status,
+    domain=None,
+    range=Optional[Union[str, "DiscussionStatusEnum"]],
+)
+
+slots.discussion__attaches_to = Slot(
+    uri=MECH_SHARED.attaches_to,
+    name="discussion__attaches_to",
+    curie=MECH_SHARED.curie("attaches_to"),
+    model_uri=COMMUNITYMECH.discussion__attaches_to,
+    domain=None,
+    range=Optional[Union[str, list[str]]],
+)
+
+slots.discussion__rationale = Slot(
+    uri=MECH_SHARED.rationale,
+    name="discussion__rationale",
+    curie=MECH_SHARED.curie("rationale"),
+    model_uri=COMMUNITYMECH.discussion__rationale,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.discussion__proposed_experiments = Slot(
+    uri=MECH_SHARED.proposed_experiments,
+    name="discussion__proposed_experiments",
+    curie=MECH_SHARED.curie("proposed_experiments"),
+    model_uri=COMMUNITYMECH.discussion__proposed_experiments,
+    domain=None,
+    range=Optional[Union[Union[dict, ProposedExperiment], list[Union[dict, ProposedExperiment]]]],
+)
+
+slots.discussion__evidence = Slot(
+    uri=MECH_SHARED.evidence,
+    name="discussion__evidence",
+    curie=MECH_SHARED.curie("evidence"),
+    model_uri=COMMUNITYMECH.discussion__evidence,
+    domain=None,
+    range=Optional[Union[Union[dict, SupportingReference], list[Union[dict, SupportingReference]]]],
+)
+
+slots.discussion__posed_by = Slot(
+    uri=MECH_SHARED.posed_by,
+    name="discussion__posed_by",
+    curie=MECH_SHARED.curie("posed_by"),
+    model_uri=COMMUNITYMECH.discussion__posed_by,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.discussion__posed_date = Slot(
+    uri=MECH_SHARED.posed_date,
+    name="discussion__posed_date",
+    curie=MECH_SHARED.curie("posed_date"),
+    model_uri=COMMUNITYMECH.discussion__posed_date,
+    domain=None,
+    range=Optional[Union[str, XSDDate]],
+)
+
+slots.discussion__resolved_date = Slot(
+    uri=MECH_SHARED.resolved_date,
+    name="discussion__resolved_date",
+    curie=MECH_SHARED.curie("resolved_date"),
+    model_uri=COMMUNITYMECH.discussion__resolved_date,
+    domain=None,
+    range=Optional[Union[str, XSDDate]],
+)
+
+slots.discussion__resolution_note = Slot(
+    uri=MECH_SHARED.resolution_note,
+    name="discussion__resolution_note",
+    curie=MECH_SHARED.curie("resolution_note"),
+    model_uri=COMMUNITYMECH.discussion__resolution_note,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.discussion__notes = Slot(
+    uri=MECH_SHARED.notes,
+    name="discussion__notes",
+    curie=MECH_SHARED.curie("notes"),
+    model_uri=COMMUNITYMECH.discussion__notes,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.proposedExperiment__experiment_id = Slot(
+    uri=MECH_SHARED.experiment_id,
+    name="proposedExperiment__experiment_id",
+    curie=MECH_SHARED.curie("experiment_id"),
+    model_uri=COMMUNITYMECH.proposedExperiment__experiment_id,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.proposedExperiment__name = Slot(
+    uri=MECH_SHARED.name,
+    name="proposedExperiment__name",
+    curie=MECH_SHARED.curie("name"),
+    model_uri=COMMUNITYMECH.proposedExperiment__name,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.proposedExperiment__description = Slot(
+    uri=MECH_SHARED.description,
+    name="proposedExperiment__description",
+    curie=MECH_SHARED.curie("description"),
+    model_uri=COMMUNITYMECH.proposedExperiment__description,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.proposedExperiment__approach = Slot(
+    uri=MECH_SHARED.approach,
+    name="proposedExperiment__approach",
+    curie=MECH_SHARED.curie("approach"),
+    model_uri=COMMUNITYMECH.proposedExperiment__approach,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.proposedExperiment__model_systems = Slot(
+    uri=MECH_SHARED.model_systems,
+    name="proposedExperiment__model_systems",
+    curie=MECH_SHARED.curie("model_systems"),
+    model_uri=COMMUNITYMECH.proposedExperiment__model_systems,
+    domain=None,
+    range=Optional[Union[str, list[str]]],
+)
+
+slots.proposedExperiment__perturbations = Slot(
+    uri=MECH_SHARED.perturbations,
+    name="proposedExperiment__perturbations",
+    curie=MECH_SHARED.curie("perturbations"),
+    model_uri=COMMUNITYMECH.proposedExperiment__perturbations,
+    domain=None,
+    range=Optional[Union[str, list[str]]],
+)
+
+slots.proposedExperiment__readouts = Slot(
+    uri=MECH_SHARED.readouts,
+    name="proposedExperiment__readouts",
+    curie=MECH_SHARED.curie("readouts"),
+    model_uri=COMMUNITYMECH.proposedExperiment__readouts,
+    domain=None,
+    range=Optional[Union[str, list[str]]],
+)
+
+slots.proposedExperiment__decision_criterion = Slot(
+    uri=MECH_SHARED.decision_criterion,
+    name="proposedExperiment__decision_criterion",
+    curie=MECH_SHARED.curie("decision_criterion"),
+    model_uri=COMMUNITYMECH.proposedExperiment__decision_criterion,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.proposedExperiment__would_support = Slot(
+    uri=MECH_SHARED.would_support,
+    name="proposedExperiment__would_support",
+    curie=MECH_SHARED.curie("would_support"),
+    model_uri=COMMUNITYMECH.proposedExperiment__would_support,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.proposedExperiment__would_refute = Slot(
+    uri=MECH_SHARED.would_refute,
+    name="proposedExperiment__would_refute",
+    curie=MECH_SHARED.curie("would_refute"),
+    model_uri=COMMUNITYMECH.proposedExperiment__would_refute,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.dataset__accession = Slot(
+    uri=MECH_SHARED.accession,
+    name="dataset__accession",
+    curie=MECH_SHARED.curie("accession"),
+    model_uri=COMMUNITYMECH.dataset__accession,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.dataset__title = Slot(
+    uri=MECH_SHARED.title,
+    name="dataset__title",
+    curie=MECH_SHARED.curie("title"),
+    model_uri=COMMUNITYMECH.dataset__title,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.dataset__description = Slot(
+    uri=MECH_SHARED.description,
+    name="dataset__description",
+    curie=MECH_SHARED.curie("description"),
+    model_uri=COMMUNITYMECH.dataset__description,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.dataset__organism = Slot(
+    uri=MECH_SHARED.organism,
+    name="dataset__organism",
+    curie=MECH_SHARED.curie("organism"),
+    model_uri=COMMUNITYMECH.dataset__organism,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.dataset__dataset_type = Slot(
+    uri=MECH_SHARED.dataset_type,
+    name="dataset__dataset_type",
+    curie=MECH_SHARED.curie("dataset_type"),
+    model_uri=COMMUNITYMECH.dataset__dataset_type,
+    domain=None,
+    range=Optional[Union[str, "DatasetTypeEnum"]],
+)
+
+slots.dataset__repository = Slot(
+    uri=MECH_SHARED.repository,
+    name="dataset__repository",
+    curie=MECH_SHARED.curie("repository"),
+    model_uri=COMMUNITYMECH.dataset__repository,
+    domain=None,
+    range=Optional[Union[str, "DatasetRepositoryEnum"]],
+)
+
+slots.dataset__sample_types = Slot(
+    uri=MECH_SHARED.sample_types,
+    name="dataset__sample_types",
+    curie=MECH_SHARED.curie("sample_types"),
+    model_uri=COMMUNITYMECH.dataset__sample_types,
+    domain=None,
+    range=Optional[Union[str, list[str]]],
+)
+
+slots.dataset__sample_count = Slot(
+    uri=MECH_SHARED.sample_count,
+    name="dataset__sample_count",
+    curie=MECH_SHARED.curie("sample_count"),
+    model_uri=COMMUNITYMECH.dataset__sample_count,
+    domain=None,
+    range=Optional[int],
+)
+
+slots.dataset__conditions = Slot(
+    uri=MECH_SHARED.conditions,
+    name="dataset__conditions",
+    curie=MECH_SHARED.curie("conditions"),
+    model_uri=COMMUNITYMECH.dataset__conditions,
+    domain=None,
+    range=Optional[Union[str, list[str]]],
+)
+
+slots.dataset__platform = Slot(
+    uri=MECH_SHARED.platform,
+    name="dataset__platform",
+    curie=MECH_SHARED.curie("platform"),
+    model_uri=COMMUNITYMECH.dataset__platform,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.dataset__url = Slot(
+    uri=MECH_SHARED.url,
+    name="dataset__url",
+    curie=MECH_SHARED.curie("url"),
+    model_uri=COMMUNITYMECH.dataset__url,
+    domain=None,
+    range=Optional[Union[str, URI]],
+)
+
+slots.dataset__publication = Slot(
+    uri=MECH_SHARED.publication,
+    name="dataset__publication",
+    curie=MECH_SHARED.curie("publication"),
+    model_uri=COMMUNITYMECH.dataset__publication,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.dataset__findings = Slot(
+    uri=MECH_SHARED.findings,
+    name="dataset__findings",
+    curie=MECH_SHARED.curie("findings"),
+    model_uri=COMMUNITYMECH.dataset__findings,
+    domain=None,
+    range=Optional[str],
+)
+
+slots.dataset__evidence = Slot(
+    uri=MECH_SHARED.evidence,
+    name="dataset__evidence",
+    curie=MECH_SHARED.curie("evidence"),
+    model_uri=COMMUNITYMECH.dataset__evidence,
+    domain=None,
+    range=Optional[Union[Union[dict, SupportingReference], list[Union[dict, SupportingReference]]]],
+)
+
+slots.dataset__notes = Slot(
+    uri=MECH_SHARED.notes,
+    name="dataset__notes",
+    curie=MECH_SHARED.curie("notes"),
+    model_uri=COMMUNITYMECH.dataset__notes,
+    domain=None,
+    range=Optional[str],
 )

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -22,6 +22,7 @@ prefixes:
   GO: http://purl.obolibrary.org/obo/GO_
   UBERON: http://purl.obolibrary.org/obo/UBERON_
   CL: http://purl.obolibrary.org/obo/CL_
+  OBI: http://purl.obolibrary.org/obo/OBI_
   PMID: http://www.ncbi.nlm.nih.gov/pubmed/
   doi: https://doi.org/
   xsd: http://www.w3.org/2001/XMLSchema#
@@ -434,6 +435,82 @@ enums:
         description: Incidental metal/REE interaction
       NOT_APPLICABLE:
         description: No significant metal/REE relevance
+
+  CultivationModeEnum:
+    description: >-
+      Operating mode / approach used to cultivate the community. Standardized
+      terms maintained in vocab/cultivation_terms.yaml (kept in sync by
+      tests/test_cultivation_vocab_sync.py) and staged for a METPO proposal.
+    permissible_values:
+      BATCH:
+        description: Closed culture with no nutrient addition or removal after inoculation.
+      FED_BATCH:
+        description: Nutrients fed during the run, with no removal of culture broth.
+      CONTINUOUS:
+        description: >-
+          Fresh medium added and culture withdrawn continuously, typically at
+          steady state.
+      SEMI_CONTINUOUS:
+        description: Periodic partial harvest and replacement of medium (draw-and-fill).
+      CHEMOSTAT:
+        description: >-
+          Continuous culture held at steady state by a fixed dilution rate and a
+          growth-limiting nutrient.
+      TURBIDOSTAT:
+        description: >-
+          Continuous culture controlled to hold constant turbidity / cell density.
+      PERFUSION:
+        description: >-
+          Continuous medium exchange with biomass retention (cells retained while
+          spent medium is removed).
+      SEQUENCING_BATCH:
+        description: Repeated fill / react / settle / draw cycles in a single vessel.
+      RETENTOSTAT:
+        description: >-
+          Continuous culture with complete biomass retention, approaching
+          near-zero growth rate.
+      OTHER:
+        description: Other cultivation mode not covered by the listed values.
+
+  CultivationSystemEnum:
+    description: >-
+      Instrumentation / vessel system used to grow the community. Standardized
+      terms maintained in vocab/cultivation_terms.yaml (kept in sync by
+      tests/test_cultivation_vocab_sync.py) and staged for a METPO proposal.
+    permissible_values:
+      STIRRED_TANK_BIOREACTOR:
+        description: Mechanically stirred tank reactor (CSTR-type).
+      PHOTOBIOREACTOR:
+        description: Light-driven reactor for cultivating phototrophic organisms.
+      MICROBIAL_FUEL_CELL:
+        description: >-
+          Bioelectrochemical system that generates electric current from
+          microbial metabolism.
+      BIOELECTROCHEMICAL_SYSTEM:
+        description: >-
+          Electrode-coupled reactor (broader than a microbial fuel cell), e.g.
+          microbial electrolysis or electrosynthesis cells.
+      CHEMOSTAT_VESSEL:
+        description: A vessel configured for chemostat (dilution-rate-controlled) continuous culture.
+      MEMBRANE_BIOREACTOR:
+        description: Reactor coupling cultivation with a membrane for biomass/liquid separation.
+      SERUM_BOTTLE:
+        description: Sealed serum bottle, commonly used for anaerobic cultivation.
+      FLASK:
+        description: Erlenmeyer / shake flask.
+      GAS_LIFT_REACTOR:
+        description: Pneumatically mixed reactor (airlift / gas-lift).
+      PACKED_BED_REACTOR:
+        description: Reactor with a fixed packed support matrix for biofilm growth.
+      MICROFLUIDIC_DEVICE:
+        description: Microfluidic cultivation chip / device.
+      HOLLOW_FIBER_REACTOR:
+        description: Hollow-fiber membrane cultivation system.
+      BIOREACTOR_UNSPECIFIED:
+        meaning: OBI:0001046
+        description: Bioreactor of unspecified type.
+      OTHER:
+        description: Other cultivation system not covered by the listed values.
 
 classes:
   Term:
@@ -928,6 +1005,80 @@ classes:
         range: EvidenceItem
         multivalued: true
 
+  CultivationSetup:
+    description: >-
+      Hardware/instrumentation and cultivation mode used to grow or sustain the
+      community. Optional — not all communities have a defined setup. Captures
+      both the system (e.g. stirred-tank bioreactor, photobioreactor, microbial
+      fuel cell) and the operating approach (batch, fed-batch, continuous, …).
+      Complements GrowthMedia (medium composition/conditions); the controlled
+      cultivation_mode/system_type values are the preferred standardized home for
+      vessel/reactor information going forward (vs the legacy free-text
+      GrowthMedia.vessel_type).
+    attributes:
+      cultivation_mode:
+        description: Operating mode / approach used to cultivate the community.
+        range: CultivationModeEnum
+      system_type:
+        description: Instrumentation / vessel system used.
+        range: CultivationSystemEnum
+      instrument_detail:
+        description: Distinguishing detail about the system not captured by system_type.
+      manufacturer_model:
+        description: Manufacturer and/or model designation of the instrument.
+      working_volume:
+        description: Working (culture) volume.
+        range: float
+      working_volume_unit:
+        description: Unit for working_volume (e.g. mL, L).
+      operating_temperature:
+        description: Operating/setpoint temperature of the cultivation system.
+        range: float
+      operating_temperature_unit:
+        description: Unit for operating_temperature (e.g. C, K).
+      feed_or_dilution_rate:
+        description: >-
+          Feed rate (fed-batch) or dilution rate (continuous/chemostat); disambiguated
+          by cultivation_mode.
+        range: float
+      feed_or_dilution_rate_unit:
+        description: Unit for feed_or_dilution_rate (e.g. h^-1, mL/h).
+      retention_time:
+        description: Hydraulic or solids retention time (see retention_time_type).
+        range: float
+      retention_time_unit:
+        description: Unit for retention_time (e.g. h, d).
+      retention_time_type:
+        description: Which retention time is reported (e.g. "HRT" or "SRT").
+      applied_potential:
+        description: Applied electrode potential (bioelectrochemical / fuel-cell systems).
+        range: float
+      applied_potential_unit:
+        description: Unit/reference for applied_potential (e.g. "mV vs SHE", V).
+      electrode_detail:
+        description: >-
+          Electrode configuration/materials for bioelectrochemical systems
+          (anode/cathode material, surface area, etc.).
+      ph_controlled:
+        description: Whether pH was actively controlled.
+        range: boolean
+      do_controlled:
+        description: Whether dissolved oxygen was actively controlled.
+        range: boolean
+      temperature_controlled:
+        description: Whether temperature was actively controlled.
+        range: boolean
+      controls_notes:
+        description: Free-text notes on process control not captured by the boolean flags.
+      protocol_url:
+        description: URL to the cultivation protocol.
+      notes:
+        description: Additional notes about the cultivation setup.
+      evidence:
+        description: Evidence supporting the cultivation-setup description.
+        range: EvidenceItem
+        multivalued: true
+
   MicrobialCommunity:
     tree_root: true
     description: A microbial community with composition and interactions
@@ -973,6 +1124,14 @@ classes:
         description: Growth media used for cultivation
         range: GrowthMedia
         multivalued: true
+      cultivation_setup:
+        description: >-
+          Hardware setup and cultivation mode(s) used to grow/sustain the
+          community. Optional; not all communities have a defined setup.
+        range: CultivationSetup
+        multivalued: true
+        required: false
+        inlined_as_list: true
       related_media:
         description: >-
           CultureMech media relevant to this community through shared environment,

--- a/tests/test_cultivation_vocab_sync.py
+++ b/tests/test_cultivation_vocab_sync.py
@@ -1,0 +1,108 @@
+"""Keep the cultivation enums (schema) and vocab/cultivation_terms.yaml in sync,
+and smoke-test the new optional cultivation_setup slot.
+
+The inline enums in the LinkML schema are canonical for validation; the vocab
+file is canonical for term metadata (definition/synonyms/mapping/status) staged
+for a METPO proposal. These tests guarantee the two never drift.
+"""
+
+import subprocess
+from pathlib import Path
+
+import yaml
+
+SCHEMA = "src/communitymech/schema/communitymech.yaml"
+VOCAB = Path("vocab/cultivation_terms.yaml")
+ENUMS = ("CultivationModeEnum", "CultivationSystemEnum")
+VALID_STATUS = {"proposed", "mapped", "minted"}
+
+
+def _schema():
+    return yaml.safe_load(Path(SCHEMA).read_text())
+
+
+def _vocab():
+    return yaml.safe_load(VOCAB.read_text())
+
+
+def test_enum_keys_equal_vocab_keys():
+    schema, vocab = _schema(), _vocab()
+    for enum in ENUMS:
+        enum_keys = set(schema["enums"][enum]["permissible_values"].keys())
+        vocab_keys = set(vocab[enum].keys())
+        missing = enum_keys - vocab_keys
+        extra = vocab_keys - enum_keys
+        assert not missing, f"{enum}: vocab missing {sorted(missing)}"
+        assert not extra, f"{enum}: vocab has stale keys {sorted(extra)}"
+
+
+def test_vocab_terms_well_formed():
+    vocab = _vocab()
+    for enum in ENUMS:
+        for key, term in vocab[enum].items():
+            for field in ("label", "definition", "mapping", "status"):
+                assert term.get(field), f"{enum}.{key} missing/empty {field}"
+            assert term["status"] in VALID_STATUS, f"{enum}.{key} bad status {term['status']}"
+            assert isinstance(term.get("synonyms", []), list), f"{enum}.{key} synonyms not a list"
+            # status mapped <=> a real ontology CURIE; proposed <=> metpo-candidate
+            if term["status"] == "mapped":
+                assert term["mapping"] != "metpo-candidate", f"{enum}.{key} mapped but no CURIE"
+            if term["mapping"] == "metpo-candidate":
+                assert term["status"] == "proposed", f"{enum}.{key} candidate must be proposed"
+
+
+def test_schema_meaning_matches_vocab_mapping():
+    """Every enum value with a schema `meaning:` must match the vocab mapping + be status mapped."""
+    schema, vocab = _schema(), _vocab()
+    for enum in ENUMS:
+        for key, pv in schema["enums"][enum]["permissible_values"].items():
+            meaning = (pv or {}).get("meaning")
+            if meaning:
+                assert vocab[enum][key]["mapping"] == meaning, (
+                    f"{enum}.{key}: schema meaning {meaning} != vocab mapping "
+                    f"{vocab[enum][key]['mapping']}"
+                )
+                assert vocab[enum][key]["status"] == "mapped"
+
+
+def test_cultivation_setup_validates(tmp_path):
+    community = {
+        "id": "CommunityMech:000999",
+        "name": "cultivation_setup smoke test",
+        "cultivation_setup": [
+            {
+                "cultivation_mode": "CHEMOSTAT",
+                "system_type": "STIRRED_TANK_BIOREACTOR",
+                "working_volume": 1.5,
+                "working_volume_unit": "L",
+                "feed_or_dilution_rate": 0.1,
+                "feed_or_dilution_rate_unit": "h^-1",
+                "ph_controlled": True,
+                "do_controlled": True,
+            },
+            {
+                "cultivation_mode": "BATCH",
+                "system_type": "MICROBIAL_FUEL_CELL",
+                "applied_potential": 200.0,
+                "applied_potential_unit": "mV vs SHE",
+                "electrode_detail": "carbon-cloth anode",
+            },
+        ],
+    }
+    f = tmp_path / "c.yaml"
+    f.write_text(yaml.safe_dump(community))
+    res = subprocess.run(
+        [
+            "uv",
+            "run",
+            "linkml-validate",
+            "-s",
+            SCHEMA,
+            "--target-class",
+            "MicrobialCommunity",
+            str(f),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0, f"cultivation_setup smoke test failed:\n{res.stdout}\n{res.stderr}"

--- a/vocab/cultivation_terms.yaml
+++ b/vocab/cultivation_terms.yaml
@@ -1,0 +1,168 @@
+# Controlled vocabulary for cultivation hardware/mode terms.
+#
+# The INLINE enums in src/communitymech/schema/communitymech.yaml
+# (CultivationModeEnum / CultivationSystemEnum) are CANONICAL for LinkML
+# validation. This file is canonical for term metadata used in ontology
+# standardization: definition, synonyms, candidate ontology mapping, and status.
+# It stages these terms for a future METPO proposal (see the metpo-proposal skill
+# and proposals/).
+#
+# INVARIANT (enforced by tests/test_cultivation_vocab_sync.py): the keys under
+# each enum here MUST exactly equal that enum's permissible-value keys, and any
+# enum value carrying a `meaning:` CURIE in the schema must appear here with the
+# same `mapping` and `status: mapped`.
+#
+# Per-term fields:
+#   label      human-readable term label
+#   definition one-sentence definition
+#   synonyms   list of alternative labels (may be empty [])
+#   mapping    confirmed existing ontology CURIE, or the literal "metpo-candidate"
+#   status     proposed (no confirmed mapping) | mapped (existing ontology IRI) | minted (METPO id assigned)
+
+CultivationModeEnum:
+  BATCH:
+    label: batch culture
+    definition: Closed culture with no nutrient addition or removal after inoculation.
+    synonyms: [batch cultivation, closed culture]
+    mapping: metpo-candidate
+    status: proposed
+  FED_BATCH:
+    label: fed-batch culture
+    definition: Cultivation in which nutrients are fed during the run with no removal of culture broth.
+    synonyms: [fed-batch cultivation, fed batch culture]
+    mapping: metpo-candidate
+    status: proposed
+  CONTINUOUS:
+    label: continuous culture
+    definition: Cultivation in which fresh medium is added and culture is withdrawn continuously, typically at steady state.
+    synonyms: [continuous cultivation, open continuous culture]
+    mapping: metpo-candidate
+    status: proposed
+  SEMI_CONTINUOUS:
+    label: semi-continuous culture
+    definition: Cultivation with periodic partial harvest and replacement of medium.
+    synonyms: [draw-and-fill culture, repeated batch culture]
+    mapping: metpo-candidate
+    status: proposed
+  CHEMOSTAT:
+    label: chemostat culture
+    definition: Continuous culture held at steady state by a fixed dilution rate and a growth-limiting nutrient.
+    synonyms: [chemostat cultivation]
+    mapping: metpo-candidate
+    status: proposed
+  TURBIDOSTAT:
+    label: turbidostat culture
+    definition: Continuous culture controlled to hold constant turbidity / cell density.
+    synonyms: [turbidostat cultivation]
+    mapping: metpo-candidate
+    status: proposed
+  PERFUSION:
+    label: perfusion culture
+    definition: Continuous medium exchange with biomass retention (cells retained while spent medium is removed).
+    synonyms: [perfusion cultivation]
+    mapping: metpo-candidate
+    status: proposed
+  SEQUENCING_BATCH:
+    label: sequencing batch culture
+    definition: Repeated fill / react / settle / draw cycles in a single vessel.
+    synonyms: [sequencing batch reactor operation, SBR operation]
+    mapping: metpo-candidate
+    status: proposed
+  RETENTOSTAT:
+    label: retentostat culture
+    definition: Continuous culture with complete biomass retention, approaching near-zero growth rate.
+    synonyms: [retentostat cultivation]
+    mapping: metpo-candidate
+    status: proposed
+  OTHER:
+    label: other cultivation mode
+    definition: Cultivation mode not covered by the listed values.
+    synonyms: []
+    mapping: metpo-candidate
+    status: proposed
+
+CultivationSystemEnum:
+  STIRRED_TANK_BIOREACTOR:
+    label: stirred-tank bioreactor
+    definition: Mechanically stirred tank reactor (CSTR-type).
+    synonyms: [CSTR, stirred bioreactor, continuous stirred-tank reactor]
+    mapping: metpo-candidate
+    status: proposed
+  PHOTOBIOREACTOR:
+    label: photobioreactor
+    definition: Light-driven reactor for cultivating phototrophic organisms.
+    synonyms: [PBR]
+    mapping: metpo-candidate
+    status: proposed
+  MICROBIAL_FUEL_CELL:
+    label: microbial fuel cell
+    definition: Bioelectrochemical system that generates electric current from microbial metabolism.
+    synonyms: [MFC]
+    mapping: metpo-candidate
+    status: proposed
+  BIOELECTROCHEMICAL_SYSTEM:
+    label: bioelectrochemical system
+    definition: Electrode-coupled reactor (broader than a microbial fuel cell), e.g. microbial electrolysis or electrosynthesis cells.
+    synonyms: [BES, microbial electrochemical system]
+    mapping: metpo-candidate
+    status: proposed
+  CHEMOSTAT_VESSEL:
+    label: chemostat vessel
+    definition: A vessel configured for chemostat (dilution-rate-controlled) continuous culture.
+    synonyms: [chemostat]
+    mapping: metpo-candidate
+    status: proposed
+  MEMBRANE_BIOREACTOR:
+    label: membrane bioreactor
+    definition: Reactor coupling cultivation with a membrane for biomass/liquid separation.
+    synonyms: [MBR]
+    mapping: metpo-candidate
+    status: proposed
+  SERUM_BOTTLE:
+    label: serum bottle
+    definition: Sealed serum bottle, commonly used for anaerobic cultivation.
+    synonyms: [anaerobic serum bottle]
+    mapping: metpo-candidate
+    status: proposed
+  FLASK:
+    label: culture flask
+    definition: Erlenmeyer / shake flask used for cultivation.
+    synonyms: [Erlenmeyer flask, shake flask]
+    mapping: metpo-candidate
+    status: proposed
+  GAS_LIFT_REACTOR:
+    label: gas-lift reactor
+    definition: Pneumatically mixed reactor (airlift / gas-lift).
+    synonyms: [airlift reactor, gas lift bioreactor]
+    mapping: metpo-candidate
+    status: proposed
+  PACKED_BED_REACTOR:
+    label: packed-bed reactor
+    definition: Reactor with a fixed packed support matrix for biofilm growth.
+    synonyms: [fixed-bed reactor]
+    mapping: metpo-candidate
+    status: proposed
+  MICROFLUIDIC_DEVICE:
+    label: microfluidic cultivation device
+    definition: Microfluidic cultivation chip / device.
+    synonyms: [microfluidic chip, lab-on-a-chip cultivation device]
+    mapping: metpo-candidate
+    status: proposed
+  HOLLOW_FIBER_REACTOR:
+    label: hollow-fiber reactor
+    definition: Hollow-fiber membrane cultivation system.
+    synonyms: [hollow fibre bioreactor]
+    mapping: metpo-candidate
+    status: proposed
+  BIOREACTOR_UNSPECIFIED:
+    label: bioreactor
+    definition: Bioreactor of unspecified type.
+    synonyms: [bioreactor, fermenter, fermentor]
+    mapping: OBI:0001046
+    status: mapped
+  OTHER:
+    label: other cultivation system
+    definition: Cultivation system not covered by the listed values.
+    synonyms: []
+    mapping: metpo-candidate
+    status: proposed


### PR DESCRIPTION
Adds an **optional, multivalued `cultivation_setup`** to `MicrobialCommunity` capturing the **hardware/instrumentation** and **operating mode** used to grow/sustain a community (not all communities have one). Schema-first; datamodel regenerated.

## What's added
- **`CultivationModeEnum`** — BATCH, FED_BATCH, CONTINUOUS, SEMI_CONTINUOUS, CHEMOSTAT, TURBIDOSTAT, PERFUSION, SEQUENCING_BATCH, RETENTOSTAT, OTHER.
- **`CultivationSystemEnum`** — stirred-tank / photo / membrane / gas-lift / packed-bed / hollow-fiber bioreactors, microbial fuel cell, bioelectrochemical system, chemostat vessel, serum bottle, flask, microfluidic device, bioreactor-unspecified, other.
- **`CultivationSetup`** class — mode + system + instrument/manufacturer detail, working volume, operating temperature, feed/dilution rate, retention time (HRT/SRT), applied potential + electrode detail (bioelectrochemical), pH/DO/temp control flags, protocol_url, notes, evidence.
- Optional top-level slot `cultivation_setup` (multivalued, `inlined_as_list`).

## Vocab file + METPO staging
`vocab/cultivation_terms.yaml` carries each term's label/definition/synonyms/mapping/status — the curation + METPO-staging source (the inline enums stay canonical for LinkML). Only a **confirmed** mapping is asserted: `BIOREACTOR_UNSPECIFIED → OBI:0001046` (`meaning:` on the enum, status `mapped`); everything else is `metpo-candidate`/`proposed` for a future METPO proposal. OBI prefix added.

`tests/test_cultivation_vocab_sync.py` keeps enum keys == vocab keys, checks term well-formedness and `meaning:`↔vocab consistency, and smoke-tests a populated `cultivation_setup`. Demonstrated on the Shewanella–Geobacter exoelectrogenic biofilm community.

## Verification
- [x] `just gen-python`, `just lint` (black/ruff/mypy)
- [x] `just validate-products` (blocking id↔label gate) — unaffected (enum/freetext-valued, no Term grounding)
- [x] `just validate-strict` — 265 files, **0 errors**
- [x] **197 pytest passed** (+4 new)
- [x] `validate-schema-terms` resolves OBI:0001046 (warn-only label note, same as existing CHEBI enum mappings; not a CI gate)

METPO proposal generation is a deliberate follow-up (per the agreed scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)