### PR TITLE
fix(qc): validate-all/validate-references-all must fail if ANY file fails (accumulate rc)

### DIFF
--- a/justfile
+++ b/justfile
@@ -18,10 +18,13 @@ validate FILE:
 # Validate all community files
 validate-all:
     #!/usr/bin/env bash
+    set -uo pipefail
+    rc=0
     for file in kb/communities/*.yaml; do
         echo "Validating $file..."
-        uv run linkml-validate -s src/communitymech/schema/communitymech.yaml "$file"
+        uv run linkml-validate -s src/communitymech/schema/communitymech.yaml "$file" || rc=1
     done
+    exit $rc
 
 # Validate the reusable per-taxon gene records (kb/taxa/) against CommonTaxon.
 # These files have CommonTaxon as their root, not MicrobialCommunity, so the
@@ -60,10 +63,13 @@ validate-references FILE:
 # Validate references in all community files
 validate-references-all:
     #!/usr/bin/env bash
+    set -uo pipefail
+    rc=0
     for file in kb/communities/*.yaml; do
         echo "\\nValidating references in $file..."
-        uv run linkml-reference-validator validate data "$file" -s src/communitymech/schema/communitymech.yaml --config conf/reference_validator.yaml
+        uv run linkml-reference-validator validate data "$file" -s src/communitymech/schema/communitymech.yaml --config conf/reference_validator.yaml || rc=1
     done
+    exit $rc
 
 # Validate cross-repo IDs (CultureMech, MediaIngredientMech) in one community file.
 # Pattern checks always run; existence checks run when sibling-repo paths are


### PR DESCRIPTION
`validate-all` and `validate-references-all` are `#!/usr/bin/env bash` loop recipes with **no `set -e` and no failure accumulation**, so the recipe's exit code was just the exit of the **last** file's validator. A failure in any non-last community file was silently dropped — and since `qc` depends on both, `just qc` could pass with broken records.

Fix: accumulate `rc` and `exit $rc`, matching the already-correct sibling recipes `validate-taxa` and `validate-terms-all` in the same justfile.

**Verified:** justfile parses; the rc pattern exits non-zero when an earlier (non-last) iteration fails, where the old loop returned 0.

Companion to CultureMech #75 (the `set -e` validate-recipe fix). MIM and TraitMech were checked and already propagate failures correctly (single-command recipes / rc-accumulating loops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)