### PR TITLE
Landing page redesign + pastel pink/blue theme

### DIFF
--- a/docs/browser.html
+++ b/docs/browser.html
@@ -1,0 +1,9159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CommunityMech - Microbial Community Knowledge Base</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background: #f8fafc;
+            color: #1a1a1a;
+            line-height: 1.6;
+        }
+
+        .container {
+            max-width: 1400px;
+            margin: 0 auto;
+            padding: 2rem;
+        }
+
+        header {
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
+            padding: 2rem 0;
+            margin-bottom: 2rem;
+        }
+
+        header .home-link {
+            display: inline-block;
+            margin-bottom: 0.75rem;
+            color: #3D7DD6;
+            text-decoration: none;
+            font-weight: 600;
+            font-size: 0.95rem;
+        }
+
+        header .home-link:hover {
+            text-decoration: underline;
+        }
+
+        h1 {
+            color: #1a1a1a;
+            font-size: 2.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .subtitle {
+            color: #64748b;
+            font-size: 1.125rem;
+        }
+
+        /* Main layout */
+        .main-container {
+            display: grid;
+            grid-template-columns: 320px 1fr;
+            gap: 1.5rem;
+            margin-top: 1rem;
+        }
+
+        /* Filter panel */
+        .filter-panel {
+            background: white;
+            border: 1px solid #e2e8f0;
+            border-radius: 8px;
+            padding: 1.5rem;
+            position: sticky;
+            top: 2rem;
+            max-height: calc(100vh - 4rem);
+            overflow-y: auto;
+            align-self: start;
+        }
+
+        .filter-panel h3 {
+            font-size: 1rem;
+            margin: 0;
+            color: #1e293b;
+        }
+
+        /* Search container */
+        .search-container {
+            position: relative;
+            margin-bottom: 0.75rem;
+        }
+
+        .search-container input {
+            width: 100%;
+            padding: 0.75rem 2.5rem 0.75rem 0.75rem;
+            border: 1px solid #e2e8f0;
+            border-radius: 4px;
+            font-size: 0.9rem;
+        }
+
+        .clear-btn {
+            position: absolute;
+            right: 0.5rem;
+            top: 50%;
+            transform: translateY(-50%);
+            background: none;
+            border: none;
+            color: #64748b;
+            cursor: pointer;
+            font-size: 1.2rem;
+            padding: 0.25rem 0.5rem;
+            line-height: 1;
+        }
+
+        .clear-btn:hover {
+            color: #1e293b;
+        }
+
+        .search-results-count {
+            font-size: 0.85rem;
+            color: #64748b;
+            margin-bottom: 1rem;
+            padding-bottom: 1rem;
+            border-bottom: 1px solid #e2e8f0;
+        }
+
+        /* Facet sections */
+        .facet-section {
+            margin-bottom: 1.5rem;
+            padding-bottom: 1rem;
+            border-bottom: 1px solid #e2e8f0;
+        }
+
+        .facet-section:last-child {
+            border-bottom: none;
+        }
+
+        .facet-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            cursor: pointer;
+            margin-bottom: 0.75rem;
+        }
+
+        .facet-toggle {
+            font-size: 1.2rem;
+            color: #64748b;
+            user-select: none;
+        }
+
+        .facet-body {
+            padding-left: 0.5rem;
+        }
+
+        .facet-body.collapsed {
+            display: none;
+        }
+
+        .facet-actions {
+            display: flex;
+            gap: 0.5rem;
+            margin-bottom: 0.75rem;
+        }
+
+        .facet-actions button {
+            padding: 0.25rem 0.5rem;
+            font-size: 0.8rem;
+            border: 1px solid #e2e8f0;
+            background: white;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+
+        .facet-actions button:hover {
+            background: #f8fafc;
+        }
+
+        /* Checkboxes */
+        .facet-checkboxes {
+            display: flex;
+            flex-direction: column;
+            gap: 0.4rem;
+        }
+
+        .facet-checkbox {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            cursor: pointer;
+            padding: 0.25rem 0;
+        }
+
+        .facet-checkbox:hover {
+            background: rgba(0, 0, 0, 0.02);
+        }
+
+        .facet-checkbox input[type="checkbox"] {
+            cursor: pointer;
+        }
+
+        .facet-label {
+            flex: 1;
+            font-size: 0.9rem;
+        }
+
+        .facet-count {
+            color: #64748b;
+            font-size: 0.85rem;
+        }
+
+        /* Active filters */
+        .active-filters {
+            background: #fef3c7;
+            border: 1px solid #fbbf24;
+            padding: 1rem;
+            border-radius: 6px;
+            margin-bottom: 1rem;
+        }
+
+        .active-filters-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.5rem;
+        }
+
+        .btn-reset {
+            padding: 0.25rem 0.5rem;
+            font-size: 0.8rem;
+            background: white;
+            border: 1px solid #f59e0b;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+
+        .btn-reset:hover {
+            background: #fef3c7;
+        }
+
+        #active-filter-tags {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.4rem;
+        }
+
+        .filter-tag {
+            background: white;
+            border: 1px solid #d1d5db;
+            border-radius: 12px;
+            padding: 0.25rem 0.5rem;
+            font-size: 0.8rem;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.3rem;
+        }
+
+        .filter-tag-remove {
+            cursor: pointer;
+            color: #64748b;
+            font-weight: bold;
+        }
+
+        .filter-tag-remove:hover {
+            color: #ef4444;
+        }
+
+        /* Community grid */
+        .content-area {
+            min-width: 0; /* Fixes grid overflow */
+        }
+
+        .umap-link {
+            margin-bottom: 2rem;
+            padding: 1.5rem;
+            background: white;
+            border-radius: 8px;
+            border: 2px solid #3D7DD6;
+        }
+
+        .umap-link h2 {
+            color: #3D7DD6;
+            font-size: 1.25rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .umap-link p {
+            color: #64748b;
+            margin-bottom: 1rem;
+        }
+
+        .umap-link a {
+            display: inline-block;
+            padding: 0.75rem 1.5rem;
+            background: #3D7DD6;
+            color: white;
+            text-decoration: none;
+            border-radius: 6px;
+            font-weight: 500;
+            transition: background 0.2s;
+        }
+
+        .umap-link a:hover {
+            background: #2f63ac;
+        }
+
+        .community-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+            gap: 1.5rem;
+        }
+
+        .community-card {
+            background: white;
+            border: 1px solid #e2e8f0;
+            border-radius: 8px;
+            padding: 1.5rem;
+            transition: transform 0.2s, box-shadow 0.2s;
+            text-decoration: none;
+            color: inherit;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .community-card:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+        }
+
+        .community-card h2 {
+            color: #3D7DD6;
+            font-size: 1.25rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .community-card .description {
+            color: #64748b;
+            font-size: 0.875rem;
+            line-height: 1.5;
+            display: -webkit-box;
+            -webkit-line-clamp: 3;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+            flex: 1;
+        }
+
+        .card-footer {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-top: 0.75rem;
+        }
+
+        .badge {
+            display: inline-block;
+            padding: 0.25rem 0.75rem;
+            border-radius: 12px;
+            font-size: 0.75rem;
+            font-weight: 500;
+        }
+
+        .badge-ENGINEERED { background: #dbeafe; color: #1e40af; }
+        .badge-STABLE { background: #d1fae5; color: #065f46; }
+        .badge-PERTURBED { background: #fed7aa; color: #92400e; }
+        .badge-SYNTHETIC { background: #e9d5ff; color: #6b21a8; }
+
+        .badge-category {
+            background: #f1f5f9;
+            color: #475569;
+            font-size: 0.7rem;
+            font-weight: 600;
+            letter-spacing: 0.05em;
+            text-transform: uppercase;
+            padding: 0.2rem 0.6rem;
+            border-radius: 10px;
+        }
+
+        .badge-member-count {
+            background: #f1f5f9;
+            color: #475569;
+            font-size: 0.75rem;
+            padding: 0.25rem 0.5rem;
+            border-radius: 10px;
+        }
+
+        .card-footer-left {
+            display: flex;
+            gap: 0.5rem;
+            align-items: center;
+        }
+
+        /* Hidden state for filtering */
+        .community-card.hidden {
+            display: none;
+        }
+
+        /* Responsive */
+        @media (max-width: 1200px) {
+            .main-container {
+                grid-template-columns: 1fr;
+            }
+
+            .filter-panel {
+                position: relative;
+                top: 0;
+                max-height: none;
+            }
+        }
+
+        footer {
+            margin-top: 3rem;
+            padding-top: 2rem;
+            border-top: 1px solid #e2e8f0;
+            text-align: center;
+            color: #64748b;
+            font-size: 0.875rem;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <a href="index.html" class="home-link">← Home</a>
+            <h1>CommunityMech</h1>
+            <p class="subtitle">Microbial Community Knowledge Base</p>
+        </div>
+    </header>
+
+    <main class="container">
+        <div class="main-container">
+            <!-- Left sidebar: Filter panel -->
+            <div class="filter-panel">
+                <!-- Enhanced search -->
+                <div class="search-container">
+                    <input type="search" id="search"
+                        placeholder="Search by name or description..."
+                        autocomplete="off">
+                    <button id="search-clear" class="clear-btn" title="Clear search">✕</button>
+                </div>
+                <div class="search-results-count">
+                    Showing <span id="results-count">265</span> of 265 communities
+                </div>
+
+                <!-- Active filters summary -->
+                <div id="active-filters" class="active-filters" style="display: none;">
+                    <div class="active-filters-header">
+                        <strong>Active Filters:</strong>
+                        <button id="reset-all" class="btn-reset">Clear All</button>
+                    </div>
+                    <div id="active-filter-tags"></div>
+                </div>
+
+                <!-- Category facet -->
+                <div class="facet-section">
+                    <div class="facet-header" onclick="toggleFacet('category-facet')">
+                        <h3>Category</h3>
+                        <span class="facet-toggle">−</span>
+                    </div>
+                    <div id="category-facet" class="facet-body">
+                        <div class="facet-actions">
+                            <button class="select-all" data-facet="category">All</button>
+                            <button class="clear-all" data-facet="category">None</button>
+                        </div>
+                        <div id="category-checkboxes" class="facet-checkboxes"></div>
+                    </div>
+                </div>
+
+                <!-- Ecological state facet -->
+                <div class="facet-section">
+                    <div class="facet-header" onclick="toggleFacet('state-facet')">
+                        <h3>Ecological State</h3>
+                        <span class="facet-toggle">−</span>
+                    </div>
+                    <div id="state-facet" class="facet-body">
+                        <div id="state-checkboxes" class="facet-checkboxes"></div>
+                    </div>
+                </div>
+
+                <!-- Metals facet -->
+                <div class="facet-section">
+                    <div class="facet-header" onclick="toggleFacet('metals-facet')">
+                        <h3>Metals</h3>
+                        <span class="facet-toggle">+</span>
+                    </div>
+                    <div id="metals-facet" class="facet-body collapsed">
+                        <div class="facet-actions">
+                            <button class="select-all" data-facet="metals">All</button>
+                            <button class="clear-all" data-facet="metals">None</button>
+                        </div>
+                        <div id="metals-checkboxes" class="facet-checkboxes"></div>
+                    </div>
+                </div>
+
+                <!-- Rare Earth Elements facet -->
+                <div class="facet-section">
+                    <div class="facet-header" onclick="toggleFacet('ree-facet')">
+                        <h3>Rare Earth Elements</h3>
+                        <span class="facet-toggle">+</span>
+                    </div>
+                    <div id="ree-facet" class="facet-body collapsed">
+                        <div class="facet-actions">
+                            <button class="select-all" data-facet="ree">All</button>
+                            <button class="clear-all" data-facet="ree">None</button>
+                        </div>
+                        <div id="ree-checkboxes" class="facet-checkboxes"></div>
+                    </div>
+                </div>
+
+                <!-- Metal Relevance facet -->
+                <div class="facet-section">
+                    <div class="facet-header" onclick="toggleFacet('relevance-facet')">
+                        <h3>Metal Relevance</h3>
+                        <span class="facet-toggle">+</span>
+                    </div>
+                    <div id="relevance-facet" class="facet-body collapsed">
+                        <div id="relevance-checkboxes" class="facet-checkboxes"></div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Right side: Community grid -->
+            <div class="content-area">
+                <div class="umap-link">
+                    <h2>📊 Explore Community Relationships</h2>
+                    <p>View the UMAP projection of all communities based on their taxonomic composition embeddings from KG-Microbe.</p>
+                    <a href="community_umap.html">View Community Embedding Space →</a>
+                </div>
+
+                <div class="community-grid" id="community-grid">
+                    
+                    <a href="communities/AMD_Acidophile_Heterotroph_Network.html"
+                       class="community-card"
+                       data-id="AMD_Acidophile_Heterotroph_Network"
+                       data-name="amd acidophile heterotroph network"
+                       data-description="a heterotrophic microbial network in acid mine drainage (amd) systems dominated by acidiphilium species and related acidophilic heterotrophs. this community plays a crucial role in coupling carbon and iron cycles in extremely acidic environments, supporting autotrophic iron oxidizers through organic matter processing and nutrient remineralization. the network thrives at ph 2-4 in amd sites globally, where heterotrophs metabolize organic compounds produced by autotrophs or released from lysed cells, preventing organic carbon accumulation that would inhibit autotrophic iron oxidizers. key members include acidiphilium multivorum (facultative fe(iii) reducer and organic carbon degrader), ferrimicrobium acidiphilum (iron-oxidizing heterotroph and dissolved organic carbon remover), acidocella facilis (obligate aerobic heterotroph), acidisphaera rubrifaciens (photoheterotrophic bacteriochlorophyll producer), and acidobacterium capsulatum (chemoorganotrophic acidophile). these organisms collectively perform organic matter degradation, ferric iron reduction, biofilm formation, and nutrient cycling. the heterotroph-autotroph coupling maintains community stability by removing inhibitory organic carbon, recycling nutrients (nitrogen, phosphorus), generating ferrous iron for autotrophic energy generation, and facilitating metal tolerance through extracellular polymeric substances (eps) production. this network represents a critical functional guild in amd ecosystems, enabling the persistence of autotrophic iron-oxidizing communities through metabolic cooperation and resource partitioning.
+"
+                       data-category="AMD"
+                       data-state="STABLE"
+                       data-metals="COPPER,GOLD,IRON"
+                       data-ree=""
+                       data-relevance="PRIMARY"
+                       data-member-count="6">
+                        <h2>AMD Acidophile Heterotroph Network</h2>
+                        <p class="description">A heterotrophic microbial network in acid mine drainage (AMD) systems dominated by Acidiphilium species and related acidophilic heterotrophs. This community plays a crucial role in coupling carbon and iron cycles in extremely acidic environments, supporting autotrophic iron oxidizers through organic matter processing and nutrient remineralization. The network thrives at pH 2-4 in AMD sites globally, where heterotrophs metabolize organic compounds produced by autotrophs or released from lysed cells, preventing organic carbon accumulation that would inhibit autotrophic iron oxidizers. Key members include Acidiphilium multivorum (facultative Fe(III) reducer and organic carbon degrader), Ferrimicrobium acidiphilum (iron-oxidizing heterotroph and dissolved organic carbon remover), Acidocella facilis (obligate aerobic heterotroph), Acidisphaera rubrifaciens (photoheterotrophic bacteriochlorophyll producer), and Acidobacterium capsulatum (chemoorganotrophic acidophile). These organisms collectively perform organic matter degradation, ferric iron reduction, biofilm formation, and nutrient cycling. The heterotroph-autotroph coupling maintains community stability by removing inhibitory organic carbon, recycling nutrients (nitrogen, phosphorus), generating ferrous iron for autotrophic energy generation, and facilitating metal tolerance through extracellular polymeric substances (EPS) production. This network represents a critical functional guild in AMD ecosystems, enabling the persistence of autotrophic iron-oxidizing communities through metabolic cooperation and resource partitioning.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    6
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">AMD</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/AMD_Nitrososphaerota_Archaeal.html"
+                       class="community-card"
+                       data-id="AMD_Nitrososphaerota_Archaeal"
+                       data-name="amd nitrososphaerota archaeal community"
+                       data-description="a novel archaeal community from acid mine drainage environments dominated by ammonia-oxidizing archaea (aoa) of the phylum nitrososphaerota (formerly thaumarchaeota). this community represents a unique nitrogen-cycling system operating at extremely low ph (2.5-4.5) where archaeal nitrifiers outcompete bacterial ammonia oxidizers. the dominant members include acidophilic aoa such as candidatus nitrosotalea devanaterra and nitrososphaera-like archaea that possess extraordinary substrate affinity (km 0.6-2.8 nm for nh3) and specialized adaptations for acidophily. these archaea oxidize ammonia to nitrite through the copper-containing ammonia monooxygenase (amo) enzyme while maintaining cytoplasmic ph homeostasis in extremely acidic environments. the community also includes supporting acidophilic archaea from thermoplasmata (ferroplasma, acidiplasma) that provide ecosystem services including organic matter processing and metal tolerance. unique features include: (1) amt-type ammonium transporters enabling nh4+ uptake rather than nh3 diffusion, (2) urea hydrolysis pathways providing localized ammonia generation, (3) extensive cell surface glycosylation reducing proton permeability, and (4) metabolic cooperation with nitrite-oxidizing bacteria (nitrospira, leptospirillum) completing the nitrification pathway. this system demonstrates how archaeal nitrifiers dominate nitrogen cycling in acidic environments where bacterial counterparts cannot function, with aoa abundance 3-10 fold higher than aob in amd sediments. the community thrives in acid sulfate soils, acid mine drainage sediments, and acidic tailings, representing a critical component of nitrogen cycling in the 30% of earth&#39;s soils with ph &lt;5.5. based on genomic data from ncbi bioproject prjna1261802 and related amd archaeal community studies.
+"
+                       data-category="AMD"
+                       data-state="STABLE"
+                       data-metals="COPPER,IRON"
+                       data-ree=""
+                       data-relevance="PRIMARY"
+                       data-member-count="4">
+                        <h2>AMD Nitrososphaerota Archaeal Community</h2>
+                        <p class="description">A novel archaeal community from acid mine drainage environments dominated by ammonia-oxidizing archaea (AOA) of the phylum Nitrososphaerota (formerly Thaumarchaeota). This community represents a unique nitrogen-cycling system operating at extremely low pH (2.5-4.5) where archaeal nitrifiers outcompete bacterial ammonia oxidizers. The dominant members include acidophilic AOA such as Candidatus Nitrosotalea devanaterra and Nitrososphaera-like archaea that possess extraordinary substrate affinity (Km 0.6-2.8 nM for NH3) and specialized adaptations for acidophily. These archaea oxidize ammonia to nitrite through the copper-containing ammonia monooxygenase (AMO) enzyme while maintaining cytoplasmic pH homeostasis in extremely acidic environments. The community also includes supporting acidophilic archaea from Thermoplasmata (Ferroplasma, Acidiplasma) that provide ecosystem services including organic matter processing and metal tolerance. Unique features include: (1) Amt-type ammonium transporters enabling NH4+ uptake rather than NH3 diffusion, (2) urea hydrolysis pathways providing localized ammonia generation, (3) extensive cell surface glycosylation reducing proton permeability, and (4) metabolic cooperation with nitrite-oxidizing bacteria (Nitrospira, Leptospirillum) completing the nitrification pathway. This system demonstrates how archaeal nitrifiers dominate nitrogen cycling in acidic environments where bacterial counterparts cannot function, with AOA abundance 3-10 fold higher than AOB in AMD sediments. The community thrives in acid sulfate soils, acid mine drainage sediments, and acidic tailings, representing a critical component of nitrogen cycling in the 30% of Earth&#39;s soils with pH &lt;5.5. Based on genomic data from NCBI BioProject PRJNA1261802 and related AMD archaeal community studies.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">AMD</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/ANME_SRB_Marine_Methane_Seep_Consortium.html"
+                       class="community-card"
+                       data-id="ANME_SRB_Marine_Methane_Seep_Consortium"
+                       data-name="anme-srb marine methane seep consortium"
+                       data-description="natural marine methane-seep consortia in which anaerobic methanotrophic archaea (anme) grow in syntrophic partnership with sulfate-reducing bacteria (srb). these structured aggregates couple anaerobic oxidation of methane to sulfate reduction, limiting methane release from ocean sediments. the interaction is frequently organized as multicellular consortia containing anme archaeal cells and bacterial sulfate reducers, with genomic evidence supporting direct interspecies electron transfer from anme to the srb partner."
+                       data-category="SYNTROPHY"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>ANME-SRB Marine Methane Seep Consortium</h2>
+                        <p class="description">Natural marine methane-seep consortia in which anaerobic methanotrophic archaea (ANME) grow in syntrophic partnership with sulfate-reducing bacteria (SRB). These structured aggregates couple anaerobic oxidation of methane to sulfate reduction, limiting methane release from ocean sediments. The interaction is frequently organized as multicellular consortia containing ANME archaeal cells and bacterial sulfate reducers, with genomic evidence supporting direct interspecies electron transfer from ANME to the SRB partner.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Aalborg_East_Full_Scale_EBPR_Community.html"
+                       class="community-card"
+                       data-id="Aalborg_East_Full_Scale_EBPR_Community"
+                       data-name="aalborg east full-scale ebpr activated sludge community"
+                       data-description="an engineered full-scale activated sludge microbial community from the aalborg east wastewater treatment plant in denmark carrying out enhanced biological phosphorus removal. the community was profiled with an 18.2 gb illumina metagenome and qfish, revealing phosphate-removal organisms including candidatus accumulibacter and tetrasphaera-related actinobacteria, flanking substrate-providing bacteria, and metagenomic enrichment for phosphate metabolism and biofilm/floc formation functions."
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Aalborg East Full-Scale EBPR Activated Sludge Community</h2>
+                        <p class="description">An engineered full-scale activated sludge microbial community from the Aalborg East wastewater treatment plant in Denmark carrying out enhanced biological phosphorus removal. The community was profiled with an 18.2 Gb Illumina metagenome and qFISH, revealing phosphate-removal organisms including Candidatus Accumulibacter and Tetrasphaera-related Actinobacteria, flanking substrate-providing bacteria, and metagenomic enrichment for phosphate metabolism and biofilm/floc formation functions.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.html"
+                       class="community-card"
+                       data-id="Acetobacterium_Clostridium_CO2_Electrolysis_Coculture"
+                       data-name="acetobacterium woodii-clostridium drakei co2 electrolysis coculture"
+                       data-description="a defined anaerobic synthetic coculture that combines a lactate-producing acetobacterium woodii mutant with clostridium drakei to convert co2 and h2 into longer-chain products. a. woodii fixes co2 with h2 and is engineered to release lactate, which c. drakei uses as an intermediate for chain elongation to caproic acid. the system is doe-relevant because it couples microbial co2 valorization with in situ water electrolysis or co2/h2 gas feeding for production of value chemicals.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Acetobacterium woodii-Clostridium drakei CO2 Electrolysis Coculture</h2>
+                        <p class="description">A defined anaerobic synthetic coculture that combines a lactate-producing Acetobacterium woodii mutant with Clostridium drakei to convert CO2 and H2 into longer-chain products. A. woodii fixes CO2 with H2 and is engineered to release lactate, which C. drakei uses as an intermediate for chain elongation to caproic acid. The system is DOE-relevant because it couples microbial CO2 valorization with in situ water electrolysis or CO2/H2 gas feeding for production of value chemicals.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.html"
+                       class="community-card"
+                       data-id="Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment"
+                       data-name="acetylene-fueled trichloroethene dechlorination groundwater enrichment"
+                       data-description="a microbial community enriched from tce/pce-contaminated groundwater and amended with acetylene (c2h2) as the sole electron donor and organic carbon source. the stable enrichment performs reductive dechlorination of trichloroethene (tce) and tetrachloroethene (pce), coupling acetylenotrophy to organohalide respiration. metagenomic analysis of the stable community identified a novel anaerobic acetylenotroph in the phylum actinobacteria, expanding the known diversity of this metabolism beyond previously documented pelobacter sfb93 + dehalococcoides mccartyi laboratory cocultures.
+"
+                       data-category="BIOREMEDIATION"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Acetylene-Fueled Trichloroethene Dechlorination Groundwater Enrichment</h2>
+                        <p class="description">A microbial community enriched from TCE/PCE-contaminated groundwater and amended with acetylene (C2H2) as the sole electron donor and organic carbon source. The stable enrichment performs reductive dechlorination of trichloroethene (TCE) and tetrachloroethene (PCE), coupling acetylenotrophy to organohalide respiration. Metagenomic analysis of the stable community identified a novel anaerobic acetylenotroph in the phylum Actinobacteria, expanding the known diversity of this metabolism beyond previously documented Pelobacter SFB93 + Dehalococcoides mccartyi laboratory cocultures.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Aerobic_Denitrification_Disturbance_SynCom.html"
+                       class="community-card"
+                       data-id="Aerobic_Denitrification_Disturbance_SynCom"
+                       data-name="aerobic denitrification disturbance-stable syncom"
+                       data-description="a three-member aerobic denitrification smc that maintains function under dibutyl phthalate and levofloxacin disturbances through division of labor."
+                       data-category="BIOREMEDIATION"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Aerobic Denitrification Disturbance-Stable SynCom</h2>
+                        <p class="description">A three-member aerobic denitrification SMC that maintains function under dibutyl phthalate and levofloxacin disturbances through division of labor.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Aerobic_Denitrification_QQ_SynCom.html"
+                       class="community-card"
+                       data-id="Aerobic_Denitrification_QQ_SynCom"
+                       data-name="aerobic denitrification quorum-quenching syncom"
+                       data-description="a three-member aerobic denitrification syncom whose quorum-quenching and ahl-mediated interactions improve nitrate removal."
+                       data-category="BIOREMEDIATION"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Aerobic Denitrification Quorum-Quenching SynCom</h2>
+                        <p class="description">A three-member aerobic denitrification SynCom whose quorum-quenching and AHL-mediated interactions improve nitrate removal.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Alaska_Tundra_Permafrost_Iron_Redox_Community.html"
+                       class="community-card"
+                       data-id="Alaska_Tundra_Permafrost_Iron_Redox_Community"
+                       data-name="alaska tundra permafrost iron-redox community"
+                       data-description="a northern alaska wet sedge tundra microbial community studied across the permafrost thaw gradient, where iron-cycling gammaproteobacteria - the heterotrophic fe(iii)-reducing rhodoferax sp. and the chemoautotrophic fe(ii)-oxidizing gallionella sp. - become numerically dominant during extended anaerobic thaw of transition-zone and permafrost soils. functional gene abundance shows that fe(iii) reduction and fe(ii) oxidation increase in lockstep with benzoate degradation and pyruvate metabolism, supporting a carbon-cycling model in which acetate and benzoate are oxidized to co2 coupled to fe(iii) reduction. concurrent decreases in ch4-metabolism gene abundance suggest that dissimilatory fe(iii) reduction competitively suppresses acetoclastic methanogenesis under the reducing thaw conditions examined.
+"
+                       data-category="METAL_REDUCTION"
+                       data-state="PERTURBED"
+                       data-metals="IRON"
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="3">
+                        <h2>Alaska Tundra Permafrost Iron-Redox Community</h2>
+                        <p class="description">A northern Alaska wet sedge tundra microbial community studied across the permafrost thaw gradient, where iron-cycling Gammaproteobacteria - the heterotrophic Fe(III)-reducing Rhodoferax sp. and the chemoautotrophic Fe(II)-oxidizing Gallionella sp. - become numerically dominant during extended anaerobic thaw of transition-zone and permafrost soils. Functional gene abundance shows that Fe(III) reduction and Fe(II) oxidation increase in lockstep with benzoate degradation and pyruvate metabolism, supporting a carbon-cycling model in which acetate and benzoate are oxidized to CO2 coupled to Fe(III) reduction. Concurrent decreases in CH4-metabolism gene abundance suggest that dissimilatory Fe(III) reduction competitively suppresses acetoclastic methanogenesis under the reducing thaw conditions examined.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">METAL_REDUCTION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.html"
+                       class="community-card"
+                       data-id="Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community"
+                       data-name="altered schaedler flora gnotobiotic mouse community"
+                       data-description="the altered schaedler flora (asf) is an eight-member defined murine gut bacterial community used in gnotobiotic mice. the community was developed as a standardized, culturable intestinal flora from mouse-derived bacteria and has been used for decades to study host-microbiota relationships, member stability, spatial distribution, immune effects, and genome-informed community metabolism."
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Altered Schaedler Flora Gnotobiotic Mouse Community</h2>
+                        <p class="description">The altered Schaedler flora (ASF) is an eight-member defined murine gut bacterial community used in gnotobiotic mice. The community was developed as a standardized, culturable intestinal flora from mouse-derived bacteria and has been used for decades to study host-microbiota relationships, member stability, spatial distribution, immune effects, and genome-informed community metabolism.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Anammox_Bioreactor_DNRA_Destabilization_Community.html"
+                       class="community-card"
+                       data-id="Anammox_Bioreactor_DNRA_Destabilization_Community"
+                       data-name="anammox bioreactor dnra destabilization community"
+                       data-description="a laboratory-scale anaerobic ammonium oxidation (anammox) bioreactor community followed from inoculation through a performance destabilization event and back to robust steady-state operation, characterized by metagenomics. metabolic analyses showed selection for nutrient-acquisition capacities in the core community. dissimilatory nitrate reduction to ammonium (dnra) was the primary nitrogen-removal pathway that competed with anammox, and increased replication of dnra-capable bacteria out-competed anammox bacteria, causing the loss of nitrogen-removal capacity. the dnra-capable bacteria were closely associated with the anammox bacterium and are considered part of the core microbial community, underscoring how bacteria that are otherwise core members can be detrimental.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="PERTURBED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Anammox Bioreactor DNRA Destabilization Community</h2>
+                        <p class="description">A laboratory-scale anaerobic ammonium oxidation (anammox) bioreactor community followed from inoculation through a performance destabilization event and back to robust steady-state operation, characterized by metagenomics. Metabolic analyses showed selection for nutrient-acquisition capacities in the core community. Dissimilatory nitrate reduction to ammonium (DNRA) was the primary nitrogen-removal pathway that competed with anammox, and increased replication of DNRA-capable bacteria out-competed anammox bacteria, causing the loss of nitrogen-removal capacity. The DNRA-capable bacteria were closely associated with the anammox bacterium and are considered part of the core microbial community, underscoring how bacteria that are otherwise core members can be detrimental.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Anammox_Granule_Metabolic_Interaction_Community.html"
+                       class="community-card"
+                       data-id="Anammox_Granule_Metabolic_Interaction_Community"
+                       data-name="anammox granule metabolic interaction community"
+                       data-description="a laboratory-scale anammox granular-sludge bioreactor community reconstructed with genome-centric metagenomics and metatranscriptomics. brocadia-affiliated anammox bacteria dominate nitrogen removal, while chlorobi-affiliated and other heterotrophic bacteria recycle nitrate to nitrite, degrade eps-derived peptides, and scavenge detrital products from anammox growth.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Anammox Granule Metabolic Interaction Community</h2>
+                        <p class="description">A laboratory-scale anammox granular-sludge bioreactor community reconstructed with genome-centric metagenomics and metatranscriptomics. Brocadia-affiliated anammox bacteria dominate nitrogen removal, while Chlorobi-affiliated and other heterotrophic bacteria recycle nitrate to nitrite, degrade EPS-derived peptides, and scavenge detrital products from anammox growth.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Angelarchaeales_Thermoplasmata_CuMMO_Soil_Sediment_Community.html"
+                       class="community-card"
+                       data-id="Angelarchaeales_Thermoplasmata_CuMMO_Soil_Sediment_Community"
+                       data-name="angelarchaeales thermoplasmata cummo soil and sediment community"
+                       data-description="a soil and aquifer-sediment microbial community in which a newly defined thermoplasmatota archaeal order, ca. angelarchaeales, encodes divergent copper membrane monooxygenases (cummos). twenty genomes from distinct archaeal species were recovered from grassland and hillslope soils and aquifer sediments. the cummo proteins resemble nitrososphaerales (ammonia monooxygenase) enzymes more than bacterial cummos and retain all functional residues required for monooxygenase activity. angelarchaeales genomes are enriched in blue copper proteins (bcps) including plastocyanin-like electron carriers and divergent nitrite reductase-like (nirk) 2-domain cupredoxin proteins, encode strong peptide and amino-acid uptake/degradation capacity, and share electron transport mechanisms with nitrososphaerales. angelarchaeales are abundant in some of the source environments.
+"
+                       data-category="EXTREME_ENVIRONMENT"
+                       data-state="STABLE"
+                       data-metals="COPPER"
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="1">
+                        <h2>Angelarchaeales Thermoplasmata CuMMO Soil and Sediment Community</h2>
+                        <p class="description">A soil and aquifer-sediment microbial community in which a newly defined Thermoplasmatota archaeal order, Ca. Angelarchaeales, encodes divergent copper membrane monooxygenases (CuMMOs). Twenty genomes from distinct archaeal species were recovered from grassland and hillslope soils and aquifer sediments. The CuMMO proteins resemble Nitrososphaerales (ammonia monooxygenase) enzymes more than bacterial CuMMOs and retain all functional residues required for monooxygenase activity. Angelarchaeales genomes are enriched in blue copper proteins (BCPs) including plastocyanin-like electron carriers and divergent nitrite reductase-like (nirK) 2-domain cupredoxin proteins, encode strong peptide and amino-acid uptake/degradation capacity, and share electron transport mechanisms with Nitrososphaerales. Angelarchaeales are abundant in some of the source environments.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">EXTREME_ENVIRONMENT</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Arabidopsis_Coumarin_Root_SynCom.html"
+                       class="community-card"
+                       data-id="Arabidopsis_Coumarin_Root_SynCom"
+                       data-name="arabidopsis coumarin root syncom"
+                       data-description="a reduced arabidopsis root-isolate syncom used to detect rhizosphere community shifts caused by phytoalexin, flavonoid, and coumarin exudates."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>Arabidopsis Coumarin Root SynCom</h2>
+                        <p class="description">A reduced Arabidopsis root-isolate SynCom used to detect rhizosphere community shifts caused by phytoalexin, flavonoid, and coumarin exudates.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Arabidopsis_Phyllosphere_SynCom7.html"
+                       class="community-card"
+                       data-id="Arabidopsis_Phyllosphere_SynCom7"
+                       data-name="arabidopsis phyllosphere syncom7"
+                       data-description="a seven-strain reduced-complexity arabidopsis phyllosphere syncom used to test host genetic effects on microbiota composition."
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>Arabidopsis Phyllosphere SynCom7</h2>
+                        <p class="description">A seven-strain reduced-complexity Arabidopsis phyllosphere SynCom used to test host genetic effects on microbiota composition.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.html"
+                       class="community-card"
+                       data-id="Asgard_Wetland_Soil_Methanogenesis_Substrate_Community"
+                       data-name="asgard archaea wetland soil methanogenesis-substrate community"
+                       data-description="a wetland soil community in which terrestrial asgard archaea modulate potential methanogenesis substrates. two complete genomes were reconstructed for soil-associated atabeyarchaeia, a newly defined asgard lineage, alongside a complete genome for freyarchaeia. metatranscriptomic data show in situ expression of [nife]-hydrogenases, pyruvate oxidation, wood-ljungdahl-pathway carbon fixation, amino acid metabolism, anaerobic aldehyde oxidation, hydrogen peroxide detoxification, and carbohydrate breakdown to acetate and formate. soil-associated asgard archaea are predicted to act as non-methanogenic acetogens, suggesting they compete with methanogens for shared substrates (h2, acetate, formate) and shape terrestrial carbon cycling.
+"
+                       data-category="METHANOGENESIS"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Asgard Archaea Wetland Soil Methanogenesis-Substrate Community</h2>
+                        <p class="description">A wetland soil community in which terrestrial Asgard archaea modulate potential methanogenesis substrates. Two complete genomes were reconstructed for soil-associated Atabeyarchaeia, a newly defined Asgard lineage, alongside a complete genome for Freyarchaeia. Metatranscriptomic data show in situ expression of [NiFe]-hydrogenases, pyruvate oxidation, Wood-Ljungdahl-pathway carbon fixation, amino acid metabolism, anaerobic aldehyde oxidation, hydrogen peroxide detoxification, and carbohydrate breakdown to acetate and formate. Soil-associated Asgard archaea are predicted to act as non-methanogenic acetogens, suggesting they compete with methanogens for shared substrates (H2, acetate, formate) and shape terrestrial carbon cycling.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">METHANOGENESIS</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/At_RSPHERE_SynCom.html"
+                       class="community-card"
+                       data-id="At_RSPHERE_SynCom"
+                       data-name="at-rsphere syncom"
+                       data-description="a synthetic bacterial community derived from the arabidopsis root microbiota culture collection (at-rsphere), representing 16 bacterial families isolated from arabidopsis thaliana roots grown in natural soil. this community was established to study plant-microbe interactions and their effects on plant productivity and carbon cycling in the rhizosphere. the consortium members were selected to represent a broad taxonomic range covering the major bacterial phyla (proteobacteria, actinobacteria, and bacteroidetes) found in the arabidopsis root microbiome. assembly sizes vary from 5-20 members depending on experimental design, enabling reductionist studies of root microbiota assembly and function.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="INCIDENTAL"
+                       data-member-count="6">
+                        <h2>At-RSPHERE SynCom</h2>
+                        <p class="description">A synthetic bacterial community derived from the Arabidopsis root microbiota culture collection (At-RSPHERE), representing 16 bacterial families isolated from Arabidopsis thaliana roots grown in natural soil. This community was established to study plant-microbe interactions and their effects on plant productivity and carbon cycling in the rhizosphere. The consortium members were selected to represent a broad taxonomic range covering the major bacterial phyla (Proteobacteria, Actinobacteria, and Bacteroidetes) found in the Arabidopsis root microbiome. Assembly sizes vary from 5-20 members depending on experimental design, enabling reductionist studies of root microbiota assembly and function.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    6
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Australian_Lead_Zinc_Polymetallic.html"
+                       class="community-card"
+                       data-id="Australian_Lead_Zinc_Polymetallic"
+                       data-name="australian lead zinc polymetallic tailings consortium"
+                       data-description="a stratified microbial community from abandoned polymetallic mine tailings in western australia, characterized by vertical zonation of acidophilic and anaerobic organisms across steep ph and redox gradients. this system represents a naturally acidifying sulfidic tailings dump where oxidative weathering of pb-zn sulfide minerals drives extreme environmental heterogeneity and microhabitat specialization. the upper oxidized layer (ph 1.5-3.0) is dominated by iron- and sulfur-oxidizing acidophiles including acidithiobacillus ferrooxidans (dual fe/s oxidation) and leptospirillum ferriphilum (specialized fe oxidation), which generate ferric iron and sulfuric acid that mobilize lead, zinc, copper, and iron from sulfide minerals including galena (pbs), sphalerite (zns), and chalcopyrite (cufes₂). the intermediate chemocline exhibits dramatic ph transitions (ph 3-5) where ferroplasma acidarmanus thrives in highly acidic microniches while facultative acidophiles transition to neutral conditions. the deeper sediment layer (ph 5-7) harbors anaerobic metal-reducing bacteria including geobacter metallireducens that reduce ferric iron to ferrous iron using organic carbon, creating redox cycling between oxic and anoxic zones. metagenome-assembled genomes (mags) reveal extensive microhabitat partitioning, with distinct populations specializing in surface oxidation, chemocline transitions, or deep anaerobic processes. metal concentrations reach toxic levels (pb: hundreds mg/kg, zn: thousands mg/kg, cu: hundreds mg/kg, fe: up to 30% w/w), selecting for metal-resistant populations. this abandoned tailings system demonstrates natural biogeochemical cycling without active mining, with microbial communities driving ongoing metal mobilization (upper layers) and potential natural attenuation (deeper layers). the mag-resolved metagenomics approach reveals cryptic microbial diversity including novel acidophilic lineages adapted to polymetallic stress, providing insights into bioremediation strategies and microbial evolution in extreme anthropogenic environments.
+"
+                       data-category="BIOREMEDIATION"
+                       data-state="PERTURBED"
+                       data-metals="COPPER,IRON,LEAD,ZINC"
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="6">
+                        <h2>Australian Lead Zinc Polymetallic Tailings Consortium</h2>
+                        <p class="description">A stratified microbial community from abandoned polymetallic mine tailings in Western Australia, characterized by vertical zonation of acidophilic and anaerobic organisms across steep pH and redox gradients. This system represents a naturally acidifying sulfidic tailings dump where oxidative weathering of Pb-Zn sulfide minerals drives extreme environmental heterogeneity and microhabitat specialization. The upper oxidized layer (pH 1.5-3.0) is dominated by iron- and sulfur-oxidizing acidophiles including Acidithiobacillus ferrooxidans (dual Fe/S oxidation) and Leptospirillum ferriphilum (specialized Fe oxidation), which generate ferric iron and sulfuric acid that mobilize lead, zinc, copper, and iron from sulfide minerals including galena (PbS), sphalerite (ZnS), and chalcopyrite (CuFeS₂). The intermediate chemocline exhibits dramatic pH transitions (pH 3-5) where Ferroplasma acidarmanus thrives in highly acidic microniches while facultative acidophiles transition to neutral conditions. The deeper sediment layer (pH 5-7) harbors anaerobic metal-reducing bacteria including Geobacter metallireducens that reduce ferric iron to ferrous iron using organic carbon, creating redox cycling between oxic and anoxic zones. Metagenome-assembled genomes (MAGs) reveal extensive microhabitat partitioning, with distinct populations specializing in surface oxidation, chemocline transitions, or deep anaerobic processes. Metal concentrations reach toxic levels (Pb: hundreds mg/kg, Zn: thousands mg/kg, Cu: hundreds mg/kg, Fe: up to 30% w/w), selecting for metal-resistant populations. This abandoned tailings system demonstrates natural biogeochemical cycling without active mining, with microbial communities driving ongoing metal mobilization (upper layers) and potential natural attenuation (deeper layers). The MAG-resolved metagenomics approach reveals cryptic microbial diversity including novel acidophilic lineages adapted to polymetallic stress, providing insights into bioremediation strategies and microbial evolution in extreme anthropogenic environments.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    6
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.html"
+                       class="community-card"
+                       data-id="Avena_Rhizosphere_CrossKingdom_SIP_Community"
+                       data-name="avena rhizosphere cross-kingdom 13c-sip community"
+                       data-description="a rhizosphere community of avena fatua traced with stable isotope probing (sip) by growing the plant in a 13co2 atmosphere. paired rhizosphere and nonrhizosphere soils sampled at 6 and 9 weeks were density-fractionated and sequenced to recover 55 bacterial genomes (&gt;=70 percent complete), complete 18s rrna sequences of 13c-enriched microeukaryotic bacterivores and fungi, and 10 circularized bacteriophage genomes. some phages were the most labeled entities in the rhizosphere, suggesting phage are important agents of turnover of plant-derived carbon in soil. crispr spacer targeting linked one phage to a burkholderiales host predicted to be a plant pathogen and another to a catenulispora sp. predicted to be a plant growth-promoting bacterium. heavily 13c-labeled bacterial genes include those involved in modulating plant signaling hormones, plant pathogenicity, and defense against microeukaryote grazing.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="5">
+                        <h2>Avena Rhizosphere Cross-Kingdom 13C-SIP Community</h2>
+                        <p class="description">A rhizosphere community of Avena fatua traced with stable isotope probing (SIP) by growing the plant in a 13CO2 atmosphere. Paired rhizosphere and nonrhizosphere soils sampled at 6 and 9 weeks were density-fractionated and sequenced to recover 55 bacterial genomes (&gt;=70 percent complete), complete 18S rRNA sequences of 13C-enriched microeukaryotic bacterivores and fungi, and 10 circularized bacteriophage genomes. Some phages were the most labeled entities in the rhizosphere, suggesting phage are important agents of turnover of plant-derived carbon in soil. CRISPR spacer targeting linked one phage to a Burkholderiales host predicted to be a plant pathogen and another to a Catenulispora sp. predicted to be a plant growth-promoting bacterium. Heavily 13C-labeled bacterial genes include those involved in modulating plant signaling hormones, plant pathogenicity, and defense against microeukaryote grazing.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    5
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.html"
+                       class="community-card"
+                       data-id="Avena_Rhizosphere_Detritusphere_Niche_Succession"
+                       data-name="avena rhizosphere and detritusphere niche-differentiated decomposer guilds"
+                       data-description="a rhizosphere and detritusphere microbial community of avena fatua characterized by time-resolved metatranscriptomics across rhizosphere, detritusphere, and combined rhizosphere-detritusphere habitats. transcripts were binned using a unique reference database from soil isolate genomes, single-cell amplified genomes, metagenomes, and stable-isotope-probing metagenomes. soil habitat significantly affected both community composition and overall gene expression, but the succession of microbial functions occurred faster than compositional change. hierarchical clustering of upregulated decomposition genes resolved four microbial guilds whose functional succession patterns suggest specialization for fresh growing roots, decaying root detritus, the combination of live and decaying root biomass, or aging root material. carbohydrate depolymerization genes were consistently upregulated in the rhizosphere.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>Avena Rhizosphere and Detritusphere Niche-Differentiated Decomposer Guilds</h2>
+                        <p class="description">A rhizosphere and detritusphere microbial community of Avena fatua characterized by time-resolved metatranscriptomics across rhizosphere, detritusphere, and combined rhizosphere-detritusphere habitats. Transcripts were binned using a unique reference database from soil isolate genomes, single-cell amplified genomes, metagenomes, and stable-isotope-probing metagenomes. Soil habitat significantly affected both community composition and overall gene expression, but the succession of microbial functions occurred faster than compositional change. Hierarchical clustering of upregulated decomposition genes resolved four microbial guilds whose functional succession patterns suggest specialization for fresh growing roots, decaying root detritus, the combination of live and decaying root biomass, or aging root material. Carbohydrate depolymerization genes were consistently upregulated in the rhizosphere.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.html"
+                       class="community-card"
+                       data-id="Bacillus_Bradyrhizobium_Straw_Humification_SynCom"
+                       data-name="bacillus-bradyrhizobium straw humification syncom"
+                       data-description="a two-member bacillus siamensis and bradyrhizobium japonicum syncom that promotes maize straw humification and soil organic carbon."
+                       data-category="LIGNOCELLULOSE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Bacillus-Bradyrhizobium Straw Humification SynCom</h2>
+                        <p class="description">A two-member Bacillus siamensis and Bradyrhizobium japonicum SynCom that promotes maize straw humification and soil organic carbon.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.html"
+                       class="community-card"
+                       data-id="Bacteroides_Eubacterium_Gnotobiotic_Gut_Model"
+                       data-name="bacteroides-eubacterium gnotobiotic gut model"
+                       data-description="a defined two-member gnotobiotic mouse gut model pairing the human gut bacteroidetes member bacteroides thetaiotaomicron vpi-5482 with the human gut firmicutes member eubacterium rectale atcc 33656. the model was used to examine niche specialization and metabolic interaction between dominant human gut phyla under controlled host and diet conditions. b. thetaiotaomicron expands polysaccharide utilization and host mucin glycan foraging in the presence of e. rectale, while e. rectale shifts away from glycan-degrading enzymes toward amino acid and sugar transport, glycolytic support, and butyrate generation from acetate.
+"
+                       data-category="SYNTROPHY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Bacteroides-Eubacterium Gnotobiotic Gut Model</h2>
+                        <p class="description">A defined two-member gnotobiotic mouse gut model pairing the human gut Bacteroidetes member Bacteroides thetaiotaomicron VPI-5482 with the human gut Firmicutes member Eubacterium rectale ATCC 33656. The model was used to examine niche specialization and metabolic interaction between dominant human gut phyla under controlled host and diet conditions. B. thetaiotaomicron expands polysaccharide utilization and host mucin glycan foraging in the presence of E. rectale, while E. rectale shifts away from glycan-degrading enzymes toward amino acid and sugar transport, glycolytic support, and butyrate generation from acetate.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.html"
+                       class="community-card"
+                       data-id="Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism"
+                       data-name="bacteroides-methanobrevibacter gnotobiotic mouse mutualism"
+                       data-description="a defined host-associated gnotobiotic mouse community used to test archaeal-bacterial mutualism in the gut. germ-free mice were colonized with bacteroides thetaiotaomicron with or without methanobrevibacter smithii or desulfovibrio piger, revealing a specific interaction in which m. smithii redirects b. thetaiotaomicron toward dietary fructan fermentation to acetate while using b. thetaiotaomicron formate for methanogenesis."
+                       data-category="SYNTROPHY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Bacteroides-Methanobrevibacter Gnotobiotic Mouse Mutualism</h2>
+                        <p class="description">A defined host-associated gnotobiotic mouse community used to test archaeal-bacterial mutualism in the gut. Germ-free mice were colonized with Bacteroides thetaiotaomicron with or without Methanobrevibacter smithii or Desulfovibrio piger, revealing a specific interaction in which M. smithii redirects B. thetaiotaomicron toward dietary fructan fermentation to acetate while using B. thetaiotaomicron formate for methanogenesis.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Banana_Fusarium_Biocontrol_SynCom12.html"
+                       class="community-card"
+                       data-id="Banana_Fusarium_Biocontrol_SynCom12"
+                       data-name="banana fusarium wilt biocontrol syncom1.2"
+                       data-description="a three-member banana rhizosphere syncom designed for biological control of fusarium oxysporum f. sp. cubense tropical race 4."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Banana Fusarium Wilt Biocontrol SynCom1.2</h2>
+                        <p class="description">A three-member banana rhizosphere SynCom designed for biological control of Fusarium oxysporum f. sp. cubense tropical race 4.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.html"
+                       class="community-card"
+                       data-id="Bay_Area_Sewage_SARS_CoV2_Surveillance_Community"
+                       data-name="san francisco bay area sewage sars-cov-2 metagenomic surveillance community"
+                       data-description="a metatranscriptomic surveillance community in municipal sewage from the san francisco bay area used to detect regionally prevalent sars-cov-2 variants during the covid-19 pandemic. rna was sequenced directly from sewage collected by municipal utility districts to generate complete and nearly complete sars-cov-2 genomes. the major consensus sars-cov-2 genotypes detected in sewage were identical to clinical genotypes, showing that wastewater metatranscriptomics can profile viral genetic diversity at the community scale.
+"
+                       data-category="OTHER"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>San Francisco Bay Area Sewage SARS-CoV-2 Metagenomic Surveillance Community</h2>
+                        <p class="description">A metatranscriptomic surveillance community in municipal sewage from the San Francisco Bay Area used to detect regionally prevalent SARS-CoV-2 variants during the COVID-19 pandemic. RNA was sequenced directly from sewage collected by municipal utility districts to generate complete and nearly complete SARS-CoV-2 genomes. The major consensus SARS-CoV-2 genotypes detected in sewage were identical to clinical genotypes, showing that wastewater metatranscriptomics can profile viral genetic diversity at the community scale.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Bayan_Obo_REE_Tailings_Consortium.html"
+                       class="community-card"
+                       data-id="Bayan_Obo_REE_Tailings_Consortium"
+                       data-name="bayan obo ree tailings consortium"
+                       data-description="an acid-producing bacterial consortium engineered to extract rare earth elements (ree) from tailings at the bayan obo mine in inner mongolia, china, the world&#39;s largest rare earth deposit. this functional bacterial consortium achieves exceptional ree recovery rates of 82-83% for the five main light rare earth elements (la, ce, pr, nd, sm) after 18 days of bioleaching using one-step or two-step processes. the tailings are iron extraction residues from medium-poor oxidized ores containing bastnaesite (ree(co₃)f) and monazite as primary ree minerals. the consortium employs acid-producing bacteria including actinomycetes (streptomyces sp.), autotrophic acidophiles (acidithiobacillus ferrooxidans), and heterotrophic acidophiles (acidiphilium cryptum) that work synergistically to mobilize ree through acidolysis and organic acid complexation. key mechanisms include production of organic acids (citric, oxalic, lactic, pyruvic), siderophores, and complexing ligands that solubilize ree from carbonate-fluoride minerals. the two-step process (sequential inoculation with heterotrophs followed by autotrophs) achieves 83.51% recovery versus 82.78% for one-step (simultaneous inoculation), demonstrating synergistic enhancement through ph control and organic acid accumulation. this system represents a critical sustainable biotechnology for recovering strategic ree materials essential for clean energy technologies, permanent magnets, and electronics while remediating millions of tons of existing bayan obo tailings.
+"
+                       data-category="BIOMINING"
+                       data-state="ENGINEERED"
+                       data-metals="IRON"
+                       data-ree="CERIUM,LANTHANUM,NEODYMIUM,PRASEODYMIUM,SAMARIUM"
+                       data-relevance="PRIMARY"
+                       data-member-count="3">
+                        <h2>Bayan Obo REE Tailings Consortium</h2>
+                        <p class="description">An acid-producing bacterial consortium engineered to extract rare earth elements (REE) from tailings at the Bayan Obo mine in Inner Mongolia, China, the world&#39;s largest rare earth deposit. This functional bacterial consortium achieves exceptional REE recovery rates of 82-83% for the five main light rare earth elements (La, Ce, Pr, Nd, Sm) after 18 days of bioleaching using one-step or two-step processes. The tailings are iron extraction residues from medium-poor oxidized ores containing bastnaesite (REE(CO₃)F) and monazite as primary REE minerals. The consortium employs acid-producing bacteria including actinomycetes (Streptomyces sp.), autotrophic acidophiles (Acidithiobacillus ferrooxidans), and heterotrophic acidophiles (Acidiphilium cryptum) that work synergistically to mobilize REE through acidolysis and organic acid complexation. Key mechanisms include production of organic acids (citric, oxalic, lactic, pyruvic), siderophores, and complexing ligands that solubilize REE from carbonate-fluoride minerals. The two-step process (sequential inoculation with heterotrophs followed by autotrophs) achieves 83.51% recovery versus 82.78% for one-step (simultaneous inoculation), demonstrating synergistic enhancement through pH control and organic acid accumulation. This system represents a critical sustainable biotechnology for recovering strategic REE materials essential for clean energy technologies, permanent magnets, and electronics while remediating millions of tons of existing Bayan Obo tailings.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOMINING</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.html"
+                       class="community-card"
+                       data-id="Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding"
+                       data-name="bifidobacterium-ruminococcus infant hmo cross-feeding coculture"
+                       data-description="an infant gut microbiome cross-feeding system reconstructed from individualized cultivations with three infant fecal inocula and supplemented with the human milk oligosaccharide 2&#39;-fucosyllactose (2&#39;fl). bifidobacterium breve typically cannot metabolize 2&#39;fl on its own, but extracellular fucosidases encoded by coexisting ruminococcus gnavus release lactose from 2&#39;fl and unlock extensive b. breve growth. targeted cocultures and supplementation of r. gnavus into an infant microbiome showed that r. gnavus promotes b. breve growth through hmo breakdown, demonstrating that infant hmo utilization depends on synergistic interactions among coexisting species.
+"
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Bifidobacterium-Ruminococcus Infant HMO Cross-Feeding Coculture</h2>
+                        <p class="description">An infant gut microbiome cross-feeding system reconstructed from individualized cultivations with three infant fecal inocula and supplemented with the human milk oligosaccharide 2&#39;-fucosyllactose (2&#39;FL). Bifidobacterium breve typically cannot metabolize 2&#39;FL on its own, but extracellular fucosidases encoded by coexisting Ruminococcus gnavus release lactose from 2&#39;FL and unlock extensive B. breve growth. Targeted cocultures and supplementation of R. gnavus into an infant microbiome showed that R. gnavus promotes B. breve growth through HMO breakdown, demonstrating that infant HMO utilization depends on synergistic interactions among coexisting species.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/BioModels_MODEL1806250003_Spittlebug_Sulcia_Sodalis.html"
+                       class="community-card"
+                       data-id="BioModels_MODEL1806250003_Spittlebug_Sulcia_Sodalis"
+                       data-name="biomodels model1806250003 spittlebug sulcia-sodalis symbiosis"
+                       data-description="biomodels record model1806250003 is a multi-compartment metabolic model of the spittlebug philaenus spumarius and its bacterial endosymbionts sulcia and sodalis."
+                       data-category="SYNTROPHY"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>BioModels MODEL1806250003 Spittlebug Sulcia-Sodalis Symbiosis</h2>
+                        <p class="description">BioModels record MODEL1806250003 is a multi-compartment metabolic model of the spittlebug Philaenus spumarius and its bacterial endosymbionts Sulcia and Sodalis.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/BioModels_MODEL1806250004_Sharpshooter_Sulcia_Baumannia.html"
+                       class="community-card"
+                       data-id="BioModels_MODEL1806250004_Sharpshooter_Sulcia_Baumannia"
+                       data-name="biomodels model1806250004 sharpshooter sulcia-baumannia symbiosis"
+                       data-description="biomodels record model1806250004 is a multi-compartment metabolic model of the sharpshooter graphocephala coccinea and its bacterial endosymbionts sulcia and baumannia."
+                       data-category="SYNTROPHY"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>BioModels MODEL1806250004 Sharpshooter Sulcia-Baumannia Symbiosis</h2>
+                        <p class="description">BioModels record MODEL1806250004 is a multi-compartment metabolic model of the sharpshooter Graphocephala coccinea and its bacterial endosymbionts Sulcia and Baumannia.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/BioModels_MODEL1806250005_Cicada_Sulcia_Hodgkinia.html"
+                       class="community-card"
+                       data-id="BioModels_MODEL1806250005_Cicada_Sulcia_Hodgkinia"
+                       data-name="biomodels model1806250005 cicada sulcia-hodgkinia symbiosis"
+                       data-description="biomodels record model1806250005 is a multi-compartment metabolic model of the cicada neotibicen canicularis and its bacterial endosymbionts sulcia and hodgkinia."
+                       data-category="SYNTROPHY"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>BioModels MODEL1806250005 Cicada Sulcia-Hodgkinia Symbiosis</h2>
+                        <p class="description">BioModels record MODEL1806250005 is a multi-compartment metabolic model of the cicada Neotibicen canicularis and its bacterial endosymbionts Sulcia and Hodgkinia.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/BioModels_MODEL2204300001_Kefir_Community_Model.html"
+                       class="community-card"
+                       data-id="BioModels_MODEL2204300001_Kefir_Community_Model"
+                       data-name="biomodels model2204300001 kefir community model"
+                       data-description="biomodels record model2204300001 is a genome-scale model from the blasche et al. kefir study and is described as a model of a microbial species participating in a kefir community."
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="6">
+                        <h2>BioModels MODEL2204300001 Kefir Community Model</h2>
+                        <p class="description">BioModels record MODEL2204300001 is a genome-scale model from the Blasche et al. kefir study and is described as a model of a microbial species participating in a kefir community.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    6
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/BioModels_MODEL2209060002_DPigrum_SAureus_Community.html"
+                       class="community-card"
+                       data-id="BioModels_MODEL2209060002_DPigrum_SAureus_Community"
+                       data-name="biomodels model2209060002 d pigrum - s aureus community"
+                       data-description="biomodels record model2209060002 is a community gem combining dolosigranulum pigrum and staphylococcus aureus to emulate interactions in a human nasal-like environment."
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>BioModels MODEL2209060002 D pigrum - S aureus Community</h2>
+                        <p class="description">BioModels record MODEL2209060002 is a community GEM combining Dolosigranulum pigrum and Staphylococcus aureus to emulate interactions in a human nasal-like environment.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/BioModels_MODEL2310020001_Mouse_Metaorganism_Model.html"
+                       class="community-card"
+                       data-id="BioModels_MODEL2310020001_Mouse_Metaorganism_Model"
+                       data-name="biomodels model2310020001 mouse metaorganism model"
+                       data-description="biomodels record model2310020001 is a host-microbiota metaorganism model that links a merged microbiota model to host organ models (brain, liver, and colon) through a shared bloodstream compartment."
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="0">
+                        <h2>BioModels MODEL2310020001 Mouse Metaorganism Model</h2>
+                        <p class="description">BioModels record MODEL2310020001 is a host-microbiota metaorganism model that links a merged microbiota model to host organ models (brain, liver, and colon) through a shared bloodstream compartment.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    0
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.html"
+                       class="community-card"
+                       data-id="BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom"
+                       data-name="biomodels model2405300001 infant gut hmo syncom"
+                       data-description="biomodels record model2405300001 contains genome-scale metabolic models used to study a synthetic human infant gut microbial community in the context of human milk oligosaccharides."
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="13">
+                        <h2>BioModels MODEL2405300001 Infant Gut HMO SynCom</h2>
+                        <p class="description">BioModels record MODEL2405300001 contains genome-scale metabolic models used to study a synthetic human infant gut microbial community in the context of human milk oligosaccharides.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    13
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/BioModels_MODEL2407300002_Sponge_Holobiont_Network.html"
+                       class="community-card"
+                       data-id="BioModels_MODEL2407300002_Sponge_Holobiont_Network"
+                       data-name="biomodels model2407300002 sponge holobiont network"
+                       data-description="biomodels record model2407300002 provides simulations and model assets for an eight-species sponge microbiome network, modeling interactions among symbiont clades in a stylissa holobiont."
+                       data-category="OTHER"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>BioModels MODEL2407300002 Sponge Holobiont Network</h2>
+                        <p class="description">BioModels record MODEL2407300002 provides simulations and model assets for an eight-species sponge microbiome network, modeling interactions among symbiont clades in a Stylissa holobiont.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.html"
+                       class="community-card"
+                       data-id="Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community"
+                       data-name="brachypodium young root rhizosphere ecofab community"
+                       data-description="a young brachypodium distachyon primary-root rhizosphere community analyzed at two spatially distinct zones (root tip and root base) using ecofabs fabricated ecosystems and conventional pot and tube containers with natural soil. 16s rrna gene analysis shows a strong rhizosphere effect with significant enrichment of otus belonging to actinobacteria, bacteroidetes, firmicutes, and proteobacteria, while community composition did not differ between root tips and root base or across growth containers. bulk metagenomic functional analysis revealed enrichment of metabolic-pathway and root-colonization genes in root tips, whereas nutrient-limitation and environmental-stress genes were enriched in bulk soil, indicating root-driven gradients in labile carbon and nutrient availability.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Brachypodium Young Root Rhizosphere EcoFAB Community</h2>
+                        <p class="description">A young Brachypodium distachyon primary-root rhizosphere community analyzed at two spatially distinct zones (root tip and root base) using EcoFABs fabricated ecosystems and conventional pot and tube containers with natural soil. 16S rRNA gene analysis shows a strong rhizosphere effect with significant enrichment of OTUs belonging to Actinobacteria, Bacteroidetes, Firmicutes, and Proteobacteria, while community composition did not differ between root tips and root base or across growth containers. Bulk metagenomic functional analysis revealed enrichment of metabolic-pathway and root-colonization genes in root tips, whereas nutrient-limitation and environmental-stress genes were enriched in bulk soil, indicating root-driven gradients in labile carbon and nutrient availability.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.html"
+                       class="community-card"
+                       data-id="Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium"
+                       data-name="buchnera-serratia cinara cedri endosymbiont consortium"
+                       data-description="a natural co-obligate aphid endosymbiont consortium in the cedar aphid cinara cedri, composed of buchnera aphidicola bcc and serratia symbiotica scc. genome-based metabolic inference shows that buchnera bcc has lost some ancestral nutritional functions, while serratia scc retains or takes over functions needed by the host-associated consortium, including shared tryptophan biosynthesis and broader metabolic complementation.
+"
+                       data-category="SYNTROPHY"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Buchnera-Serratia Cinara cedri Endosymbiont Consortium</h2>
+                        <p class="description">A natural co-obligate aphid endosymbiont consortium in the cedar aphid Cinara cedri, composed of Buchnera aphidicola BCc and Serratia symbiotica SCc. Genome-based metabolic inference shows that Buchnera BCc has lost some ancestral nutritional functions, while Serratia SCc retains or takes over functions needed by the host-associated consortium, including shared tryptophan biosynthesis and broader metabolic complementation.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/CRC_Fusobacterium_Control_SynCom.html"
+                       class="community-card"
+                       data-id="CRC_Fusobacterium_Control_SynCom"
+                       data-name="crc fusobacterium control syncom"
+                       data-description="a bottom-up designed seven-species synthetic microbial community for ecological control of fusobacterium nucleatum-associated colorectal cancer models."
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>CRC Fusobacterium Control SynCom</h2>
+                        <p class="description">A bottom-up designed seven-species synthetic microbial community for ecological control of Fusobacterium nucleatum-associated colorectal cancer models.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.html"
+                       class="community-card"
+                       data-id="Cable_Bacteria_Photosynthetic_Biofilm_Sediment"
+                       data-name="cable bacteria beneath photosynthetic biofilm sediment community"
+                       data-description="a coastal sediment community in which long filamentous desulfobulbaceae cable bacteria connect sulfide-rich deeper sediment to oxygen supplied near the sediment-water interface by an oxygenic photosynthetic biofilm. the system links sulfur oxidation, oxygen production, sulfate-reduction-driven sulfide supply, and centimeter-scale long-distance electron transfer.
+"
+                       data-category="OTHER"
+                       data-state="TRANSIENT"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Cable Bacteria beneath Photosynthetic Biofilm Sediment Community</h2>
+                        <p class="description">A coastal sediment community in which long filamentous Desulfobulbaceae cable bacteria connect sulfide-rich deeper sediment to oxygen supplied near the sediment-water interface by an oxygenic photosynthetic biofilm. The system links sulfur oxidation, oxygen production, sulfate-reduction-driven sulfide supply, and centimeter-scale long-distance electron transfer.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-TRANSIENT">TRANSIENT</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.html"
+                       class="community-card"
+                       data-id="Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture"
+                       data-name="caldibacillus-clostridium aerotolerant cellulose coculture"
+                       data-description="a designed two-member thermophilic coculture for aerotolerant cellulose conversion. the community pairs the cellulolytic strict anaerobe clostridium thermocellum with the noncellulolytic facultative anaerobe caldibacillus debilis gb1. c. debilis gb1 provides respiratory protection under oxidative conditions, enabling synergistic cellulose utilization and ethanogenic biofuel production under an aerobic atmosphere.
+"
+                       data-category="LIGNOCELLULOSE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Caldibacillus-Clostridium Aerotolerant Cellulose Coculture</h2>
+                        <p class="description">A designed two-member thermophilic coculture for aerotolerant cellulose conversion. The community pairs the cellulolytic strict anaerobe Clostridium thermocellum with the noncellulolytic facultative anaerobe Caldibacillus debilis GB1. C. debilis GB1 provides respiratory protection under oxidative conditions, enabling synergistic cellulose utilization and ethanogenic biofuel production under an aerobic atmosphere.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.html"
+                       class="community-card"
+                       data-id="Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture"
+                       data-name="caldicellulosiruptor two-species hydrogen coculture"
+                       data-description="a de novo constructed, continuous-flow, hydrogen-producing coculture pairing caldicellulosiruptor saccharolyticus dsm 8903 with the strain reported as caldicellulosiruptor kristjanssonii dsm 12137. the system was designed to test whether two extreme thermophilic sugar-fermenting caldicellulosiruptor strains could stably coexist while converting glucose and xylose, major lignocellulosic hydrolysate sugars, to hydrogen-rich fermentation products.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Caldicellulosiruptor Two-Species Hydrogen Coculture</h2>
+                        <p class="description">A de novo constructed, continuous-flow, hydrogen-producing coculture pairing Caldicellulosiruptor saccharolyticus DSM 8903 with the strain reported as Caldicellulosiruptor kristjanssonii DSM 12137. The system was designed to test whether two extreme thermophilic sugar-fermenting Caldicellulosiruptor strains could stably coexist while converting glucose and xylose, major lignocellulosic hydrolysate sugars, to hydrogen-rich fermentation products.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/California_Grassland_Precipitation_Legacy_Soil_Community.html"
+                       class="community-card"
+                       data-id="California_Grassland_Precipitation_Legacy_Soil_Community"
+                       data-name="california grassland precipitation legacy soil community"
+                       data-description="a semiarid california mediterranean-climate grassland soil microbial community studied under two field-imposed precipitation regimes (100 percent versus 50 percent of mean annual precipitation) and assayed during the first autumn rewet. quantitative h2-18o stable-isotope-probing, 16s rrna amplicon sequencing, metagenomics, and metatranscriptomics revealed that reduced winter precipitation imposed a lasting legacy on community turnover: microbial growth declined by about one order of magnitude and mortality by about two orders of magnitude relative to ambient plots, lowering community growth efficiency (new biomass growth divided by respiration). soil organic carbon shifted from microbial-necromass-derived lipid-, amino-sugar-, and protein-like compounds toward more oxidized lignin- and tannin-like plant detritus compounds. meta-omics linked high-cge communities to n-rich necromass consumption with elevated amino acid and peptidoglycan biosynthesis and aromatic compound degradation, while low-cge communities had elevated carbohydrate metabolism and lipid turnover consistent with plant-detritus processing and membrane maintenance.
+"
+                       data-category="CARBON_SEQUESTRATION"
+                       data-state="PERTURBED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>California Grassland Precipitation Legacy Soil Community</h2>
+                        <p class="description">A semiarid California Mediterranean-climate grassland soil microbial community studied under two field-imposed precipitation regimes (100 percent versus 50 percent of mean annual precipitation) and assayed during the first autumn rewet. Quantitative H2-18O stable-isotope-probing, 16S rRNA amplicon sequencing, metagenomics, and metatranscriptomics revealed that reduced winter precipitation imposed a lasting legacy on community turnover: microbial growth declined by about one order of magnitude and mortality by about two orders of magnitude relative to ambient plots, lowering community growth efficiency (new biomass growth divided by respiration). Soil organic carbon shifted from microbial-necromass-derived lipid-, amino-sugar-, and protein-like compounds toward more oxidized lignin- and tannin-like plant detritus compounds. Meta-omics linked high-CGE communities to N-rich necromass consumption with elevated amino acid and peptidoglycan biosynthesis and aromatic compound degradation, while low-CGE communities had elevated carbohydrate metabolism and lipid turnover consistent with plant-detritus processing and membrane maintenance.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">CARBON_SEQUESTRATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Candida_Parapsilosis_Hospitalized_Infant_Microbiome.html"
+                       class="community-card"
+                       data-id="Candida_Parapsilosis_Hospitalized_Infant_Microbiome"
+                       data-name="candida parapsilosis hospitalized infant gut microbiome community"
+                       data-description="an in situ infant gut microbiome study of candida parapsilosis colonization in hospitalized infants, combining genomics, transcriptomics, and proteomics. five unique c. parapsilosis genomes were assembled from infant gut samples and compared, providing the first multi-omics characterization of how this common cause of invasive candidiasis adapts genetically and behaviorally to the developing infant microbiome context. the work fills a gap left by pure-culture studies and informs understanding of how c. parapsilosis functions in a microbiome rather than in isolation.
+"
+                       data-category="OTHER"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>Candida parapsilosis Hospitalized Infant Gut Microbiome Community</h2>
+                        <p class="description">An in situ infant gut microbiome study of Candida parapsilosis colonization in hospitalized infants, combining genomics, transcriptomics, and proteomics. Five unique C. parapsilosis genomes were assembled from infant gut samples and compared, providing the first multi-omics characterization of how this common cause of invasive candidiasis adapts genetically and behaviorally to the developing infant microbiome context. The work fills a gap left by pure-culture studies and informs understanding of how C. parapsilosis functions in a microbiome rather than in isolation.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/CeMbio_Caenorhabditis_Elegans_Microbiome.html"
+                       class="community-card"
+                       data-id="CeMbio_Caenorhabditis_Elegans_Microbiome"
+                       data-name="cembio caenorhabditis elegans microbiome"
+                       data-description="cembio is a defined, ecologically informed twelve-strain bacterial community representing the natural caenorhabditis elegans microbiome. the v1.0 community includes enterobacter hormaechei ceent1, lelliottia amnigena jub66, acinetobacter guillouiae myb10, sphingomonas molluscorum jub134, stenotrophomonas indicatrix jub19, pseudomonas lurida myb11, pseudomonas berkeleyensis mspm1, comamonas piscis bigb0172, pantoea nemavictus bigb0393, ochrobactrum vermis myb71, sphingobacterium multivorum bigb0170, and chryseobacterium scophthalmum jub44. the resource pairs a genetically tractable host with cultured, genome-sequenced, cgc-distributed commensal isolates that colonize the worm gut as a community, alter nematode developmental timing, and support follow-up behavioral and metabolic studies with the same reference composition.
+"
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>CeMbio Caenorhabditis elegans Microbiome</h2>
+                        <p class="description">CeMbio is a defined, ecologically informed twelve-strain bacterial community representing the natural Caenorhabditis elegans microbiome. The v1.0 community includes Enterobacter hormaechei CEent1, Lelliottia amnigena JUb66, Acinetobacter guillouiae MYb10, Sphingomonas molluscorum JUb134, Stenotrophomonas indicatrix JUb19, Pseudomonas lurida MYb11, Pseudomonas berkeleyensis MSPm1, Comamonas piscis BIGb0172, Pantoea nemavictus BIGb0393, Ochrobactrum vermis MYb71, Sphingobacterium multivorum BIGb0170, and Chryseobacterium scophthalmum JUb44. The resource pairs a genetically tractable host with cultured, genome-sequenced, CGC-distributed commensal isolates that colonize the worm gut as a community, alter nematode developmental timing, and support follow-up behavioral and metabolic studies with the same reference composition.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.html"
+                       class="community-card"
+                       data-id="Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture"
+                       data-name="cellulomonas-rhodobacter cellulose photohydrogen coculture"
+                       data-description="a defined anaerobic cellulose-to-hydrogen coculture pairing cellulolytic cellulomonas sp. strain atcc 21399 with the purple nonsulfur phototroph rhodopseudomonas capsulata, now classified as rhodobacter capsulatus. the cellulomonas partner ferments cellulose to organic acids, while r. capsulata grows photoheterotrophically on those products and evolves molecular hydrogen through nitrogenase. the system is doe-relevant as an early model for lignocellulosic biohydrogen production by division of labor between cellulose fermentation and phototrophic hydrogen evolution.
+"
+                       data-category="LIGNOCELLULOSE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Cellulomonas-Rhodobacter Cellulose Photohydrogen Coculture</h2>
+                        <p class="description">A defined anaerobic cellulose-to-hydrogen coculture pairing cellulolytic Cellulomonas sp. strain ATCC 21399 with the purple nonsulfur phototroph Rhodopseudomonas capsulata, now classified as Rhodobacter capsulatus. The Cellulomonas partner ferments cellulose to organic acids, while R. capsulata grows photoheterotrophically on those products and evolves molecular hydrogen through nitrogenase. The system is DOE-relevant as an early model for lignocellulosic biohydrogen production by division of labor between cellulose fermentation and phototrophic hydrogen evolution.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Cellulose_Methane_Quad_Culture_SynCom.html"
+                       class="community-card"
+                       data-id="Cellulose_Methane_Quad_Culture_SynCom"
+                       data-name="cellulose-to-methane quad-culture syncom"
+                       data-description="a four-species anaerobic synthetic community coupling cellulose degradation, sulfate reduction, and methanogenesis."
+                       data-category="METHANOGENESIS"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Cellulose-to-Methane Quad-Culture SynCom</h2>
+                        <p class="description">A four-species anaerobic synthetic community coupling cellulose degradation, sulfate reduction, and methanogenesis.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">METHANOGENESIS</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Cheese_Rind_InSitu_InVitro_Model_Community.html"
+                       class="community-card"
+                       data-id="Cheese_Rind_InSitu_InVitro_Model_Community"
+                       data-name="cheese rind in situ-in vitro model community"
+                       data-description="a tractable fermented-food surface biofilm system based on cheese rind microbial communities. wolfe and colleagues surveyed 137 rind communities across 10 countries, isolated representatives of the dominant bacterial and fungal genera, and reconstructed simplified cheese-curd-agar communities in vitro to test how moisture, washing, ph, and bacterial-fungal interactions shape reproducible community assembly and succession.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Cheese Rind In Situ-In Vitro Model Community</h2>
+                        <p class="description">A tractable fermented-food surface biofilm system based on cheese rind microbial communities. Wolfe and colleagues surveyed 137 rind communities across 10 countries, isolated representatives of the dominant bacterial and fungal genera, and reconstructed simplified cheese-curd-agar communities in vitro to test how moisture, washing, pH, and bacterial-fungal interactions shape reproducible community assembly and succession.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Chlamydomonas_Bacterial_H2_Consortium.html"
+                       class="community-card"
+                       data-id="Chlamydomonas_Bacterial_H2_Consortium"
+                       data-name="chlamydomonas-bacterial hydrogen production consortium"
+                       data-description="a synthetic algae-bacteria consortium for sustainable hydrogen production, composed of the green alga chlamydomonas reinhardtii and three bacterial species: microbacterium forte sp. nov., bacillus cereus, and stenotrophomonas goyi sp. nov. this mutualistic association produces up to 313 ml h2/l over 17 days in high-cell density cultures. m. forte is the primary bacterial species responsible for improving algal hydrogen production, while the complete bacterial community enhances and sustains photobiological h2 generation through metabolic cooperation.
+"
+                       data-category="PHYTOPLANKTON"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="4">
+                        <h2>Chlamydomonas-Bacterial Hydrogen Production Consortium</h2>
+                        <p class="description">A synthetic algae-bacteria consortium for sustainable hydrogen production, composed of the green alga Chlamydomonas reinhardtii and three bacterial species: Microbacterium forte sp. nov., Bacillus cereus, and Stenotrophomonas goyi sp. nov. This mutualistic association produces up to 313 mL H2/L over 17 days in high-cell density cultures. M. forte is the primary bacterial species responsible for improving algal hydrogen production, while the complete bacterial community enhances and sustains photobiological H2 generation through metabolic cooperation.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">PHYTOPLANKTON</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Chlamydomonas_Methylobacterium_Mutualism.html"
+                       class="community-card"
+                       data-id="Chlamydomonas_Methylobacterium_Mutualism"
+                       data-name="chlamydomonas-methylobacterium mutualistic consortium"
+                       data-description="a two-member mutualistic consortium consisting of the green alga chlamydomonas reinhardtii and the methylotrophic bacterium methylobacterium aquaticum, isolated from a freshwater environment. this natural association demonstrates reciprocal metabolic exchange under nitrogen stress conditions, mediated by indole-3-acetic acid (iaa) signaling. the alga provides photosynthetically fixed carbon and oxygen, while methylobacterium modulates iaa levels through both production and degradation, influencing algal physiology and stress responses. this system serves as a model for understanding algae-bacteria interactions in freshwater ecosystems and potential applications in sustainable algal biotechnology under nutrient limitation.
+"
+                       data-category="PHYTOPLANKTON"
+                       data-state="STABLE"
+                       data-metals="IRON"
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="2">
+                        <h2>Chlamydomonas-Methylobacterium Mutualistic Consortium</h2>
+                        <p class="description">A two-member mutualistic consortium consisting of the green alga Chlamydomonas reinhardtii and the methylotrophic bacterium Methylobacterium aquaticum, isolated from a freshwater environment. This natural association demonstrates reciprocal metabolic exchange under nitrogen stress conditions, mediated by indole-3-acetic acid (IAA) signaling. The alga provides photosynthetically fixed carbon and oxygen, while Methylobacterium modulates IAA levels through both production and degradation, influencing algal physiology and stress responses. This system serves as a model for understanding algae-bacteria interactions in freshwater ecosystems and potential applications in sustainable algal biotechnology under nutrient limitation.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">PHYTOPLANKTON</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Chlorella_Azospirillum_Synthetic_Mutualism.html"
+                       class="community-card"
+                       data-id="Chlorella_Azospirillum_Synthetic_Mutualism"
+                       data-name="chlorella-azospirillum synthetic mutualism"
+                       data-description="a defined algal-bacterial synthetic mutualism pairing the freshwater green microalga chlorella sorokiniana utex 2714 with the plant-growth-promoting bacterium azospirillum brasilense cd. the pair has been studied in co-immobilized alginate bead systems and related culture formats to test how nutrient availability shapes mutualistic population growth, tryptophan, thiamine, and indole-3-acetic acid exchange, starch accumulation, and algal-bacterial aggregation. the system is relevant to environmental biotechnology, microalgal biomass production, and algal-bacterial interaction design.
+"
+                       data-category="PHYTOPLANKTON"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Chlorella-Azospirillum Synthetic Mutualism</h2>
+                        <p class="description">A defined algal-bacterial synthetic mutualism pairing the freshwater green microalga Chlorella sorokiniana UTEX 2714 with the plant-growth-promoting bacterium Azospirillum brasilense Cd. The pair has been studied in co-immobilized alginate bead systems and related culture formats to test how nutrient availability shapes mutualistic population growth, tryptophan, thiamine, and indole-3-acetic acid exchange, starch accumulation, and algal-bacterial aggregation. The system is relevant to environmental biotechnology, microalgal biomass production, and algal-bacterial interaction design.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">PHYTOPLANKTON</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.html"
+                       class="community-card"
+                       data-id="Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture"
+                       data-name="chlorella-ecoli mixotrophic biofuel precursor coculture"
+                       data-description="a defined algal-bacterial coculture in which chlorella minutissima was grown with escherichia coli in airlift reactors under mixotrophic glucose, glycerol, and acetate conditions. the coculture produced more algal biomass, consumed more carbon substrate, and increased lipid and starch productivity relative to axenic algal cultures. this system is relevant to doe-aligned algal biofuel biotechnology because it tests whether bacterial contamination or partnership can improve production of algal biofuel precursors rather than suppressing algal biomass.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Chlorella-Ecoli Mixotrophic Biofuel Precursor Coculture</h2>
+                        <p class="description">A defined algal-bacterial coculture in which Chlorella minutissima was grown with Escherichia coli in airlift reactors under mixotrophic glucose, glycerol, and acetate conditions. The coculture produced more algal biomass, consumed more carbon substrate, and increased lipid and starch productivity relative to axenic algal cultures. This system is relevant to DOE-aligned algal biofuel biotechnology because it tests whether bacterial contamination or partnership can improve production of algal biofuel precursors rather than suppressing algal biomass.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Chlorella_Rhizobium_Bioflocculation.html"
+                       class="community-card"
+                       data-id="Chlorella_Rhizobium_Bioflocculation"
+                       data-name="chlorella-rhizobium bioflocculation"
+                       data-description="a co-culture system pairing the microalgae chlorella vulgaris with the bioflocculant-producing bacterium rhizobium radiobacter f2 for enhanced algal harvesting in wastewater treatment applications. the bacterium produces extracellular polysaccharide bioflocculants that induce aggregation and flocculation of algal cells, enabling efficient biomass recovery for biofuel production. this bioflocculation approach avoids the negative effects of traditional chemical flocculants and provides a cost-effective, environmentally friendly method for microalgae harvesting, with flocculation efficiency improving from 0.2% (axenic algae) to &gt;90% with bacterial co-culture.
+"
+                       data-category="PHYTOPLANKTON"
+                       data-state="ENGINEERED"
+                       data-metals="IRON"
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="2">
+                        <h2>Chlorella-Rhizobium Bioflocculation</h2>
+                        <p class="description">A co-culture system pairing the microalgae Chlorella vulgaris with the bioflocculant-producing bacterium Rhizobium radiobacter F2 for enhanced algal harvesting in wastewater treatment applications. The bacterium produces extracellular polysaccharide bioflocculants that induce aggregation and flocculation of algal cells, enabling efficient biomass recovery for biofuel production. This bioflocculation approach avoids the negative effects of traditional chemical flocculants and provides a cost-effective, environmentally friendly method for microalgae harvesting, with flocculation efficiency improving from 0.2% (axenic algae) to &gt;90% with bacterial co-culture.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">PHYTOPLANKTON</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.html"
+                       class="community-card"
+                       data-id="Chlorochromatium_Aggregatum_Phototrophic_Consortium"
+                       data-name="chlorochromatium aggregatum phototrophic consortium"
+                       data-description="a structured freshwater phototrophic bacterial consortium in which one central motile heterotrophic beta-proteobacterium, candidatus symbiobacter mobilis, is surrounded by approximately 15 green sulfur bacterial chlorobium chlorochromatii epibionts. genome analyses support a highly specialized symbiosis involving metabolite exchange, central-bacterium sensing and motility toward light and sulfide, cell-cell adhesion, and possible quinone-mediated electron exchange."
+                       data-category="SYNTROPHY"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Chlorochromatium aggregatum Phototrophic Consortium</h2>
+                        <p class="description">A structured freshwater phototrophic bacterial consortium in which one central motile heterotrophic beta-proteobacterium, Candidatus Symbiobacter mobilis, is surrounded by approximately 15 green sulfur bacterial Chlorobium chlorochromatii epibionts. Genome analyses support a highly specialized symbiosis involving metabolite exchange, central-bacterium sensing and motility toward light and sulfide, cell-cell adhesion, and possible quinone-mediated electron exchange.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Chromium_Sulfur_Reduction_Enrichment.html"
+                       class="community-card"
+                       data-id="Chromium_Sulfur_Reduction_Enrichment"
+                       data-name="chromium sulfur reduction enrichment"
+                       data-description="a novel enrichment culture from chromium-contaminated tailings capable of coupled cr(vi) reduction and sulfur oxidation, representing a dual detoxification mechanism for bioremediation applications. this engineered community is dominated by intrasporangiaceae sp. (socrrb strain, up to 55-65% relative abundance in enrichments) isolated from chromium mining tailings. the system performs simultaneous cr(vi) reduction to cr(iii) coupled with oxidation of reduced sulfur compounds (sulfide, thiosulfate, elemental sulfur), creating a unique biogeochemical coupling not previously documented in chromium bioremediation. intrasporangiaceae sp. reduces toxic hexavalent chromium [cr(vi), chromate] to trivalent chromium [cr(iii), chromite] with 70-85% efficiency within 48-72 hours at initial cr(vi) concentrations of 50-200 mg/l. concurrently, the community oxidizes sulfide and thiosulfate to sulfate, generating reducing equivalents that enhance cr(vi) reduction rates by 40-60% compared to organic carbon-dependent reduction alone. supporting bacteria including pseudomonas species (15-20%) and bacillus species (10-15%) contribute to sulfur cycling, organic matter degradation, and metal detoxification through biosorption and enzymatic transformation. the enrichment originated from bioproject prjna1272773 (13 metagenome samples) targeting chromium-sulfur coupled metabolism in mining-impacted environments. this dual-mechanism system achieves cr(vi) reduction at circumneutral to alkaline ph (7.0-8.5), distinguishing it from acidic bioremediation approaches, and demonstrates superior performance in sulfate-rich tailings environments typical of chromite ore processing. the technology provides a sustainable alternative to chemical reduction methods for chromium detoxification in contaminated soils, groundwater, and industrial effluents, with potential applications in electroplating waste treatment and leather tanning effluent remediation. chromium concentrations decrease from 150-200 mg/l to below regulatory limits (&lt;5 mg/l total cr) within 5-7 days under optimal conditions.
+"
+                       data-category="METAL_REDUCTION"
+                       data-state="ENGINEERED"
+                       data-metals="CHROMIUM,IRON"
+                       data-ree=""
+                       data-relevance="PRIMARY"
+                       data-member-count="3">
+                        <h2>Chromium Sulfur Reduction Enrichment</h2>
+                        <p class="description">A novel enrichment culture from chromium-contaminated tailings capable of coupled Cr(VI) reduction and sulfur oxidation, representing a dual detoxification mechanism for bioremediation applications. This engineered community is dominated by Intrasporangiaceae sp. (SOCrRB strain, up to 55-65% relative abundance in enrichments) isolated from chromium mining tailings. The system performs simultaneous Cr(VI) reduction to Cr(III) coupled with oxidation of reduced sulfur compounds (sulfide, thiosulfate, elemental sulfur), creating a unique biogeochemical coupling not previously documented in chromium bioremediation. Intrasporangiaceae sp. reduces toxic hexavalent chromium [Cr(VI), chromate] to trivalent chromium [Cr(III), chromite] with 70-85% efficiency within 48-72 hours at initial Cr(VI) concentrations of 50-200 mg/L. Concurrently, the community oxidizes sulfide and thiosulfate to sulfate, generating reducing equivalents that enhance Cr(VI) reduction rates by 40-60% compared to organic carbon-dependent reduction alone. Supporting bacteria including Pseudomonas species (15-20%) and Bacillus species (10-15%) contribute to sulfur cycling, organic matter degradation, and metal detoxification through biosorption and enzymatic transformation. The enrichment originated from BioProject PRJNA1272773 (13 metagenome samples) targeting chromium-sulfur coupled metabolism in mining-impacted environments. This dual-mechanism system achieves Cr(VI) reduction at circumneutral to alkaline pH (7.0-8.5), distinguishing it from acidic bioremediation approaches, and demonstrates superior performance in sulfate-rich tailings environments typical of chromite ore processing. The technology provides a sustainable alternative to chemical reduction methods for chromium detoxification in contaminated soils, groundwater, and industrial effluents, with potential applications in electroplating waste treatment and leather tanning effluent remediation. Chromium concentrations decrease from 150-200 mg/L to below regulatory limits (&lt;5 mg/L total Cr) within 5-7 days under optimal conditions.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">METAL_REDUCTION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Cinnamate_Degradation_Consortium.html"
+                       class="community-card"
+                       data-id="Cinnamate_Degradation_Consortium"
+                       data-name="cinnamate β-oxidation consortium"
+                       data-description="a syntrophic 3-member anaerobic consortium for degradation of cinnamate via β-oxidation to benzoate, consisting of papillibacter cinnamivorans, syntrophus sp., and methanobacterium formicicum. p. cinnamivorans performs β-oxidation of cinnamate to benzoate, followed by syntrophic benzoate degradation by syntrophus sp. to acetate, h2, and co2, with the methanogen consuming h2 to produce methane. this stepwise aromatic compound degradation pathway is important for anaerobic bioremediation.
+"
+                       data-category="SYNTROPHY"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="3">
+                        <h2>Cinnamate β-Oxidation Consortium</h2>
+                        <p class="description">A syntrophic 3-member anaerobic consortium for degradation of cinnamate via β-oxidation to benzoate, consisting of Papillibacter cinnamivorans, Syntrophus sp., and Methanobacterium formicicum. P. cinnamivorans performs β-oxidation of cinnamate to benzoate, followed by syntrophic benzoate degradation by Syntrophus sp. to acetate, H2, and CO2, with the methanogen consuming H2 to produce methane. This stepwise aromatic compound degradation pathway is important for anaerobic bioremediation.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.html"
+                       class="community-card"
+                       data-id="Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture"
+                       data-name="clostridium autoethanogenum-clostridium kluyveri syngas coculture"
+                       data-description="a defined anaerobic synthetic coculture combining the acetogenic syngas fermenter clostridium autoethanogenum with the chain-elongating bacterium clostridium kluyveri. c. autoethanogenum converts carbon monoxide or syngas into acetate and ethanol, while c. kluyveri consumes these products for chain elongation, producing c4 and c6 fatty acids and higher alcohols. the system is relevant to doe carbon utilization and renewable fuels because it couples gas fermentation with microbial upgrading of co/syngas-derived intermediates in one growth vessel.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Clostridium autoethanogenum-Clostridium kluyveri Syngas Coculture</h2>
+                        <p class="description">A defined anaerobic synthetic coculture combining the acetogenic syngas fermenter Clostridium autoethanogenum with the chain-elongating bacterium Clostridium kluyveri. C. autoethanogenum converts carbon monoxide or syngas into acetate and ethanol, while C. kluyveri consumes these products for chain elongation, producing C4 and C6 fatty acids and higher alcohols. The system is relevant to DOE carbon utilization and renewable fuels because it couples gas fermentation with microbial upgrading of CO/syngas-derived intermediates in one growth vessel.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.html"
+                       class="community-card"
+                       data-id="Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture"
+                       data-name="clostridium-caldicellulosiruptor minimal medium coculture"
+                       data-description="a thermophilic, anaerobic, two-member laboratory coculture pairing clostridium thermocellum atcc 27405 with caldicellulosiruptor bescii dsm 6725. the system was used to test whether low-ionic-strength defined medium with reduced nitrogen, sulfur, phosphate, and vitamin supplements could maintain both cellulolytic bacterial populations during conversion of cellulosic substrates relevant to consolidated bioprocessing.
+"
+                       data-category="LIGNOCELLULOSE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Clostridium-Caldicellulosiruptor Minimal Medium Coculture</h2>
+                        <p class="description">A thermophilic, anaerobic, two-member laboratory coculture pairing Clostridium thermocellum ATCC 27405 with Caldicellulosiruptor bescii DSM 6725. The system was used to test whether low-ionic-strength defined medium with reduced nitrogen, sulfur, phosphate, and vitamin supplements could maintain both cellulolytic bacterial populations during conversion of cellulosic substrates relevant to consolidated bioprocessing.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.html"
+                       class="community-card"
+                       data-id="Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture"
+                       data-name="clostridium carboxidivorans-clostridium kluyveri co chain-elongation coculture"
+                       data-description="a defined anaerobic synthetic coculture pairing the autotrophic solventogenic acetogen clostridium carboxidivorans with the chain-elongating bacterium clostridium kluyveri. in co/co2-fed stirred-tank bioreactors, c. kluyveri elongates c2 products to organic acids, and c. carboxidivorans reduces those acids to longer-chain alcohols such as butanol and hexanol. the system is doe-relevant because it couples waste-gas/syngas fermentation, carbon utilization, and production of liquid fuels and platform chemicals.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Clostridium carboxidivorans-Clostridium kluyveri CO Chain-Elongation Coculture</h2>
+                        <p class="description">A defined anaerobic synthetic coculture pairing the autotrophic solventogenic acetogen Clostridium carboxidivorans with the chain-elongating bacterium Clostridium kluyveri. In CO/CO2-fed stirred-tank bioreactors, C. kluyveri elongates C2 products to organic acids, and C. carboxidivorans reduces those acids to longer-chain alcohols such as butanol and hexanol. The system is DOE-relevant because it couples waste-gas/syngas fermentation, carbon utilization, and production of liquid fuels and platform chemicals.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.html"
+                       class="community-card"
+                       data-id="Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture"
+                       data-name="clostridium cellulolyticum-geobacter sulfurreducens cellulose mfc coculture"
+                       data-description="a defined binary microbial fuel cell coculture pairing the cellulolytic fermenter clostridium cellulolyticum with the electrochemically active bacterium geobacter sulfurreducens. the community couples cellulose hydrolysis and fermentation to anode respiration: c. cellulolyticum metabolizes cellulose, while g. sulfurreducens uses fermentation products to transfer electrons to the anode. the same exact two-species composition was reported in an initial cellulose-to-electricity study and a follow-up cellulose-fed microbial biofilm ecology study. the system is relevant to doe bioenergy because it converts cellulosic biomass into electricity in a controlled bioelectrochemical reactor.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Clostridium cellulolyticum-Geobacter sulfurreducens Cellulose MFC Coculture</h2>
+                        <p class="description">A defined binary microbial fuel cell coculture pairing the cellulolytic fermenter Clostridium cellulolyticum with the electrochemically active bacterium Geobacter sulfurreducens. The community couples cellulose hydrolysis and fermentation to anode respiration: C. cellulolyticum metabolizes cellulose, while G. sulfurreducens uses fermentation products to transfer electrons to the anode. The same exact two-species composition was reported in an initial cellulose-to-electricity study and a follow-up cellulose-fed microbial biofilm ecology study. The system is relevant to DOE bioenergy because it converts cellulosic biomass into electricity in a controlled bioelectrochemical reactor.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.html"
+                       class="community-card"
+                       data-id="Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture"
+                       data-name="clostridium cellulovorans-methanosarcina barkeri cellulose methane coculture"
+                       data-description="a defined anaerobic cellulose-to-methane coculture combining the cellulolytic fermenter clostridium cellulovorans 743b with the metabolically versatile methanogen methanosarcina barkeri fusaro. c. cellulovorans degrades cellulose and produces methanogenesis precursors including hydrogen, formate, and acetate, while m. barkeri consumes those products for methanogenesis. the system is relevant to doe bioenergy because it is an experimentally tractable model for renewable methane production from cellulosic biomass and for engineering anaerobic biomethanation consortia.
+"
+                       data-category="METHANOGENESIS"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Clostridium cellulovorans-Methanosarcina barkeri Cellulose Methane Coculture</h2>
+                        <p class="description">A defined anaerobic cellulose-to-methane coculture combining the cellulolytic fermenter Clostridium cellulovorans 743B with the metabolically versatile methanogen Methanosarcina barkeri Fusaro. C. cellulovorans degrades cellulose and produces methanogenesis precursors including hydrogen, formate, and acetate, while M. barkeri consumes those products for methanogenesis. The system is relevant to DOE bioenergy because it is an experimentally tractable model for renewable methane production from cellulosic biomass and for engineering anaerobic biomethanation consortia.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">METHANOGENESIS</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.html"
+                       class="community-card"
+                       data-id="Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture"
+                       data-name="clostridium cellulovorans-rhodopseudomonas palustris cellulose biohydrogen coculture"
+                       data-description="a defined two-member cellulose-to-biohydrogen coculture combining the cellulolytic dark-fermentative bacterium clostridium cellulovorans 743b with the purple nonsulfur photosynthetic bacterium rhodopseudomonas palustris cga009. the coculture links cellulose degradation, volatile-fatty-acid exchange, ph stabilization, and photofermentative hydrogen production. it is doe-relevant as a genetically tractable model for lignocellulosic bioenergy, integrated dark/photo fermentation, and mechanistic design of biohydrogen consortia.
+"
+                       data-category="LIGNOCELLULOSE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Clostridium cellulovorans-Rhodopseudomonas palustris Cellulose Biohydrogen Coculture</h2>
+                        <p class="description">A defined two-member cellulose-to-biohydrogen coculture combining the cellulolytic dark-fermentative bacterium Clostridium cellulovorans 743B with the purple nonsulfur photosynthetic bacterium Rhodopseudomonas palustris CGA009. The coculture links cellulose degradation, volatile-fatty-acid exchange, pH stabilization, and photofermentative hydrogen production. It is DOE-relevant as a genetically tractable model for lignocellulosic bioenergy, integrated dark/photo fermentation, and mechanistic design of biohydrogen consortia.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.html"
+                       class="community-card"
+                       data-id="Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture"
+                       data-name="clostridium ljungdahlii-clostridium kluyveri syngas alcohol coculture"
+                       data-description="a defined anaerobic synthetic coculture that combines the acetogenic syngas fermenter clostridium ljungdahlii with the chain-elongating bacterium clostridium kluyveri in a continuously fed syngas bioprocess with in-line product extraction. c. ljungdahlii converts syngas into ethanol and acetate, while c. kluyveri uses ethanol for reverse-beta-oxidation chain elongation to butyrate and caproate. the same community also produced longer-chain alcohols including butanol, hexanol, and traces of octanol within a narrow ph range. the system is relevant to doe carbon utilization and renewable fuels because it converts c1 gases into c4-c8 fuels and chemicals through microbial cross-feeding.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Clostridium ljungdahlii-Clostridium kluyveri Syngas Alcohol Coculture</h2>
+                        <p class="description">A defined anaerobic synthetic coculture that combines the acetogenic syngas fermenter Clostridium ljungdahlii with the chain-elongating bacterium Clostridium kluyveri in a continuously fed syngas bioprocess with in-line product extraction. C. ljungdahlii converts syngas into ethanol and acetate, while C. kluyveri uses ethanol for reverse-beta-oxidation chain elongation to butyrate and caproate. The same community also produced longer-chain alcohols including butanol, hexanol, and traces of octanol within a narrow pH range. The system is relevant to DOE carbon utilization and renewable fuels because it converts C1 gases into C4-C8 fuels and chemicals through microbial cross-feeding.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.html"
+                       class="community-card"
+                       data-id="Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium"
+                       data-name="clostridium phytofermentans-e. coli cellobiose biofilm consortium"
+                       data-description="a rationally designed two-member artificial consortium composed of clostridium phytofermentans isdg, currently represented in ncbi taxonomy as lachnoclostridium phytofermentans isdg, and escherichia coli k-12 mg1655. the community was built to improve conversion of cellulose-derived sugars into ethanol, biomass, and other bioproduct-relevant outputs through division of labor between a cellulolytic obligate anaerobe and a facultative anaerobe. it is doe-relevant because it models consolidated lignocellulosic bioprocessing, cellobiose conversion, biofilm oxygen partitioning, and cross-feeding mechanisms that can improve cellulosic fuel and chemical production.
+"
+                       data-category="LIGNOCELLULOSE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Clostridium phytofermentans-E. coli Cellobiose Biofilm Consortium</h2>
+                        <p class="description">A rationally designed two-member artificial consortium composed of Clostridium phytofermentans ISDg, currently represented in NCBI Taxonomy as Lachnoclostridium phytofermentans ISDg, and Escherichia coli K-12 MG1655. The community was built to improve conversion of cellulose-derived sugars into ethanol, biomass, and other bioproduct-relevant outputs through division of labor between a cellulolytic obligate anaerobe and a facultative anaerobe. It is DOE-relevant because it models consolidated lignocellulosic bioprocessing, cellobiose conversion, biofilm oxygen partitioning, and cross-feeding mechanisms that can improve cellulosic fuel and chemical production.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.html"
+                       class="community-card"
+                       data-id="Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture"
+                       data-name="clostridium-saccharomyces cellulose ethanol coculture"
+                       data-description="a synthetic two-member cellulose-to-ethanol coculture pairing the cellulolytic mesophile clostridium phytofermentans isdg, currently represented in ncbi taxonomy as lachnoclostridium phytofermentans isdg, with the engineered cellodextrin-fermenting yeast saccharomyces cerevisiae cdt-1. the consortium is maintained by controlled oxygen delivery: the yeast removes inhibitory oxygen and receives soluble sugars released during c. phytofermentans cellulose hydrolysis. with added endoglucanase, the coculture produced approximately 22 g/l ethanol from 100 g/l alpha-cellulose. this system is relevant to doe lignocellulosic biofuel and consolidated bioprocessing goals.
+"
+                       data-category="LIGNOCELLULOSE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Clostridium-Saccharomyces Cellulose Ethanol Coculture</h2>
+                        <p class="description">A synthetic two-member cellulose-to-ethanol coculture pairing the cellulolytic mesophile Clostridium phytofermentans ISDg, currently represented in NCBI Taxonomy as Lachnoclostridium phytofermentans ISDg, with the engineered cellodextrin-fermenting yeast Saccharomyces cerevisiae cdt-1. The consortium is maintained by controlled oxygen delivery: the yeast removes inhibitory oxygen and receives soluble sugars released during C. phytofermentans cellulose hydrolysis. With added endoglucanase, the coculture produced approximately 22 g/L ethanol from 100 g/L alpha-cellulose. This system is relevant to DOE lignocellulosic biofuel and consolidated bioprocessing goals.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.html"
+                       class="community-card"
+                       data-id="Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture"
+                       data-name="clostridium-thermoanaerobacter cellulosic bioethanol coculture"
+                       data-description="a thermophilic, anaerobic, two-member laboratory coculture for consolidated cellulosic bioethanol production. the cellulolytic clostridium thermocellum lqri member hydrolyzes and ferments cellulose, while the non-cellulolytic thermoanaerobacter pseudethanolicus strain x514 partner improves ethanol production from cellulose-derived fermentation intermediates. the system is doe-relevant because it uses a defined coculture to increase ethanolic fermentation of recalcitrant cellulosic material under batch and cyclic fed-batch bioprocess conditions.
+"
+                       data-category="LIGNOCELLULOSE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Clostridium-Thermoanaerobacter Cellulosic Bioethanol Coculture</h2>
+                        <p class="description">A thermophilic, anaerobic, two-member laboratory coculture for consolidated cellulosic bioethanol production. The cellulolytic Clostridium thermocellum LQRI member hydrolyzes and ferments cellulose, while the non-cellulolytic Thermoanaerobacter pseudethanolicus strain X514 partner improves ethanol production from cellulose-derived fermentation intermediates. The system is DOE-relevant because it uses a defined coculture to increase ethanolic fermentation of recalcitrant cellulosic material under batch and cyclic fed-batch bioprocess conditions.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.html"
+                       class="community-card"
+                       data-id="Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture"
+                       data-name="clostridium-thermoanaerobacterium jn4-gd17 cellulosic biofuel coculture"
+                       data-description="a thermophilic two-member cellulosic biofuel coculture composed of clostridium thermocellum jn4 and thermoanaerobacterium thermosaccharolyticum gd17. the system improves overall cellulosic biofuel production efficiency relative to c. thermocellum alone, but later mechanistic work indicates that gd17 also competitively hampers c. thermocellum jn4 growth while using glucose and cellobiose released during cellulose degradation.
+"
+                       data-category="LIGNOCELLULOSE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Clostridium-Thermoanaerobacterium JN4-GD17 Cellulosic Biofuel Coculture</h2>
+                        <p class="description">A thermophilic two-member cellulosic biofuel coculture composed of Clostridium thermocellum JN4 and Thermoanaerobacterium thermosaccharolyticum GD17. The system improves overall cellulosic biofuel production efficiency relative to C. thermocellum alone, but later mechanistic work indicates that GD17 also competitively hampers C. thermocellum JN4 growth while using glucose and cellobiose released during cellulose degradation.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.html"
+                       class="community-card"
+                       data-id="Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture"
+                       data-name="clostridium thermocellum-saccharoperbutylacetonicum cellulosic butanol coculture"
+                       data-description="a staged two-member coculture for producing n-butanol from crystalline cellulose. the cellulolytic thermophile clostridium thermocellum, represented in ncbi taxonomy as acetivibrio thermocellus atcc 27405, first hydrolyzes avicel cellulose. the butanol-producing clostridium saccharoperbutylacetonicum strain n1-4 is then added for solvent production. the system is doe-relevant because it couples consolidated cellulose deconstruction to cellulosic butanol production, a liquid biofuel and bioproduct target.
+"
+                       data-category="LIGNOCELLULOSE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Clostridium Thermocellum-Saccharoperbutylacetonicum Cellulosic Butanol Coculture</h2>
+                        <p class="description">A staged two-member coculture for producing n-butanol from crystalline cellulose. The cellulolytic thermophile Clostridium thermocellum, represented in NCBI Taxonomy as Acetivibrio thermocellus ATCC 27405, first hydrolyzes Avicel cellulose. The butanol-producing Clostridium saccharoperbutylacetonicum strain N1-4 is then added for solvent production. The system is DOE-relevant because it couples consolidated cellulose deconstruction to cellulosic butanol production, a liquid biofuel and bioproduct target.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.html"
+                       class="community-card"
+                       data-id="Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community"
+                       data-name="coastal forested wetland seawater-ion microcosm community"
+                       data-description="a restored coastal forested freshwater wetland soil community from the timberlake observatory for wetland restoration in north carolina, curated around a manipulative laboratory microcosm experiment that disentangled sulfate from other seawater ions. intact wetland soil cores received deionized water, artificial seawater, artificial seawater without sulfate, or sulfate alone, followed by dna sequencing, biogeochemical measurements, and greenhouse gas flux measurements. the experiment found that artificial seawater altered microbial richness, composition, functional genes, and emissions of carbon dioxide, methane, and nitrous oxide whether sulfate was present or absent, whereas sulfate alone did not alter emissions or enrich sulfate-reducing bacteria or sulfur cycling genes. the record is doe-relevant because authors were affiliated with the doe joint genome institute and lawrence berkeley national laboratory, and sequencing followed doe jgi methods.
+"
+                       data-category="METHANOGENESIS"
+                       data-state="PERTURBED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Coastal Forested Wetland Seawater-Ion Microcosm Community</h2>
+                        <p class="description">A restored coastal forested freshwater wetland soil community from the Timberlake Observatory for Wetland Restoration in North Carolina, curated around a manipulative laboratory microcosm experiment that disentangled sulfate from other seawater ions. Intact wetland soil cores received deionized water, artificial seawater, artificial seawater without sulfate, or sulfate alone, followed by DNA sequencing, biogeochemical measurements, and greenhouse gas flux measurements. The experiment found that artificial seawater altered microbial richness, composition, functional genes, and emissions of carbon dioxide, methane, and nitrous oxide whether sulfate was present or absent, whereas sulfate alone did not alter emissions or enrich sulfate-reducing bacteria or sulfur cycling genes. The record is DOE-relevant because authors were affiliated with the DOE Joint Genome Institute and Lawrence Berkeley National Laboratory, and sequencing followed DOE JGI methods.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">METHANOGENESIS</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.html"
+                       class="community-card"
+                       data-id="Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium"
+                       data-name="coniochaeta-sphingobacterium-citrobacter wheat straw consortium"
+                       data-description="a three-member bacterial-fungal synthetic consortium cultivated on wheat straw to study division of labor during lignocellulose degradation. the community combines the fungus coniochaeta sp. 2t2.1 with the bacterium originally reported as sphingobacterium multivorum w15 and later proposed as sphingobacterium paramultivorum w15, plus citrobacter freundii so4. the system is relevant to doe bioenergy because it links a joint genome institute fungal genome resource to transcriptomic and metatranscriptomic evidence for cellulose, xylan, hemicellulose, lignin-modification, detoxification, and vitamin b2-associated functions in a model lignocellulose-degrading consortium.
+"
+                       data-category="LIGNOCELLULOSE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Coniochaeta-Sphingobacterium-Citrobacter Wheat Straw Consortium</h2>
+                        <p class="description">A three-member bacterial-fungal synthetic consortium cultivated on wheat straw to study division of labor during lignocellulose degradation. The community combines the fungus Coniochaeta sp. 2T2.1 with the bacterium originally reported as Sphingobacterium multivorum w15 and later proposed as Sphingobacterium paramultivorum w15, plus Citrobacter freundii so4. The system is relevant to DOE bioenergy because it links a Joint Genome Institute fungal genome resource to transcriptomic and metatranscriptomic evidence for cellulose, xylan, hemicellulose, lignin-modification, detoxification, and vitamin B2-associated functions in a model lignocellulose-degrading consortium.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Copper_Biomining_Heap_Leach.html"
+                       class="community-card"
+                       data-id="Copper_Biomining_Heap_Leach"
+                       data-name="copper biomining heap leach consortium"
+                       data-description="an industrial microbial consortium used for commercial copper bioleaching from low-grade sulfide ores in heap leach operations. this acidophilic community oxidizes ferrous iron and reduced sulfur compounds, generating ferric iron (fe³⁺) and sulfuric acid that solubilize copper from chalcopyrite (cufes₂) and other copper sulfide minerals. the consortium demonstrates temporal succession over the 200-300 day leaching cycle, with acidithiobacillus ferrooxidans dominating early stages (ph &gt;2, low fe, ~10⁷ copies/ml at 200 days), followed by leptospirillum ferriphilum and ferroplasma acidiphilum in aged heaps (ph 1.67-1.83, high fe³⁺ ~1.9 g/l, ~10⁵ copies/ml at &gt;250 days). acidithiobacillus thiooxidans maintains constant sulfur oxidation activity (10⁵ copies/ml) throughout the cycle. sulfobacillus species contribute at low abundance (10³-10⁴ copies/ml) with increased activity in older heaps. the community operates at ph 1.5-2.5, temperatures 20-60°c depending on thermophilic strains, and produces the fe³⁺ oxidant critical for copper dissolution (reaching 1.86-1.9 g/l fe³⁺). this biohydrometallurgical process extracts copper from ores uneconomical for conventional smelting, with industrial operations achieving commercial-scale metal recovery through percolation of acidic leach solutions through heaps of crushed ore.
+"
+                       data-category="BIOMINING"
+                       data-state="ENGINEERED"
+                       data-metals="COPPER,IRON"
+                       data-ree=""
+                       data-relevance="PRIMARY"
+                       data-member-count="5">
+                        <h2>Copper Biomining Heap Leach Consortium</h2>
+                        <p class="description">An industrial microbial consortium used for commercial copper bioleaching from low-grade sulfide ores in heap leach operations. This acidophilic community oxidizes ferrous iron and reduced sulfur compounds, generating ferric iron (Fe³⁺) and sulfuric acid that solubilize copper from chalcopyrite (CuFeS₂) and other copper sulfide minerals. The consortium demonstrates temporal succession over the 200-300 day leaching cycle, with Acidithiobacillus ferrooxidans dominating early stages (pH &gt;2, low Fe, ~10⁷ copies/ml at 200 days), followed by Leptospirillum ferriphilum and Ferroplasma acidiphilum in aged heaps (pH 1.67-1.83, high Fe³⁺ ~1.9 g/L, ~10⁵ copies/ml at &gt;250 days). Acidithiobacillus thiooxidans maintains constant sulfur oxidation activity (10⁵ copies/ml) throughout the cycle. Sulfobacillus species contribute at low abundance (10³-10⁴ copies/ml) with increased activity in older heaps. The community operates at pH 1.5-2.5, temperatures 20-60°C depending on thermophilic strains, and produces the Fe³⁺ oxidant critical for copper dissolution (reaching 1.86-1.9 g/L Fe³⁺). This biohydrometallurgical process extracts copper from ores uneconomical for conventional smelting, with industrial operations achieving commercial-scale metal recovery through percolation of acidic leach solutions through heaps of crushed ore.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    5
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOMINING</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Coscinodiscus_Synthetic_Community.html"
+                       class="community-card"
+                       data-id="Coscinodiscus_Synthetic_Community"
+                       data-name="coscinodiscus synthetic community"
+                       data-description="a synthetic marine phytoplankton community consisting of the large centric diatom coscinodiscus radiatus and four phylogenetically distinct bacterial isolates from different marine bacterial lineages. this model system was established to examine species-specific diatom-bacteria interactions and community dynamics. the bacteria include two roseobacteraceae members (mameliella cs4 and roseovarius rose1), a gammaproteobacterium (marinobacter cs1), and a flavobacterium (croceibacter crocei1). the consortium demonstrates context-dependent bacterial effects on diatom growth that vary with algal fitness state, growth phase, and community composition, with no universal algicidal or growth-promoting bacteria observed. this system is relevant to understanding carbon cycling and primary production in marine ecosystems.
+"
+                       data-category="PHYTOPLANKTON"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="5">
+                        <h2>Coscinodiscus Synthetic Community</h2>
+                        <p class="description">A synthetic marine phytoplankton community consisting of the large centric diatom Coscinodiscus radiatus and four phylogenetically distinct bacterial isolates from different marine bacterial lineages. This model system was established to examine species-specific diatom-bacteria interactions and community dynamics. The bacteria include two Roseobacteraceae members (Mameliella CS4 and Roseovarius Rose1), a gammaproteobacterium (Marinobacter CS1), and a Flavobacterium (Croceibacter Crocei1). The consortium demonstrates context-dependent bacterial effects on diatom growth that vary with algal fitness state, growth phase, and community composition, with no universal algicidal or growth-promoting bacteria observed. This system is relevant to understanding carbon cycling and primary production in marine ecosystems.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    5
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">PHYTOPLANKTON</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community.html"
+                       class="community-card"
+                       data-id="Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community"
+                       data-name="crystal geyser co2-rich aquifer autotrophic cpr lysolipid community"
+                       data-description="a deep co2-rich subsurface aquifer community below the colorado plateau, sampled from groundwater brought to the surface by eruptions of crystal geyser. coupled lipidomic and metagenomic analyses show that bacterial and archaeal co2 fixation in the deep subsurface provides the organic carbon pool, supporting an autotrophy-based deep biosphere. candidate phyla radiation (cpr) bacterial putative symbionts lack complete lipid biosynthesis pathways but still possess regular lipid membranes, which may originate from other community members; these other members also adapt to high in situ pressure by increasing fatty acid unsaturation. an unusually high abundance of lysolipids attributed to cpr bacteria may represent an adaptation to membrane curvature stress induced by their small cell sizes.
+"
+                       data-category="EXTREME_ENVIRONMENT"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Crystal Geyser CO2-Rich Aquifer Autotrophic CPR Lysolipid Community</h2>
+                        <p class="description">A deep CO2-rich subsurface aquifer community below the Colorado Plateau, sampled from groundwater brought to the surface by eruptions of Crystal Geyser. Coupled lipidomic and metagenomic analyses show that bacterial and archaeal CO2 fixation in the deep subsurface provides the organic carbon pool, supporting an autotrophy-based deep biosphere. Candidate Phyla Radiation (CPR) bacterial putative symbionts lack complete lipid biosynthesis pathways but still possess regular lipid membranes, which may originate from other community members; these other members also adapt to high in situ pressure by increasing fatty acid unsaturation. An unusually high abundance of lysolipids attributed to CPR bacteria may represent an adaptation to membrane curvature stress induced by their small cell sizes.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">EXTREME_ENVIRONMENT</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.html"
+                       class="community-card"
+                       data-id="Cyprus_Copper_Sulphide_Bioleaching_Consortium"
+                       data-name="cyprus copper sulphide bioleaching consortium"
+                       data-description="an acidophilic copper bioleaching consortium established from a copper bioleaching column in cyprus on chalcopyrite (cufes2) and sub-cultured to chalcocite (cu2s) to test how mineral type and surface chemistry shape community composition. genome-resolved metagenomics after 4 and 8 weeks of cultivation identified dominant members including acidithiobacillus species and strains, a rhodospirilales, leptospirillum ferrodiazotrophum, and thermoplasmatales archaea, with abundance trends linked to mineralogy and to surface-attached versus planktonic lifestyles. many bacteria carried plasmids encoding metal resistance, sulphur metabolism, and crispr-cas loci, with evidence of intra-plasmid competition via crispr spacers on an acidithiobacillus plasmid targeting plasmid-borne conjugal transfer genes.
+"
+                       data-category="BIOMINING"
+                       data-state="ENGINEERED"
+                       data-metals="COPPER,IRON"
+                       data-ree=""
+                       data-relevance="PRIMARY"
+                       data-member-count="4">
+                        <h2>Cyprus Copper Sulphide Bioleaching Consortium</h2>
+                        <p class="description">An acidophilic copper bioleaching consortium established from a copper bioleaching column in Cyprus on chalcopyrite (CuFeS2) and sub-cultured to chalcocite (Cu2S) to test how mineral type and surface chemistry shape community composition. Genome-resolved metagenomics after 4 and 8 weeks of cultivation identified dominant members including Acidithiobacillus species and strains, a Rhodospirilales, Leptospirillum ferrodiazotrophum, and Thermoplasmatales archaea, with abundance trends linked to mineralogy and to surface-attached versus planktonic lifestyles. Many bacteria carried plasmids encoding metal resistance, sulphur metabolism, and CRISPR-Cas loci, with evidence of intra-plasmid competition via CRISPR spacers on an Acidithiobacillus plasmid targeting plasmid-borne conjugal transfer genes.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOMINING</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/DVM_Triculture.html"
+                       class="community-card"
+                       data-id="DVM_Triculture"
+                       data-name="dvm tri-culture"
+                       data-description="a three-member synthetic consortium consisting of desulfovibrio vulgaris (dv), methanococcus maripaludis (mm), and methanosarcina barkeri (mb) that converts lactate to methane under varying sulfate conditions. d. vulgaris oxidizes lactate to acetate, co2, and h2. both methanogens (mm and mb) can consume the h2 produced by dv, with mm being a hydrogenotrophic methanogen and mb capable of using both h2-co2 and acetate for methanogenesis. the community demonstrates differential responses to geochemical gradients, particularly sulfate availability. in the absence of sulfate, all three species co-exist and methane production increases by almost 100% compared to dv-mm co-cultures. however, increasing sulfate levels shift community dynamics as dv preferentially uses sulfate as an electron acceptor, creating competitive situations for both methanogens. this system provides insights into how geochemical gradients (particularly sulfate) regulate microbial interactions and methane production in anaerobic environments.
+"
+                       data-category="METHANOGENESIS"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="3">
+                        <h2>DVM Tri-culture</h2>
+                        <p class="description">A three-member synthetic consortium consisting of Desulfovibrio vulgaris (Dv), Methanococcus maripaludis (Mm), and Methanosarcina barkeri (Mb) that converts lactate to methane under varying sulfate conditions. D. vulgaris oxidizes lactate to acetate, CO2, and H2. Both methanogens (Mm and Mb) can consume the H2 produced by Dv, with Mm being a hydrogenotrophic methanogen and Mb capable of using both H2-CO2 and acetate for methanogenesis. The community demonstrates differential responses to geochemical gradients, particularly sulfate availability. In the absence of sulfate, all three species co-exist and methane production increases by almost 100% compared to Dv-Mm co-cultures. However, increasing sulfate levels shift community dynamics as Dv preferentially uses sulfate as an electron acceptor, creating competitive situations for both methanogens. This system provides insights into how geochemical gradients (particularly sulfate) regulate microbial interactions and methane production in anaerobic environments.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">METHANOGENESIS</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Dangl_SynComm_35.html"
+                       class="community-card"
+                       data-id="Dangl_SynComm_35"
+                       data-name="jeff dangl&#39;s syncomm 35"
+                       data-description="a 35-member synthetic community (syncomm 35) composed of genome-sequenced bacterial strains representing typical taxonomic diversity of arabidopsis root commensals. this community was designed to interrogate plant immune responses, particularly pattern-triggered immunity (pti/mti). of the 35 members, 10 are robust suppressors of mamp-triggered immunity (flg22 response), 13 are partial suppressors, and 11 are non-suppressors. the community includes 32 strains isolated from brassicaceae roots (mainly arabidopsis), 2 strains from unplanted soil, and e. coli dh5α as a control. syncomm 35 collectively suppresses specific transcriptional sectors of plant immunity, particularly wrky transcription factors, receptor-like kinases, and secondary metabolite biosynthesis genes, while suppressors achieve enhanced colonization capacity.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="INCIDENTAL"
+                       data-member-count="8">
+                        <h2>Jeff Dangl&#39;s SynComm 35</h2>
+                        <p class="description">A 35-member synthetic community (SynComm 35) composed of genome-sequenced bacterial strains representing typical taxonomic diversity of Arabidopsis root commensals. This community was designed to interrogate plant immune responses, particularly pattern-triggered immunity (PTI/MTI). Of the 35 members, 10 are robust suppressors of MAMP-triggered immunity (flg22 response), 13 are partial suppressors, and 11 are non-suppressors. The community includes 32 strains isolated from Brassicaceae roots (mainly Arabidopsis), 2 strains from unplanted soil, and E. coli DH5α as a control. SynComm 35 collectively suppresses specific transcriptional sectors of plant immunity, particularly WRKY transcription factors, receptor-like kinases, and secondary metabolite biosynthesis genes, while suppressors achieve enhanced colonization capacity.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    8
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.html"
+                       class="community-card"
+                       data-id="Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession"
+                       data-name="deepwater horizon deep-sea oil plume succession"
+                       data-description="a natural, perturbed deep-sea hydrocarbon-plume microbial community that developed during the 2010 deepwater horizon blowout in the gulf of mexico. the plume selected indigenous hydrocarbon-degrading gammaproteobacteria, with early enrichment of oceanospirillales-like petroleum degraders followed by colwellia, cycloclasticus, methylotrophic bacteria, and other taxa with non-redundant hydrocarbon degradation capacities.
+"
+                       data-category="BIOREMEDIATION"
+                       data-state="PERTURBED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="5">
+                        <h2>Deepwater Horizon Deep-Sea Oil Plume Succession</h2>
+                        <p class="description">A natural, perturbed deep-sea hydrocarbon-plume microbial community that developed during the 2010 Deepwater Horizon blowout in the Gulf of Mexico. The plume selected indigenous hydrocarbon-degrading Gammaproteobacteria, with early enrichment of Oceanospirillales-like petroleum degraders followed by Colwellia, Cycloclasticus, methylotrophic bacteria, and other taxa with non-redundant hydrocarbon degradation capacities.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    5
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Defined_Multispecies_Enamel_Caries_Model.html"
+                       class="community-card"
+                       data-id="Defined_Multispecies_Enamel_Caries_Model"
+                       data-name="defined multispecies enamel caries model"
+                       data-description="a defined four-member oral biofilm model for in vitro enamel caries development, composed of lactobacillus casei, streptococcus mutans, streptococcus salivarius, and streptococcus sanguinis on salivary-pellicle-coated enamel slabs. the system was used to quantify how sucrose, fluoride, and calcium shift biofilm growth and enamel demineralization."
+                       data-category="ORAL"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Defined Multispecies Enamel Caries Model</h2>
+                        <p class="description">A defined four-member oral biofilm model for in vitro enamel caries development, composed of Lactobacillus casei, Streptococcus mutans, Streptococcus salivarius, and Streptococcus sanguinis on salivary-pellicle-coated enamel slabs. The system was used to quantify how sucrose, fluoride, and calcium shift biofilm growth and enamel demineralization.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">ORAL</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.html"
+                       class="community-card"
+                       data-id="Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy"
+                       data-name="dehalococcoides-desulfovibrio lactate-fed tce dechlorination coculture"
+                       data-description="a defined anaerobic syntrophic coculture pairing dehalococcoides mccartyi strain 195 with desulfovibrio vulgaris hildenborough. in this laboratory model for chlorinated-solvent groundwater bioremediation, d. vulgaris hildenborough ferments lactate and supplies hydrogen and acetate that support strain 195 growth and reductive dechlorination. the system is doe-relevant because it resolves metabolite exchange and stress responses that affect organohalide-respiring communities used for in situ trichloroethene bioremediation.
+"
+                       data-category="BIOREMEDIATION"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Dehalococcoides-Desulfovibrio Lactate-Fed TCE Dechlorination Coculture</h2>
+                        <p class="description">A defined anaerobic syntrophic coculture pairing Dehalococcoides mccartyi strain 195 with Desulfovibrio vulgaris Hildenborough. In this laboratory model for chlorinated-solvent groundwater bioremediation, D. vulgaris Hildenborough ferments lactate and supplies hydrogen and acetate that support strain 195 growth and reductive dechlorination. The system is DOE-relevant because it resolves metabolite exchange and stress responses that affect organohalide-respiring communities used for in situ trichloroethene bioremediation.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.html"
+                       class="community-card"
+                       data-id="Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture"
+                       data-name="dehalococcoides-desulfovibrio-pelosinus corrinoid triculture"
+                       data-description="a defined anaerobic three-member dechlorinating consortium containing dehalococcoides mccartyi strain 195, desulfovibrio vulgaris hildenborough, and pelosinus fermentans r7. in cobalamin-free, tce- and lactate-amended medium supplemented with the lower ligand dmb, dvh supplies hydrogen while pfr7 supplies corrinoids that dhc195 salvages and remodels into cobalamin. the triculture is relevant to doe subsurface bioremediation because it identifies separable hydrogen-transfer and corrinoid-transfer mechanisms that support organohalide respiration in chlorinated-solvent dechlorinating communities.
+"
+                       data-category="BIOREMEDIATION"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Dehalococcoides-Desulfovibrio-Pelosinus Corrinoid Triculture</h2>
+                        <p class="description">A defined anaerobic three-member dechlorinating consortium containing Dehalococcoides mccartyi strain 195, Desulfovibrio vulgaris Hildenborough, and Pelosinus fermentans R7. In cobalamin-free, TCE- and lactate-amended medium supplemented with the lower ligand DMB, DvH supplies hydrogen while PfR7 supplies corrinoids that Dhc195 salvages and remodels into cobalamin. The triculture is relevant to DOE subsurface bioremediation because it identifies separable hydrogen-transfer and corrinoid-transfer mechanisms that support organohalide respiration in chlorinated-solvent dechlorinating communities.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.html"
+                       class="community-card"
+                       data-id="Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture"
+                       data-name="dehalococcoides-methanosarcina dmb-guided cobalamin coculture"
+                       data-description="a defined two-member chlorinated-ethene bioremediation coculture pairing dehalococcoides mccartyi strain bav1 with methanosarcina barkeri strain fusaro. d. mccartyi bav1 is corrinoid auxotrophic and requires a cobalamin-type cofactor for organohalide respiration. m. barkeri fusaro produces extracellular factor iii, which did not by itself support dehalococcoides reductive dechlorination activity, but addition of 5,6-dimethylbenzimidazole enabled guided biosynthesis of cobalamin that supported dehalococcoides activity and growth. the system is relevant to doe chlorinated-solvent groundwater bioremediation because it resolves a cofactor-mediated interaction controlling reductive dechlorination.
+"
+                       data-category="BIOREMEDIATION"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="INCIDENTAL"
+                       data-member-count="2">
+                        <h2>Dehalococcoides-Methanosarcina DMB-Guided Cobalamin Coculture</h2>
+                        <p class="description">A defined two-member chlorinated-ethene bioremediation coculture pairing Dehalococcoides mccartyi strain BAV1 with Methanosarcina barkeri strain Fusaro. D. mccartyi BAV1 is corrinoid auxotrophic and requires a cobalamin-type cofactor for organohalide respiration. M. barkeri Fusaro produces extracellular factor III, which did not by itself support Dehalococcoides reductive dechlorination activity, but addition of 5,6-dimethylbenzimidazole enabled guided biosynthesis of cobalamin that supported Dehalococcoides activity and growth. The system is relevant to DOE chlorinated-solvent groundwater bioremediation because it resolves a cofactor-mediated interaction controlling reductive dechlorination.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.html"
+                       class="community-card"
+                       data-id="Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture"
+                       data-name="dehalococcoides-pelobacter acetylene tce coculture"
+                       data-description="a defined anaerobic laboratory coculture in which the acetylene-fermenting bacterium historically reported as pelobacter strain sfb93 is paired with dehalococcoides mccartyi strain 195 to sustain reductive dechlorination of trichloroethene when acetylene is provided as electron donor and carbon source. the system is relevant to chlorinated-solvent groundwater bioremediation because acetylene can be generated during abiotic tce degradation and can inhibit dechlorination at high concentrations.
+"
+                       data-category="BIOREMEDIATION"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Dehalococcoides-Pelobacter Acetylene TCE Coculture</h2>
+                        <p class="description">A defined anaerobic laboratory coculture in which the acetylene-fermenting bacterium historically reported as Pelobacter strain SFB93 is paired with Dehalococcoides mccartyi strain 195 to sustain reductive dechlorination of trichloroethene when acetylene is provided as electron donor and carbon source. The system is relevant to chlorinated-solvent groundwater bioremediation because acetylene can be generated during abiotic TCE degradation and can inhibit dechlorination at high concentrations.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.html"
+                       class="community-card"
+                       data-id="Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture"
+                       data-name="dehalococcoides-syntrophomonas tce dechlorination coculture"
+                       data-description="a defined two-member anaerobic syntrophic coculture in which dehalococcoides mccartyi strain 195 reductively dechlorinates trichloroethene while syntrophomonas wolfei ferments butyrate or crotonate-derived carbon to provide hydrogen and acetate. the system is relevant to chlorinated-solvent groundwater bioremediation because it models interspecies hydrogen transfer and metabolite exchange that support tce dechlorination by dehalococcoides-containing communities.
+"
+                       data-category="BIOREMEDIATION"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Dehalococcoides-Syntrophomonas TCE Dechlorination Coculture</h2>
+                        <p class="description">A defined two-member anaerobic syntrophic coculture in which Dehalococcoides mccartyi strain 195 reductively dechlorinates trichloroethene while Syntrophomonas wolfei ferments butyrate or crotonate-derived carbon to provide hydrogen and acetate. The system is relevant to chlorinated-solvent groundwater bioremediation because it models interspecies hydrogen transfer and metabolite exchange that support TCE dechlorination by Dehalococcoides-containing communities.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Desert_Tomato_Salt_Stress_SynCom5.html"
+                       class="community-card"
+                       data-id="Desert_Tomato_Salt_Stress_SynCom5"
+                       data-name="desert-derived tomato salt stress syncom5"
+                       data-description="a five-member desert-root bacterial syncom that protects tomato plants from high salt stress in non-sterile soil."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>Desert-Derived Tomato Salt Stress SynCom5</h2>
+                        <p class="description">A five-member desert-root bacterial SynCom that protects tomato plants from high salt stress in non-sterile soil.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Desulfovibrio_Methanococcus_Syntrophy.html"
+                       class="community-card"
+                       data-id="Desulfovibrio_Methanococcus_Syntrophy"
+                       data-name="desulfovibrio-methanococcus syntrophic consortium"
+                       data-description="a syntrophic, obligate two-member anaerobic consortium consisting of desulfovibrio vulgaris hildenborough, which oxidizes lactate to acetate, h2, and co2 in the absence of sulfate, and methanococcus maripaludis s2, a hydrogenotrophic methanogen. d. vulgaris can reduce sulfate when available, but in sulfate-free environments it must grow syntrophically by coupling lactate oxidation to interspecies hydrogen transfer. m. maripaludis consumes the h2 and co2 produced by d. vulgaris to produce methane, maintaining the low h2 partial pressure thermodynamically required for continued lactate oxidation. this syntrophic relationship is fundamental to understanding microbial metabolism in sulfate-depleted anaerobic environments and represents a classic model system for studying syntrophic electron transfer mechanisms.
+"
+                       data-category="SYNTROPHY"
+                       data-state="STABLE"
+                       data-metals="IRON"
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="2">
+                        <h2>Desulfovibrio-Methanococcus Syntrophic Consortium</h2>
+                        <p class="description">A syntrophic, obligate two-member anaerobic consortium consisting of Desulfovibrio vulgaris Hildenborough, which oxidizes lactate to acetate, H2, and CO2 in the absence of sulfate, and Methanococcus maripaludis S2, a hydrogenotrophic methanogen. D. vulgaris can reduce sulfate when available, but in sulfate-free environments it must grow syntrophically by coupling lactate oxidation to interspecies hydrogen transfer. M. maripaludis consumes the H2 and CO2 produced by D. vulgaris to produce methane, maintaining the low H2 partial pressure thermodynamically required for continued lactate oxidation. This syntrophic relationship is fundamental to understanding microbial metabolism in sulfate-depleted anaerobic environments and represents a classic model system for studying syntrophic electron transfer mechanisms.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Desulfovibrio_Methanosarcina_Lactate_Syntrophy.html"
+                       class="community-card"
+                       data-id="Desulfovibrio_Methanosarcina_Lactate_Syntrophy"
+                       data-name="desulfovibrio-methanosarcina lactate syntrophy"
+                       data-description="a classic anaerobic two-member syntrophic coculture in which desulfovibrio desulfuricans degrades lactate in the absence of added sulfate and methanosarcina barkeri consumes fermentation products for methanogenesis. lactate is first degraded to acetate and methane; later acetate is converted to methane and carbon dioxide, illustrating how hydrogen and substrate dynamics regulate coupled lactate oxidation and methanogenesis.
+"
+                       data-category="SYNTROPHY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Desulfovibrio-Methanosarcina Lactate Syntrophy</h2>
+                        <p class="description">A classic anaerobic two-member syntrophic coculture in which Desulfovibrio desulfuricans degrades lactate in the absence of added sulfate and Methanosarcina barkeri consumes fermentation products for methanogenesis. Lactate is first degraded to acetate and methane; later acetate is converted to methane and carbon dioxide, illustrating how hydrogen and substrate dynamics regulate coupled lactate oxidation and methanogenesis.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.html"
+                       class="community-card"
+                       data-id="Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota"
+                       data-name="drosophila five-species gnotobiotic gut microbiota"
+                       data-description="a defined five-species drosophila melanogaster gut microbiota assembled from fly-gut isolates of acetobacter pomorum, acetobacter tropicalis, lactobacillus brevis, lactobacillus fructivorans, and lactobacillus plantarum. the community was used to colonize axenic drosophila and test how acetobacter-lactobacillus interactions shape host development, glucose, triglyceride allocation, and host-genotype-dependent microbiota effects.
+"
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Drosophila Five-Species Gnotobiotic Gut Microbiota</h2>
+                        <p class="description">A defined five-species Drosophila melanogaster gut microbiota assembled from fly-gut isolates of Acetobacter pomorum, Acetobacter tropicalis, Lactobacillus brevis, Lactobacillus fructivorans, and Lactobacillus plantarum. The community was used to colonize axenic Drosophila and test how Acetobacter-Lactobacillus interactions shape host development, glucose, triglyceride allocation, and host-genotype-dependent microbiota effects.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.html"
+                       class="community-card"
+                       data-id="Drought_Rhizosphere_Iron_Actinobacteria_Community"
+                       data-name="drought-induced rhizosphere iron-enriched actinobacteria community"
+                       data-description="a root-associated rhizosphere microbial community in which drought stress drives reproducible enrichment of bacterial lineages whose iron transport and metabolism functionalities are overrepresented. genome-resolved metagenomics and comparative genomics show carbohydrate and secondary- metabolite transport functions also dominate drought-enriched taxa. time- series root rna-seq data show that root iron homeostasis is impacted by drought, and loss of a plant phytosiderophore iron transporter increases actinobacteria abundance. exogenous iron application disrupts the drought- induced actinobacteria enrichment and removes their host phenotype improvement, implicating iron metabolism as a microbiome-drought axis.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="PERTURBED"
+                       data-metals="IRON"
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="1">
+                        <h2>Drought-Induced Rhizosphere Iron-Enriched Actinobacteria Community</h2>
+                        <p class="description">A root-associated rhizosphere microbial community in which drought stress drives reproducible enrichment of bacterial lineages whose iron transport and metabolism functionalities are overrepresented. Genome-resolved metagenomics and comparative genomics show carbohydrate and secondary- metabolite transport functions also dominate drought-enriched taxa. Time- series root RNA-Seq data show that root iron homeostasis is impacted by drought, and loss of a plant phytosiderophore iron transporter increases Actinobacteria abundance. Exogenous iron application disrupts the drought- induced Actinobacteria enrichment and removes their host phenotype improvement, implicating iron metabolism as a microbiome-drought axis.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/ENIGMA_Denitrifying_SynCom.html"
+                       class="community-card"
+                       data-id="ENIGMA_Denitrifying_SynCom"
+                       data-name="enigma denitrifying syncom"
+                       data-description="a two-member denitrifying synthetic community from the enigma program, composed of rhodanobacter thiooxydans fw510-r12 and acidovorax sp. gw101-3h11 isolated from a heavily nitrate-contaminated superfund site. the consortium exhibits pathway-partitioned denitrification via nitrite and nitric oxide exchange, with cooperativity that can be disrupted under high nitrate conditions leading to nitrite accumulation and nitrous oxide off-gassing."
+                       data-category="BIOREMEDIATION"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>ENIGMA Denitrifying SynCom</h2>
+                        <p class="description">A two-member denitrifying synthetic community from the ENIGMA program, composed of Rhodanobacter thiooxydans FW510-R12 and Acidovorax sp. GW101-3H11 isolated from a heavily nitrate-contaminated superfund site. The consortium exhibits pathway-partitioned denitrification via nitrite and nitric oxide exchange, with cooperativity that can be disrupted under high nitrate conditions leading to nitrite accumulation and nitrous oxide off-gassing.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Early_Dental_Biofilm_FiveSpecies.html"
+                       class="community-card"
+                       data-id="Early_Dental_Biofilm_FiveSpecies"
+                       data-name="early dental biofilm five-species model"
+                       data-description="a defined five-member oral biofilm model representing early acidogenic stages of the caries process. the community combines streptococcus oralis, streptococcus sanguinis, streptococcus mitis, streptococcus downei, and actinomyces naeslundii in flow-channel biofilms to reproduce the composition, architecture, and microscale ph heterogeneity of early dental plaque."
+                       data-category="ORAL"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="5">
+                        <h2>Early Dental Biofilm Five-Species Model</h2>
+                        <p class="description">A defined five-member oral biofilm model representing early acidogenic stages of the caries process. The community combines Streptococcus oralis, Streptococcus sanguinis, Streptococcus mitis, Streptococcus downei, and Actinomyces naeslundii in flow-channel biofilms to reproduce the composition, architecture, and microscale pH heterogeneity of early dental plaque.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    5
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">ORAL</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/East_River_Floodplain_Core_Microbiome.html"
+                       class="community-card"
+                       data-id="East_River_Floodplain_Core_Microbiome"
+                       data-name="east river floodplain core microbiome"
+                       data-description="a natural floodplain-soil microbial community from the doe-supported east river watershed in colorado. metagenomic and metatranscriptomic sampling across upper, middle, and lower east river meander-bound floodplains reconstructed 248 representative subspecies-level genomes and identified a core floodplain microbiome. the core community is enriched in aerobic respiration, aerobic carbon monoxide oxidation, thiosulfate oxidation, nitrification, methanol and formate oxidation, and carbon fixation capacities that vary with soil organic carbon and floodplain position."
+                       data-category="CARBON_SEQUESTRATION"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>East River Floodplain Core Microbiome</h2>
+                        <p class="description">A natural floodplain-soil microbial community from the DOE-supported East River watershed in Colorado. Metagenomic and metatranscriptomic sampling across upper, middle, and lower East River meander-bound floodplains reconstructed 248 representative subspecies-level genomes and identified a core floodplain microbiome. The core community is enriched in aerobic respiration, aerobic carbon monoxide oxidation, thiosulfate oxidation, nitrification, methanol and formate oxidation, and carbon fixation capacities that vary with soil organic carbon and floodplain position.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">CARBON_SEQUESTRATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/East_River_Hillslope_Riparian_Transect_Community.html"
+                       class="community-card"
+                       data-id="East_River_Hillslope_Riparian_Transect_Community"
+                       data-name="east river hillslope riparian transect microbial community"
+                       data-description="a natural, depth-resolved microbial community from a hillslope-to-riparian transect in the doe-supported east river watershed near crested butte, colorado. metagenomic and geochemical analyses showed that distance from the east river, proximity to the groundwater table, and underlying weathered shale strongly structure microbial community composition and metabolic potential. riparian-zone communities are compositionally distinct from hillslope communities and are functionally differentiated by capacities for carbon fixation, nitrogen fixation, sulfate reduction, candidate phyla radiation bacteria in saturated sediments, and selenium reduction at depth.
+"
+                       data-category="CARBON_SEQUESTRATION"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>East River Hillslope Riparian Transect Microbial Community</h2>
+                        <p class="description">A natural, depth-resolved microbial community from a hillslope-to-riparian transect in the DOE-supported East River watershed near Crested Butte, Colorado. Metagenomic and geochemical analyses showed that distance from the East River, proximity to the groundwater table, and underlying weathered shale strongly structure microbial community composition and metabolic potential. Riparian-zone communities are compositionally distinct from hillslope communities and are functionally differentiated by capacities for carbon fixation, nitrogen fixation, sulfate reduction, Candidate Phyla Radiation bacteria in saturated sediments, and selenium reduction at depth.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">CARBON_SEQUESTRATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/EcoFAB_Ring_Trial_SynCom17.html"
+                       class="community-card"
+                       data-id="EcoFAB_Ring_Trial_SynCom17"
+                       data-name="ecofab 2.0 root microbiome ring trial syncom17"
+                       data-description="a 17-member synthetic bacterial community (syncom17) used in a standardized inter-laboratory ring trial across five international laboratories (lbnl, unc chapel hill, max planck cologne, forschungszentrum julich, u melbourne) to study root microbiome recruitment and exudate composition of the model grass brachypodium distachyon in ecofab 2.0 fabricated ecosystem devices. all 17 members were originally isolated from switchgrass rhizosphere soil and span four bacterial phyla (actinomycetota, bacillota, bacteroidota, pseudomonadota). in the full syncom17, paraburkholderia sp. oas925 reproducibly dominates root colonization (~98% relative abundance) across all five labs, uniquely possessing a type 3 secretion system (t3ss), high motility, and acid resistance. removing paraburkholderia (syncom16) yields a more variable community dominated by rhodococcus sp. oas809 (~68%), mycobacterium sp. oae908 (~14%), and methylobacterium sp. oae515 (~15%). the study demonstrated that ecofab 2.0 with standardized protocols achieves reproducible plant phenotype, exudate, and community structure data across continents, providing benchmark datasets for plant-microbiome research.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="17">
+                        <h2>EcoFAB 2.0 Root Microbiome Ring Trial SynCom17</h2>
+                        <p class="description">A 17-member synthetic bacterial community (SynCom17) used in a standardized inter-laboratory ring trial across five international laboratories (LBNL, UNC Chapel Hill, Max Planck Cologne, Forschungszentrum Julich, U Melbourne) to study root microbiome recruitment and exudate composition of the model grass Brachypodium distachyon in EcoFAB 2.0 fabricated ecosystem devices. All 17 members were originally isolated from switchgrass rhizosphere soil and span four bacterial phyla (Actinomycetota, Bacillota, Bacteroidota, Pseudomonadota). In the full SynCom17, Paraburkholderia sp. OAS925 reproducibly dominates root colonization (~98% relative abundance) across all five labs, uniquely possessing a Type 3 Secretion System (T3SS), high motility, and acid resistance. Removing Paraburkholderia (SynCom16) yields a more variable community dominated by Rhodococcus sp. OAS809 (~68%), Mycobacterium sp. OAE908 (~14%), and Methylobacterium sp. OAE515 (~15%). The study demonstrated that EcoFAB 2.0 with standardized protocols achieves reproducible plant phenotype, exudate, and community structure data across continents, providing benchmark datasets for plant-microbiome research.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    17
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Emiliania_Phaeobacter_Dynamic_Interaction.html"
+                       class="community-card"
+                       data-id="Emiliania_Phaeobacter_Dynamic_Interaction"
+                       data-name="emiliania huxleyi-phaeobacter inhibens dynamic interaction"
+                       data-description="a defined marine algal-bacterial co-culture model between the coccolithophore emiliania huxleyi ccmp3266 and the roseobacter-group bacterium phaeobacter inhibens dsm 17395. the interaction is dynamic: attached bacteria initially promote algal growth but later kill aging algal hosts. evidence supports algal nutrient provisioning to the heterotrophic bacterium, bacterial attachment to naked algal cells, and indole-3-acetic acid production stimulated by algal-exuded tryptophan.
+"
+                       data-category="PHYTOPLANKTON"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Emiliania huxleyi-Phaeobacter inhibens Dynamic Interaction</h2>
+                        <p class="description">A defined marine algal-bacterial co-culture model between the coccolithophore Emiliania huxleyi CCMP3266 and the Roseobacter-group bacterium Phaeobacter inhibens DSM 17395. The interaction is dynamic: attached bacteria initially promote algal growth but later kill aging algal hosts. Evidence supports algal nutrient provisioning to the heterotrophic bacterium, bacterial attachment to naked algal cells, and indole-3-acetic acid production stimulated by algal-exuded tryptophan.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">PHYTOPLANKTON</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.html"
+                       class="community-card"
+                       data-id="Engineered_Gut_Amino_Acid_CrossFeeding_Consortium"
+                       data-name="engineered gut amino acid cross-feeding consortium"
+                       data-description="a four-species engineered mammalian-gut consortium in which escherichia coli, salmonella enterica serovar typhimurium, bacteroides thetaiotaomicron, and bacteroides fragilis were modified to create amino acid auxotrophies and amino acid overproduction. the design converts a consortium otherwise shaped by antagonistic interactions into one with engineered beneficial cross-feeding, increasing population evenness in anaerobic in vitro culture and in low-protein-diet gnotobiotic mice.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Engineered Gut Amino Acid Cross-Feeding Consortium</h2>
+                        <p class="description">A four-species engineered mammalian-gut consortium in which Escherichia coli, Salmonella enterica serovar Typhimurium, Bacteroides thetaiotaomicron, and Bacteroides fragilis were modified to create amino acid auxotrophies and amino acid overproduction. The design converts a consortium otherwise shaped by antagonistic interactions into one with engineered beneficial cross-feeding, increasing population evenness in anaerobic in vitro culture and in low-protein-diet gnotobiotic mice.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Episymbiotic_CPR_DPANN_Groundwater_Community.html"
+                       class="community-card"
+                       data-id="Episymbiotic_CPR_DPANN_Groundwater_Community"
+                       data-name="episymbiotic cpr bacteria and dpann archaea groundwater community"
+                       data-description="a groundwater microbial community framework combining genome-resolved metagenomics from one agricultural and seven pristine groundwater sites, yielding 746 candidate phyla radiation (cpr) bacterial and dpann archaeal genomes. pristine sites, which serve as local sources of drinking water, contained up to 31 percent cpr bacteria and 4 percent dpann archaea. little species-level overlap of metagenome-assembled genomes was observed across the sites, indicating that cpr and dpann communities are differentiated according to physicochemical conditions and host populations. cryogenic transmission electron microscopy and genomic analysis identified cpr and dpann lineages that reproducibly attach to host cells, with attachment apparently stimulating cpr bacterial growth.
+"
+                       data-category="EXTREME_ENVIRONMENT"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Episymbiotic CPR Bacteria and DPANN Archaea Groundwater Community</h2>
+                        <p class="description">A groundwater microbial community framework combining genome-resolved metagenomics from one agricultural and seven pristine groundwater sites, yielding 746 Candidate Phyla Radiation (CPR) bacterial and DPANN archaeal genomes. Pristine sites, which serve as local sources of drinking water, contained up to 31 percent CPR bacteria and 4 percent DPANN archaea. Little species-level overlap of metagenome-assembled genomes was observed across the sites, indicating that CPR and DPANN communities are differentiated according to physicochemical conditions and host populations. Cryogenic transmission electron microscopy and genomic analysis identified CPR and DPANN lineages that reproducibly attach to host cells, with attachment apparently stimulating CPR bacterial growth.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">EXTREME_ENVIRONMENT</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Ewaste_Bioleaching_Consortium.html"
+                       class="community-card"
+                       data-id="Ewaste_Bioleaching_Consortium"
+                       data-name="e-waste bioleaching consortium"
+                       data-description="an engineered acidophilic microbial consortium adapted for recovering valuable metals from electronic waste, particularly printed circuit boards (pcbs). this consortium consists primarily of iron-oxidizing bacteria dominated by leptospirillum ferriphilum with sulfobacillus benefaciens, acidithiobacillus ferrooxidans, and acidithiobacillus thiooxidans contributing to metal solubilization. the community operates at extremely low ph (1.2 ± 0.1) and moderate temperature (35°c), oxidizing ferrous iron to generate ferric iron (fe³⁺) that dissolves base metals (copper, zinc, nickel) and mobilizes precious metals (gold, silver, palladium) from pcb components. metal recovery is exceptional: 100% copper dissolution (2.6-4.2 g/l), 100% zinc (303-543 mg/l), and 70% nickel (30-52 mg/l). however, pcb materials are toxic to the consortium, delaying the pre-oxidation phase from 11 days at 1% pcb load to 18 days at 2% load, with no growth above 8% pcb. successive subculturing adapts the consortium to pcb toxicity, reducing lag phase by 2.6-fold. this biotechnological approach offers an environmentally-friendly alternative to pyrometallurgical e-waste processing (smelting), avoiding toxic emissions while recovering critical materials including copper for electrical applications and precious metals for electronics manufacturing. the two-step process may include subsequent cyanide-producing heterotrophs (pseudomonas fluorescens, p. putida) for enhanced gold and silver extraction.
+"
+                       data-category="BIOMINING"
+                       data-state="ENGINEERED"
+                       data-metals="COPPER,GOLD,IRON,NICKEL,PALLADIUM,SILVER,ZINC"
+                       data-ree=""
+                       data-relevance="PRIMARY"
+                       data-member-count="5">
+                        <h2>E-waste Bioleaching Consortium</h2>
+                        <p class="description">An engineered acidophilic microbial consortium adapted for recovering valuable metals from electronic waste, particularly printed circuit boards (PCBs). This consortium consists primarily of iron-oxidizing bacteria dominated by Leptospirillum ferriphilum with Sulfobacillus benefaciens, Acidithiobacillus ferrooxidans, and Acidithiobacillus thiooxidans contributing to metal solubilization. The community operates at extremely low pH (1.2 ± 0.1) and moderate temperature (35°C), oxidizing ferrous iron to generate ferric iron (Fe³⁺) that dissolves base metals (copper, zinc, nickel) and mobilizes precious metals (gold, silver, palladium) from PCB components. Metal recovery is exceptional: 100% copper dissolution (2.6-4.2 g/L), 100% zinc (303-543 mg/L), and 70% nickel (30-52 mg/L). However, PCB materials are toxic to the consortium, delaying the pre-oxidation phase from 11 days at 1% PCB load to 18 days at 2% load, with no growth above 8% PCB. Successive subculturing adapts the consortium to PCB toxicity, reducing lag phase by 2.6-fold. This biotechnological approach offers an environmentally-friendly alternative to pyrometallurgical e-waste processing (smelting), avoiding toxic emissions while recovering critical materials including copper for electrical applications and precious metals for electronics manufacturing. The two-step process may include subsequent cyanide-producing heterotrophs (Pseudomonas fluorescens, P. putida) for enhanced gold and silver extraction.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    5
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOMINING</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Ferroplasma_Leptospirillum_Syntrophy.html"
+                       class="community-card"
+                       data-id="Ferroplasma_Leptospirillum_Syntrophy"
+                       data-name="ferroplasma-leptospirillum iron-cycling syntrophy"
+                       data-description="a synergistic two-member consortium consisting of the cell wall-lacking archaeon ferroplasma acidiphilum and the iron-oxidizing bacterium leptospirillum ferriphilum, found in extremely acidic, metal-rich environments including acid mine drainage and biomining operations. this partnership demonstrates mutualistic metabolic cooperation where both organisms oxidize ferrous iron but occupy complementary ecological niches. ferroplasma grows chemomixotrophically, oxidizing fe²⁺ while consuming organic matter secreted by leptospirillum, thereby maintaining low organic compound concentrations that would otherwise inhibit leptospirillum through toxic effects. in return, leptospirillum provides organic carbon that ferroplasma requires for mixotrophic growth. recent transcriptomic studies show f. acidiphilum upregulates energy and stress resistance genes in l. ferriphilum under organic matter stress. the co-culture outperforms pure cultures in chalcopyrite and pyrite bioleaching, achieving 31.5% higher copper extraction and 31.7% higher ferric iron generation compared to monocultures under yeast extract stress (0.5 g/l). cell growth is favorably affected by filtered medium from the partner organism, confirming synergistic interaction. this archaeal-bacterial partnership thrives at extremely low ph (ph &lt;2), temperatures 30-50°c, and high metal concentrations, representing a model system for understanding cross-domain syntrophy in extreme environments. the consortium plays major roles in biogeochemical cycling of sulfur and sulfide metals in highly acidic habitats.
+"
+                       data-category="AMD"
+                       data-state="STABLE"
+                       data-metals="COPPER,IRON"
+                       data-ree=""
+                       data-relevance="PRIMARY"
+                       data-member-count="2">
+                        <h2>Ferroplasma-Leptospirillum Iron-Cycling Syntrophy</h2>
+                        <p class="description">A synergistic two-member consortium consisting of the cell wall-lacking archaeon Ferroplasma acidiphilum and the iron-oxidizing bacterium Leptospirillum ferriphilum, found in extremely acidic, metal-rich environments including acid mine drainage and biomining operations. This partnership demonstrates mutualistic metabolic cooperation where both organisms oxidize ferrous iron but occupy complementary ecological niches. Ferroplasma grows chemomixotrophically, oxidizing Fe²⁺ while consuming organic matter secreted by Leptospirillum, thereby maintaining low organic compound concentrations that would otherwise inhibit Leptospirillum through toxic effects. In return, Leptospirillum provides organic carbon that Ferroplasma requires for mixotrophic growth. Recent transcriptomic studies show F. acidiphilum upregulates energy and stress resistance genes in L. ferriphilum under organic matter stress. The co-culture outperforms pure cultures in chalcopyrite and pyrite bioleaching, achieving 31.5% higher copper extraction and 31.7% higher ferric iron generation compared to monocultures under yeast extract stress (0.5 g/L). Cell growth is favorably affected by filtered medium from the partner organism, confirming synergistic interaction. This archaeal-bacterial partnership thrives at extremely low pH (pH &lt;2), temperatures 30-50°C, and high metal concentrations, representing a model system for understanding cross-domain syntrophy in extreme environments. The consortium plays major roles in biogeochemical cycling of sulfur and sulfide metals in highly acidic habitats.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">AMD</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/GLBRC_Exometabolite_Transwell_SynCom.html"
+                       class="community-card"
+                       data-id="GLBRC_Exometabolite_Transwell_SynCom"
+                       data-name="glbrc exometabolite transwell syncom system"
+                       data-description="a synthetic community assay system for probing chemically mediated microbial interactions through shared exometabolites."
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>GLBRC Exometabolite Transwell SynCom System</h2>
+                        <p class="description">A synthetic community assay system for probing chemically mediated microbial interactions through shared exometabolites.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/GLBRC_Populus_Variovorax_SynCom28.html"
+                       class="community-card"
+                       data-id="GLBRC_Populus_Variovorax_SynCom28"
+                       data-name="glbrc populus variovorax syncom28"
+                       data-description="a defined, genome-resolved 28-strain synthetic community of variovorax isolates from populus deltoides and populus trichocarpa roots. the community was used to identify strain-level partitioning between rhizosphere and endosphere compartments and genomic traits associated with endosphere specialization."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="INCIDENTAL"
+                       data-member-count="28">
+                        <h2>GLBRC Populus Variovorax SynCom28</h2>
+                        <p class="description">A defined, genome-resolved 28-strain synthetic community of Variovorax isolates from Populus deltoides and Populus trichocarpa roots. The community was used to identify strain-level partitioning between rhizosphere and endosphere compartments and genomic traits associated with endosphere specialization.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    28
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/GLBRC_UFMP_Fermentation_Community.html"
+                       class="community-card"
+                       data-id="GLBRC_UFMP_Fermentation_Community"
+                       data-name="glbrc ultra-filtered milk permeate fermentation community"
+                       data-description="a fermentative microbial community maintained in a 282-day continuous bioreactor experiment fed ultra-filtered milk permeate (ufmp), a low-value dairy coproduct. originally inoculated from an acid-phase digester at the nine springs wastewater treatment plant (madison, wi). metagenome-assembled genomes (mags) revealed functional partitioning between phyla: actinobacteriota members (olsenella, bifidobacterium, pauljensenia) degrade lactose via the leloir pathway and bifid shunt, producing acetic, lactic, and succinic acids. firmicutes members (clostridium, agathobacter) perform chain elongation via reverse beta-oxidation, converting lactic acid, ethanol, or lactose into butyric, hexanoic, and octanoic acids. this cross-feeding between actinobacteriota (acid producers) and firmicutes (chain elongators) forms the core metabolic network enabling conversion of dairy waste into renewable chemicals via the carboxylate platform.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="10">
+                        <h2>GLBRC Ultra-Filtered Milk Permeate Fermentation Community</h2>
+                        <p class="description">A fermentative microbial community maintained in a 282-day continuous bioreactor experiment fed ultra-filtered milk permeate (UFMP), a low-value dairy coproduct. Originally inoculated from an acid-phase digester at the Nine Springs Wastewater Treatment Plant (Madison, WI). Metagenome-assembled genomes (MAGs) revealed functional partitioning between phyla: Actinobacteriota members (Olsenella, Bifidobacterium, Pauljensenia) degrade lactose via the Leloir pathway and bifid shunt, producing acetic, lactic, and succinic acids. Firmicutes members (Clostridium, Agathobacter) perform chain elongation via reverse beta-oxidation, converting lactic acid, ethanol, or lactose into butyric, hexanoic, and octanoic acids. This cross-feeding between Actinobacteriota (acid producers) and Firmicutes (chain elongators) forms the core metabolic network enabling conversion of dairy waste into renewable chemicals via the carboxylate platform.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    10
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/GOM_Oil_Degrading_Consortium.html"
+                       class="community-card"
+                       data-id="GOM_Oil_Degrading_Consortium"
+                       data-name="gulf of mexico oil-degrading consortium"
+                       data-description="a marine bacterial consortium from the gulf of mexico designed for bioremediation of oil-contaminated seawater. the consortium consists of four bacteria: pseudomonas sp., halopseudomonas aestusnigri gom5, paenarthrobacter sp. gom3, and alcanivorax sp. together, they achieve 62% oil removal over 75 days, degrading both n-alkanes and 12 polyaromatic hydrocarbons (pahs) including fluorene, dibenzothiophene, phenanthrenes, and pyrene. the consortium exhibits stable population dynamics with distributed metabolic loads across members.
+"
+                       data-category="BIOREMEDIATION"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="4">
+                        <h2>Gulf of Mexico Oil-Degrading Consortium</h2>
+                        <p class="description">A marine bacterial consortium from the Gulf of Mexico designed for bioremediation of oil-contaminated seawater. The consortium consists of four bacteria: Pseudomonas sp., Halopseudomonas aestusnigri GOM5, Paenarthrobacter sp. GOM3, and Alcanivorax sp. Together, they achieve 62% oil removal over 75 days, degrading both n-alkanes and 12 polyaromatic hydrocarbons (PAHs) including fluorene, dibenzothiophene, phenanthrenes, and pyrene. The consortium exhibits stable population dynamics with distributed metabolic loads across members.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Garlic_Pseudomonas_SynCom6.html"
+                       class="community-card"
+                       data-id="Garlic_Pseudomonas_SynCom6"
+                       data-name="garlic rhizosphere pseudomonas syncom6"
+                       data-description="a six-strain pseudomonas syncom selected from garlic rhizosphere microbiome data for plant growth promotion."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>Garlic Rhizosphere Pseudomonas SynCom6</h2>
+                        <p class="description">A six-strain Pseudomonas SynCom selected from garlic rhizosphere microbiome data for plant growth promotion.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Geobacter_Clostridium_DIET.html"
+                       class="community-card"
+                       data-id="Geobacter_Clostridium_DIET"
+                       data-name="geobacter-clostridium diet community"
+                       data-description="a syntrophic two-member consortium consisting of geobacter sulfurreducens and clostridium pasteurianum that performs direct interspecies electron transfer (diet) during glycerol fermentation. g. sulfurreducens acts as an exoelectrogen, oxidizing acetate and transferring electrons directly to c. pasteurianum via electrically conductive pili (nanowires). these electron transfers induce a metabolic shift in c. pasteurianum&#39;s glycerol fermentation pathway, redirecting carbon flux away from ethanol and butanol production toward increased 1,3-propanediol (pdo) and butyrate production. this represents a unique application of diet where electron transfer serves not to drive methanogenesis but to modulate fermentation pathways, achieving a 37% increase in 1,3-propanediol and 38% increase in butyrate production. the bacteria establish physical contact through nanowires, enabling electron exchange without relying on diffusible hydrogen or formate carriers. this coculture demonstrates how controlled interspecies electron transfer can be exploited to optimize production of industrially relevant metabolites like 1,3-propanediol.
+"
+                       data-category="DIET"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="2">
+                        <h2>Geobacter-Clostridium DIET Community</h2>
+                        <p class="description">A syntrophic two-member consortium consisting of Geobacter sulfurreducens and Clostridium pasteurianum that performs direct interspecies electron transfer (DIET) during glycerol fermentation. G. sulfurreducens acts as an exoelectrogen, oxidizing acetate and transferring electrons directly to C. pasteurianum via electrically conductive pili (nanowires). These electron transfers induce a metabolic shift in C. pasteurianum&#39;s glycerol fermentation pathway, redirecting carbon flux away from ethanol and butanol production toward increased 1,3-propanediol (PDO) and butyrate production. This represents a unique application of DIET where electron transfer serves not to drive methanogenesis but to modulate fermentation pathways, achieving a 37% increase in 1,3-propanediol and 38% increase in butyrate production. The bacteria establish physical contact through nanowires, enabling electron exchange without relying on diffusible hydrogen or formate carriers. This coculture demonstrates how controlled interspecies electron transfer can be exploited to optimize production of industrially relevant metabolites like 1,3-propanediol.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">DIET</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Geobacter_Methanosaeta_DIET.html"
+                       class="community-card"
+                       data-id="Geobacter_Methanosaeta_DIET"
+                       data-name="geobacter-methanosaeta diet community"
+                       data-description="a syntrophic two-member consortium consisting of geobacter metallireducens and methanosaeta harundinacea that performs direct interspecies electron transfer (diet) during ethanol oxidation. g. metallireducens oxidizes ethanol and transfers electrons directly to m. harundinacea via electrically conductive pili and aggregates, bypassing the need for diffusible electron carriers like h2 or formate. m. harundinacea uses these electrons to reduce co2 to methane. this coculture forms conductive aggregates and achieves stoichiometric conversion of ethanol to methane via diet. unlike hydrogen-mediated syntrophy, diet relies on biological electrical connections between cells, with conductive aggregates serving as conduits for long-range electron transfer. m. harundinacea is an obligate acetoclastic methanogen that can also accept electrons via diet for co2 reduction, making it unique among acetoclastic methanogens in supporting direct electron transfer mechanisms.
+"
+                       data-category="DIET"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="2">
+                        <h2>Geobacter-Methanosaeta DIET Community</h2>
+                        <p class="description">A syntrophic two-member consortium consisting of Geobacter metallireducens and Methanosaeta harundinacea that performs direct interspecies electron transfer (DIET) during ethanol oxidation. G. metallireducens oxidizes ethanol and transfers electrons directly to M. harundinacea via electrically conductive pili and aggregates, bypassing the need for diffusible electron carriers like H2 or formate. M. harundinacea uses these electrons to reduce CO2 to methane. This coculture forms conductive aggregates and achieves stoichiometric conversion of ethanol to methane via DIET. Unlike hydrogen-mediated syntrophy, DIET relies on biological electrical connections between cells, with conductive aggregates serving as conduits for long-range electron transfer. M. harundinacea is an obligate acetoclastic methanogen that can also accept electrons via DIET for CO2 reduction, making it unique among acetoclastic methanogens in supporting direct electron transfer mechanisms.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">DIET</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Geobacter_Methanosarcina_DIET.html"
+                       class="community-card"
+                       data-id="Geobacter_Methanosarcina_DIET"
+                       data-name="geobacter-methanosarcina diet community"
+                       data-description="a syntrophic two-member consortium consisting of geobacter metallireducens and methanosarcina barkeri that performs direct interspecies electron transfer (diet) during ethanol oxidation. g. metallireducens oxidizes ethanol and transfers electrons directly to m. barkeri via electrically conductive pili (e-pili), bypassing the need for diffusible electron carriers like h2 or formate. m. barkeri uses these electrons to reduce co2 to methane. this coculture forms aggregates and achieves stoichiometric conversion of ethanol to methane via diet. unlike hydrogen-mediated syntrophy, diet relies on biological electrical connections between cells, with pili serving as conduits for long-range electron transfer. m. barkeri is unique as a methanogen capable of using either h2 or electrons from diet for co2 reduction, making it a model organism for studying electrical connections in microbial communities.
+"
+                       data-category="DIET"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="2">
+                        <h2>Geobacter-Methanosarcina DIET Community</h2>
+                        <p class="description">A syntrophic two-member consortium consisting of Geobacter metallireducens and Methanosarcina barkeri that performs direct interspecies electron transfer (DIET) during ethanol oxidation. G. metallireducens oxidizes ethanol and transfers electrons directly to M. barkeri via electrically conductive pili (e-pili), bypassing the need for diffusible electron carriers like H2 or formate. M. barkeri uses these electrons to reduce CO2 to methane. This coculture forms aggregates and achieves stoichiometric conversion of ethanol to methane via DIET. Unlike hydrogen-mediated syntrophy, DIET relies on biological electrical connections between cells, with pili serving as conduits for long-range electron transfer. M. barkeri is unique as a methanogen capable of using either H2 or electrons from DIET for CO2 reduction, making it a model organism for studying electrical connections in microbial communities.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">DIET</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.html"
+                       class="community-card"
+                       data-id="Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture"
+                       data-name="geobacter-pseudomonas formate-fumarate electroactive coculture"
+                       data-description="a defined electroactive syntrophic coculture pairing geobacter sulfurreducens with pseudomonas aeruginosa in a restricted formate-fumarate medium. the community was used to study interspecies electron transfer and adaptive shifts from syntrophy toward competition. early coculture growth depends on cooperative metabolism and direct interspecies electron transfer associated with geobacter cytochromes, while adapted cocultures show increased geobacter dominance and hydrogen/formate-linked electron-transfer features. the system is relevant to doe biogeochemistry and bioelectrochemical applications because geobacter-pseudomonas interactions connect extracellular electron transfer, metal cycling, and microbial community modeling.
+"
+                       data-category="DIET"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="2">
+                        <h2>Geobacter-Pseudomonas Formate-Fumarate Electroactive Coculture</h2>
+                        <p class="description">A defined electroactive syntrophic coculture pairing Geobacter sulfurreducens with Pseudomonas aeruginosa in a restricted formate-fumarate medium. The community was used to study interspecies electron transfer and adaptive shifts from syntrophy toward competition. Early coculture growth depends on cooperative metabolism and direct interspecies electron transfer associated with Geobacter cytochromes, while adapted cocultures show increased Geobacter dominance and hydrogen/formate-linked electron-transfer features. The system is relevant to DOE biogeochemistry and bioelectrochemical applications because Geobacter-Pseudomonas interactions connect extracellular electron transfer, metal cycling, and microbial community modeling.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">DIET</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Grassland_Soil_WetUp_Virus_Host_Community.html"
+                       class="community-card"
+                       data-id="Grassland_Soil_WetUp_Virus_Host_Community"
+                       data-name="grassland soil wet-up virus-host community"
+                       data-description="a grassland soil virus-host community whose dynamics were measured following rewetting of a seasonally dry california mediterranean-climate soil. dry soil holds a diverse but low-biomass reservoir of virions, of which only a subset thrives following wet-up. quantitative isotope tracing, time-resolved metagenomics, and viromics show viral richness declines by 50 percent within 24 hours post wet-up while viral biomass increases four-fold within one week. lytic, not lysogenic, cycles dominate the response. viruses drive a measurable and continuous rate of cell lysis, accounting for up to 46 percent of microbial death one week after wet-up, contributing to microbial biomass turnover and the widely reported post-wet-up co2 efflux.
+"
+                       data-category="CARBON_SEQUESTRATION"
+                       data-state="PERTURBED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Grassland Soil Wet-Up Virus-Host Community</h2>
+                        <p class="description">A grassland soil virus-host community whose dynamics were measured following rewetting of a seasonally dry California Mediterranean-climate soil. Dry soil holds a diverse but low-biomass reservoir of virions, of which only a subset thrives following wet-up. Quantitative isotope tracing, time-resolved metagenomics, and viromics show viral richness declines by 50 percent within 24 hours post wet-up while viral biomass increases four-fold within one week. Lytic, not lysogenic, cycles dominate the response. Viruses drive a measurable and continuous rate of cell lysis, accounting for up to 46 percent of microbial death one week after wet-up, contributing to microbial biomass turnover and the widely reported post-wet-up CO2 efflux.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">CARBON_SEQUESTRATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.html"
+                       class="community-card"
+                       data-id="Groundwater_Elusimicrobia_Diverse_Metabolisms"
+                       data-name="groundwater elusimicrobia diverse metabolisms community"
+                       data-description="a genomic survey of 94 draft-quality, non-redundant elusimicrobia genomes (30 newly reconstructed) from diverse animal-associated and natural environments. genomes group into 12 clades, 10 previously lacking reference genomes. groundwater-associated elusimicrobia are predicted to be capable of heterotrophic or autotrophic lifestyles, oxygen- or nitrate/nitrite-dependent respiration, degradation of a variety of organic compounds, and rhodobacter nitrogen fixation (rnf) complex-dependent acetogenesis using hydrogen and carbon dioxide. two groundwater-associated clades often encode a new nitrogenase paralog co-occurring with an extensive suite of radical s-adenosylmethionine (sam) proteins. similar genomic loci occur in gracilibacteria and myxococcales genomes and are predicted to reduce a tetrapyrrole, possibly to form a novel cofactor. the animal-associated clades nest within free-living clades, supporting an evolutionary trajectory from free-living to animal-associated lifestyles via genome reduction.
+"
+                       data-category="EXTREME_ENVIRONMENT"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Groundwater Elusimicrobia Diverse Metabolisms Community</h2>
+                        <p class="description">A genomic survey of 94 draft-quality, non-redundant Elusimicrobia genomes (30 newly reconstructed) from diverse animal-associated and natural environments. Genomes group into 12 clades, 10 previously lacking reference genomes. Groundwater-associated Elusimicrobia are predicted to be capable of heterotrophic or autotrophic lifestyles, oxygen- or nitrate/nitrite-dependent respiration, degradation of a variety of organic compounds, and Rhodobacter nitrogen fixation (Rnf) complex-dependent acetogenesis using hydrogen and carbon dioxide. Two groundwater-associated clades often encode a new nitrogenase paralog co-occurring with an extensive suite of radical S-Adenosylmethionine (SAM) proteins. Similar genomic loci occur in Gracilibacteria and Myxococcales genomes and are predicted to reduce a tetrapyrrole, possibly to form a novel cofactor. The animal-associated clades nest within free-living clades, supporting an evolutionary trajectory from free-living to animal-associated lifestyles via genome reduction.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">EXTREME_ENVIRONMENT</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Hanford_300_Area_Unconfined_Aquifer_Community.html"
+                       class="community-card"
+                       data-id="Hanford_300_Area_Unconfined_Aquifer_Community"
+                       data-name="hanford 300 area unconfined aquifer community"
+                       data-description="a natural, contaminant-impacted groundwater microbial community from the hanford site 300 area integrated field research challenge site in eastern washington. 16s rrna gene pyrosequencing of groundwater bacteria and archaea across three well clusters and multiple depths showed strong temporal and spatial community dynamics linked to columbia river water intrusion, depth, nitrate, uranium, and redox conditions. the community includes proteobacteria, bacteroidetes, actinobacteria, acidobacteria, op3, low-abundance archaea, and functional guilds such as putative methane oxidizers, sulfur oxidizers, ammonia-oxidizing archaea, and metal reducers."
+                       data-category="BIOREMEDIATION"
+                       data-state="PERTURBED"
+                       data-metals="URANIUM"
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="4">
+                        <h2>Hanford 300 Area Unconfined Aquifer Community</h2>
+                        <p class="description">A natural, contaminant-impacted groundwater microbial community from the Hanford Site 300 Area Integrated Field Research Challenge site in eastern Washington. 16S rRNA gene pyrosequencing of groundwater bacteria and archaea across three well clusters and multiple depths showed strong temporal and spatial community dynamics linked to Columbia River water intrusion, depth, nitrate, uranium, and redox conditions. The community includes Proteobacteria, Bacteroidetes, Actinobacteria, Acidobacteria, OP3, low-abundance archaea, and functional guilds such as putative methane oxidizers, sulfur oxidizers, ammonia-oxidizing archaea, and metal reducers.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/High_Solids_Switchgrass_Methanogenic_Microbiome.html"
+                       class="community-card"
+                       data-id="High_Solids_Switchgrass_Methanogenic_Microbiome"
+                       data-name="high-solids switchgrass methanogenic microbiome"
+                       data-description="a thermophilic, anaerobic, semi-continuously fed methanogenic enrichment microbiome cultivated on mid-season switchgrass at high solids loadings. the community maintained fractional carbohydrate solubilization as solids loading increased from 30 to 150 g/l, with methane and carbon dioxide as the main steady-state products. metaproteomics identified bacterial carbohydrate-active enzyme strategies and archaeal methanogenesis functions relevant to doe bioenergy efforts to understand robust lignocellulose deconstruction under industrially relevant process conditions.
+"
+                       data-category="LIGNOCELLULOSE"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="5">
+                        <h2>High-Solids Switchgrass Methanogenic Microbiome</h2>
+                        <p class="description">A thermophilic, anaerobic, semi-continuously fed methanogenic enrichment microbiome cultivated on mid-season switchgrass at high solids loadings. The community maintained fractional carbohydrate solubilization as solids loading increased from 30 to 150 g/L, with methane and carbon dioxide as the main steady-state products. Metaproteomics identified bacterial carbohydrate-active enzyme strategies and archaeal methanogenesis functions relevant to DOE bioenergy efforts to understand robust lignocellulose deconstruction under industrially relevant process conditions.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    5
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Honeybee_Core20_Defined_Microbiota.html"
+                       class="community-card"
+                       data-id="Honeybee_Core20_Defined_Microbiota"
+                       data-name="honeybee core-20 defined microbiota"
+                       data-description="a stably transmitted 20-strain synthetic gut microbiota from honeybee intestine that primes host immunity and reduces hafnia alvei prevalence."
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>Honeybee Core-20 Defined Microbiota</h2>
+                        <p class="description">A stably transmitted 20-strain synthetic gut microbiota from honeybee intestine that primes host immunity and reduces Hafnia alvei prevalence.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Horonobe_Mizunami_URL_Subsurface_Microbiome.html"
+                       class="community-card"
+                       data-id="Horonobe_Mizunami_URL_Subsurface_Microbiome"
+                       data-name="horonobe and mizunami underground research laboratory subsurface microbiome"
+                       data-description="a multi-year, depth-resolved groundwater microbiome study of the horonobe (sedimentary rock) and mizunami (granitic rock) underground research laboratories in japan, sampling defined intervals between 140 and 400 m below the surface over four years. draft genomes were reconstructed for more than 90 percent of all detected organisms. the horonobe and mizunami microbiomes are dissimilar at the community level, but hydrogen metabolism, rubisco-based co2 fixation, reduction of nitrogen compounds, and sulfate reduction are well represented in both, while methane metabolism is more prevalent at the organic- and co2-rich horonobe url. high fluid flow zones and tunnel proximity select for candidate phyla radiation bacteria in the mizunami url. approximately one third of genomically defined organisms have near-identical genotypes at multiple depths within horonobe, and closely-related species recur in three other usa subsurface environments, constraining expectations of global subsurface biodiversity.
+"
+                       data-category="EXTREME_ENVIRONMENT"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Horonobe and Mizunami Underground Research Laboratory Subsurface Microbiome</h2>
+                        <p class="description">A multi-year, depth-resolved groundwater microbiome study of the Horonobe (sedimentary rock) and Mizunami (granitic rock) Underground Research Laboratories in Japan, sampling defined intervals between 140 and 400 m below the surface over four years. Draft genomes were reconstructed for more than 90 percent of all detected organisms. The Horonobe and Mizunami microbiomes are dissimilar at the community level, but hydrogen metabolism, rubisco-based CO2 fixation, reduction of nitrogen compounds, and sulfate reduction are well represented in both, while methane metabolism is more prevalent at the organic- and CO2-rich Horonobe URL. High fluid flow zones and tunnel proximity select for candidate phyla radiation bacteria in the Mizunami URL. Approximately one third of genomically defined organisms have near-identical genotypes at multiple depths within Horonobe, and closely-related species recur in three other USA subsurface environments, constraining expectations of global subsurface biodiversity.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">EXTREME_ENVIRONMENT</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Iberian_Pit_Lake_Stratified_Community.html"
+                       class="community-card"
+                       data-id="Iberian_Pit_Lake_Stratified_Community"
+                       data-name="iberian pit lake stratified community"
+                       data-description="a permanently stratified (meromictic) acidic pit lake community from the iberian pyrite belt in southwestern spain/portugal, distinguished by dramatic vertical metabolic zonation and subsurface anaerobic processes in an extreme acid mine drainage environment. the pit lake ecosystem exhibits three distinct layers: an upper oxic mixolimnion (ph 2.2-3.1, 0-3m depth), a chemocline transition zone (11m), and an anoxic monimolimnion (ph 3.0-4.5, 35m depth). the upper layer is dominated by acidophilic green algae (coccomyxa onubensis) and heterotrophic bacteria (acidiphilium), while the chemocline hosts intense sulfate reduction and iron cycling by specialized proteobacteria (desulfomonile, candidatus acidulodesulfobacterium). the deep anoxic layer harbors archaeal heterotrophs (thermoplasmatales, 46% of sequences) that scavenge organic carbon and perform sulfide oxidation using trace oxygen, along with iron-reducing bacteria (geobacter) and subsurface methanogens (methanobrevibacter, methanospirillum). the permanent stratification creates steep geochemical gradients with iron concentrations increasing from 2 mm fe³⁺ in surface waters to 113 mm fe²⁺ at depth, sulfate ranging from 26-126 mm, and oxygen transitioning from oxic to completely anoxic conditions. this system represents a natural laboratory for studying coupled aerobic-anaerobic metabolism, metal cycling, biosulfidogenesis, and subsurface methanogenesis under polyextreme conditions (acidity, metals, anoxia). the iberian pyrite belt pit lakes demonstrate how microbial stratification can support complex biogeochemical cycling and potential natural attenuation of toxic metals through sulfide precipitation.
+"
+                       data-category="AMD"
+                       data-state="STABLE"
+                       data-metals="COPPER,IRON,ZINC"
+                       data-ree=""
+                       data-relevance="PRIMARY"
+                       data-member-count="8">
+                        <h2>Iberian Pit Lake Stratified Community</h2>
+                        <p class="description">A permanently stratified (meromictic) acidic pit lake community from the Iberian Pyrite Belt in southwestern Spain/Portugal, distinguished by dramatic vertical metabolic zonation and subsurface anaerobic processes in an extreme acid mine drainage environment. The pit lake ecosystem exhibits three distinct layers: an upper oxic mixolimnion (pH 2.2-3.1, 0-3m depth), a chemocline transition zone (11m), and an anoxic monimolimnion (pH 3.0-4.5, 35m depth). The upper layer is dominated by acidophilic green algae (Coccomyxa onubensis) and heterotrophic bacteria (Acidiphilium), while the chemocline hosts intense sulfate reduction and iron cycling by specialized Proteobacteria (Desulfomonile, Candidatus Acidulodesulfobacterium). The deep anoxic layer harbors archaeal heterotrophs (Thermoplasmatales, 46% of sequences) that scavenge organic carbon and perform sulfide oxidation using trace oxygen, along with iron-reducing bacteria (Geobacter) and subsurface methanogens (Methanobrevibacter, Methanospirillum). The permanent stratification creates steep geochemical gradients with iron concentrations increasing from 2 mM Fe³⁺ in surface waters to 113 mM Fe²⁺ at depth, sulfate ranging from 26-126 mM, and oxygen transitioning from oxic to completely anoxic conditions. This system represents a natural laboratory for studying coupled aerobic-anaerobic metabolism, metal cycling, biosulfidogenesis, and subsurface methanogenesis under polyextreme conditions (acidity, metals, anoxia). The Iberian Pyrite Belt pit lakes demonstrate how microbial stratification can support complex biogeochemical cycling and potential natural attenuation of toxic metals through sulfide precipitation.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    8
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">AMD</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Industrial_Bioreactor_Consortium.html"
+                       class="community-card"
+                       data-id="Industrial_Bioreactor_Consortium"
+                       data-name="industrial bioleaching reactor consortium"
+                       data-description="an industrial-scale moderately thermophilic acidophilic microbial consortium operating in continuous and batch bioreactors for metal extraction from sulfide ores and concentrates. this consortium represents a unique system with complete genomic characterization of six key organisms: acidiplasma sp., acidithiobacillus caldus, cuniculiplasma divulgatum, ferroplasma acidiphilum, ferroplasma sp., and thermoplasmatales archaeon. the community operates at moderate thermophilic temperatures (40-50°c) and extremely low ph (1.5-2.0), oxidizing ferrous iron and reduced sulfur compounds to generate ferric iron (fe³⁺) and sulfuric acid for dissolving chalcopyrite (cufes₂) and other metal sulfides. comparative analysis across batch versus continuous reactor modes reveals distinct population dynamics, with acidithiobacillus caldus dominating early stages (up to 60% at ph &gt;2), sulfobacillus benefaciens in mid-stages (62-66%), and ferroplasma thermophilum in late stages (66% under acidic, metal-rich conditions). the adapted consortium achieves exceptional copper extraction of 60.4% from 20% pulp density chalcopyrite concentrate in 25 days, producing 22.90 g/l dissolved copper. operating under controlled carbon sources (co₂, molasses) and temperature gradients (40-50°c), this system demonstrates how operational parameters shape microbial community structure and metal recovery efficiency. the availability of six complete reference genomes (prjna976529) enables genomic-level investigation of biooxidation mechanisms, making this the most comprehensively characterized industrial bioleaching consortium for biotechnological applications in extractive metallurgy.
+"
+                       data-category="BIOMINING"
+                       data-state="ENGINEERED"
+                       data-metals="COPPER,IRON"
+                       data-ree=""
+                       data-relevance="PRIMARY"
+                       data-member-count="8">
+                        <h2>Industrial Bioleaching Reactor Consortium</h2>
+                        <p class="description">An industrial-scale moderately thermophilic acidophilic microbial consortium operating in continuous and batch bioreactors for metal extraction from sulfide ores and concentrates. This consortium represents a unique system with complete genomic characterization of six key organisms: Acidiplasma sp., Acidithiobacillus caldus, Cuniculiplasma divulgatum, Ferroplasma acidiphilum, Ferroplasma sp., and Thermoplasmatales archaeon. The community operates at moderate thermophilic temperatures (40-50°C) and extremely low pH (1.5-2.0), oxidizing ferrous iron and reduced sulfur compounds to generate ferric iron (Fe³⁺) and sulfuric acid for dissolving chalcopyrite (CuFeS₂) and other metal sulfides. Comparative analysis across batch versus continuous reactor modes reveals distinct population dynamics, with Acidithiobacillus caldus dominating early stages (up to 60% at pH &gt;2), Sulfobacillus benefaciens in mid-stages (62-66%), and Ferroplasma thermophilum in late stages (66% under acidic, metal-rich conditions). The adapted consortium achieves exceptional copper extraction of 60.4% from 20% pulp density chalcopyrite concentrate in 25 days, producing 22.90 g/L dissolved copper. Operating under controlled carbon sources (CO₂, molasses) and temperature gradients (40-50°C), this system demonstrates how operational parameters shape microbial community structure and metal recovery efficiency. The availability of six complete reference genomes (PRJNA976529) enables genomic-level investigation of biooxidation mechanisms, making this the most comprehensively characterized industrial bioleaching consortium for biotechnological applications in extractive metallurgy.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    8
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOMINING</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.html"
+                       class="community-card"
+                       data-id="Industrial_Milk_Line_FourSpecies_Model_Biofilm"
+                       data-name="industrial milk-line four-species model biofilm"
+                       data-description="a laboratory four-species bacterial biofilm model derived from an industrial milk pasteurization-line biofilm. the community contains rhodocyclus sp., pseudomonas fluorescens, kocuria varians, and bacillus cereus, forms reproducible biofilms, and was used to resolve dynamic positive and negative interspecies interactions, including a bacillus cereus thiocillin i-mediated negative interaction that shapes species distribution and robustness.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Industrial Milk-Line Four-Species Model Biofilm</h2>
+                        <p class="description">A laboratory four-species bacterial biofilm model derived from an industrial milk pasteurization-line biofilm. The community contains Rhodocyclus sp., Pseudomonas fluorescens, Kocuria varians, and Bacillus cereus, forms reproducible biofilms, and was used to resolve dynamic positive and negative interspecies interactions, including a Bacillus cereus thiocillin I-mediated negative interaction that shapes species distribution and robustness.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Infant_Gut_DNA_Phage_Succession_Community.html"
+                       class="community-card"
+                       data-id="Infant_Gut_DNA_Phage_Succession_Community"
+                       data-name="infant gut dna phageome succession community"
+                       data-description="a longitudinal infant gut dna bacteriophage community reconstructed from 819 fecal metagenomes from 28 full-term and 24 preterm infants and their mothers across the first 3 years of life, using a large phage sequence database and strain-resolved analyses. early-life phageome richness increases over time and reaches adult-like complexity by age 3. approximately 9 percent of early phage colonizers persist for 3 years and are predominantly maternally transmitted phages infecting bacteroides, with higher persistence in full-term infants. phages with stop-codon reassignment are more likely to persist than non-recoded phages, and in-frame reassigned stop codons increase over the 3-year window. maternal seeding, stop-codon reassignment, host crispr-cas locus prevalence, and phage diversity together drive stable viral colonization.
+"
+                       data-category="OTHER"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Infant Gut DNA Phageome Succession Community</h2>
+                        <p class="description">A longitudinal infant gut DNA bacteriophage community reconstructed from 819 fecal metagenomes from 28 full-term and 24 preterm infants and their mothers across the first 3 years of life, using a large phage sequence database and strain-resolved analyses. Early-life phageome richness increases over time and reaches adult-like complexity by age 3. Approximately 9 percent of early phage colonizers persist for 3 years and are predominantly maternally transmitted phages infecting Bacteroides, with higher persistence in full-term infants. Phages with stop-codon reassignment are more likely to persist than non-recoded phages, and in-frame reassigned stop codons increase over the 3-year window. Maternal seeding, stop-codon reassignment, host CRISPR-Cas locus prevalence, and phage diversity together drive stable viral colonization.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Infant_Gut_Strain_Persistence_Maternal_Community.html"
+                       class="community-card"
+                       data-id="Infant_Gut_Strain_Persistence_Maternal_Community"
+                       data-name="infant gut strain persistence and maternal seeding community"
+                       data-description="a longitudinal infant gut bacterial community studied at strain resolution over the first year of life across 13 full-term and 9 preterm infants and 17 mother-infant pairs. infants&#39; initially distinct microbiomes converge by age 1 year. approximately 11 percent of early colonizers, primarily bacteroides and bifidobacterium, persist through the first year and are more prevalent in full-term than in preterm infants. maternal gut strains are significantly more likely to persist in the infant gut than other strains. enrichment in genes for surface adhesion, iron acquisition, and carbohydrate degradation may explain why some strains persist through the first year of life.
+"
+                       data-category="OTHER"
+                       data-state="STABLE"
+                       data-metals="IRON"
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="3">
+                        <h2>Infant Gut Strain Persistence and Maternal Seeding Community</h2>
+                        <p class="description">A longitudinal infant gut bacterial community studied at strain resolution over the first year of life across 13 full-term and 9 preterm infants and 17 mother-infant pairs. Infants&#39; initially distinct microbiomes converge by age 1 year. Approximately 11 percent of early colonizers, primarily Bacteroides and Bifidobacterium, persist through the first year and are more prevalent in full-term than in preterm infants. Maternal gut strains are significantly more likely to persist in the infant gut than other strains. Enrichment in genes for surface adhesion, iron acquisition, and carbohydrate degradation may explain why some strains persist through the first year of life.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Ion_Adsorption_REE_Indigenous_Community.html"
+                       class="community-card"
+                       data-id="Ion_Adsorption_REE_Indigenous_Community"
+                       data-name="ion-adsorption ree indigenous community"
+                       data-description="a highly diverse indigenous microbial community in ion-adsorption rare earth element (ree) deposits in weathering profiles of south china, demonstrating remarkable selectivity for heavy rare earth elements (hree) through bacterial teichoic acid binding. this natural community comprises over 700 genera spanning bacterial (84.2% dominated by proteobacteria 46.9%, acidobacteria 14.6%, actinobacteria 9.0%, firmicutes 6.3%) and fungal (ascomycota 47.8%, basidiomycota 40.4%) lineages distributed through weathering profiles up to 40 meters depth. the community exhibits unique hree vs lree fractionation capability, with gram-positive bacteria (bacillus, micrococcus) preferentially adsorbing hree (82-85% efficiency) compared to lree (70-78%), driven by teichoic acids in cell walls that provide selective phosphate binding sites for heavier lanthanides. removal of teichoic acids reduces ree adsorption from 65.5% to 17.8%, confirming their critical role. the community accelerates ree mineralization in supergene weathering environments through bioweathering of granite, dissolution of ree-bearing minerals, and biosorption-mediated hree enrichment. ion-adsorption deposits represent the world&#39;s main source of strategically critical hree (dy, y, tb, eu) used in permanent magnets and phosphors, with over 40 deposit sites in south china. the indigenous microbial community functions across ph gradients (4.3-7.0), exhibits oligotrophic k-strategist adaptations (acidobacteria), and demonstrates co-localization of ytterbium with phosphate-rich cell walls. this natural hree fractionation system offers a sustainable model for selective ree recovery and explains the geological genesis of commercially valuable hree-enriched clay deposits.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="STABLE"
+                       data-metals="IRON"
+                       data-ree="DYSPROSIUM,ERBIUM,GADOLINIUM,TERBIUM,YTTERBIUM,YTTRIUM"
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="7">
+                        <h2>Ion-Adsorption REE Indigenous Community</h2>
+                        <p class="description">A highly diverse indigenous microbial community in ion-adsorption rare earth element (REE) deposits in weathering profiles of South China, demonstrating remarkable selectivity for heavy rare earth elements (HREE) through bacterial teichoic acid binding. This natural community comprises over 700 genera spanning bacterial (84.2% dominated by Proteobacteria 46.9%, Acidobacteria 14.6%, Actinobacteria 9.0%, Firmicutes 6.3%) and fungal (Ascomycota 47.8%, Basidiomycota 40.4%) lineages distributed through weathering profiles up to 40 meters depth. The community exhibits unique HREE vs LREE fractionation capability, with Gram-positive bacteria (Bacillus, Micrococcus) preferentially adsorbing HREE (82-85% efficiency) compared to LREE (70-78%), driven by teichoic acids in cell walls that provide selective phosphate binding sites for heavier lanthanides. Removal of teichoic acids reduces REE adsorption from 65.5% to 17.8%, confirming their critical role. The community accelerates REE mineralization in supergene weathering environments through bioweathering of granite, dissolution of REE-bearing minerals, and biosorption-mediated HREE enrichment. Ion-adsorption deposits represent the world&#39;s main source of strategically critical HREE (Dy, Y, Tb, Eu) used in permanent magnets and phosphors, with over 40 deposit sites in South China. The indigenous microbial community functions across pH gradients (4.3-7.0), exhibits oligotrophic K-strategist adaptations (Acidobacteria), and demonstrates co-localization of ytterbium with phosphate-rich cell walls. This natural HREE fractionation system offers a sustainable model for selective REE recovery and explains the geological genesis of commercially valuable HREE-enriched clay deposits.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    7
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Jala_Maize_PGPB_SynCom.html"
+                       class="community-card"
+                       data-id="Jala_Maize_PGPB_SynCom"
+                       data-name="jala maize pgpb syncom"
+                       data-description="synthetic microbial communities assembled from plant growth-promoting bacteria of the jala maize landrace to improve zea mays growth and yield."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Jala Maize PGPB SynCom</h2>
+                        <p class="description">Synthetic microbial communities assembled from plant growth-promoting bacteria of the Jala maize landrace to improve Zea mays growth and yield.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/KB1_Chlorinated_Ethene_Dechlorinating_Consortium.html"
+                       class="community-card"
+                       data-id="KB1_Chlorinated_Ethene_Dechlorinating_Consortium"
+                       data-name="kb-1 chlorinated ethene dechlorinating consortium"
+                       data-description="kb-1 is a natural anaerobic bioaugmentation consortium used for reductive dechlorination of chlorinated ethenes in contaminated groundwater. the culture contains dehalococcoides-related organohalide-respiring bacteria that convert tetrachloroethene and trichloroethene through chlorinated intermediates to ethene. nondechlorinating acetogens, including acetobacterium and sporomusa, support the community by providing cobamide-related cofactors needed by dehalococcoides."
+                       data-category="BIOREMEDIATION"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>KB-1 Chlorinated Ethene Dechlorinating Consortium</h2>
+                        <p class="description">KB-1 is a natural anaerobic bioaugmentation consortium used for reductive dechlorination of chlorinated ethenes in contaminated groundwater. The culture contains Dehalococcoides-related organohalide-respiring bacteria that convert tetrachloroethene and trichloroethene through chlorinated intermediates to ethene. Nondechlorinating acetogens, including Acetobacterium and Sporomusa, support the community by providing cobamide-related cofactors needed by Dehalococcoides.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/KBase_Models_for_Zahmeeth_Original_PLOS.html"
+                       class="community-card"
+                       data-id="KBase_Models_for_Zahmeeth_Original_PLOS"
+                       data-name="kbase models for zahmeeth original plos"
+                       data-description="public kbase narrative centered on metabolic model editing, merged community modeling, and flux analyses for the zahmeeth original plos model set."
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>KBase Models for Zahmeeth Original PLOS</h2>
+                        <p class="description">Public KBase narrative centered on metabolic model editing, merged community modeling, and flux analyses for the Zahmeeth Original PLOS model set.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/KBase_ORT_Workflow_Community_Model.html"
+                       class="community-card"
+                       data-id="KBase_ORT_Workflow_Community_Model"
+                       data-name="kbase ort workflow community model"
+                       data-description="public kbase ort workflow narrative that includes genome annotation, metabolic model reconstruction and gapfilling, merged community model generation, and flux balance analysis."
+                       data-category="BIOREMEDIATION"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>KBase ORT Workflow Community Model</h2>
+                        <p class="description">Public KBase ORT workflow narrative that includes genome annotation, metabolic model reconstruction and gapfilling, merged community model generation, and flux balance analysis.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/KBase_Synthetic_Bacterial_Community_R2A.html"
+                       class="community-card"
+                       data-id="KBase_Synthetic_Bacterial_Community_R2A"
+                       data-name="kbase synthetic bacterial community in r2a medium"
+                       data-description="public kbase narrative for community modeling and flux balance analysis of a synthetic bacterial community in r2a medium. the workflow applies gapfilling, merged community model construction, and fba for a populus-associated syncom context."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>KBase Synthetic Bacterial Community in R2A Medium</h2>
+                        <p class="description">Public KBase narrative for community modeling and flux balance analysis of a synthetic bacterial community in R2A medium. The workflow applies gapfilling, merged community model construction, and FBA for a Populus-associated SynCom context.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Kombucha_KMC_IMBG1_Fermentation_Community.html"
+                       class="community-card"
+                       data-id="Kombucha_KMC_IMBG1_Fermentation_Community"
+                       data-name="kombucha kmc-imbg1 fermentation community"
+                       data-description="a ukrainian kombucha microbial community variant, kmc-imbg1, profiled by culture-dependent isolation and 16s/its metabarcoding across sweetened black-tea and honey/cabbage-brine microenvironments. the core community contains cellulose-forming acetobacteria, especially komagataeibacter and gluconobacter, together with dominant yeasts such as pichia and brettanomyces/dekkera; growth conditions alter the accessory community and yeast composition.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Kombucha KMC-IMBG1 Fermentation Community</h2>
+                        <p class="description">A Ukrainian kombucha microbial community variant, KMC-IMBG1, profiled by culture-dependent isolation and 16S/ITS metabarcoding across sweetened black-tea and honey/cabbage-brine microenvironments. The core community contains cellulose-forming acetobacteria, especially Komagataeibacter and Gluconobacter, together with dominant yeasts such as Pichia and Brettanomyces/Dekkera; growth conditions alter the accessory community and yeast composition.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/LBNL_Brachypodium_Drought_SynCom15.html"
+                       class="community-card"
+                       data-id="LBNL_Brachypodium_Drought_SynCom15"
+                       data-name="lbnl brachypodium drought syncom15"
+                       data-description="a stable 15-member brachypodium rhizosphere syncom constructed with network and cultivation-guided methods to promote drought resilience."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>LBNL Brachypodium Drought SynCom15</h2>
+                        <p class="description">A stable 15-member Brachypodium rhizosphere SynCom constructed with network and cultivation-guided methods to promote drought resilience.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/LBNL_Human_Gut_Interaction_SynCom.html"
+                       class="community-card"
+                       data-id="LBNL_Human_Gut_Interaction_SynCom"
+                       data-name="lbnl human gut interaction syncom"
+                       data-description="a diverse synthetic human gut microbiome community used with model-guided time-series experiments to infer pairwise ecological interactions and metabolic drivers of coexistence."
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>LBNL Human Gut Interaction SynCom</h2>
+                        <p class="description">A diverse synthetic human gut microbiome community used with model-guided time-series experiments to infer pairwise ecological interactions and metabolic drivers of coexistence.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/LBNL_Switchgrass_Soil_SynCom16.html"
+                       class="community-card"
+                       data-id="LBNL_Switchgrass_Soil_SynCom16"
+                       data-name="lbnl switchgrass soil syncom16"
+                       data-description="a 16-member synthetic soil community from switchgrass-associated soil, optimized for reproducible in vitro and ecofab plant-microbe experiments."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>LBNL Switchgrass Soil SynCom16</h2>
+                        <p class="description">A 16-member synthetic soil community from switchgrass-associated soil, optimized for reproducible in vitro and EcoFAB plant-microbe experiments.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Lac_Pavin_Stratified_Lake_Community.html"
+                       class="community-card"
+                       data-id="Lac_Pavin_Stratified_Lake_Community"
+                       data-name="lac pavin permanently stratified lake community"
+                       data-description="a depth-stratified microbial community in lac pavin, a deep, permanently stratified lake in central france. genome-resolved analyses across the oxygen gradient reveal enrichment of distinct c1 and co2 fixation pathways in the oxic lake interface and the anoxic zone and sediments, with oxygen shaping non-cpr bacterial and archaeal metabolic strategies. rubisco genes are detected throughout the water column and sediments, including form ii/iii and form iii-related enzymes encoded by candidate phyla radiation (cpr) bacteria in the water column and dpann archaea in the sediments. methane oxidation and its byproducts are largely spatially separated from methane production, which is mediated by diverse sediment methanogens that vary on the centimeter scale.
+"
+                       data-category="METHANOGENESIS"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Lac Pavin Permanently Stratified Lake Community</h2>
+                        <p class="description">A depth-stratified microbial community in Lac Pavin, a deep, permanently stratified lake in central France. Genome-resolved analyses across the oxygen gradient reveal enrichment of distinct C1 and CO2 fixation pathways in the oxic lake interface and the anoxic zone and sediments, with oxygen shaping non-CPR bacterial and archaeal metabolic strategies. RuBisCO genes are detected throughout the water column and sediments, including form II/III and form III-related enzymes encoded by Candidate Phyla Radiation (CPR) bacteria in the water column and DPANN archaea in the sediments. Methane oxidation and its byproducts are largely spatially separated from methane production, which is mediated by diverse sediment methanogens that vary on the centimeter scale.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">METHANOGENESIS</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.html"
+                       class="community-card"
+                       data-id="Lake_Washington_Methane_Oxygen_Methylotroph_Community"
+                       data-name="lake washington methane-oxygen methylotroph community"
+                       data-description="a methane-consuming freshwater lake sediment community from lake washington, seattle, represented by methane-fed sediment microcosms and follow-up community modeling studies. methane addition selects both bona fide methane-oxidizing methylococcaceae and non-methanotrophic methylotrophic methylophilaceae, supporting a guild-based community rather than a single-organism methane oxidation model. oxygen tension structures specific partnerships: methylosarcina and methylophilus dominate higher-oxygen microcosms, whereas methylobacter and methylotenera dominate lower-oxygen microcosms. the system is doe-relevant because it links methane mitigation, freshwater sediment carbon cycling, methylotroph ecology, and genome-scale modeling of methane-cycling communities.
+"
+                       data-category="CARBON_SEQUESTRATION"
+                       data-state="PERTURBED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="8">
+                        <h2>Lake Washington Methane-Oxygen Methylotroph Community</h2>
+                        <p class="description">A methane-consuming freshwater lake sediment community from Lake Washington, Seattle, represented by methane-fed sediment microcosms and follow-up community modeling studies. Methane addition selects both bona fide methane-oxidizing Methylococcaceae and non-methanotrophic methylotrophic Methylophilaceae, supporting a guild-based community rather than a single-organism methane oxidation model. Oxygen tension structures specific partnerships: Methylosarcina and Methylophilus dominate higher-oxygen microcosms, whereas Methylobacter and Methylotenera dominate lower-oxygen microcosms. The system is DOE-relevant because it links methane mitigation, freshwater sediment carbon cycling, methylotroph ecology, and genome-scale modeling of methane-cycling communities.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    8
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">CARBON_SEQUESTRATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Lotus_LjSC3.html"
+                       class="community-card"
+                       data-id="Lotus_LjSC3"
+                       data-name="lotus lj-sc3 synthetic community"
+                       data-description="a 16-member synthetic community (lj-sc3) derived from lotus japonicus roots and nodules, designed to study host preference and community assembly dynamics in legume-microbe interactions. the community represents bacterial families from the lj-sphere culture collection, including nitrogen-fixing symbionts from rhizobiaceae and phyllobacteriaceae families, as well as commensal bacteria from burkholderiaceae, oxalobacteriaceae, pseudomonadaceae, and microbacteriaceae. this community exhibits host preference when co-inoculated with arabidopsis-derived strains, preferentially colonizing lotus roots in a community context. the sc3 community enables investigation of nitrogen fixation, nodulation, priority effects during microbiota assembly, and bacterial invasiveness in the rhizosphere.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="INCIDENTAL"
+                       data-member-count="10">
+                        <h2>Lotus Lj-SC3 Synthetic Community</h2>
+                        <p class="description">A 16-member synthetic community (Lj-SC3) derived from Lotus japonicus roots and nodules, designed to study host preference and community assembly dynamics in legume-microbe interactions. The community represents bacterial families from the Lj-SPHERE culture collection, including nitrogen-fixing symbionts from Rhizobiaceae and Phyllobacteriaceae families, as well as commensal bacteria from Burkholderiaceae, Oxalobacteriaceae, Pseudomonadaceae, and Microbacteriaceae. This community exhibits host preference when co-inoculated with Arabidopsis-derived strains, preferentially colonizing Lotus roots in a community context. The SC3 community enables investigation of nitrogen fixation, nodulation, priority effects during microbiota assembly, and bacterial invasiveness in the rhizosphere.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    10
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/MAMC_M48_Lignocellulose.html"
+                       class="community-card"
+                       data-id="MAMC_M48_Lignocellulose"
+                       data-name="mamc-m48 lignocellulose-degrading consortium"
+                       data-description="a minimal active microbial consortium (mamc-m48) for lignocellulose degradation, optimized through reductive screening from 18 candidate strains. the 5-member consortium consists of stenotrophomonas maltophilia jn40, paenibacillus sp. palxil05, microbacterium sp. uyfa68, chryseobacterium taiwanense ducc3723, and brevundimonas sp. r3. enriched from soil bacteria on sugarcane waste, this synthetic community achieves 50.6% degradation of all lignocellulose fractions, reaching 96.5% of the degradation rate observed with the full 18-species pool, demonstrating high efficiency with minimal complexity.
+"
+                       data-category="LIGNOCELLULOSE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="INCIDENTAL"
+                       data-member-count="5">
+                        <h2>MAMC-M48 Lignocellulose-Degrading Consortium</h2>
+                        <p class="description">A minimal active microbial consortium (MAMC-M48) for lignocellulose degradation, optimized through reductive screening from 18 candidate strains. The 5-member consortium consists of Stenotrophomonas maltophilia JN40, Paenibacillus sp. PALXIL05, Microbacterium sp. UYFA68, Chryseobacterium taiwanense DUCC3723, and Brevundimonas sp. R3. Enriched from soil bacteria on sugarcane waste, this synthetic community achieves 50.6% degradation of all lignocellulose fractions, reaching 96.5% of the degradation rate observed with the full 18-species pool, demonstrating high efficiency with minimal complexity.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    5
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/MSC1_Dominant_Core.html"
+                       class="community-card"
+                       data-id="MSC1_Dominant_Core"
+                       data-name="msc-1 dominant core"
+                       data-description="a naturally evolved dominant core subset of the model soil consortium-1 (msc-1) containing 13 bacterial species from arid grassland soil. this stable consortium was enriched through serial dilution and passaging on chitin as the primary carbon source. the core members include representatives from actinobacteria, bacteroidetes, and proteobacteria, with key species including rhodococcus sp., dyadobacter sp., taibaiella sp., bosea sp., and streptomyces sp. the consortium exhibits cooperative chitin degradation and nitrogen mineralization functions essential for soil carbon and nitrogen cycling.
+"
+                       data-category="BIOREMEDIATION"
+                       data-state="STABLE"
+                       data-metals="IRON"
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="13">
+                        <h2>MSC-1 Dominant Core</h2>
+                        <p class="description">A naturally evolved dominant core subset of the Model Soil Consortium-1 (MSC-1) containing 13 bacterial species from arid grassland soil. This stable consortium was enriched through serial dilution and passaging on chitin as the primary carbon source. The core members include representatives from Actinobacteria, Bacteroidetes, and Proteobacteria, with key species including Rhodococcus sp., Dyadobacter sp., Taibaiella sp., Bosea sp., and Streptomyces sp. The consortium exhibits cooperative chitin degradation and nitrogen mineralization functions essential for soil carbon and nitrogen cycling.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    13
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/MSC2_Model_Soil_Consortium.html"
+                       class="community-card"
+                       data-id="MSC2_Model_Soil_Consortium"
+                       data-name="model soil consortium-2 (msc-2)"
+                       data-description="reduced-complexity model soil consortium assembled from msc-1 isolates to study community-level chitin decomposition, interspecies interactions, and emergent phenotypes in soil. msc-2 contains eight bacterial members spanning diverse phyla and was used for isolate genome sequencing, 16s profiling, metatranscriptomics, metabolomics, and kbase-enabled metabolic modeling in the hofmockel soil microbiome sfa context."
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="8">
+                        <h2>Model Soil Consortium-2 (MSC-2)</h2>
+                        <p class="description">Reduced-complexity model soil consortium assembled from MSC-1 isolates to study community-level chitin decomposition, interspecies interactions, and emergent phenotypes in soil. MSC-2 contains eight bacterial members spanning diverse phyla and was used for isolate genome sequencing, 16S profiling, metatranscriptomics, metabolomics, and KBase-enabled metabolic modeling in the Hofmockel Soil Microbiome SFA context.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    8
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/MUCC_Freshwater_Wetland_Methane_Network_Community.html"
+                       class="community-card"
+                       data-id="MUCC_Freshwater_Wetland_Methane_Network_Community"
+                       data-name="mucc freshwater wetland methane-cycling network community"
+                       data-description="a multi-site terrestrial freshwater wetland microbial community synthesis curated around the multi-omics for understanding climate change (mucc) v2.0.0 database. the study integrates 16s rrna amplicon datasets, metagenomes, metatranscriptomes, and annual methane flux measurements across nine wetlands to link microbial community structure, methane-cycling guilds, decomposition networks, and methane emissions. it identifies eight methane-cycling genera shared across wetlands, highlights wetland-specific metabolic interactions in marshes, and reports methanoregula as a hub methanogen and predictor of methane flux. the record is doe-relevant because the study was supported by doe office of science ber awards and included metagenomic and metatranscriptomic sequencing at the doe joint genome institute.
+"
+                       data-category="METHANOGENESIS"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>MUCC Freshwater Wetland Methane-Cycling Network Community</h2>
+                        <p class="description">A multi-site terrestrial freshwater wetland microbial community synthesis curated around the Multi-Omics for Understanding Climate Change (MUCC) v2.0.0 database. The study integrates 16S rRNA amplicon datasets, metagenomes, metatranscriptomes, and annual methane flux measurements across nine wetlands to link microbial community structure, methane-cycling guilds, decomposition networks, and methane emissions. It identifies eight methane-cycling genera shared across wetlands, highlights wetland-specific metabolic interactions in marshes, and reports Methanoregula as a hub methanogen and predictor of methane flux. The record is DOE-relevant because the study was supported by DOE Office of Science BER awards and included metagenomic and metatranscriptomic sequencing at the DOE Joint Genome Institute.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">METHANOGENESIS</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Maize_Benzoxazinoid_Metabolizing_SynComs.html"
+                       class="community-card"
+                       data-id="Maize_Benzoxazinoid_Metabolizing_SynComs"
+                       data-name="maize benzoxazinoid-metabolizing syncoms"
+                       data-description="two maize root bacterial syncoms sharing six common strains and differing in a seventh benzoxazinoid-metabolizing member."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>Maize Benzoxazinoid-Metabolizing SynComs</h2>
+                        <p class="description">Two maize root bacterial SynComs sharing six common strains and differing in a seventh benzoxazinoid-metabolizing member.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Maize_Drought_Response_SynCom.html"
+                       class="community-card"
+                       data-id="Maize_Drought_Response_SynCom"
+                       data-name="maize drought response syncom"
+                       data-description="a plant-beneficial bacterial syncom that modulates physiology and drought response of commercial maize hybrids."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>Maize Drought Response SynCom</h2>
+                        <p class="description">A plant-beneficial bacterial SynCom that modulates physiology and drought response of commercial maize hybrids.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Maize_Root_Simplified_Community.html"
+                       class="community-card"
+                       data-id="Maize_Root_Simplified_Community"
+                       data-name="maize root simplified bacterial community"
+                       data-description="a representative 7-member bacterial community from maize rhizosphere, developed through selective iterations to model root-associated microbiome function. the community consists of enterobacter cloacae aa4, stenotrophomonas maltophilia aa1, ochrobactrum pituitosum aa2, herbaspirillum frisingense, pseudomonas putida, curtobacterium pusillum, and chryseobacterium indologenes. this simplified community reproducibly assembles on root surfaces and provides biocontrol against fusarium verticillioides, a phytopathogenic fungus. e. cloacae aa4 plays a keystone role, as its removal causes dramatic community composition changes.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="INCIDENTAL"
+                       data-member-count="9">
+                        <h2>Maize Root Simplified Bacterial Community</h2>
+                        <p class="description">A representative 7-member bacterial community from maize rhizosphere, developed through selective iterations to model root-associated microbiome function. The community consists of Enterobacter cloacae AA4, Stenotrophomonas maltophilia AA1, Ochrobactrum pituitosum AA2, Herbaspirillum frisingense, Pseudomonas putida, Curtobacterium pusillum, and Chryseobacterium indologenes. This simplified community reproducibly assembles on root surfaces and provides biocontrol against Fusarium verticillioides, a phytopathogenic fungus. E. cloacae AA4 plays a keystone role, as its removal causes dramatic community composition changes.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    9
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Medicago_Nodule_Biofertilizer_SynCom.html"
+                       class="community-card"
+                       data-id="Medicago_Nodule_Biofertilizer_SynCom"
+                       data-name="medicago nodule biofertilizer syncom"
+                       data-description="a four-strain nodule synthetic bacterial community with ensifer and pseudomonas members for medicago sativa biofertilization under abiotic stress."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Medicago Nodule Biofertilizer SynCom</h2>
+                        <p class="description">A four-strain nodule synthetic bacterial community with Ensifer and Pseudomonas members for Medicago sativa biofertilization under abiotic stress.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Mediterranean_Grassland_qSIP_Rainfall_Community.html"
+                       class="community-card"
+                       data-id="Mediterranean_Grassland_qSIP_Rainfall_Community"
+                       data-name="mediterranean grassland qsip rainfall-gradient community"
+                       data-description="an active soil microbial community in three mediterranean-climate grassland soils sampled across a rainfall gradient and assayed with genome-resolved quantitative stable isotope probing (qsip) following an h2-18o labeling experiment to identify actively growing organisms and link growth and motility traits to historical precipitation. qsip-informed genome-resolved metagenomics resolves the active subset of community members, with higher year-round precipitation correlating with higher activity and growth rates of flagellar motile microorganisms.
+"
+                       data-category="CARBON_SEQUESTRATION"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Mediterranean Grassland qSIP Rainfall-Gradient Community</h2>
+                        <p class="description">An active soil microbial community in three Mediterranean-climate grassland soils sampled across a rainfall gradient and assayed with genome-resolved quantitative stable isotope probing (qSIP) following an H2-18O labeling experiment to identify actively growing organisms and link growth and motility traits to historical precipitation. qSIP-informed genome-resolved metagenomics resolves the active subset of community members, with higher year-round precipitation correlating with higher activity and growth rates of flagellar motile microorganisms.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">CARBON_SEQUESTRATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Mercury_SFA_EFPC_Sediment_Community.html"
+                       class="community-card"
+                       data-id="Mercury_SFA_EFPC_Sediment_Community"
+                       data-name="mercury sfa east fork poplar creek sediment community"
+                       data-description="a sediment microbial community from east fork poplar creek (efpc) in oak ridge, tennessee, contaminated with mercury from historical weapons production at the y-12 national security complex. 28 metagenome-assembled genomes (mags) were reconstructed from two sediment core sections (0-3 cm and 9-12 cm depth), with 27 representing novel prokaryotic species. 27 of 28 mags contained putative heavy metal resistance genes or atpase efflux pump genes, reflecting strong selective pressure from chronic mercury contamination. 17 of 28 mags contained selenium assimilatory metabolism traits. the community includes both bacterial and archaeal members, with several lineages carrying hgca/hgcb genes for mercury methylation, a process that converts inorganic mercury to the more bioavailable and toxic methylmercury. methanogenic archaea in similar contaminated environments have been shown to methylate mercury at rates rivaling those of sulfate- and iron-reducing bacteria.
+"
+                       data-category="BIOREMEDIATION"
+                       data-state="PERTURBED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="11">
+                        <h2>Mercury SFA East Fork Poplar Creek Sediment Community</h2>
+                        <p class="description">A sediment microbial community from East Fork Poplar Creek (EFPC) in Oak Ridge, Tennessee, contaminated with mercury from historical weapons production at the Y-12 National Security Complex. 28 metagenome-assembled genomes (MAGs) were reconstructed from two sediment core sections (0-3 cm and 9-12 cm depth), with 27 representing novel prokaryotic species. 27 of 28 MAGs contained putative heavy metal resistance genes or ATPase efflux pump genes, reflecting strong selective pressure from chronic mercury contamination. 17 of 28 MAGs contained selenium assimilatory metabolism traits. The community includes both bacterial and archaeal members, with several lineages carrying hgcA/hgcB genes for mercury methylation, a process that converts inorganic mercury to the more bioavailable and toxic methylmercury. Methanogenic archaea in similar contaminated environments have been shown to methylate mercury at rates rivaling those of sulfate- and iron-reducing bacteria.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    11
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Methane_Oxidation_CrVI_Reduction_SynCom.html"
+                       class="community-card"
+                       data-id="Methane_Oxidation_CrVI_Reduction_SynCom"
+                       data-name="methane oxidation-cr(vi) reduction syncom"
+                       data-description="a methane-oxidizing synthetic microbial community coupling cr(vi) reduction to division of labor and extracellular electron transfer."
+                       data-category="BIOREMEDIATION"
+                       data-state="ENGINEERED"
+                       data-metals="CHROMIUM"
+                       data-ree=""
+                       data-relevance="PRIMARY"
+                       data-member-count="3">
+                        <h2>Methane Oxidation-Cr(VI) Reduction SynCom</h2>
+                        <p class="description">A methane-oxidizing synthetic microbial community coupling Cr(VI) reduction to division of labor and extracellular electron transfer.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.html"
+                       class="community-card"
+                       data-id="Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture"
+                       data-name="methylacidiphilum-galdieria thermoacidophilic methane coculture"
+                       data-description="a defined thermoacidophilic methanotroph-microalga coculture pairing methylacidiphilum sp. rtk17.1 with galdieria sp. rtk37.1 for methane and carbon dioxide valorisation. in methane-fed photobioreactor studies, the methanotroph benefits from oxygen supplied by the extremophilic microalga under low-oxygen conditions, enhancing growth and methane oxidation. follow-up work showed that this interaction is density-dependent: low initial methylacidiphilum:galdieria ratios improve net carbon fixation, whereas elevated methanotroph abundance can impose oxygen competition, causing chlorosis and reduced carbon assimilation.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Methylacidiphilum-Galdieria Thermoacidophilic Methane Coculture</h2>
+                        <p class="description">A defined thermoacidophilic methanotroph-microalga coculture pairing Methylacidiphilum sp. RTK17.1 with Galdieria sp. RTK37.1 for methane and carbon dioxide valorisation. In methane-fed photobioreactor studies, the methanotroph benefits from oxygen supplied by the extremophilic microalga under low-oxygen conditions, enhancing growth and methane oxidation. Follow-up work showed that this interaction is density-dependent: low initial Methylacidiphilum:Galdieria ratios improve net carbon fixation, whereas elevated methanotroph abundance can impose oxygen competition, causing chlorosis and reduced carbon assimilation.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.html"
+                       class="community-card"
+                       data-id="Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture"
+                       data-name="methylocaldum-cupriavidus methane acetate cross-feeding coculture"
+                       data-description="a defined artificial aerobic coculture pairing the marine methanotroph methylocaldum marinum s8 with the non-methylotrophic acetate-utilizing bacterium cupriavidus necator nbrc 102504. the coculture was used to test whether methane-derived metabolites excreted by m. marinum s8 can support a partner that is not a methylotroph. the system is doe-relevant because it links methane oxidation to acetate-mediated growth of a bioproduction-relevant heterotroph, providing a model for methane-to-bioproduct community design.
+"
+                       data-category="CARBON_SEQUESTRATION"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Methylocaldum-Cupriavidus Methane Acetate Cross-Feeding Coculture</h2>
+                        <p class="description">A defined artificial aerobic coculture pairing the marine methanotroph Methylocaldum marinum S8 with the non-methylotrophic acetate-utilizing bacterium Cupriavidus necator NBRC 102504. The coculture was used to test whether methane-derived metabolites excreted by M. marinum S8 can support a partner that is not a methylotroph. The system is DOE-relevant because it links methane oxidation to acetate-mediated growth of a bioproduction-relevant heterotroph, providing a model for methane-to-bioproduct community design.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">CARBON_SEQUESTRATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.html"
+                       class="community-card"
+                       data-id="Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture"
+                       data-name="methylocaldum-methyloceanibacter methane cross-feeding coculture"
+                       data-description="a defined aerobic methane-fed laboratory coculture pairing the marine methanotroph methylocaldum marinum s8 with the facultative methylotroph methyloceanibacter caenitepidi gela4. m. marinum s8 oxidizes methane and supports syntrophic growth of m. caenitepidi gela4 on methane-derived carbon. transcriptome and chemical analyses indicate that acetate, rather than methanol alone, is likely a major cross-fed carbon source in this model methanotroph-methylotroph community.
+"
+                       data-category="CARBON_SEQUESTRATION"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Methylocaldum-Methyloceanibacter Methane Cross-Feeding Coculture</h2>
+                        <p class="description">A defined aerobic methane-fed laboratory coculture pairing the marine methanotroph Methylocaldum marinum S8 with the facultative methylotroph Methyloceanibacter caenitepidi Gela4. M. marinum S8 oxidizes methane and supports syntrophic growth of M. caenitepidi Gela4 on methane-derived carbon. Transcriptome and chemical analyses indicate that acetate, rather than methanol alone, is likely a major cross-fed carbon source in this model methanotroph-methylotroph community.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">CARBON_SEQUESTRATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.html"
+                       class="community-card"
+                       data-id="Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture"
+                       data-name="methylocystis-rhodococcus methane vfa phbv coculture"
+                       data-description="a defined synthetic coculture pairing the type ii methanotroph methylocystis parvus with the heterotrophic bacterium rhodococcus opacus for methane-linked polyhydroxyalkanoate production. the coculture was first evaluated for methane-to-poly(3-hydroxybutyrate) conversion and then used in a two-stage phbv accumulation strategy with nutrient starvation, methane, oxygen or air, valeric acid, and a volatile fatty acid mixture containing acetic, propionic, butyric, and valeric acids. the system is relevant to methane valorization, waste-derived volatile fatty acid upgrading, and biopolymer production.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Methylocystis-Rhodococcus Methane VFA PHBV Coculture</h2>
+                        <p class="description">A defined synthetic coculture pairing the type II methanotroph Methylocystis parvus with the heterotrophic bacterium Rhodococcus opacus for methane-linked polyhydroxyalkanoate production. The coculture was first evaluated for methane-to-poly(3-hydroxybutyrate) conversion and then used in a two-stage PHBV accumulation strategy with nutrient starvation, methane, oxygen or air, valeric acid, and a volatile fatty acid mixture containing acetic, propionic, butyric, and valeric acids. The system is relevant to methane valorization, waste-derived volatile fatty acid upgrading, and biopolymer production.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.html"
+                       class="community-card"
+                       data-id="Methylomicrobium_Chlorella_Methane_Sequestration_Coculture"
+                       data-name="methylomicrobium-chlorella methane sequestration coculture"
+                       data-description="a defined halotolerant methanotroph-microalga coculture pairing methylomicrobium alcaliphilum 20z, currently represented by ncbi as methylotuvimicrobium alcaliphilum 20z, with chlorella sp. hs2. the two-member system was assembled to test biological methane and carbon dioxide mitigation through metabolic coupling in saline culture, with increased methane removal, improved growth of both members, ph recovery, and greater biomass carbon sequestration reported in coculture. the system is relevant to doe interests in methane mitigation, carbon capture and utilization, photosynthetic-methanotrophic consortia, and c1 bioconversion.
+"
+                       data-category="CARBON_SEQUESTRATION"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Methylomicrobium-Chlorella Methane Sequestration Coculture</h2>
+                        <p class="description">A defined halotolerant methanotroph-microalga coculture pairing Methylomicrobium alcaliphilum 20Z, currently represented by NCBI as Methylotuvimicrobium alcaliphilum 20Z, with Chlorella sp. HS2. The two-member system was assembled to test biological methane and carbon dioxide mitigation through metabolic coupling in saline culture, with increased methane removal, improved growth of both members, pH recovery, and greater biomass carbon sequestration reported in coculture. The system is relevant to DOE interests in methane mitigation, carbon capture and utilization, photosynthetic-methanotrophic consortia, and C1 bioconversion.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">CARBON_SEQUESTRATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.html"
+                       class="community-card"
+                       data-id="Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture"
+                       data-name="methylotuvimicrobium-synechococcus gas feedstock coculture"
+                       data-description="a defined synthetic methanotroph-cyanobacterium coculture developed at pacific northwest national laboratory for simultaneous use of methane and carbon dioxide gas feedstocks. the methanotrophic bacterium methylomicrobium alcaliphilum 20z, currently represented by ncbi as methylotuvimicrobium alcaliphilum 20z, is coupled to the cyanobacterium synechococcus pcc 7002, currently represented by ncbi as picosynechococcus sp. pcc 7002. the coculture converts ch4 and co2 into microbial biomass through oxygenic photosynthesis-driven o2 supply to the methanotroph and respiratory co2 supply to the photoautotroph, with follow-up work using the same species pair for quantitative coculture characterization.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Methylotuvimicrobium-Synechococcus Gas Feedstock Coculture</h2>
+                        <p class="description">A defined synthetic methanotroph-cyanobacterium coculture developed at Pacific Northwest National Laboratory for simultaneous use of methane and carbon dioxide gas feedstocks. The methanotrophic bacterium Methylomicrobium alcaliphilum 20z, currently represented by NCBI as Methylotuvimicrobium alcaliphilum 20Z, is coupled to the cyanobacterium Synechococcus PCC 7002, currently represented by NCBI as Picosynechococcus sp. PCC 7002. The coculture converts CH4 and CO2 into microbial biomass through oxygenic photosynthesis-driven O2 supply to the methanotroph and respiratory CO2 supply to the photoautotroph, with follow-up work using the same species pair for quantitative coculture characterization.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Microcoleus_Massilia_Cyanosphere_Urea_Mutualism.html"
+                       class="community-card"
+                       data-id="Microcoleus_Massilia_Cyanosphere_Urea_Mutualism"
+                       data-name="microcoleus-massilia cyanosphere urea mutualism"
+                       data-description="a defined biological soil crust cyanosphere coculture pairing the pioneer cyanobacterium microcoleus vaginatus pcc 9802 with the heterotrophic cyanosphere isolate massilia sp. meth4. across repeated studies of the same exact strain pair, m. vaginatus provides photosynthetically fixed organic carbon while the diazotrophic massilia partner supports nitrogen acquisition through a specific carbon-for-nitrogen mutualism, including urea-mediated nitrogen transfer and gaba/glutamate signaling that organizes close spatial association.
+"
+                       data-category="SYNTROPHY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Microcoleus-Massilia Cyanosphere Urea Mutualism</h2>
+                        <p class="description">A defined biological soil crust cyanosphere coculture pairing the pioneer cyanobacterium Microcoleus vaginatus PCC 9802 with the heterotrophic cyanosphere isolate Massilia sp. METH4. Across repeated studies of the same exact strain pair, M. vaginatus provides photosynthetically fixed organic carbon while the diazotrophic Massilia partner supports nitrogen acquisition through a specific carbon-for-nitrogen mutualism, including urea-mediated nitrogen transfer and GABA/glutamate signaling that organizes close spatial association.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.html"
+                       class="community-card"
+                       data-id="Miscanthus_REE_Tailings_Nitrogen_SynCom10"
+                       data-name="miscanthus ree tailings nitrogen syncom10"
+                       data-description="a ten-strain miscanthus root-derived syncom with nitrification and denitrification capabilities for ammonia nitrogen removal in rare earth mine tailings."
+                       data-category="BIOREMEDIATION"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="5">
+                        <h2>Miscanthus REE Tailings Nitrogen SynCom10</h2>
+                        <p class="description">A ten-strain Miscanthus root-derived SynCom with nitrification and denitrification capabilities for ammonia nitrogen removal in rare earth mine tailings.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    5
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Mixed_Gallium_LED_Recovery_Consortium.html"
+                       class="community-card"
+                       data-id="Mixed_Gallium_LED_Recovery_Consortium"
+                       data-name="mixed gallium led recovery consortium"
+                       data-description="an engineered acidophilic microbial consortium specifically designed for recovering gallium from waste light-emitting diodes (leds) through non-contact bioleaching. this mixed community consists of three iron- and sulfur-oxidizing bacteria in equal proportions (1:1:1 ratio): acidithiobacillus thiooxidans, acidithiobacillus ferrooxidans, and leptospirillum ferrooxidans. the consortium produces biogenic lixiviants - primarily sulfuric acid (h₂so₄) from sulfur oxidation and ferric iron (fe³⁺) from iron oxidation - that solubilize gallium from gan-based led materials without direct contact between microbes and solid waste. operating at ph 1.0-1.5 and 15 g/l pulp density, the system achieves exceptional 99.5% gallium leaching efficiency within just 3 days. the non-contact bioleaching approach separates the bioreactor (where microbes generate lixiviants) from the leaching reactor (where acids attack led waste), preventing microbial inhibition by toxic led components while enabling gallium recovery. in addition to gallium, the process recovers copper and nickel from led substrates and interconnects. this biotechnological platform offers a sustainable alternative to harsh chemical leaching methods, utilizing microbial metabolism to extract critical materials from electronic waste while avoiding toxic emissions and reducing environmental impact.
+"
+                       data-category="BIOMINING"
+                       data-state="ENGINEERED"
+                       data-metals="COPPER,GALLIUM,IRON,NICKEL"
+                       data-ree=""
+                       data-relevance="PRIMARY"
+                       data-member-count="3">
+                        <h2>Mixed Gallium LED Recovery Consortium</h2>
+                        <p class="description">An engineered acidophilic microbial consortium specifically designed for recovering gallium from waste light-emitting diodes (LEDs) through non-contact bioleaching. This mixed community consists of three iron- and sulfur-oxidizing bacteria in equal proportions (1:1:1 ratio): Acidithiobacillus thiooxidans, Acidithiobacillus ferrooxidans, and Leptospirillum ferrooxidans. The consortium produces biogenic lixiviants - primarily sulfuric acid (H₂SO₄) from sulfur oxidation and ferric iron (Fe³⁺) from iron oxidation - that solubilize gallium from GaN-based LED materials without direct contact between microbes and solid waste. Operating at pH 1.0-1.5 and 15 g/L pulp density, the system achieves exceptional 99.5% gallium leaching efficiency within just 3 days. The non-contact bioleaching approach separates the bioreactor (where microbes generate lixiviants) from the leaching reactor (where acids attack LED waste), preventing microbial inhibition by toxic LED components while enabling gallium recovery. In addition to gallium, the process recovers copper and nickel from LED substrates and interconnects. This biotechnological platform offers a sustainable alternative to harsh chemical leaching methods, utilizing microbial metabolism to extract critical materials from electronic waste while avoiding toxic emissions and reducing environmental impact.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOMINING</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Model_Cyanobacterial_Consortia_Core_Microbiome.html"
+                       class="community-card"
+                       data-id="Model_Cyanobacterial_Consortia_Core_Microbiome"
+                       data-name="model cyanobacterial consortia core microbiome"
+                       data-description="a laboratory framework of 108 stable cyanobacteria-heterotroph consortia generated by coculturing five well-characterized model cyanobacterial strains with microorganisms filtered from three distinct freshwater sources. metagenomic analysis across the 108 consortia identified a 25-species noncyanobacterial core microbiome that recurred independently of cyanobacterial host species or inoculum source, with statistically supported core functions in micronutrient biosynthesis, metabolite transport, and anoxygenic photosynthesis, and a significant enrichment of plasmids in core species suggesting plasmid-mediated symbiotic roles.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Model Cyanobacterial Consortia Core Microbiome</h2>
+                        <p class="description">A laboratory framework of 108 stable cyanobacteria-heterotroph consortia generated by coculturing five well-characterized model cyanobacterial strains with microorganisms filtered from three distinct freshwater sources. Metagenomic analysis across the 108 consortia identified a 25-species noncyanobacterial core microbiome that recurred independently of cyanobacterial host species or inoculum source, with statistically supported core functions in micronutrient biosynthesis, metabolite transport, and anoxygenic photosynthesis, and a significant enrichment of plasmids in core species suggesting plasmid-mediated symbiotic roles.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.html"
+                       class="community-card"
+                       data-id="Model_Lignocellulose_Formaldehyde_Crossfeeding_Community"
+                       data-name="model lignocellulose formaldehyde cross-feeding community"
+                       data-description="a synthetic model lignocellulose-degrading community developed to study plant-biomass transformation and mitigation of toxic formaldehyde produced during breakdown of methoxylated aromatic compounds. the system includes pseudomonas putida as a lignin degrader, cellulomonas fimi as a cellulose degrader, methylorubrum extorquens as a methylotrophic formaldehyde consumer, and yarrowia lipolytica as an oleaginous yeast included in some consortium variants.
+"
+                       data-category="LIGNOCELLULOSE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Model Lignocellulose Formaldehyde Cross-Feeding Community</h2>
+                        <p class="description">A synthetic model lignocellulose-degrading community developed to study plant-biomass transformation and mitigation of toxic formaldehyde produced during breakdown of methoxylated aromatic compounds. The system includes Pseudomonas putida as a lignin degrader, Cellulomonas fimi as a cellulose degrader, Methylorubrum extorquens as a methylotrophic formaldehyde consumer, and Yarrowia lipolytica as an oleaginous yeast included in some consortium variants.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Multiomics_Corn_Straw_Degradation_SynCom.html"
+                       class="community-card"
+                       data-id="Multiomics_Corn_Straw_Degradation_SynCom"
+                       data-name="multiomics corn straw degradation syncom"
+                       data-description="a core synthetic microbial community designed by multiomics linkage technology to degrade corn straw lignocellulose."
+                       data-category="LIGNOCELLULOSE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>Multiomics Corn Straw Degradation SynCom</h2>
+                        <p class="description">A core synthetic microbial community designed by multiomics linkage technology to degrade corn straw lignocellulose.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Mushroom_Spring_Hot_Spring_Phototrophic_Mat_Community.html"
+                       class="community-card"
+                       data-id="Mushroom_Spring_Hot_Spring_Phototrophic_Mat_Community"
+                       data-name="mushroom spring hot-spring phototrophic mat community"
+                       data-description="a natural alkaline geothermal microbial mat community from mushroom spring in yellowstone national park. the community is structured around thermophilic synechococcus cyanobacteria, filamentous anoxygenic phototrophs related to roseiflexus and chloroflexus, and an undermat community that includes thermodesulfovibrio-like sulfate reducers. it is a doe-relevant model for high-temperature photosynthesis, diel carbon and nitrogen cycling, metagenome-resolved community metabolism, and carbon flow in phototrophic microbial mats.
+"
+                       data-category="EXTREME_ENVIRONMENT"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Mushroom Spring Hot-Spring Phototrophic Mat Community</h2>
+                        <p class="description">A natural alkaline geothermal microbial mat community from Mushroom Spring in Yellowstone National Park. The community is structured around thermophilic Synechococcus cyanobacteria, filamentous anoxygenic phototrophs related to Roseiflexus and Chloroflexus, and an undermat community that includes Thermodesulfovibrio-like sulfate reducers. It is a DOE-relevant model for high-temperature photosynthesis, diel carbon and nitrogen cycling, metagenome-resolved community metabolism, and carbon flow in phototrophic microbial mats.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">EXTREME_ENVIRONMENT</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/NCycle_Bioflocculation_Model_Consortium.html"
+                       class="community-card"
+                       data-id="NCycle_Bioflocculation_Model_Consortium"
+                       data-name="n-cycle bioflocculation model consortium"
+                       data-description="a reduced-complexity n-cycle model consortium of nitrifiers and denitrifiers used to study bioflocculation mechanisms in biological wastewater treatment."
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>N-Cycle Bioflocculation Model Consortium</h2>
+                        <p class="description">A reduced-complexity N-cycle model consortium of nitrifiers and denitrifiers used to study bioflocculation mechanisms in biological wastewater treatment.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Naica_Deep_Subsurface_Thermophilic.html"
+                       class="community-card"
+                       data-id="Naica_Deep_Subsurface_Thermophilic"
+                       data-name="naica deep subsurface thermophilic community"
+                       data-description="a deep subsurface thermophilic microbial community from the naica mine crystal cave system in chihuahua, mexico, representing one of earth&#39;s most extreme oligotrophic deep biosphere habitats. this community thrives in hydrothermal waters at 700-760 m depth with temperatures of 54-60°c, extremely low nutrient availability, and isolation from surface inputs. the prokaryotic community is dominated by chemolithoautotrophic archaea, particularly basal thaumarchaeota (performing ammonia oxidation) and environmental thermoplasmatales lineages (euryarchaeota), with bacterial diversity limited to candidate division op3, firmicutes, and alpha/beta-proteobacteria. high gc content of archaeal and op3 16s rrna genes confirms thermophilic adaptation to 50-70°c. genes encoding archaeal ammonia monooxygenase (amoa) demonstrate that naica thaumarchaeota are thermophilic chemolithoautotrophic nitrifiers adapted to extreme energy limitation. the system exhibits astrobiology significance as an analog for subsurface life on mars and icy moons, with fluid inclusions in giant gypsum crystals potentially harboring ancient microbes for up to 50,000-60,000 years. the absence of detectable eukaryotes reflects the extreme oligotrophy and thermal stress. this natural deep biosphere community provides insights into minimal energy requirements for life, thermophilic adaptation, and survival strategies in isolated subsurface aquifers with extremely limited carbon and nitrogen availability.
+"
+                       data-category="EXTREME_ENVIRONMENT"
+                       data-state="STABLE"
+                       data-metals="IRON"
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="6">
+                        <h2>Naica Deep Subsurface Thermophilic Community</h2>
+                        <p class="description">A deep subsurface thermophilic microbial community from the Naica Mine crystal cave system in Chihuahua, Mexico, representing one of Earth&#39;s most extreme oligotrophic deep biosphere habitats. This community thrives in hydrothermal waters at 700-760 m depth with temperatures of 54-60°C, extremely low nutrient availability, and isolation from surface inputs. The prokaryotic community is dominated by chemolithoautotrophic archaea, particularly basal Thaumarchaeota (performing ammonia oxidation) and environmental Thermoplasmatales lineages (Euryarchaeota), with bacterial diversity limited to Candidate Division OP3, Firmicutes, and Alpha/Beta-proteobacteria. High GC content of archaeal and OP3 16S rRNA genes confirms thermophilic adaptation to 50-70°C. Genes encoding archaeal ammonia monooxygenase (amoA) demonstrate that Naica Thaumarchaeota are thermophilic chemolithoautotrophic nitrifiers adapted to extreme energy limitation. The system exhibits astrobiology significance as an analog for subsurface life on Mars and icy moons, with fluid inclusions in giant gypsum crystals potentially harboring ancient microbes for up to 50,000-60,000 years. The absence of detectable eukaryotes reflects the extreme oligotrophy and thermal stress. This natural deep biosphere community provides insights into minimal energy requirements for life, thermophilic adaptation, and survival strategies in isolated subsurface aquifers with extremely limited carbon and nitrogen availability.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    6
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">EXTREME_ENVIRONMENT</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Neocallimastix_Methanobrevibacter_Xylan_Coculture.html"
+                       class="community-card"
+                       data-id="Neocallimastix_Methanobrevibacter_Xylan_Coculture"
+                       data-name="neocallimastix-methanobrevibacter xylanolytic coculture"
+                       data-description="a defined anaerobic rumen-derived coculture in which the xylan-degrading fungus neocallimastix frontalis pnk2 is grown with the hydrogenotrophic archaeon methanobrevibacter smithii on xylan. the methanogen removes fermentation products through interspecies hydrogen transfer, shifting fungal metabolism toward acetate formation and increasing xylan utilization and extracellular hemicellulase activities.
+"
+                       data-category="LIGNOCELLULOSE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Neocallimastix-Methanobrevibacter Xylanolytic Coculture</h2>
+                        <p class="description">A defined anaerobic rumen-derived coculture in which the xylan-degrading fungus Neocallimastix frontalis PNK2 is grown with the hydrogenotrophic archaeon Methanobrevibacter smithii on xylan. The methanogen removes fermentation products through interspecies hydrogen transfer, shifting fungal metabolism toward acetate formation and increasing xylan utilization and extracellular hemicellulase activities.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Ngawha_Geothermal_Mercury_Cycling_Community.html"
+                       class="community-card"
+                       data-id="Ngawha_Geothermal_Mercury_Cycling_Community"
+                       data-name="ngawha geothermal acidic springs mercury cycling community"
+                       data-description="an acidic warm spring microbial community from the ngawha geothermal field (northland region, aotearoa new zealand) characterized by genome-resolved metagenomics and mercury speciation analysis. two adjacent springs differ in mercury speciation, with dissolved total and methylated mercury concentrations among the highest reported from natural sources (250 to 16,000 ng/l total; 0.5 to 13.9 ng/l methylmercury). sediment total mercury ranges from 1,274 to 7,000 ug/g. despite ultrahigh mercury levels, the geothermal microbiome is unexpectedly diverse and dominated by acidophilic and mesophilic sulfur- and iron-cycling bacteria, mercury- and arsenic- resistant bacteria, and thermophilic and acidophilic archaea. a conceptual model integrates community structure and metagenomic potential with abiotic and biotic controls on hg methylation, demethylation, and reduction to volatile hg(0).
+"
+                       data-category="EXTREME_ENVIRONMENT"
+                       data-state="STABLE"
+                       data-metals="MERCURY,IRON"
+                       data-ree=""
+                       data-relevance="PRIMARY"
+                       data-member-count="3">
+                        <h2>Ngawha Geothermal Acidic Springs Mercury Cycling Community</h2>
+                        <p class="description">An acidic warm spring microbial community from the Ngawha Geothermal Field (Northland Region, Aotearoa New Zealand) characterized by genome-resolved metagenomics and mercury speciation analysis. Two adjacent springs differ in mercury speciation, with dissolved total and methylated mercury concentrations among the highest reported from natural sources (250 to 16,000 ng/L total; 0.5 to 13.9 ng/L methylmercury). Sediment total mercury ranges from 1,274 to 7,000 ug/g. Despite ultrahigh mercury levels, the geothermal microbiome is unexpectedly diverse and dominated by acidophilic and mesophilic sulfur- and iron-cycling bacteria, mercury- and arsenic- resistant bacteria, and thermophilic and acidophilic archaea. A conceptual model integrates community structure and metagenomic potential with abiotic and biotic controls on Hg methylation, demethylation, and reduction to volatile Hg(0).
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">EXTREME_ENVIRONMENT</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/OMM12_Gnotobiotic_Mouse_Gut_Community.html"
+                       class="community-card"
+                       data-id="OMM12_Gnotobiotic_Mouse_Gut_Community"
+                       data-name="omm12 gnotobiotic mouse gut community"
+                       data-description="omm12, also called oligo-mm12 or oligo-mouse-microbiota, is a defined 12-strain murine intestinal bacterial community used to colonize germ-free mice for reproducible microbiome research. the community includes lactobacillus reuteri i49, enterococcus faecalis kb1, blautia coccoides yl58, clostridium innocuum i46, flavonifractor plautii yl31, clostridium clostridioforme yl32, acutalibacter muris kb18, bacteroides caecimuris i48, muribaculum intestinale yl27, bifidobacterium longum subsp. animalis yl2, akkermansia muciniphila yl44, and turicimonas muris yl45. it is used as a reduced, genome-characterized model of the mouse gut microbiota for colonization resistance, mucosal immunology, microbial ecology, host-microbiome metabolic cross-talk, and facility-to-facility reproducibility studies."
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>OMM12 Gnotobiotic Mouse Gut Community</h2>
+                        <p class="description">OMM12, also called Oligo-MM12 or Oligo-Mouse-Microbiota, is a defined 12-strain murine intestinal bacterial community used to colonize germ-free mice for reproducible microbiome research. The community includes Lactobacillus reuteri I49, Enterococcus faecalis KB1, Blautia coccoides YL58, Clostridium innocuum I46, Flavonifractor plautii YL31, Clostridium clostridioforme YL32, Acutalibacter muris KB18, Bacteroides caecimuris I48, Muribaculum intestinale YL27, Bifidobacterium longum subsp. animalis YL2, Akkermansia muciniphila YL44, and Turicimonas muris YL45. It is used as a reduced, genome-characterized model of the mouse gut microbiota for colonization resistance, mucosal immunology, microbial ecology, host-microbiome metabolic cross-talk, and facility-to-facility reproducibility studies.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.html"
+                       class="community-card"
+                       data-id="ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model"
+                       data-name="ornl clostridium-desulfovibrio-geobacter trophic model community"
+                       data-description="a three-species anaerobic continuous-culture model community established to study trophic and electron-acceptor interactions relevant to subsurface anaerobic environments. clostridium cellulolyticum ferments cellobiose, while desulfovibrio vulgaris hildenborough and geobacter sulfurreducens depend on fermentation products and use sulfate and fumarate, respectively, as supplied electron acceptors.
+"
+                       data-category="BIOREMEDIATION"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>ORNL Clostridium-Desulfovibrio-Geobacter Trophic Model Community</h2>
+                        <p class="description">A three-species anaerobic continuous-culture model community established to study trophic and electron-acceptor interactions relevant to subsurface anaerobic environments. Clostridium cellulolyticum ferments cellobiose, while Desulfovibrio vulgaris Hildenborough and Geobacter sulfurreducens depend on fermentation products and use sulfate and fumarate, respectively, as supplied electron acceptors.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/ORNL_PMI_Populus_PD10_SynCom.html"
+                       class="community-card"
+                       data-id="ORNL_PMI_Populus_PD10_SynCom"
+                       data-name="ornl pmi populus pd10 syncom"
+                       data-description="a 10-member synthetic bacterial community (pd10) assembled by the oak ridge national laboratory plant-microbe interfaces (pmi) team from populus deltoides rhizosphere isolates. the community was used as a bottom-up model system to study assembly dynamics, medium-dependent community structure, metabolic exchange, and antagonistic interactions during stable community formation."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="INCIDENTAL"
+                       data-member-count="10">
+                        <h2>ORNL PMI Populus PD10 SynCom</h2>
+                        <p class="description">A 10-member synthetic bacterial community (PD10) assembled by the Oak Ridge National Laboratory Plant-Microbe Interfaces (PMI) team from Populus deltoides rhizosphere isolates. The community was used as a bottom-up model system to study assembly dynamics, medium-dependent community structure, metabolic exchange, and antagonistic interactions during stable community formation.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    10
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.html"
+                       class="community-card"
+                       data-id="Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community"
+                       data-name="oak ridge frc uranium-nitrate groundwater community"
+                       data-description="a natural contaminated-groundwater microbial community from the u.s. doe oak ridge field research center, where groundwater wells span strong gradients in acidity, nitrate, uranium, and other metal contaminants. clone-library and isolate studies link geochemistry to community structure, with lower diversity in highly contaminated wells and enrichment of organisms capable of uranium, nitrate, and iron reduction. this record represents the field community, distinct from existing defined enigma denitrifying syncom records derived from oak ridge isolates."
+                       data-category="BIOREMEDIATION"
+                       data-state="PERTURBED"
+                       data-metals="URANIUM,IRON,NICKEL,COBALT,ZINC"
+                       data-ree=""
+                       data-relevance="PRIMARY"
+                       data-member-count="4">
+                        <h2>Oak Ridge FRC Uranium-Nitrate Groundwater Community</h2>
+                        <p class="description">A natural contaminated-groundwater microbial community from the U.S. DOE Oak Ridge Field Research Center, where groundwater wells span strong gradients in acidity, nitrate, uranium, and other metal contaminants. Clone-library and isolate studies link geochemistry to community structure, with lower diversity in highly contaminated wells and enrichment of organisms capable of uranium, nitrate, and iron reduction. This record represents the field community, distinct from existing defined ENIGMA denitrifying SynCom records derived from Oak Ridge isolates.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Okeke_Lu_Cellulolytic_Consortium.html"
+                       class="community-card"
+                       data-id="Okeke_Lu_Cellulolytic_Consortium"
+                       data-name="okeke-lu cellulolytic-xylanolytic consortium"
+                       data-description="a defined 5-member bacterial consortium from alabama soil capable of dual cellulose and hemicellulose degradation. the consortium consists of pseudoxanthomonas byssovorax db1, microbacterium oxydans db2, bacillus sp. db7, ochrobactrum sp. db8, and klebsiella sp. db13. isolates db1 and db2 display the highest cellulase activity (27.83 and 31.22 u/mg), producing a complete enzyme system including filter paper cellulase, β-glucosidase, xylanase, and β-xylosidase for comprehensive lignocellulose bioprocessing.
+"
+                       data-category="LIGNOCELLULOSE"
+                       data-state="STABLE"
+                       data-metals="IRON"
+                       data-ree=""
+                       data-relevance="INCIDENTAL"
+                       data-member-count="5">
+                        <h2>Okeke-Lu Cellulolytic-Xylanolytic Consortium</h2>
+                        <p class="description">A defined 5-member bacterial consortium from Alabama soil capable of dual cellulose and hemicellulose degradation. The consortium consists of Pseudoxanthomonas byssovorax DB1, Microbacterium oxydans DB2, Bacillus sp. DB7, Ochrobactrum sp. DB8, and Klebsiella sp. DB13. Isolates DB1 and DB2 display the highest cellulase activity (27.83 and 31.22 U/mg), producing a complete enzyme system including filter paper cellulase, β-glucosidase, xylanase, and β-xylosidase for comprehensive lignocellulose bioprocessing.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    5
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.html"
+                       class="community-card"
+                       data-id="Ostreococcus_Dinoroseobacter_BVitamin_Mutualism"
+                       data-name="ostreococcus-dinoroseobacter b-vitamin mutualism"
+                       data-description="a defined marine algal-bacterial coculture in which the picoeukaryotic alga ostreococcus tauri oth95 and the roseobacter dinoroseobacter shibae df-12 form a reciprocal b-vitamin mutualism. d. shibae supplies cobalamin and thiamine needed by o. tauri, while o. tauri satisfies bacterial requirements for other b vitamins in a stable long-term coculture; the interaction is experimentally tractable under controlled light, temperature, and vitamin-amendment regimes.
+"
+                       data-category="PHYTOPLANKTON"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Ostreococcus-Dinoroseobacter B-Vitamin Mutualism</h2>
+                        <p class="description">A defined marine algal-bacterial coculture in which the picoeukaryotic alga Ostreococcus tauri OTH95 and the roseobacter Dinoroseobacter shibae DF-12 form a reciprocal B-vitamin mutualism. D. shibae supplies cobalamin and thiamine needed by O. tauri, while O. tauri satisfies bacterial requirements for other B vitamins in a stable long-term coculture; the interaction is experimentally tractable under controlled light, temperature, and vitamin-amendment regimes.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">PHYTOPLANKTON</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/PET_Artificial_FourSpecies_Degradation_Consortium.html"
+                       class="community-card"
+                       data-id="PET_Artificial_FourSpecies_Degradation_Consortium"
+                       data-name="pet artificial four-species degradation consortium"
+                       data-description="an engineered artificial consortium for polyethylene terephthalate (pet) biodegradation composed of two metabolically engineered bacillus subtilis 168 strains that secrete petase and mhetase, plus rhodococcus jostii rha1 and pseudomonas putida kt2440. the design partitions pet depolymerization, terephthalic acid utilization, and ethylene glycol utilization across different members to reduce product inhibition during pet degradation.
+"
+                       data-category="BIOREMEDIATION"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>PET Artificial Four-Species Degradation Consortium</h2>
+                        <p class="description">An engineered artificial consortium for polyethylene terephthalate (PET) biodegradation composed of two metabolically engineered Bacillus subtilis 168 strains that secrete PETase and MHETase, plus Rhodococcus jostii RHA1 and Pseudomonas putida KT2440. The design partitions PET depolymerization, terephthalic acid utilization, and ethylene glycol utilization across different members to reduce product inhibition during PET degradation.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/PGM_Spent_Catalyst_Bioleaching.html"
+                       class="community-card"
+                       data-id="PGM_Spent_Catalyst_Bioleaching"
+                       data-name="pgm spent catalyst bioleaching consortium"
+                       data-description="an engineered acidophilic microbial consortium designed for sustainable recovery of platinum group metals (pgms) from spent automotive catalysts and hydroprocessing catalysts. this bioleaching system employs a two-stage mechanism combining acidithiobacillus thiooxidans for alumina support dissolution with biogenic thiosulfate producers for pgm complexation and mobilization. spent three-way catalysts (twc) from automotive exhaust systems contain precious metals (pt, pd, rh) deposited on alumina (al₂o₃) supports, while spent petroleum refinery hydroprocessing catalysts contain pd, ni, mo, and al. the consortium operates under acidic conditions in column bioreactors, achieving exceptional recovery rates: 93.2% pd extraction, 82.9% ni, 33.4% al, and 22.7% mo from spent petroleum catalysts. the bioleaching mechanism proceeds in two stages: (1) at. thiooxidans generates sulfuric acid that dissolves the alumina support matrix, exposing embedded pgm particles, and (2) biogenic thiosulfate (s₂o₃²⁻) produced during sulfur oxidation forms stable complexes with pd and other pgms in the presence of copper and ammonia, mobilizing them from the catalyst surface. the thiosulfate-copper-ammonia system enables selective pgm leaching without harsh cyanide reagents. this biotechnological approach offers an environmentally sustainable alternative to conventional pyrometallurgical pgm recovery (high-temperature smelting) and aggressive chemical leaching (aqua regia, cyanide), while addressing circular economy needs for critical materials recovery from automotive and industrial waste streams. the technology represents a significant advance in green metallurgy for spent catalyst recycling.
+"
+                       data-category="BIOMINING"
+                       data-state="ENGINEERED"
+                       data-metals="COPPER,IRON,NICKEL,PALLADIUM"
+                       data-ree=""
+                       data-relevance="PRIMARY"
+                       data-member-count="4">
+                        <h2>PGM Spent Catalyst Bioleaching Consortium</h2>
+                        <p class="description">An engineered acidophilic microbial consortium designed for sustainable recovery of platinum group metals (PGMs) from spent automotive catalysts and hydroprocessing catalysts. This bioleaching system employs a two-stage mechanism combining Acidithiobacillus thiooxidans for alumina support dissolution with biogenic thiosulfate producers for PGM complexation and mobilization. Spent three-way catalysts (TWC) from automotive exhaust systems contain precious metals (Pt, Pd, Rh) deposited on alumina (Al₂O₃) supports, while spent petroleum refinery hydroprocessing catalysts contain Pd, Ni, Mo, and Al. The consortium operates under acidic conditions in column bioreactors, achieving exceptional recovery rates: 93.2% Pd extraction, 82.9% Ni, 33.4% Al, and 22.7% Mo from spent petroleum catalysts. The bioleaching mechanism proceeds in two stages: (1) At. thiooxidans generates sulfuric acid that dissolves the alumina support matrix, exposing embedded PGM particles, and (2) biogenic thiosulfate (S₂O₃²⁻) produced during sulfur oxidation forms stable complexes with Pd and other PGMs in the presence of copper and ammonia, mobilizing them from the catalyst surface. The thiosulfate-copper-ammonia system enables selective PGM leaching without harsh cyanide reagents. This biotechnological approach offers an environmentally sustainable alternative to conventional pyrometallurgical PGM recovery (high-temperature smelting) and aggressive chemical leaching (aqua regia, cyanide), while addressing circular economy needs for critical materials recovery from automotive and industrial waste streams. The technology represents a significant advance in green metallurgy for spent catalyst recycling.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOMINING</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/PMI_Variovorax_Thermotolerance_Collection.html"
+                       class="community-card"
+                       data-id="PMI_Variovorax_Thermotolerance_Collection"
+                       data-name="pmi variovorax thermotolerance collection"
+                       data-description="a 25-strain variovorax collection from populus roots, screened for bacterial effects on arabidopsis thaliana thermotolerance using a rapid hydroponic assay. six strains (cf313, yr634, gv004, gv035, yr752, ov084) significantly improve plant heat tolerance at 45c. cf313 was selected for detailed follow-up study. the thermal benefit requires direct contact with living bacteria; heat-killed bacteria and culture supernatants provide no protection."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="6">
+                        <h2>PMI Variovorax Thermotolerance Collection</h2>
+                        <p class="description">A 25-strain Variovorax collection from Populus roots, screened for bacterial effects on Arabidopsis thaliana thermotolerance using a rapid hydroponic assay. Six strains (CF313, YR634, GV004, GV035, YR752, OV084) significantly improve plant heat tolerance at 45C. CF313 was selected for detailed follow-up study. The thermal benefit requires direct contact with living bacteria; heat-killed bacteria and culture supernatants provide no protection.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    6
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.html"
+                       class="community-card"
+                       data-id="PSY_Transgenic_Rice_Rhizosphere_Methane_Community"
+                       data-name="psy transgenic rice rhizosphere methane-mitigating community"
+                       data-description="a rice rhizosphere microbial community whose h2 cycling and methanogenesis are reshaped by host overexpression of plant peptides containing sulfated tyrosine (psy) genes. two independent transgenic rice genotypes (psy1 and psy2) reduced cumulative ch4 emissions by 38 percent and 58 percent over 70 days relative to controls. genome-resolved metatranscriptomic, metagenomic, metabolomic, and metabolic modeling data from psy rhizosphere soils show lower ratios of ch4 production versus consumption gene activities (largely hydrogenotrophic), decreased h2-producing gene activity, and increased bacterial h2 oxidation pathways. assembled genomes of rhizosphere h2-oxidizing bacteria are enriched in gluconeogenic-acid utilization genes, and their activity is likely stimulated by elevated gluconeogenic-acid amino acids in psy rice root exudates, lowering h2 available for hydrogenotrophic methanogens.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>PSY Transgenic Rice Rhizosphere Methane-Mitigating Community</h2>
+                        <p class="description">A rice rhizosphere microbial community whose H2 cycling and methanogenesis are reshaped by host overexpression of PLANT PEPTIDES CONTAINING SULFATED TYROSINE (PSY) genes. Two independent transgenic rice genotypes (PSY1 and PSY2) reduced cumulative CH4 emissions by 38 percent and 58 percent over 70 days relative to controls. Genome-resolved metatranscriptomic, metagenomic, metabolomic, and metabolic modeling data from PSY rhizosphere soils show lower ratios of CH4 production versus consumption gene activities (largely hydrogenotrophic), decreased H2-producing gene activity, and increased bacterial H2 oxidation pathways. Assembled genomes of rhizosphere H2-oxidizing bacteria are enriched in gluconeogenic-acid utilization genes, and their activity is likely stimulated by elevated gluconeogenic-acid amino acids in PSY rice root exudates, lowering H2 available for hydrogenotrophic methanogens.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Panzhihua_Vanadium_Titanium_Tailings.html"
+                       class="community-card"
+                       data-id="Panzhihua_Vanadium_Titanium_Tailings"
+                       data-name="panzhihua vanadium titanium tailings community"
+                       data-description="a perturbed indigenous microbial community from vanadium-titanium magnetite mine tailings in panzhihua, sichuan, china, the world&#39;s largest v-ti magnetite deposit and largest vanadium production city. this community comprises nitrogen-fixing rhizobia (bradyrhizobium pachyrhizi, rhizobium species), metal-reducing bacteria, and indigenous microbiota that facilitate phytoremediation of polymetallic tailings containing vanadium (340 mg/kg), titanium, iron, copper, nickel, manganese, and zinc. the panzhihua deposit has generated approximately 570 million tons of tailing slurries from mining activities, creating a massive contamination challenge requiring sustainable bioremediation. the indigenous microbial community has adapted to extreme metal stress through nitrogen fixation coupled with plant growth promotion, enabling successful legume-based phytoremediation with pongamia pinnata and leucaena leucocephala. bradyrhizobium species demonstrate exceptional heavy metal tolerance while maintaining nitrogen-fixing capacity (increasing plant nitrogen content by 10-145%), promoting plant growth through iaa production, and facilitating metal phytoextraction (enhancing cu and ni uptake by 600%). metal-reducing bacteria contribute to vanadium detoxification through dissimilatory v(v) reduction to less soluble v(iv), decreasing vanadium bioavailability and mobilization risk. the community drives transformation of soil organic carbon, increasing active carbon components and carbon transformation enzymes during revegetation, improving overall tailings soil quality. this system represents a critical model for coupling nitrogen fixation, metal tolerance, and phytoremediation in polymetallic mine tailings, addressing both resource recovery and environmental remediation challenges in the world&#39;s largest vanadium-titanium deposit.
+"
+                       data-category="BIOREMEDIATION"
+                       data-state="PERTURBED"
+                       data-metals="COPPER,IRON,NICKEL,TITANIUM,VANADIUM,ZINC"
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="6">
+                        <h2>Panzhihua Vanadium Titanium Tailings Community</h2>
+                        <p class="description">A perturbed indigenous microbial community from vanadium-titanium magnetite mine tailings in Panzhihua, Sichuan, China, the world&#39;s largest V-Ti magnetite deposit and largest vanadium production city. This community comprises nitrogen-fixing rhizobia (Bradyrhizobium pachyrhizi, Rhizobium species), metal-reducing bacteria, and indigenous microbiota that facilitate phytoremediation of polymetallic tailings containing vanadium (340 mg/kg), titanium, iron, copper, nickel, manganese, and zinc. The Panzhihua deposit has generated approximately 570 million tons of tailing slurries from mining activities, creating a massive contamination challenge requiring sustainable bioremediation. The indigenous microbial community has adapted to extreme metal stress through nitrogen fixation coupled with plant growth promotion, enabling successful legume-based phytoremediation with Pongamia pinnata and Leucaena leucocephala. Bradyrhizobium species demonstrate exceptional heavy metal tolerance while maintaining nitrogen-fixing capacity (increasing plant nitrogen content by 10-145%), promoting plant growth through IAA production, and facilitating metal phytoextraction (enhancing Cu and Ni uptake by 600%). Metal-reducing bacteria contribute to vanadium detoxification through dissimilatory V(V) reduction to less soluble V(IV), decreasing vanadium bioavailability and mobilization risk. The community drives transformation of soil organic carbon, increasing active carbon components and carbon transformation enzymes during revegetation, improving overall tailings soil quality. This system represents a critical model for coupling nitrogen fixation, metal tolerance, and phytoremediation in polymetallic mine tailings, addressing both resource recovery and environmental remediation challenges in the world&#39;s largest vanadium-titanium deposit.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    6
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Peanut_Seed_Bacterial_CS_SynCom.html"
+                       class="community-card"
+                       data-id="Peanut_Seed_Bacterial_CS_SynCom"
+                       data-name="peanut seed bacterial cs syncom"
+                       data-description="a combined peanut seed-borne bacterial synthetic community that suppresses aspergillus flavus and fusarium oxysporum while promoting seedling growth."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>Peanut Seed Bacterial CS SynCom</h2>
+                        <p class="description">A combined peanut seed-borne bacterial synthetic community that suppresses Aspergillus flavus and Fusarium oxysporum while promoting seedling growth.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.html"
+                       class="community-card"
+                       data-id="Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture"
+                       data-name="pelotomaculum-methanocella propionate rna-seq coculture"
+                       data-description="a defined anaerobic syntrophic coculture pairing the propionate-oxidizing bacterium pelotomaculum thermopropionicum with the hydrogenotrophic methanogen methanocella conradii. rna-seq comparisons against monocultures showed coordinated transcriptional shifts in catabolism, methanogenesis, electron bifurcation/confurcation, formate handling, signal transduction, and amino acid exchange. the system is relevant to doe interests in anaerobic carbon cycling, methane production, syntrophic propionate degradation, and transcriptome-guided bioreactor microbiology.
+"
+                       data-category="SYNTROPHY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Pelotomaculum-Methanocella Propionate RNA-Seq Coculture</h2>
+                        <p class="description">A defined anaerobic syntrophic coculture pairing the propionate-oxidizing bacterium Pelotomaculum thermopropionicum with the hydrogenotrophic methanogen Methanocella conradii. RNA-seq comparisons against monocultures showed coordinated transcriptional shifts in catabolism, methanogenesis, electron bifurcation/confurcation, formate handling, signal transduction, and amino acid exchange. The system is relevant to DOE interests in anaerobic carbon cycling, methane production, syntrophic propionate degradation, and transcriptome-guided bioreactor microbiology.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Pelotomaculum_Methanothermobacter_Syntrophy.html"
+                       class="community-card"
+                       data-id="Pelotomaculum_Methanothermobacter_Syntrophy"
+                       data-name="pelotomaculum-methanothermobacter syntrophic consortium"
+                       data-description="a thermophilic syntrophic, obligate two-member anaerobic consortium consisting of pelotomaculum thermopropionicum, which oxidizes propionate and other organic acids (ethanol, lactate, alcohols) to acetate, co2, and h2, and methanothermobacter thermautotrophicus, a hydrogen-utilizing thermophilic methanogen. p. thermopropionicum oxidizes propionate only in coculture with h2-using methanogens, as it uses protons as the electron acceptor with h2 as the electron sink product. the removal of h2 by m. thermautotrophicus is thermodynamically essential for continued propionate oxidation by p. thermopropionicum. this thermophilic syntrophic relationship is fundamental to understanding propionate degradation and methane production at elevated temperatures (55°c) in anaerobic environments such as thermophilic digesters and hot springs.
+"
+                       data-category="SYNTROPHY"
+                       data-state="STABLE"
+                       data-metals="IRON,TITANIUM"
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="2">
+                        <h2>Pelotomaculum-Methanothermobacter Syntrophic Consortium</h2>
+                        <p class="description">A thermophilic syntrophic, obligate two-member anaerobic consortium consisting of Pelotomaculum thermopropionicum, which oxidizes propionate and other organic acids (ethanol, lactate, alcohols) to acetate, CO2, and H2, and Methanothermobacter thermautotrophicus, a hydrogen-utilizing thermophilic methanogen. P. thermopropionicum oxidizes propionate only in coculture with H2-using methanogens, as it uses protons as the electron acceptor with H2 as the electron sink product. The removal of H2 by M. thermautotrophicus is thermodynamically essential for continued propionate oxidation by P. thermopropionicum. This thermophilic syntrophic relationship is fundamental to understanding propionate degradation and methane production at elevated temperatures (55°C) in anaerobic environments such as thermophilic digesters and hot springs.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Pepper_Growth_Rhizosphere_SynCom.html"
+                       class="community-card"
+                       data-id="Pepper_Growth_Rhizosphere_SynCom"
+                       data-name="pepper growth rhizosphere syncom"
+                       data-description="a pepper seedling syncom treatment that enhances growth and root morphology by modulating rhizosphere microbial communities."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>Pepper Growth Rhizosphere SynCom</h2>
+                        <p class="description">A pepper seedling SynCom treatment that enhances growth and root morphology by modulating rhizosphere microbial communities.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Pepper_Phytophthora_SynCom5.html"
+                       class="community-card"
+                       data-id="Pepper_Phytophthora_SynCom5"
+                       data-name="pepper phytophthora-resistance syncom5"
+                       data-description="a five-isolate pepper rhizosphere syncom that reduces phytophthora capsici disease severity and enhances pepper growth."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Pepper Phytophthora-Resistance SynCom5</h2>
+                        <p class="description">A five-isolate pepper rhizosphere SynCom that reduces Phytophthora capsici disease severity and enhances pepper growth.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Phenol_Carboxylation_Consortium.html"
+                       class="community-card"
+                       data-id="Phenol_Carboxylation_Consortium"
+                       data-name="phenol carboxylation consortium"
+                       data-description="an obligate syntrophic 4-member consortium for anaerobic degradation of phenol via carboxylation to benzoate. the consortium consists of a short motile rod, a long non-motile rod, desulfovibrio sp., and methanospirillum sp. (methanogen). under methanogenic conditions (n2/co2), phenol is carboxylated to benzoate, which is then degraded to acetate, ch4, and co2. the three bacterial types exhibit obligate syntrophic interdependence with the methanogen for complete aromatic pollutant mineralization.
+"
+                       data-category="SYNTROPHY"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Phenol Carboxylation Consortium</h2>
+                        <p class="description">An obligate syntrophic 4-member consortium for anaerobic degradation of phenol via carboxylation to benzoate. The consortium consists of a short motile rod, a long non-motile rod, Desulfovibrio sp., and Methanospirillum sp. (methanogen). Under methanogenic conditions (N2/CO2), phenol is carboxylated to benzoate, which is then degraded to acetate, CH4, and CO2. The three bacterial types exhibit obligate syntrophic interdependence with the methanogen for complete aromatic pollutant mineralization.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Phormidium_Alkaline_Consortium.html"
+                       class="community-card"
+                       data-id="Phormidium_Alkaline_Consortium"
+                       data-name="phormidium alkaline consortium"
+                       data-description="a natural cyanobacterial-heterotrophic consortium dominated by candidatus phormidium alkaliphilum, isolated from soda lakes. this consortium represents a robust, stable community optimized for carbon sequestration in high-ph environments (ph &gt;11). the community includes 8-12 core members with 29 identified heterotrophic metagenome-assembled genomes spanning bacteroidota, alphaproteobacteria, gammaproteobacteria, verrucomicrobiota, patescibacteria, and planctomycetota. the consortium demonstrated exceptional stability with 4 years of crash-free growth in laboratory culture, maintaining biomass productivity of 15.2 g/m²/day. ecological interactions include carbon transfer from cyanobacteria to heterotrophs, nutrient remineralization, vitamin provision (b12, b1, b7), and functional niche partitioning that enhances community robustness. the consortium enables direct co2 capture from air at alkaline ph, making it highly relevant for biotechnological carbon sequestration applications. stable isotope probing with ¹³c-bicarbonate revealed tight coupling of carbon flux from primary production to heterotrophic populations, particularly wenzhouxiangella species.
+"
+                       data-category="CARBON_SEQUESTRATION"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="6">
+                        <h2>Phormidium Alkaline Consortium</h2>
+                        <p class="description">A natural cyanobacterial-heterotrophic consortium dominated by Candidatus Phormidium alkaliphilum, isolated from soda lakes. This consortium represents a robust, stable community optimized for carbon sequestration in high-pH environments (pH &gt;11). The community includes 8-12 core members with 29 identified heterotrophic metagenome-assembled genomes spanning Bacteroidota, Alphaproteobacteria, Gammaproteobacteria, Verrucomicrobiota, Patescibacteria, and Planctomycetota. The consortium demonstrated exceptional stability with 4 years of crash-free growth in laboratory culture, maintaining biomass productivity of 15.2 g/m²/day. Ecological interactions include carbon transfer from cyanobacteria to heterotrophs, nutrient remineralization, vitamin provision (B12, B1, B7), and functional niche partitioning that enhances community robustness. The consortium enables direct CO2 capture from air at alkaline pH, making it highly relevant for biotechnological carbon sequestration applications. Stable isotope probing with ¹³C-bicarbonate revealed tight coupling of carbon flux from primary production to heterotrophic populations, particularly Wenzhouxiangella species.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    6
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">CARBON_SEQUESTRATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Phylogenetically_Diverse_Denitrifying_SynCom.html"
+                       class="community-card"
+                       data-id="Phylogenetically_Diverse_Denitrifying_SynCom"
+                       data-name="phylogenetically diverse denitrifying syncom"
+                       data-description="closely related and distantly related synthetic denitrifying communities used to test how phylogenetic diversity affects denitrification and stability."
+                       data-category="BIOREMEDIATION"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Phylogenetically Diverse Denitrifying SynCom</h2>
+                        <p class="description">Closely related and distantly related synthetic denitrifying communities used to test how phylogenetic diversity affects denitrification and stability.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Polaromonas_Vanadium_Reduction_Community.html"
+                       class="community-card"
+                       data-id="Polaromonas_Vanadium_Reduction_Community"
+                       data-name="polaromonas vanadium reduction community"
+                       data-description="a microbial community from vanadium mine tailings in northern china capable of reducing toxic soluble vanadate [v(v)] to less soluble vanadyl [v(iv)], facilitating vanadium detoxification and immobilization. this community is dominated by polaromonas species (burkholderiaceae family, up to 46% relative abundance in tailings) that perform dissimilatory v(v) reduction using genes homologous to iron and metal reduction pathways (cyma, omca, narg). the tailings harbor diverse metal-reducing bacteria including sulfate reducers (desulfovibrio, desulfitobacterium) and iron-reducing proteobacteria (geobacter-related organisms) that contribute to reductive immobilization of vanadium and co-occurring metals. v(v) reduction to v(iv) decreases vanadium solubility by 2-3 orders of magnitude, transforming mobile vanadate into sparingly soluble vanadyl species and v(iv)-containing minerals. the community is enriched from highly contaminated mine tailings with total vanadium concentrations reaching 10,500 mg/kg and bioavailable v(v) at 15-25 mg/l in pore water. under anaerobic conditions with electron donors (lactate, acetate, hydrogen), the community achieves 60-85% v(v) reduction within 7-14 days. genes encoding c-type cytochromes (cyma, omca), nitrate reductases (narg, napa), and arsenate reductases (arra) mediate v(v) reduction through outer membrane electron transfer pathways. this represents the first demonstration of microbial v(v) reduction in circumneutral ph mine tailings, providing a biological approach for vanadium immobilization and mine remediation. the system is particularly relevant for emerging vanadium contamination from steel production, petroleum processing, and vanadium redox flow battery manufacturing.
+"
+                       data-category="OTHER"
+                       data-state="PERTURBED"
+                       data-metals="CHROMIUM,IRON,VANADIUM"
+                       data-ree=""
+                       data-relevance="INCIDENTAL"
+                       data-member-count="4">
+                        <h2>Polaromonas Vanadium Reduction Community</h2>
+                        <p class="description">A microbial community from vanadium mine tailings in northern China capable of reducing toxic soluble vanadate [V(V)] to less soluble vanadyl [V(IV)], facilitating vanadium detoxification and immobilization. This community is dominated by Polaromonas species (Burkholderiaceae family, up to 46% relative abundance in tailings) that perform dissimilatory V(V) reduction using genes homologous to iron and metal reduction pathways (cymA, omcA, narG). The tailings harbor diverse metal-reducing bacteria including sulfate reducers (Desulfovibrio, Desulfitobacterium) and iron-reducing Proteobacteria (Geobacter-related organisms) that contribute to reductive immobilization of vanadium and co-occurring metals. V(V) reduction to V(IV) decreases vanadium solubility by 2-3 orders of magnitude, transforming mobile vanadate into sparingly soluble vanadyl species and V(IV)-containing minerals. The community is enriched from highly contaminated mine tailings with total vanadium concentrations reaching 10,500 mg/kg and bioavailable V(V) at 15-25 mg/L in pore water. Under anaerobic conditions with electron donors (lactate, acetate, hydrogen), the community achieves 60-85% V(V) reduction within 7-14 days. Genes encoding c-type cytochromes (cymA, omcA), nitrate reductases (narG, napA), and arsenate reductases (arrA) mediate V(V) reduction through outer membrane electron transfer pathways. This represents the first demonstration of microbial V(V) reduction in circumneutral pH mine tailings, providing a biological approach for vanadium immobilization and mine remediation. The system is particularly relevant for emerging vanadium contamination from steel production, petroleum processing, and vanadium redox flow battery manufacturing.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Populus_Salt_Tolerant_SynComs.html"
+                       class="community-card"
+                       data-id="Populus_Salt_Tolerant_SynComs"
+                       data-name="populus salt-tolerant rhizosphere syncoms"
+                       data-description="function-driven populus rhizosphere syncoms selected from high-salt soil to improve salt resistance in hybrid poplar."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>Populus Salt-Tolerant Rhizosphere SynComs</h2>
+                        <p class="description">Function-driven Populus rhizosphere SynComs selected from high-salt soil to improve salt resistance in hybrid poplar.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.html"
+                       class="community-card"
+                       data-id="Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community"
+                       data-name="prairie pothole wetland sulfur-carbon virus-host community"
+                       data-description="natural wetland sediment microbial and viral communities from the prairie pothole region of north america, curated around genome-resolved metagenomic evidence for high-rate sulfur and carbon cycling. the study recovered sulfate-reduction marker genes, candidate sulfate-reducing genomes, methanogenesis marker genes, putative methanogen genomes, and abundant novel viral populations predicted to target dominant sulfate reducers and methanogens. the community is doe-relevant because dna sequencing and analysis were conducted by the doe joint genome institute and because the system links wetland methane emissions, sulfate reduction, carbon mineralization, and virus-host controls.
+"
+                       data-category="METHANOGENESIS"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Prairie Pothole Wetland Sulfur-Carbon Virus-Host Community</h2>
+                        <p class="description">Natural wetland sediment microbial and viral communities from the Prairie Pothole Region of North America, curated around genome-resolved metagenomic evidence for high-rate sulfur and carbon cycling. The study recovered sulfate-reduction marker genes, candidate sulfate-reducing genomes, methanogenesis marker genes, putative methanogen genomes, and abundant novel viral populations predicted to target dominant sulfate reducers and methanogens. The community is DOE-relevant because DNA sequencing and analysis were conducted by the DOE Joint Genome Institute and because the system links wetland methane emissions, sulfate reduction, carbon mineralization, and virus-host controls.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">METHANOGENESIS</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.html"
+                       class="community-card"
+                       data-id="Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community"
+                       data-name="premature infant gut escherichia in-situ physiological-condition community"
+                       data-description="a premature infant gut microbiome study that combines metagenomic and metatranscriptomic sequencing to probe the in situ physiological conditions experienced by escherichia spp. in four premature infants (two of whom developed necrotizing enterocolitis, nec). twenty fecal samples spanning 4-6 time points per infant were analyzed using sample-specific metagenome-assembled genomes (mags) as references for transcript mapping, and a &#34;diametric ratio&#34; method that compares transcript ratios of genes with opposite transcription responses to eliminate biases related to organism abundance. diametric ratios of genes associated with low oxygen levels were significantly higher in samples from infants later diagnosed with nec than in samples without nec, and the method extends to other physiological conditions such as nitric oxide exposure and osmotic pressure.
+"
+                       data-category="OTHER"
+                       data-state="PERTURBED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>Premature Infant Gut Escherichia In-Situ Physiological-Condition Community</h2>
+                        <p class="description">A premature infant gut microbiome study that combines metagenomic and metatranscriptomic sequencing to probe the in situ physiological conditions experienced by Escherichia spp. in four premature infants (two of whom developed necrotizing enterocolitis, NEC). Twenty fecal samples spanning 4-6 time points per infant were analyzed using sample-specific metagenome-assembled genomes (MAGs) as references for transcript mapping, and a &#34;diametric ratio&#34; method that compares transcript ratios of genes with opposite transcription responses to eliminate biases related to organism abundance. Diametric ratios of genes associated with low oxygen levels were significantly higher in samples from infants later diagnosed with NEC than in samples without NEC, and the method extends to other physiological conditions such as nitric oxide exposure and osmotic pressure.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Prochlorococcus_Alteromonas_Helper_Coculture.html"
+                       class="community-card"
+                       data-id="Prochlorococcus_Alteromonas_Helper_Coculture"
+                       data-name="prochlorococcus-alteromonas helper coculture"
+                       data-description="a defined marine phototroph-heterotroph coculture in which the cyanobacterium prochlorococcus marinus mit9312 is paired with the heterotrophic helper bacterium alteromonas macleodii ez55. the system models an ocean-surface interaction where prochlorococcus is vulnerable to hydrogen peroxide because it lacks catalase, while alteromonas removes reactive oxygen species and thereby expands the conditions under which prochlorococcus can grow. elevated carbon dioxide perturbs this interaction by reducing alteromonas catalase expression and hydrogen peroxide removal."
+                       data-category="PHYTOPLANKTON"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Prochlorococcus-Alteromonas Helper Coculture</h2>
+                        <p class="description">A defined marine phototroph-heterotroph coculture in which the cyanobacterium Prochlorococcus marinus MIT9312 is paired with the heterotrophic helper bacterium Alteromonas macleodii EZ55. The system models an ocean-surface interaction where Prochlorococcus is vulnerable to hydrogen peroxide because it lacks catalase, while Alteromonas removes reactive oxygen species and thereby expands the conditions under which Prochlorococcus can grow. Elevated carbon dioxide perturbs this interaction by reducing Alteromonas catalase expression and hydrogen peroxide removal.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">PHYTOPLANKTON</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.html"
+                       class="community-card"
+                       data-id="Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment"
+                       data-name="propanotrophic chlorinated ethene cometabolism enrichment cultures"
+                       data-description="propane-enriched aerobic mixed cultures derived from three michigan state university long-term ecological research agricultural soils (soils t2, t3, t4) and from impacted-site sediment at a west coast naval station (site 1), evaluated for cometabolic biodegradation of three chlorinated ethenes - trichloroethene (tce), cis-1,2-dichloroethene (cdce), and 1,1-dichloroethene (1,1-dce) - in the presence of propane as growth substrate. substrate-specific selection drove distinct dominance patterns: cdce-amended cultures were dominated by mycolicibacterium followed by mycobacterium, tce-amended cultures were dominated by rhodococcus (r. opacus or r. wratislaviensis from agricultural soils; mycolicibacterium/mycobacterium/rhodococcus mixture from the impacted site sediment), and the subset of 1,1-dce-degrading cultures was dominated by pseudonocardia (with a truncated propane monooxygenase alpha subunit suggesting alternative enzymes drive 1,1-dce transformation). the enrichments express group 5 (prmabcd) and putative group 6 propane monooxygenases. the system supports development of propane-based bioaugmentation strategies for mixed chlorinated solvent contamination under aerobic conditions.
+"
+                       data-category="BIOREMEDIATION"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="8">
+                        <h2>Propanotrophic Chlorinated Ethene Cometabolism Enrichment Cultures</h2>
+                        <p class="description">Propane-enriched aerobic mixed cultures derived from three Michigan State University Long-Term Ecological Research agricultural soils (Soils T2, T3, T4) and from impacted-site sediment at a West Coast Naval Station (Site 1), evaluated for cometabolic biodegradation of three chlorinated ethenes - trichloroethene (TCE), cis-1,2-dichloroethene (cDCE), and 1,1-dichloroethene (1,1-DCE) - in the presence of propane as growth substrate. Substrate-specific selection drove distinct dominance patterns: cDCE-amended cultures were dominated by Mycolicibacterium followed by Mycobacterium, TCE-amended cultures were dominated by Rhodococcus (R. opacus or R. wratislaviensis from agricultural soils; Mycolicibacterium/Mycobacterium/Rhodococcus mixture from the impacted site sediment), and the subset of 1,1-DCE-degrading cultures was dominated by Pseudonocardia (with a truncated propane monooxygenase alpha subunit suggesting alternative enzymes drive 1,1-DCE transformation). The enrichments express group 5 (prmABCD) and putative group 6 propane monooxygenases. The system supports development of propane-based bioaugmentation strategies for mixed chlorinated solvent contamination under aerobic conditions.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    8
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Pseudomonas_Pedobacter_Social_Spreading_Coculture.html"
+                       class="community-card"
+                       data-id="Pseudomonas_Pedobacter_Social_Spreading_Coculture"
+                       data-name="pseudomonas-pedobacter social spreading coculture"
+                       data-description="a two-species soil-bacterial model community composed of pseudomonas fluorescens pf0-1 and pedobacter sp. v48. when mixed on low-nutrient, high-salt hard agar, the two sessile monocultures produce an emergent interspecies social spreading phenotype in which both bacteria comigrate across the agar surface. the system is used to study contact-dependent and environment-dependent emergent motility in small soil microbial communities.
+"
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Pseudomonas-Pedobacter Social Spreading Coculture</h2>
+                        <p class="description">A two-species soil-bacterial model community composed of Pseudomonas fluorescens Pf0-1 and Pedobacter sp. V48. When mixed on low-nutrient, high-salt hard agar, the two sessile monocultures produce an emergent interspecies social spreading phenotype in which both bacteria comigrate across the agar surface. The system is used to study contact-dependent and environment-dependent emergent motility in small soil microbial communities.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Pseudomonas_Rhodococcus_Chloronitrobenzene_Coculture.html"
+                       class="community-card"
+                       data-id="Pseudomonas_Rhodococcus_Chloronitrobenzene_Coculture"
+                       data-name="pseudomonas-rhodococcus chloronitrobenzene coculture"
+                       data-description="a defined two-member aerobic laboratory coculture for chloronitrobenzene bioremediation. pseudomonas putida hs12 was isolated using nitrobenzene enrichment and performs the first partial reductive and acetylation steps on 3- and 4-chloronitrobenzene. rhodococcus sp. strain hs51 degrades the chlorohydroxyacetanilide intermediates, allowing the coculture to mineralize 3- and 4-chloronitrobenzenes when an additional carbon source is supplied.
+"
+                       data-category="BIOREMEDIATION"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Pseudomonas-Rhodococcus Chloronitrobenzene Coculture</h2>
+                        <p class="description">A defined two-member aerobic laboratory coculture for chloronitrobenzene bioremediation. Pseudomonas putida HS12 was isolated using nitrobenzene enrichment and performs the first partial reductive and acetylation steps on 3- and 4-chloronitrobenzene. Rhodococcus sp. strain HS51 degrades the chlorohydroxyacetanilide intermediates, allowing the coculture to mineralize 3- and 4-chloronitrobenzenes when an additional carbon source is supplied.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Pseudonitzschia_Sulfitobacter_Association.html"
+                       class="community-card"
+                       data-id="Pseudonitzschia_Sulfitobacter_Association"
+                       data-name="pseudo-nitzschia-sulfitobacter marine association"
+                       data-description="a mutualistic marine diatom-bacteria association between pseudo-nitzschia multiseries and sulfitobacter sp. sa11, mediated by auxin and tryptophan signaling. the diatom produces tryptophan and taurine, which the bacterium uses to synthesize indole-3-acetic acid (iaa) auxin that promotes diatom growth. the bacterium also secretes ammonia as a nitrogen source. this interaction is widespread in ocean ecosystems and plays a significant role in carbon cycling and primary production.
+"
+                       data-category="PHYTOPLANKTON"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="2">
+                        <h2>Pseudo-nitzschia-Sulfitobacter Marine Association</h2>
+                        <p class="description">A mutualistic marine diatom-bacteria association between Pseudo-nitzschia multiseries and Sulfitobacter sp. SA11, mediated by auxin and tryptophan signaling. The diatom produces tryptophan and taurine, which the bacterium uses to synthesize indole-3-acetic acid (IAA) auxin that promotes diatom growth. The bacterium also secretes ammonia as a nitrogen source. This interaction is widespread in ocean ecosystems and plays a significant role in carbon cycling and primary production.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">PHYTOPLANKTON</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Rammelsberg_Cobalt_Nickel_Tailings.html"
+                       class="community-card"
+                       data-id="Rammelsberg_Cobalt_Nickel_Tailings"
+                       data-name="rammelsberg cobalt-nickel tailings consortium"
+                       data-description="a mesophilic acidophilic bacterial consortium applied to bioleach cobalt, copper, and other valuable metals from sulfidic mine tailings at the rammelsberg polymetallic massive sulfide deposit in the harz mountains, germany. this consortium represents one of the only industrial-scale cobalt bioleaching processes globally and demonstrates exceptional efficiency in recovering critical battery materials from low-grade mine tailings. the adapted microbial community consists mainly of acidithiobacillus ferrooxidans (iron-oxidizing) and acidithiobacillus thiooxidans (sulfur-oxidizing), achieving 91% cobalt and 57% copper extraction from bulk tailings (co 0.02%, cu 0.12%) after 13 days in stirred tank reactors at 10% pulp density. the consortium exhibits synergistic cooperation between iron and sulfur oxidizers, where iron oxidation by at. ferrooxidans generates ferric iron that chemically oxidizes sulfide minerals, while sulfur oxidation by at. thiooxidans prevents elemental sulfur passivation and maintains low ph through sulfuric acid production. mineralogical analysis revealed that cobalt occurs on the surface of framboidal pyrite and is mobilized through microbial attack. this system demonstrates the biotechnological potential for recovering critical materials (cobalt, copper, nickel) from mine waste through environmentally sustainable bioprocessing, addressing both resource recovery and mine tailings remediation challenges relevant to the circular economy and battery supply chains.
+"
+                       data-category="BIOMINING"
+                       data-state="ENGINEERED"
+                       data-metals="COBALT,COPPER,IRON,NICKEL"
+                       data-ree=""
+                       data-relevance="PRIMARY"
+                       data-member-count="2">
+                        <h2>Rammelsberg Cobalt-Nickel Tailings Consortium</h2>
+                        <p class="description">A mesophilic acidophilic bacterial consortium applied to bioleach cobalt, copper, and other valuable metals from sulfidic mine tailings at the Rammelsberg polymetallic massive sulfide deposit in the Harz Mountains, Germany. This consortium represents one of the only industrial-scale cobalt bioleaching processes globally and demonstrates exceptional efficiency in recovering critical battery materials from low-grade mine tailings. The adapted microbial community consists mainly of Acidithiobacillus ferrooxidans (iron-oxidizing) and Acidithiobacillus thiooxidans (sulfur-oxidizing), achieving 91% cobalt and 57% copper extraction from bulk tailings (Co 0.02%, Cu 0.12%) after 13 days in stirred tank reactors at 10% pulp density. The consortium exhibits synergistic cooperation between iron and sulfur oxidizers, where iron oxidation by At. ferrooxidans generates ferric iron that chemically oxidizes sulfide minerals, while sulfur oxidation by At. thiooxidans prevents elemental sulfur passivation and maintains low pH through sulfuric acid production. Mineralogical analysis revealed that cobalt occurs on the surface of framboidal pyrite and is mobilized through microbial attack. This system demonstrates the biotechnological potential for recovering critical materials (cobalt, copper, nickel) from mine waste through environmentally sustainable bioprocessing, addressing both resource recovery and mine tailings remediation challenges relevant to the circular economy and battery supply chains.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOMINING</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.html"
+                       class="community-card"
+                       data-id="Rhodopseudomonas_Ecoli_CrossFeeding_Coculture"
+                       data-name="rhodopseudomonas-e. coli cross-feeding coculture"
+                       data-description="a reciprocal cross-feeding coculture pairing n2-fixing rhodopseudomonas palustris with fermentative escherichia coli."
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Rhodopseudomonas-E. coli Cross-Feeding Coculture</h2>
+                        <p class="description">A reciprocal cross-feeding coculture pairing N2-fixing Rhodopseudomonas palustris with fermentative Escherichia coli.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.html"
+                       class="community-card"
+                       data-id="Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture"
+                       data-name="rhodopseudomonas-geobacter magnetite redox coculture"
+                       data-description="a defined laboratory coculture in which the phototrophic fe(ii)-oxidizing bacterium rhodopseudomonas palustris tie-1 and the anaerobic fe(iii)-reducing bacterium geobacter sulfurreducens cycle electrons through magnetite. the system demonstrates that mixed-valence magnetite can act as a recyclable electron donor and electron acceptor, effectively functioning as a naturally occurring biogeochemical battery under changing light and redox conditions. this community is doe-relevant because mineral-mediated electron flow shapes subsurface elemental cycling and can influence contaminant fate in sediments, aquifers, and engineered remediation settings.
+"
+                       data-category="METAL_REDUCTION"
+                       data-state="ENGINEERED"
+                       data-metals="IRON"
+                       data-ree=""
+                       data-relevance="PRIMARY"
+                       data-member-count="2">
+                        <h2>Rhodopseudomonas-Geobacter Magnetite Redox Coculture</h2>
+                        <p class="description">A defined laboratory coculture in which the phototrophic Fe(II)-oxidizing bacterium Rhodopseudomonas palustris TIE-1 and the anaerobic Fe(III)-reducing bacterium Geobacter sulfurreducens cycle electrons through magnetite. The system demonstrates that mixed-valence magnetite can act as a recyclable electron donor and electron acceptor, effectively functioning as a naturally occurring biogeochemical battery under changing light and redox conditions. This community is DOE-relevant because mineral-mediated electron flow shapes subsurface elemental cycling and can influence contaminant fate in sediments, aquifers, and engineered remediation settings.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">METAL_REDUCTION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Rice_Acid_Soil_Bioinoculant_SynCom.html"
+                       class="community-card"
+                       data-id="Rice_Acid_Soil_Bioinoculant_SynCom"
+                       data-name="rice acid soil bioinoculant syncom"
+                       data-description="a customized rhizosphere-competent bacterial syncom used as a bioinoculant to improve rice production in acid soils."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>Rice Acid Soil Bioinoculant SynCom</h2>
+                        <p class="description">A customized rhizosphere-competent bacterial SynCom used as a bioinoculant to improve rice production in acid soils.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Rice_Duckweed_Bacillus_SynCom.html"
+                       class="community-card"
+                       data-id="Rice_Duckweed_Bacillus_SynCom"
+                       data-name="rice-duckweed bacillus biocontrol syncom"
+                       data-description="an 8-member, bacillus-dominated synthetic community (syncom) assembled from a rice-duckweed agroecosystem by targeting taxa consistently shared across soil, root and shoot niches. the syncom concurrently promotes rice growth and suppresses sheath blight caused by rhizoctonia solani, reducing the final disease index by 70% without detectable phytotoxicity. leave-one-member perturbations reveal a division-of-labor architecture: individual strains specialize in auxin production, siderophore-linked iron mobilization, or lipopeptide/polyketide-based antagonism, yielding complementary yet partially redundant contributions that render community performance resilient to single-member loss. 8 members total; strain-level identifiers available in supplementary data."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="INCIDENTAL"
+                       data-member-count="4">
+                        <h2>Rice-Duckweed Bacillus Biocontrol SynCom</h2>
+                        <p class="description">An 8-member, Bacillus-dominated synthetic community (SynCom) assembled from a rice-duckweed agroecosystem by targeting taxa consistently shared across soil, root and shoot niches. The SynCom concurrently promotes rice growth and suppresses sheath blight caused by Rhizoctonia solani, reducing the final disease index by 70% without detectable phytotoxicity. Leave-one-member perturbations reveal a division-of-labor architecture: individual strains specialize in auxin production, siderophore-linked iron mobilization, or lipopeptide/polyketide-based antagonism, yielding complementary yet partially redundant contributions that render community performance resilient to single-member loss. 8 members total; strain-level identifiers available in supplementary data.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Rice_P_Uptake_Intercropping_SynCom4.html"
+                       class="community-card"
+                       data-id="Rice_P_Uptake_Intercropping_SynCom4"
+                       data-name="rice phosphorus uptake intercropping syncom4"
+                       data-description="a four-strain rice rhizosphere syncom from intercropping systems that enhances biomass and phosphorus uptake."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Rice Phosphorus Uptake Intercropping SynCom4</h2>
+                        <p class="description">A four-strain rice rhizosphere SynCom from intercropping systems that enhances biomass and phosphorus uptake.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Richmond_Mine_AMD_Biofilm.html"
+                       class="community-card"
+                       data-id="Richmond_Mine_AMD_Biofilm"
+                       data-name="richmond mine amd biofilm"
+                       data-description="a thick, subaerial biofilm community from the richmond mine at iron mountain, california, representing one of the most extreme acid mine drainage (amd) environments on earth. this predominantly lithotrophic biofilm thrives at extraordinarily low ph (0.5-1.0) with temperatures ranging from 30-50°c and metal ion concentrations in the decagrams per liter range. the community is dominated by iron-oxidizing bacteria (leptospirillum spp.) and archaea (ferroplasma acidarmanus) that drive pyrite dissolution through ferric iron generation. leptospirillum group ii comprises 71% of detected clones, with ferroplasma reaching up to 85% of cells in highly acidic microniches. the biofilm also contains nitrogen-fixing leptospirillum group iii (l. ferrodiazotrophum), making it a keystone species in this nitrogen-limited ecosystem. ultra-small arman archaea (micrarchaeota and parvarchaeota) with genome sizes ~1 mb represent novel lineages found at 5-25% relative abundance. the community oxidizes approximately 1-2 × 10⁵ moles of pyrite per day, generating extreme acidity and solubilizing metals including iron (up to 24 g/l), zinc (several g/l), and copper (hundreds mg/l). this natural biofilm serves as a model system for understanding microbial life at ph extremes and has implications for biomining, bioremediation, and astrobiology.
+"
+                       data-category="AMD"
+                       data-state="STABLE"
+                       data-metals="COPPER,IRON,ZINC"
+                       data-ree=""
+                       data-relevance="PRIMARY"
+                       data-member-count="6">
+                        <h2>Richmond Mine AMD Biofilm</h2>
+                        <p class="description">A thick, subaerial biofilm community from the Richmond Mine at Iron Mountain, California, representing one of the most extreme acid mine drainage (AMD) environments on Earth. This predominantly lithotrophic biofilm thrives at extraordinarily low pH (0.5-1.0) with temperatures ranging from 30-50°C and metal ion concentrations in the decagrams per liter range. The community is dominated by iron-oxidizing bacteria (Leptospirillum spp.) and archaea (Ferroplasma acidarmanus) that drive pyrite dissolution through ferric iron generation. Leptospirillum group II comprises 71% of detected clones, with Ferroplasma reaching up to 85% of cells in highly acidic microniches. The biofilm also contains nitrogen-fixing Leptospirillum group III (L. ferrodiazotrophum), making it a keystone species in this nitrogen-limited ecosystem. Ultra-small ARMAN archaea (Micrarchaeota and Parvarchaeota) with genome sizes ~1 Mb represent novel lineages found at 5-25% relative abundance. The community oxidizes approximately 1-2 × 10⁵ moles of pyrite per day, generating extreme acidity and solubilizing metals including iron (up to 24 g/L), zinc (several g/L), and copper (hundreds mg/L). This natural biofilm serves as a model system for understanding microbial life at pH extremes and has implications for biomining, bioremediation, and astrobiology.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    6
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">AMD</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Rifle_Aquifer_Bioanode_EET_Community.html"
+                       class="community-card"
+                       data-id="Rifle_Aquifer_Bioanode_EET_Community"
+                       data-name="rifle aquifer bioanode extracellular electron transfer community"
+                       data-description="an electroactive microbial community established and maintained for almost four years in microbial electrochemical cells (mxcs) inoculated with a well-studied aquifer near rifle, co. anodes were poised mostly at -0.2 to -0.25 v vs she to mimic iron-oxide mineral redox potentials, with acetate as the sole carbon source. genome-resolved metagenomics of two biofilm and 26 planktonic samples yielded 84 bacterial and 2 archaeal near-complete draft genomes. a novel geobacter sp. with at least 72 putative multiheme c-type cytochromes dominated the electrode-attached community, while diverse other organisms (actinobacteria, ignavibacteria, chloroflexi, acidobacteria, firmicutes, beta- and gammaproteobacteria) also encoded multiheme cytochromes, porin-cytochrome complexes, and electrically conductive pili (e-pili), identifying a small subset of rifle aquifer organisms that may mediate mineral redox transformations.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals="IRON"
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="7">
+                        <h2>Rifle Aquifer Bioanode Extracellular Electron Transfer Community</h2>
+                        <p class="description">An electroactive microbial community established and maintained for almost four years in microbial electrochemical cells (MXCs) inoculated with a well-studied aquifer near Rifle, CO. Anodes were poised mostly at -0.2 to -0.25 V vs SHE to mimic iron-oxide mineral redox potentials, with acetate as the sole carbon source. Genome-resolved metagenomics of two biofilm and 26 planktonic samples yielded 84 bacterial and 2 archaeal near-complete draft genomes. A novel Geobacter sp. with at least 72 putative multiheme c-type cytochromes dominated the electrode-attached community, while diverse other organisms (Actinobacteria, Ignavibacteria, Chloroflexi, Acidobacteria, Firmicutes, Beta- and Gammaproteobacteria) also encoded multiheme cytochromes, porin-cytochrome complexes, and electrically conductive pili (e-pili), identifying a small subset of Rifle aquifer organisms that may mediate mineral redox transformations.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    7
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Rifle_Uranium_Reducing_Community.html"
+                       class="community-card"
+                       data-id="Rifle_Uranium_Reducing_Community"
+                       data-name="rifle uranium-reducing community"
+                       data-description="a microbial community stimulated for in situ bioremediation of uranium-contaminated groundwater at the old rifle site in rifle, colorado. this aquifer community demonstrates sequential reduction processes following acetate biostimulation at 1-3 mm concentrations. the community transitions through distinct metabolic phases: phase i (days 0-50) dominated by geobacter species (up to 89% of community) performing fe(iii) reduction coupled to u(vi) reduction, achieving 70% uranium removal within 50 days and reducing concentrations below the epa treatment goal of 0.18 μm in some wells. phase ii (&gt;50 days) shifts to sulfate-reducing bacteria including desulfobacteraceae (45% by day 80), desulfosporosinus, and desulfotomaculum acetoxidans as fe(iii) becomes depleted. geobacter metallireducens and anaeromyxobacter dehalogenans reduce soluble u(vi) to insoluble u(iv), forming biogenic uraninite nanoparticles that immobilize uranium. desulfovibrio species contribute to uranium reduction through enzymatic pathways while generating hydrogen sulfide that can chemically reduce uranium. this represents the first successful field demonstration of uranium bioremediation via stimulating subsurface geobacter populations, providing an alternative to pump-and-treat remediation. groundwater flow rate is 0.82 m/day, creating dynamic conditions where microbial metabolism must outpace uranium advection.
+"
+                       data-category="BIOREMEDIATION"
+                       data-state="PERTURBED"
+                       data-metals="IRON,URANIUM"
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="5">
+                        <h2>Rifle Uranium-Reducing Community</h2>
+                        <p class="description">A microbial community stimulated for in situ bioremediation of uranium-contaminated groundwater at the Old Rifle site in Rifle, Colorado. This aquifer community demonstrates sequential reduction processes following acetate biostimulation at 1-3 mM concentrations. The community transitions through distinct metabolic phases: Phase I (days 0-50) dominated by Geobacter species (up to 89% of community) performing Fe(III) reduction coupled to U(VI) reduction, achieving 70% uranium removal within 50 days and reducing concentrations below the EPA treatment goal of 0.18 μM in some wells. Phase II (&gt;50 days) shifts to sulfate-reducing bacteria including Desulfobacteraceae (45% by day 80), Desulfosporosinus, and Desulfotomaculum acetoxidans as Fe(III) becomes depleted. Geobacter metallireducens and Anaeromyxobacter dehalogenans reduce soluble U(VI) to insoluble U(IV), forming biogenic uraninite nanoparticles that immobilize uranium. Desulfovibrio species contribute to uranium reduction through enzymatic pathways while generating hydrogen sulfide that can chemically reduce uranium. This represents the first successful field demonstration of uranium bioremediation via stimulating subsurface Geobacter populations, providing an alternative to pump-and-treat remediation. Groundwater flow rate is 0.82 m/day, creating dynamic conditions where microbial metabolism must outpace uranium advection.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    5
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/SF356_Cellulose_Degrader.html"
+                       class="community-card"
+                       data-id="SF356_Cellulose_Degrader"
+                       data-name="sf356 thermophilic cellulose-degrading community"
+                       data-description="a stable thermophilic cellulose-degrading consortium (sf356) from composting systems, consisting of five bacterial strains: clostridium straminisolvens csk1, clostridium sp. fg4, pseudoxanthomonas sp. m1-3, brevibacillus sp. m1-5, and bordetella sp. m1-6. the community exhibits both functional and structural stability over 20 subcultures at 50°c. synergistic interactions occur between the anaerobic cellulolytic clostridium and aerobic bacteria, where aerobes create anaerobic conditions while receiving acetate and glucose from cellulose fermentation.
+"
+                       data-category="LIGNOCELLULOSE"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="5">
+                        <h2>SF356 Thermophilic Cellulose-Degrading Community</h2>
+                        <p class="description">A stable thermophilic cellulose-degrading consortium (SF356) from composting systems, consisting of five bacterial strains: Clostridium straminisolvens CSK1, Clostridium sp. FG4, Pseudoxanthomonas sp. M1-3, Brevibacillus sp. M1-5, and Bordetella sp. M1-6. The community exhibits both functional and structural stability over 20 subcultures at 50°C. Synergistic interactions occur between the anaerobic cellulolytic Clostridium and aerobic bacteria, where aerobes create anaerobic conditions while receiving acetate and glucose from cellulose fermentation.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    5
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/SIHUMIx_Human_Intestinal_Model_Community.html"
+                       class="community-card"
+                       data-id="SIHUMIx_Human_Intestinal_Model_Community"
+                       data-name="sihumix human intestinal model community"
+                       data-description="sihumix is an extended simplified human intestinal microbiota consisting of eight bacterial strains used as a reduced-complexity in vitro model of the human gut microbiome. the community includes common intestinal anaerobes and facultative bacteria spanning major gut-associated lineages, and it is maintained under anaerobic bioreactor conditions in complex intestinal medium. sihumix supports controlled metaproteomic, metabolomic, metatranscriptomic, and community stability studies, including analysis of short-chain fatty acid output and community-specific small proteins.
+"
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="8">
+                        <h2>SIHUMIx Human Intestinal Model Community</h2>
+                        <p class="description">SIHUMIx is an extended simplified human intestinal microbiota consisting of eight bacterial strains used as a reduced-complexity in vitro model of the human gut microbiome. The community includes common intestinal anaerobes and facultative bacteria spanning major gut-associated lineages, and it is maintained under anaerobic bioreactor conditions in complex intestinal medium. SIHUMIx supports controlled metaproteomic, metabolomic, metatranscriptomic, and community stability studies, including analysis of short-chain fatty acid output and community-specific small proteins.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    8
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/SMutans_CAlbicans_ECC_Biofilm.html"
+                       class="community-card"
+                       data-id="SMutans_CAlbicans_ECC_Biofilm"
+                       data-name="streptococcus mutans - candida albicans ecc biofilm model"
+                       data-description="a defined cross-kingdom dual-species plaque biofilm model capturing the synergistic virulence of streptococcus mutans and candida albicans in early childhood caries. coinfection produces an eps-rich biofilm with higher biomass, larger microcolonies, and more severe carious lesions than either species alone."
+                       data-category="ORAL"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Streptococcus mutans - Candida albicans ECC Biofilm Model</h2>
+                        <p class="description">A defined cross-kingdom dual-species plaque biofilm model capturing the synergistic virulence of Streptococcus mutans and Candida albicans in early childhood caries. Coinfection produces an EPS-rich biofilm with higher biomass, larger microcolonies, and more severe carious lesions than either species alone.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">ORAL</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/SMutans_SSputigena_ECC_Pathobiont.html"
+                       class="community-card"
+                       data-id="SMutans_SSputigena_ECC_Pathobiont"
+                       data-name="streptococcus mutans - selenomonas sputigena ecc pathobiont model"
+                       data-description="a defined dual-species oral biofilm model derived from early childhood caries discovery-validation work. selenomonas sputigena becomes trapped within streptococcus mutans exoglucans, builds a honeycomb-like multicellular superstructure, enhances acidogenesis, and increases enamel lesion severity in vivo."
+                       data-category="ORAL"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Streptococcus mutans - Selenomonas sputigena ECC Pathobiont Model</h2>
+                        <p class="description">A defined dual-species oral biofilm model derived from early childhood caries discovery-validation work. Selenomonas sputigena becomes trapped within Streptococcus mutans exoglucans, builds a honeycomb-like multicellular superstructure, enhances acidogenesis, and increases enamel lesion severity in vivo.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">ORAL</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/SMutans_VParvula_ASC_Biofilm.html"
+                       class="community-card"
+                       data-id="SMutans_VParvula_ASC_Biofilm"
+                       data-name="streptococcus mutans - veillonella parvula adult severe caries model"
+                       data-description="a defined dual-species oral biofilm model for adult severe caries pairing streptococcus mutans with the asc-associated pathobiont veillonella parvula. the coculture increases mature biofilm formation, acid resistance, oxidative stress tolerance, and rodent caries severity relative to streptococcus mutans alone."
+                       data-category="ORAL"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Streptococcus mutans - Veillonella parvula Adult Severe Caries Model</h2>
+                        <p class="description">A defined dual-species oral biofilm model for adult severe caries pairing Streptococcus mutans with the ASC-associated pathobiont Veillonella parvula. The coculture increases mature biofilm formation, acid resistance, oxidative stress tolerance, and rodent caries severity relative to Streptococcus mutans alone.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">ORAL</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/SPRUCE_Peatland_Methane_Cycling_Community.html"
+                       class="community-card"
+                       data-id="SPRUCE_Peatland_Methane_Cycling_Community"
+                       data-name="spruce peatland methane-cycling microbial community"
+                       data-description="a natural peatland microbial community studied in the doe-supported spruce whole-ecosystem warming experiment at the s1 bog in northern minnesota. the community inhabits acidic, carbon-rich, waterlogged peat and mediates terminal anaerobic carbon turnover, including acetoclastic and hydrogenotrophic methanogenesis. metagenome-assembled genomes and metatranscriptomes show depth-stratified microbial composition, active methanogenesis by candidatus methanoflorens, and temperature-sensitive methane and carbon dioxide production driven by activity changes rather than wholesale community replacement."
+                       data-category="METHANOGENESIS"
+                       data-state="PERTURBED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>SPRUCE Peatland Methane-Cycling Microbial Community</h2>
+                        <p class="description">A natural peatland microbial community studied in the DOE-supported SPRUCE whole-ecosystem warming experiment at the S1 Bog in northern Minnesota. The community inhabits acidic, carbon-rich, waterlogged peat and mediates terminal anaerobic carbon turnover, including acetoclastic and hydrogenotrophic methanogenesis. Metagenome-assembled genomes and metatranscriptomes show depth-stratified microbial composition, active methanogenesis by Candidatus Methanoflorens, and temperature-sensitive methane and carbon dioxide production driven by activity changes rather than wholesale community replacement.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">METHANOGENESIS</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.html"
+                       class="community-card"
+                       data-id="Saanich_Inlet_OMZ_Redox_Gradient_Community"
+                       data-name="saanich inlet oxygen minimum zone redox-gradient community"
+                       data-description="a natural marine water-column microbial community from saanich inlet, a seasonally anoxic fjord on vancouver island, canada that serves as a model oxygen minimum zone. integrated geochemistry, rate measurements, metagenomics, metatranscriptomics, metaproteomics, and qpcr link community structure to coupled carbon, nitrogen, and sulfur cycling across a redox gradient, including sup05-driven incomplete sulfide-dependent denitrification, nitrite leakage supporting anammox, and a complementary nitrous oxide reduction niche."
+                       data-category="EXTREME_ENVIRONMENT"
+                       data-state="PERTURBED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Saanich Inlet Oxygen Minimum Zone Redox-Gradient Community</h2>
+                        <p class="description">A natural marine water-column microbial community from Saanich Inlet, a seasonally anoxic fjord on Vancouver Island, Canada that serves as a model oxygen minimum zone. Integrated geochemistry, rate measurements, metagenomics, metatranscriptomics, metaproteomics, and qPCR link community structure to coupled carbon, nitrogen, and sulfur cycling across a redox gradient, including SUP05-driven incomplete sulfide-dependent denitrification, nitrite leakage supporting anammox, and a complementary nitrous oxide reduction niche.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">EXTREME_ENVIRONMENT</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.html"
+                       class="community-card"
+                       data-id="Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture"
+                       data-name="saccharomyces-acinetobacter lignocellulose hydrolysate detoxification coculture"
+                       data-description="a defined two-member synthetic coculture pairing engineered saccharomyces cerevisiae and engineered acinetobacter baylyi adp1 for upgrading a synthetic lignocellulosic hydrolysate. a. baylyi adp1 bioconverts the furan aldehyde inhibitors furfural and 5-hydroxymethylfurfural that are present in lignocellulose hydrolysates without competing with s. cerevisiae for substrates, while also redirecting s. cerevisiae&#39;s residual carbon sources and byproducts into wax esters. the detoxification function raises s. cerevisiae&#39;s lactic acid productivity approximately 1.5-fold compared to a monoculture, making the coculture a candidate platform for inhibitor-tolerant lignocellulose conversion.
+"
+                       data-category="LIGNOCELLULOSE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Saccharomyces-Acinetobacter Lignocellulose Hydrolysate Detoxification Coculture</h2>
+                        <p class="description">A defined two-member synthetic coculture pairing engineered Saccharomyces cerevisiae and engineered Acinetobacter baylyi ADP1 for upgrading a synthetic lignocellulosic hydrolysate. A. baylyi ADP1 bioconverts the furan aldehyde inhibitors furfural and 5-hydroxymethylfurfural that are present in lignocellulose hydrolysates without competing with S. cerevisiae for substrates, while also redirecting S. cerevisiae&#39;s residual carbon sources and byproducts into wax esters. The detoxification function raises S. cerevisiae&#39;s lactic acid productivity approximately 1.5-fold compared to a monoculture, making the coculture a candidate platform for inhibitor-tolerant lignocellulose conversion.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Saccharomyces_Chlamydomonas_Fungal_Algal_Mutualism.html"
+                       class="community-card"
+                       data-id="Saccharomyces_Chlamydomonas_Fungal_Algal_Mutualism"
+                       data-name="saccharomyces-chlamydomonas fungal-algal mutualism"
+                       data-description="a two-member synthetic fungal-algal community pairing saccharomyces cerevisiae with chlamydomonas reinhardtii under engineered laboratory conditions that force reciprocal carbon and nitrogen exchange. yeast metabolizes glucose and supplies carbon dioxide to the alga, while the alga photosynthetically releases oxygen and converts nitrite into reduced nitrogen that supports yeast growth.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Saccharomyces-Chlamydomonas Fungal-Algal Mutualism</h2>
+                        <p class="description">A two-member synthetic fungal-algal community pairing Saccharomyces cerevisiae with Chlamydomonas reinhardtii under engineered laboratory conditions that force reciprocal carbon and nitrogen exchange. Yeast metabolizes glucose and supplies carbon dioxide to the alga, while the alga photosynthetically releases oxygen and converts nitrite into reduced nitrogen that supports yeast growth.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Salar_Atacama_Lithium_Brine_Community.html"
+                       class="community-card"
+                       data-id="Salar_Atacama_Lithium_Brine_Community"
+                       data-name="salar de atacama lithium brine community"
+                       data-description="a halophilic archaeal-bacterial consortium from the world&#39;s largest lithium reserve in the salar de atacama, chile. this community thrives in extreme hypersaline brines with lithium concentrations up to 1,500 ppm (1.5 g/l) and total salinity ranging from 34.7% (natural brine) to 55.6% (concentrated brine during industrial processing). the community is strongly dominated by halophilic archaea of the family halobacteriaceae, with natural brines showing higher archaeal diversity (halovenus 26.8%, natronomonas 20.1%, haloarcula 14%, halobacterium 13%) compared to concentrated brines where halovenus becomes even more dominant (41%). bacterial diversity is phylogenetically richer in concentrated brines, with rhodothermaceae (represented solely by salinibacter, 56% in natural brine) being the most abundant bacterial family. the community demonstrates remarkable lithium tolerance and adaptation to chaotropic stress, making it highly relevant for understanding microbial ecology in extreme saline environments and potential biotechnological applications in lithium extraction and critical mineral bioprocessing. lithium acts as a modulator of microbial richness and diversity, with bacterial diversity increasing and archaeal diversity decreasing as lithium concentration rises during industrial processing.
+"
+                       data-category="EXTREME_ENVIRONMENT"
+                       data-state="STABLE"
+                       data-metals="IRON,LITHIUM"
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="6">
+                        <h2>Salar de Atacama Lithium Brine Community</h2>
+                        <p class="description">A halophilic archaeal-bacterial consortium from the world&#39;s largest lithium reserve in the Salar de Atacama, Chile. This community thrives in extreme hypersaline brines with lithium concentrations up to 1,500 ppm (1.5 g/L) and total salinity ranging from 34.7% (natural brine) to 55.6% (concentrated brine during industrial processing). The community is strongly dominated by halophilic archaea of the family Halobacteriaceae, with natural brines showing higher archaeal diversity (Halovenus 26.8%, Natronomonas 20.1%, Haloarcula 14%, Halobacterium 13%) compared to concentrated brines where Halovenus becomes even more dominant (41%). Bacterial diversity is phylogenetically richer in concentrated brines, with Rhodothermaceae (represented solely by Salinibacter, 56% in natural brine) being the most abundant bacterial family. The community demonstrates remarkable lithium tolerance and adaptation to chaotropic stress, making it highly relevant for understanding microbial ecology in extreme saline environments and potential biotechnological applications in lithium extraction and critical mineral bioprocessing. Lithium acts as a modulator of microbial richness and diversity, with bacterial diversity increasing and archaeal diversity decreasing as lithium concentration rises during industrial processing.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    6
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">EXTREME_ENVIRONMENT</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Shewanella_Denitrifying_Richness_SynComs.html"
+                       class="community-card"
+                       data-id="Shewanella_Denitrifying_Richness_SynComs"
+                       data-name="shewanella denitrifying richness syncoms"
+                       data-description="a panel of synthetic denitrifying communities assembled from 12 shewanella denitrifiers with richness spanning one to twelve species."
+                       data-category="BIOREMEDIATION"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>Shewanella Denitrifying Richness SynComs</h2>
+                        <p class="description">A panel of synthetic denitrifying communities assembled from 12 Shewanella denitrifiers with richness spanning one to twelve species.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.html"
+                       class="community-card"
+                       data-id="Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community"
+                       data-name="shewanella-geobacter three-species exoelectrogenic biofilm community"
+                       data-description="a defined three-species anode-associated exoelectrogenic biofilm community composed of shewanella oneidensis, geobacter sulfurreducens, and geobacter metallireducens. the community was assembled to study biofilm formation dynamics, strain interactions, redox potential resilience, and electron transfer activity in bioelectrochemical systems.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Shewanella-Geobacter Three-Species Exoelectrogenic Biofilm Community</h2>
+                        <p class="description">A defined three-species anode-associated exoelectrogenic biofilm community composed of Shewanella oneidensis, Geobacter sulfurreducens, and Geobacter metallireducens. The community was assembled to study biofilm formation dynamics, strain interactions, redox potential resilience, and electron transfer activity in bioelectrochemical systems.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.html"
+                       class="community-card"
+                       data-id="Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell"
+                       data-name="shewanella-streptococcus starch-fueled microbial fuel cell coculture"
+                       data-description="a defined starch-fed microbial fuel cell community pairing the exoelectrogen shewanella oneidensis mr-1 with the starch-fermenting lactic acid producer streptococcus bovis 148. the system was tested in two configurations: two-step fermentation, where s. bovis first converted starch to lactic acid before s. oneidensis generated electricity, and parallel fermentation, where cultivation and fermentation by both organisms occurred simultaneously. the community is relevant to doe bioenergy and bioelectrochemical systems because it couples conversion of a polymeric biomass substrate to lactate cross-feeding and extracellular electron transfer in a microbial fuel cell.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Shewanella-Streptococcus Starch-Fueled Microbial Fuel Cell Coculture</h2>
+                        <p class="description">A defined starch-fed microbial fuel cell community pairing the exoelectrogen Shewanella oneidensis MR-1 with the starch-fermenting lactic acid producer Streptococcus bovis 148. The system was tested in two configurations: two-step fermentation, where S. bovis first converted starch to lactic acid before S. oneidensis generated electricity, and parallel fermentation, where cultivation and fermentation by both organisms occurred simultaneously. The community is relevant to DOE bioenergy and bioelectrochemical systems because it couples conversion of a polymeric biomass substrate to lactate cross-feeding and extracellular electron transfer in a microbial fuel cell.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/SkinCom_Synthetic_Skin_Community.html"
+                       class="community-card"
+                       data-id="SkinCom_Synthetic_Skin_Community"
+                       data-name="skincom synthetic skin community"
+                       data-description="a standardized synthetic skin microbial community for reproducible in vitro and in vivo studies of skin-associated microbe-metabolite interactions."
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>SkinCom Synthetic Skin Community</h2>
+                        <p class="description">A standardized synthetic skin microbial community for reproducible in vitro and in vivo studies of skin-associated microbe-metabolite interactions.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Soil_BGC_Phylum_Depth_Vegetation_Community.html"
+                       class="community-card"
+                       data-id="Soil_BGC_Phylum_Depth_Vegetation_Community"
+                       data-name="soil biosynthetic gene cluster phylum-depth-vegetation community"
+                       data-description="a soil bacterial community surveyed for secondary-metabolite biosynthetic gene cluster (bgc) content across three sites in a northern california critical zone observatory with varying vegetation and bedrock. 1,334 metagenome-assembled genomes were reconstructed and screened for bgcs, including genomes for prolific producers among actinobacteria, chloroflexi, and candidate phylum candidatus dormibacteraeota. one candidate phyla radiation (cpr) bacterial genome encoded a ribosomally synthesized linear azole/azoline-containing peptide, a capacity also found in other publicly available cpr genomes. bacteria with higher biosynthetic potential were enriched in shallow soils and grassland soils, with bgc-type patterns varying by taxonomy.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Soil Biosynthetic Gene Cluster Phylum-Depth-Vegetation Community</h2>
+                        <p class="description">A soil bacterial community surveyed for secondary-metabolite biosynthetic gene cluster (BGC) content across three sites in a northern California Critical Zone Observatory with varying vegetation and bedrock. 1,334 metagenome-assembled genomes were reconstructed and screened for BGCs, including genomes for prolific producers among Actinobacteria, Chloroflexi, and candidate phylum Candidatus Dormibacteraeota. One Candidate Phyla Radiation (CPR) bacterial genome encoded a ribosomally synthesized linear azole/azoline-containing peptide, a capacity also found in other publicly available CPR genomes. Bacteria with higher biosynthetic potential were enriched in shallow soils and grassland soils, with BGC-type patterns varying by taxonomy.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.html"
+                       class="community-card"
+                       data-id="Soil_CPR_Nanoarchaea_Rare_Biosphere_Community"
+                       data-name="soil cpr bacteria and nanoarchaea rare-biosphere community"
+                       data-description="a rare-biosphere community of candidate phyla radiation (cpr) bacteria and dpann archaea recovered from grassland soil by concentrating particles smaller than 0.2 micrometers prior to metagenomic sequencing. cpr and dpann sequences were enriched 100- to 1,000-fold compared to bulk soil (estimated at roughly 1 to 100 cells per gram of soil for each lineage) and include doudnabacteria (sm2f11) and pacearchaeota - organisms rarely reported in soil - alongside saccharibacteria, parcubacteria, and microgenomates as well as diapherotrites, parvarchaeota, aenigmarchaeota, nanoarchaeota, and nanohaloarchaeota. most members likely live symbiotic anaerobic lifestyles, but some saccharibacteria, parcubacteria, and doudnabacteria encode components of aerobic metabolism that may be particularly relevant in oxic soil habitats.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Soil CPR Bacteria and Nanoarchaea Rare-Biosphere Community</h2>
+                        <p class="description">A rare-biosphere community of Candidate Phyla Radiation (CPR) bacteria and DPANN archaea recovered from grassland soil by concentrating particles smaller than 0.2 micrometers prior to metagenomic sequencing. CPR and DPANN sequences were enriched 100- to 1,000-fold compared to bulk soil (estimated at roughly 1 to 100 cells per gram of soil for each lineage) and include Doudnabacteria (SM2F11) and Pacearchaeota - organisms rarely reported in soil - alongside Saccharibacteria, Parcubacteria, and Microgenomates as well as Diapherotrites, Parvarchaeota, Aenigmarchaeota, Nanoarchaeota, and Nanohaloarchaeota. Most members likely live symbiotic anaerobic lifestyles, but some Saccharibacteria, Parcubacteria, and Doudnabacteria encode components of aerobic metabolism that may be particularly relevant in oxic soil habitats.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Soil_Corrinoid_B12_Reservoir_Community.html"
+                       class="community-card"
+                       data-id="Soil_Corrinoid_B12_Reservoir_Community"
+                       data-name="soil corrinoid reservoir microbial community"
+                       data-description="a grassland soil microbial community in which the structurally diverse corrinoid (vitamin b12-related) cofactor pool serves as a key determinant of community structure. analysis of metagenome-assembled genomes implicates thermoproteota, actinobacteria, and proteobacteria as the principal corrinoid suppliers. corrinoids accumulate adhered to the soil matrix at levels exceeding the requirements of cultured bacteria. enrichment cultures and soil microcosms seeded with different corrinoids exhibit distinct shifts in bacterial community composition, supporting the hypothesis that corrinoid structure shapes communities, with environmental context modulating both community-level and taxon-specific responses.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="PERTURBED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Soil Corrinoid Reservoir Microbial Community</h2>
+                        <p class="description">A grassland soil microbial community in which the structurally diverse corrinoid (vitamin B12-related) cofactor pool serves as a key determinant of community structure. Analysis of metagenome-assembled genomes implicates Thermoproteota, Actinobacteria, and Proteobacteria as the principal corrinoid suppliers. Corrinoids accumulate adhered to the soil matrix at levels exceeding the requirements of cultured bacteria. Enrichment cultures and soil microcosms seeded with different corrinoids exhibit distinct shifts in bacterial community composition, supporting the hypothesis that corrinoid structure shapes communities, with environmental context modulating both community-level and taxon-specific responses.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Sorghum_SRC1_Subset.html"
+                       class="community-card"
+                       data-id="Sorghum_SRC1_Subset"
+                       data-name="sorghum src1 subset community"
+                       data-description="a simplified synthetic rhizosphere community (src1-subset) derived from the larger src1 consortium for enhancing sorghum bioenergy crop productivity. the subset consists of 16-20 bacterial strains selected from the full 57-strain src1 community, including multiple pseudomonas, bacillus, and arthrobacter strains. this engineered community was designed using network analysis to identify hub taxa and strains capable of utilizing sorghum-specific root exudate compounds. field-tested studies demonstrate that the community effectively colonizes sorghum rhizosphere and roots, leading to increased shoot biomass and improved yield performance under field conditions. the growth enhancement correlates with transcriptional dampening of lignin biosynthesis in the host plant.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="INCIDENTAL"
+                       data-member-count="7">
+                        <h2>Sorghum SRC1 Subset Community</h2>
+                        <p class="description">A simplified synthetic rhizosphere community (SRC1-subset) derived from the larger SRC1 consortium for enhancing sorghum bioenergy crop productivity. The subset consists of 16-20 bacterial strains selected from the full 57-strain SRC1 community, including multiple Pseudomonas, Bacillus, and Arthrobacter strains. This engineered community was designed using network analysis to identify hub taxa and strains capable of utilizing sorghum-specific root exudate compounds. Field-tested studies demonstrate that the community effectively colonizes sorghum rhizosphere and roots, leading to increased shoot biomass and improved yield performance under field conditions. The growth enhancement correlates with transcriptional dampening of lignin biosynthesis in the host plant.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    7
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/South_Bay_Salt_Pond_Methane_Restoration_Community.html"
+                       class="community-card"
+                       data-id="South_Bay_Salt_Pond_Methane_Restoration_Community"
+                       data-name="south bay salt pond methane restoration microbial community"
+                       data-description="natural sediment microbial communities from former industrial salt ponds, a restored salt pond, and a reference tidal wetland in the san francisco south bay ravenswood complex. doe jgi-supported 16s rrna amplicon and shotgun metagenomic analyses linked wetland restoration state to microbial composition, metabolic potential, and methane flux. unrestored salt ponds had elevated methane emissions that were positively correlated with salinity and sulfate, while the restored pond resembled the reference wetland more closely and showed lower salinity, sulfate, and methane emissions. the study implicates archaeal methanogenesis and bacterial methylphosphonate degradation as methane-generating mechanisms in these coastal wetland sediments.
+"
+                       data-category="METHANOGENESIS"
+                       data-state="PERTURBED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>South Bay Salt Pond Methane Restoration Microbial Community</h2>
+                        <p class="description">Natural sediment microbial communities from former industrial salt ponds, a restored salt pond, and a reference tidal wetland in the San Francisco South Bay Ravenswood complex. DOE JGI-supported 16S rRNA amplicon and shotgun metagenomic analyses linked wetland restoration state to microbial composition, metabolic potential, and methane flux. Unrestored salt ponds had elevated methane emissions that were positively correlated with salinity and sulfate, while the restored pond resembled the reference wetland more closely and showed lower salinity, sulfate, and methane emissions. The study implicates archaeal methanogenesis and bacterial methylphosphonate degradation as methane-generating mechanisms in these coastal wetland sediments.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">METHANOGENESIS</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.html"
+                       class="community-card"
+                       data-id="Soybean_Chlorophyll_Selected_Biofertilizer_SynCom"
+                       data-name="soybean chlorophyll-selected biofertilizer syncom"
+                       data-description="a plant-guided soybean rhizosphere syncom selected through iterative chlorophyll-based microbiome engineering to improve nodulation and biomass in soil."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Soybean Chlorophyll-Selected Biofertilizer SynCom</h2>
+                        <p class="description">A plant-guided soybean rhizosphere SynCom selected through iterative chlorophyll-based microbiome engineering to improve nodulation and biomass in soil.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Soybean_N_Fixation_sfSynCom.html"
+                       class="community-card"
+                       data-id="Soybean_N_Fixation_sfSynCom"
+                       data-name="soybean n-fixation simplified syncom"
+                       data-description="a simplified synthetic community (sfsyncom) for enhanced symbiotic nitrogen fixation in soybean, based on core-helper strain interactions. the consortium consists of bradyrhizobium elkanii bxyd3 as the core nitrogen-fixing symbiont and two pantoea helper strains. the helper strains produce acyl homoserine lactones (ahl) that enhance colonization and infection of soybean roots by b. elkanii through quorum sensing, significantly improving nodulation and nitrogen fixation compared to single-strain inoculation.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="INCIDENTAL"
+                       data-member-count="4">
+                        <h2>Soybean N-Fixation Simplified SynCom</h2>
+                        <p class="description">A simplified synthetic community (sfSynCom) for enhanced symbiotic nitrogen fixation in soybean, based on core-helper strain interactions. The consortium consists of Bradyrhizobium elkanii BXYD3 as the core nitrogen-fixing symbiont and two Pantoea helper strains. The helper strains produce acyl homoserine lactones (AHL) that enhance colonization and infection of soybean roots by B. elkanii through quorum sensing, significantly improving nodulation and nitrogen fixation compared to single-strain inoculation.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Sphingobium_Rhodococcus_Lignin_Dimer_Valorization_Coculture.html"
+                       class="community-card"
+                       data-id="Sphingobium_Rhodococcus_Lignin_Dimer_Valorization_Coculture"
+                       data-name="sphingobium-rhodococcus lignin-dimer valorization coculture"
+                       data-description="a defined synthetic lignin-valorization coculture pairing a lignin-derived dimer-cleaving sphingobium sp. with the aromatic-monomer-converting bacterium rhodococcus opacus. the coculture was designed to funnel multiple low-molecular-weight lignin-derived dimers into cis,cis-muconate and gallate, addressing a key bottleneck in biological lignin conversion. the system is doe-relevant because it targets lignin, a major underutilized component of lignocellulosic biomass, and demonstrates division of labor for microbial production of renewable chemical intermediates from lignin-derived aromatics.
+"
+                       data-category="LIGNOCELLULOSE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Sphingobium-Rhodococcus Lignin-Dimer Valorization Coculture</h2>
+                        <p class="description">A defined synthetic lignin-valorization coculture pairing a lignin-derived dimer-cleaving Sphingobium sp. with the aromatic-monomer-converting bacterium Rhodococcus opacus. The coculture was designed to funnel multiple low-molecular-weight lignin-derived dimers into cis,cis-muconate and gallate, addressing a key bottleneck in biological lignin conversion. The system is DOE-relevant because it targets lignin, a major underutilized component of lignocellulosic biomass, and demonstrates division of labor for microbial production of renewable chemical intermediates from lignin-derived aromatics.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.html"
+                       class="community-card"
+                       data-id="Stordalen_Mire_Methylotrophic_Methanogenesis_Community"
+                       data-name="stordalen mire methylotrophic methanogenesis community"
+                       data-description="natural thaw-gradient peat microbial communities from stordalen mire in arctic sweden, curated around genome-resolved multi-omics evidence for direct and indirect methylotrophic routes to methane production. the study expanded genomic representation of native methanogens, identified methanogenic mags with methylotrophic potential and transcriptional activity, detected broad bacterial anaerobic methylotrophic potential, and observed active methylotrophy across palsa, bog, and fen stages of permafrost thaw. the community is doe-relevant through usdoe office of science ber, pnnl emsl, and jgi involvement and links permafrost thaw, wetland carbon cycling, and methane emissions.
+"
+                       data-category="METHANOGENESIS"
+                       data-state="PERTURBED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Stordalen Mire Methylotrophic Methanogenesis Community</h2>
+                        <p class="description">Natural thaw-gradient peat microbial communities from Stordalen Mire in Arctic Sweden, curated around genome-resolved multi-omics evidence for direct and indirect methylotrophic routes to methane production. The study expanded genomic representation of native methanogens, identified methanogenic MAGs with methylotrophic potential and transcriptional activity, detected broad bacterial anaerobic methylotrophic potential, and observed active methylotrophy across palsa, bog, and fen stages of permafrost thaw. The community is DOE-relevant through USDOE Office of Science BER, PNNL EMSL, and JGI involvement and links permafrost thaw, wetland carbon cycling, and methane emissions.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">METHANOGENESIS</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Subsurface_Carboxydocella_CO_Aquifer_Community.html"
+                       class="community-card"
+                       data-id="Subsurface_Carboxydocella_CO_Aquifer_Community"
+                       data-name="subsurface carboxydocella co-oxidation aquifer community"
+                       data-description="a deep subsurface (1.4 km) aquifer microbial community perturbed by injection of 150 tons of supercritical co2 (scco2) in a geosequestration experiment. detailed genome-resolved metagenomics resolved the native carboxydotrophic carboxydocella, a thermophilic co-utilizing anaerobe whose relative abundance decreased post-scco2 injection. analysis of its carbon monoxide dehydrogenase (codh) gene before and after the experiment documented a switch in co-oxidation potential by carboxydocella, with implications for subsurface flow of carbon and electrons from oxidation of the metabolic intermediate co.
+"
+                       data-category="CARBON_SEQUESTRATION"
+                       data-state="PERTURBED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>Subsurface Carboxydocella CO-Oxidation Aquifer Community</h2>
+                        <p class="description">A deep subsurface (1.4 km) aquifer microbial community perturbed by injection of 150 tons of supercritical CO2 (scCO2) in a geosequestration experiment. Detailed genome-resolved metagenomics resolved the native carboxydotrophic Carboxydocella, a thermophilic CO-utilizing anaerobe whose relative abundance decreased post-scCO2 injection. Analysis of its carbon monoxide dehydrogenase (CODH) gene before and after the experiment documented a switch in CO-oxidation potential by Carboxydocella, with implications for subsurface flow of carbon and electrons from oxidation of the metabolic intermediate CO.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">CARBON_SEQUESTRATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.html"
+                       class="community-card"
+                       data-id="Sulfide_Spring_Autotrophic_CPR_Biofilm"
+                       data-name="sulfide spring autotrophic cpr-hosting biofilm"
+                       data-description="an autotrophic biofilm community in sulfide-rich springs sustained by deeply sourced groundwater. genome-resolved metagenomics combined with bulk geochemistry and scanning transmission x-ray microscopy (stxm) at room temperature and 87 k reveals biofilms dominated by chemolithotrophic sulfur-oxidizing bacteria including thiothrix and beggiatoa, with diverse candidate phyla radiation (cpr) bacteria (gracilibacteria, absconditabacteria, saccharibacteria, peregrinibacteria, berkelbacteria, microgenomates, parcubacteria). stxm imaging shows ultra-small cells adhered near filamentous bacteria, suggesting cpr episymbiosis. carbon k and sulfur l2,3 edge nexafs spectroscopy indicates that filamentous bacteria contain protein-encapsulated elemental sulfur granules consistent with thiothrix-like sulfur oxidation, and berkelbacteria and moranbacteria are predicted to encode a novel electron bifurcation system.
+"
+                       data-category="EXTREME_ENVIRONMENT"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Sulfide Spring Autotrophic CPR-Hosting Biofilm</h2>
+                        <p class="description">An autotrophic biofilm community in sulfide-rich springs sustained by deeply sourced groundwater. Genome-resolved metagenomics combined with bulk geochemistry and scanning transmission X-ray microscopy (STXM) at room temperature and 87 K reveals biofilms dominated by chemolithotrophic sulfur-oxidizing bacteria including Thiothrix and Beggiatoa, with diverse Candidate Phyla Radiation (CPR) bacteria (Gracilibacteria, Absconditabacteria, Saccharibacteria, Peregrinibacteria, Berkelbacteria, Microgenomates, Parcubacteria). STXM imaging shows ultra-small cells adhered near filamentous bacteria, suggesting CPR episymbiosis. Carbon K and sulfur L2,3 edge NEXAFS spectroscopy indicates that filamentous bacteria contain protein-encapsulated elemental sulfur granules consistent with Thiothrix-like sulfur oxidation, and Berkelbacteria and Moranbacteria are predicted to encode a novel electron bifurcation system.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">EXTREME_ENVIRONMENT</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/SynComBac10_Chicken_Intestinal_SynCom.html"
+                       class="community-card"
+                       data-id="SynComBac10_Chicken_Intestinal_SynCom"
+                       data-name="syncombac10 chicken intestinal syncom"
+                       data-description="a 10-member synthetic chicken intestinal community that promotes gut homeostasis and anti-salmonella immunity through segmented filamentous bacteria establishment."
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>SynComBac10 Chicken Intestinal SynCom</h2>
+                        <p class="description">A 10-member synthetic chicken intestinal community that promotes gut homeostasis and anti-Salmonella immunity through segmented filamentous bacteria establishment.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.html"
+                       class="community-card"
+                       data-id="Synechococcus_Azotobacter_Photoproduction_Mutualism"
+                       data-name="synechococcus-azotobacter photoproduction mutualism"
+                       data-description="a designed two-member light-driven microbial mutualism pairing sucrose-exporting cscb synechococcus elongatus pcc 7942 with the diazotroph azotobacter vinelandii av3. the engineered cyanobacterium fixes carbon under illumination and exports sucrose, while a. vinelandii fixes nitrogen and can produce industrially relevant biopolymers such as polyhydroxybutyrate and alginate. the coculture was engineered to grow without added fixed carbon or fixed nitrogen and is relevant to doe interests in photosynthetic bioproduction, carbon utilization, and nitrogen self-sufficient synthetic consortia.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="INCIDENTAL"
+                       data-member-count="2">
+                        <h2>Synechococcus-Azotobacter Photoproduction Mutualism</h2>
+                        <p class="description">A designed two-member light-driven microbial mutualism pairing sucrose-exporting cscB Synechococcus elongatus PCC 7942 with the diazotroph Azotobacter vinelandii AV3. The engineered cyanobacterium fixes carbon under illumination and exports sucrose, while A. vinelandii fixes nitrogen and can produce industrially relevant biopolymers such as polyhydroxybutyrate and alginate. The coculture was engineered to grow without added fixed carbon or fixed nitrogen and is relevant to DOE interests in photosynthetic bioproduction, carbon utilization, and nitrogen self-sufficient synthetic consortia.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Synechococcus_Bacillus_SPC.html"
+                       class="community-card"
+                       data-id="Synechococcus_Bacillus_SPC"
+                       data-name="synechococcus-bacillus synthetic photosynthetic consortium"
+                       data-description="a synthetic, light-driven consortium pairing the cyanobacterium synechococcus elongatus pcc 7942 (engineered to secrete sucrose via the cscb+ transporter) with bacillus subtilis 168. the cyanobacterium fixes co2 and exports sucrose, which supports heterotrophic growth of b. subtilis. this modular platform demonstrates a stable photosynthetic co-culture for sustainable carbon cycling.
+"
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Synechococcus-Bacillus Synthetic Photosynthetic Consortium</h2>
+                        <p class="description">A synthetic, light-driven consortium pairing the cyanobacterium Synechococcus elongatus PCC 7942 (engineered to secrete sucrose via the cscB+ transporter) with Bacillus subtilis 168. The cyanobacterium fixes CO2 and exports sucrose, which supports heterotrophic growth of B. subtilis. This modular platform demonstrates a stable photosynthetic co-culture for sustainable carbon cycling.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Synechococcus_Ecoli_SPC.html"
+                       class="community-card"
+                       data-id="Synechococcus_Ecoli_SPC"
+                       data-name="synechococcus-e.coli synthetic photosynthetic consortium"
+                       data-description="a synthetic, light-driven consortium pairing the cyanobacterium synechococcus elongatus pcc 7942 (engineered to secrete sucrose via the cscb+ transporter) with escherichia coli. the cyanobacterium fixes co2 and exports up to 85% of fixed carbon as sucrose, which supports heterotrophic growth of e. coli. this modular platform enables stable, long-term photosynthetic co-culture for biofuel precursor production and demonstrates a synthetic cross-feeding interaction that persists over days to months.
+"
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="INCIDENTAL"
+                       data-member-count="2">
+                        <h2>Synechococcus-E.coli Synthetic Photosynthetic Consortium</h2>
+                        <p class="description">A synthetic, light-driven consortium pairing the cyanobacterium Synechococcus elongatus PCC 7942 (engineered to secrete sucrose via the cscB+ transporter) with Escherichia coli. The cyanobacterium fixes CO2 and exports up to 85% of fixed carbon as sucrose, which supports heterotrophic growth of E. coli. This modular platform enables stable, long-term photosynthetic co-culture for biofuel precursor production and demonstrates a synthetic cross-feeding interaction that persists over days to months.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.html"
+                       class="community-card"
+                       data-id="Synechococcus_Halomonas_Light_Driven_PHB_Coculture"
+                       data-name="synechococcus-halomonas light-driven phb coculture"
+                       data-description="a synthetic, light-driven two-member phototroph-heterotroph consortium pairing sucrose-exporting synechococcus elongatus pcc 7942 cscb with the halotolerant polyhydroxybutyrate producer halomonas boliviensis lc1. the cyanobacterium fixes carbon dioxide under illumination and exports sucrose, while h. boliviensis consumes the cyanobacterial sucrose and accumulates the bioplastic precursor polyhydroxybutyrate. the system is relevant to doe carbon utilization and bioproduct goals because it couples photosynthetic carbon fixation to heterotrophic biopolymer production in a modular synthetic coculture.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Synechococcus-Halomonas Light-Driven PHB Coculture</h2>
+                        <p class="description">A synthetic, light-driven two-member phototroph-heterotroph consortium pairing sucrose-exporting Synechococcus elongatus PCC 7942 cscB with the halotolerant polyhydroxybutyrate producer Halomonas boliviensis LC1. The cyanobacterium fixes carbon dioxide under illumination and exports sucrose, while H. boliviensis consumes the cyanobacterial sucrose and accumulates the bioplastic precursor polyhydroxybutyrate. The system is relevant to DOE carbon utilization and bioproduct goals because it couples photosynthetic carbon fixation to heterotrophic biopolymer production in a modular synthetic coculture.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.html"
+                       class="community-card"
+                       data-id="Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture"
+                       data-name="synechococcus-pseudomonas phototrophic pha and dnt coculture"
+                       data-description="a synthetic, light-driven two-species coculture pairing engineered synechococcus elongatus pcc 7942 cscb with engineered pseudomonas putida strains that consume cyanobacterial sucrose. the cyanobacterium fixes co2 and exports sucrose under salt/iptg induction, while p. putida converts the transferred carbon into polyhydroxyalkanoates (pha) and, in a related engineered implementation, transforms the industrial pollutant 2,4-dinitrotoluene. this platform is relevant to doe carbon utilization, bioproduct formation, and contaminant bioremediation because it couples photosynthetic co2 fixation to heterotrophic biocatalysis in a controlled laboratory community.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Synechococcus-Pseudomonas Phototrophic PHA and DNT Coculture</h2>
+                        <p class="description">A synthetic, light-driven two-species coculture pairing engineered Synechococcus elongatus PCC 7942 cscB with engineered Pseudomonas putida strains that consume cyanobacterial sucrose. The cyanobacterium fixes CO2 and exports sucrose under salt/IPTG induction, while P. putida converts the transferred carbon into polyhydroxyalkanoates (PHA) and, in a related engineered implementation, transforms the industrial pollutant 2,4-dinitrotoluene. This platform is relevant to DOE carbon utilization, bioproduct formation, and contaminant bioremediation because it couples photosynthetic CO2 fixation to heterotrophic biocatalysis in a controlled laboratory community.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.html"
+                       class="community-card"
+                       data-id="Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium"
+                       data-name="synechococcus-shewanella d-lactate biophotovoltaic consortium"
+                       data-description="a two-species engineered biophotovoltaic consortium pairing engineered synechococcus elongatus utex 2973 with engineered shewanella oneidensis mr-1. the cyanobacterium converts light and carbon dioxide into d-lactate, and the exoelectrogenic shewanella partner oxidizes d-lactate and transfers electrons to an anode. the system is relevant to doe bioenergy and bioelectrochemical research because it demonstrates division of labor for renewable electricity production from photosynthesis, metabolite transfer, and extracellular electron transfer.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="INCIDENTAL"
+                       data-member-count="2">
+                        <h2>Synechococcus-Shewanella D-Lactate Biophotovoltaic Consortium</h2>
+                        <p class="description">A two-species engineered biophotovoltaic consortium pairing engineered Synechococcus elongatus UTEX 2973 with engineered Shewanella oneidensis MR-1. The cyanobacterium converts light and carbon dioxide into D-lactate, and the exoelectrogenic Shewanella partner oxidizes D-lactate and transfers electrons to an anode. The system is relevant to DOE bioenergy and bioelectrochemical research because it demonstrates division of labor for renewable electricity production from photosynthesis, metabolite transfer, and extracellular electron transfer.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Synechococcus_Yarrowia_SPC.html"
+                       class="community-card"
+                       data-id="Synechococcus_Yarrowia_SPC"
+                       data-name="synechococcus-yarrowia synthetic photosynthetic consortium"
+                       data-description="a synthetic, light-driven consortium pairing the cyanobacterium synechococcus elongatus pcc 7942 (engineered to secrete sucrose via the cscb+ transporter) with the oleaginous yeast yarrowia lipolytica po1g. the cyanobacterium fixes co2 and exports sucrose, which y. lipolytica converts to lipids for biofuel production. this system demonstrates photosynthetic carbon capture coupled to lipid biosynthesis in a modular platform.
+"
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Synechococcus-Yarrowia Synthetic Photosynthetic Consortium</h2>
+                        <p class="description">A synthetic, light-driven consortium pairing the cyanobacterium Synechococcus elongatus PCC 7942 (engineered to secrete sucrose via the cscB+ transporter) with the oleaginous yeast Yarrowia lipolytica Po1g. The cyanobacterium fixes CO2 and exports sucrose, which Y. lipolytica converts to lipids for biofuel production. This system demonstrates photosynthetic carbon capture coupled to lipid biosynthesis in a modular platform.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.html"
+                       class="community-card"
+                       data-id="Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture"
+                       data-name="synthetic lichen synechococcus-rhodotorula coculture"
+                       data-description="a synthetic lichen-inspired phototroph-heterotroph coculture pairing engineered sucrose-secreting synechococcus elongatus pcc 7942 with the oleaginous yeast rhodotorula glutinis. the cyanobacterium fixes carbon dioxide under illumination and exports sucrose, while r. glutinis consumes the cyanobacterial photosynthate, increases coculture biomass and lipid yield, and alleviates reactive oxygen stress that limits low-density cyanobacterial axenic growth.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Synthetic Lichen Synechococcus-Rhodotorula Coculture</h2>
+                        <p class="description">A synthetic lichen-inspired phototroph-heterotroph coculture pairing engineered sucrose-secreting Synechococcus elongatus PCC 7942 with the oleaginous yeast Rhodotorula glutinis. The cyanobacterium fixes carbon dioxide under illumination and exports sucrose, while R. glutinis consumes the cyanobacterial photosynthate, increases coculture biomass and lipid yield, and alleviates reactive oxygen stress that limits low-density cyanobacterial axenic growth.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Synthetic_Periphyton_Freshwater_Biofilm.html"
+                       class="community-card"
+                       data-id="Synthetic_Periphyton_Freshwater_Biofilm"
+                       data-name="synthetic periphyton freshwater biofilm"
+                       data-description="a 26-member phototrophic synthetic periphyton biofilm used as a reproducible freshwater model system for species dynamics and stressor response."
+                       data-category="PHYTOPLANKTON"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Synthetic Periphyton Freshwater Biofilm</h2>
+                        <p class="description">A 26-member phototrophic synthetic periphyton biofilm used as a reproducible freshwater model system for species dynamics and stressor response.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">PHYTOPLANKTON</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Syntrophobacter_Methanobacterium_Syntrophy.html"
+                       class="community-card"
+                       data-id="Syntrophobacter_Methanobacterium_Syntrophy"
+                       data-name="syntrophobacter-methanobacterium syntrophic consortium"
+                       data-description="a syntrophic, obligate two-member anaerobic consortium consisting of syntrophobacter fumaroxidans, which oxidizes propionate to acetate, and methanobacterium formicicum, a hydrogen and formate-utilizing methanogen. s. fumaroxidans degrades propionate via the methylmalonyl-coa pathway only in coculture with h2/formate-using archaea, as it uses protons as the electron acceptor with h2 and formate as electron sink products. the removal of h2 and formate by m. formicicum is thermodynamically essential for continued propionate oxidation by s. fumaroxidans. this syntrophic relationship is fundamental to understanding methane production from propionate in anaerobic environments such as digesters, sediments, and wastewater treatment systems, playing a critical role in biogeochemical cycling.
+"
+                       data-category="SYNTROPHY"
+                       data-state="STABLE"
+                       data-metals="IRON"
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="2">
+                        <h2>Syntrophobacter-Methanobacterium Syntrophic Consortium</h2>
+                        <p class="description">A syntrophic, obligate two-member anaerobic consortium consisting of Syntrophobacter fumaroxidans, which oxidizes propionate to acetate, and Methanobacterium formicicum, a hydrogen and formate-utilizing methanogen. S. fumaroxidans degrades propionate via the methylmalonyl-CoA pathway only in coculture with H2/formate-using archaea, as it uses protons as the electron acceptor with H2 and formate as electron sink products. The removal of H2 and formate by M. formicicum is thermodynamically essential for continued propionate oxidation by S. fumaroxidans. This syntrophic relationship is fundamental to understanding methane production from propionate in anaerobic environments such as digesters, sediments, and wastewater treatment systems, playing a critical role in biogeochemical cycling.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Syntrophobacter_Methanospirillum_Syntrophy.html"
+                       class="community-card"
+                       data-id="Syntrophobacter_Methanospirillum_Syntrophy"
+                       data-name="syntrophobacter-methanospirillum syntrophic consortium"
+                       data-description="a syntrophic, obligate two-member anaerobic consortium consisting of syntrophobacter fumaroxidans, which oxidizes propionate to acetate, and methanospirillum hungatei, a hydrogen and formate-utilizing methanogen. s. fumaroxidans degrades propionate via the methylmalonyl-coa pathway only in coculture with h2/formate-using archaea, as it uses protons as the electron acceptor with h2 and formate as electron sink products. the removal of h2 and formate by m. hungatei is thermodynamically essential for continued propionate oxidation by s. fumaroxidans. this syntrophic relationship is fundamental to understanding methane production from propionate in anaerobic environments such as digesters, sediments, and wastewater treatment systems, playing a critical role in biogeochemical cycling.
+"
+                       data-category="SYNTROPHY"
+                       data-state="STABLE"
+                       data-metals="IRON"
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="2">
+                        <h2>Syntrophobacter-Methanospirillum Syntrophic Consortium</h2>
+                        <p class="description">A syntrophic, obligate two-member anaerobic consortium consisting of Syntrophobacter fumaroxidans, which oxidizes propionate to acetate, and Methanospirillum hungatei, a hydrogen and formate-utilizing methanogen. S. fumaroxidans degrades propionate via the methylmalonyl-CoA pathway only in coculture with H2/formate-using archaea, as it uses protons as the electron acceptor with H2 and formate as electron sink products. The removal of H2 and formate by M. hungatei is thermodynamically essential for continued propionate oxidation by S. fumaroxidans. This syntrophic relationship is fundamental to understanding methane production from propionate in anaerobic environments such as digesters, sediments, and wastewater treatment systems, playing a critical role in biogeochemical cycling.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.html"
+                       class="community-card"
+                       data-id="Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture"
+                       data-name="syntrophomonas-methanococcus butyrate growth coordination coculture"
+                       data-description="a defined mesophilic anaerobic coculture pairing the butyrate-oxidizing syntroph syntrophomonas wolfei with the hydrogenotrophic methanogen methanococcus maripaludis. the system is used to study how a fatty acid-oxidizing bacterium and a methanogen synchronize growth, form syntrophic aggregates, and maintain cell-to-cell attraction during methanogenic butyrate conversion. it is relevant to doe interests in anaerobic carbon cycling, methane production, syntrophic energy sharing, and engineered bioreactor microbiology.
+"
+                       data-category="SYNTROPHY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Syntrophomonas-Methanococcus Butyrate Growth Coordination Coculture</h2>
+                        <p class="description">A defined mesophilic anaerobic coculture pairing the butyrate-oxidizing syntroph Syntrophomonas wolfei with the hydrogenotrophic methanogen Methanococcus maripaludis. The system is used to study how a fatty acid-oxidizing bacterium and a methanogen synchronize growth, form syntrophic aggregates, and maintain cell-to-cell attraction during methanogenic butyrate conversion. It is relevant to DOE interests in anaerobic carbon cycling, methane production, syntrophic energy sharing, and engineered bioreactor microbiology.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Syntrophomonas_Methanospirillum_Syntrophy.html"
+                       class="community-card"
+                       data-id="Syntrophomonas_Methanospirillum_Syntrophy"
+                       data-name="syntrophomonas-methanospirillum syntrophic consortium"
+                       data-description="a syntrophic, obligate two-member anaerobic consortium consisting of syntrophomonas wolfei, which β-oxidizes saturated fatty acids (butyrate through octanoate) to acetate, and methanospirillum hungatei, a hydrogen-utilizing methanogen. s. wolfei degrades butyrate only in coculture with h2-using bacteria, as it uses protons as the electron acceptor with h2 as the electron sink product. the removal of h2 by m. hungatei is thermodynamically essential for continued fatty acid oxidation by s. wolfei. this classic syntrophic relationship is fundamental to understanding methane production from fatty acids in anaerobic environments such as digesters, sediments, and the rumen.
+"
+                       data-category="SYNTROPHY"
+                       data-state="STABLE"
+                       data-metals="IRON"
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="2">
+                        <h2>Syntrophomonas-Methanospirillum Syntrophic Consortium</h2>
+                        <p class="description">A syntrophic, obligate two-member anaerobic consortium consisting of Syntrophomonas wolfei, which β-oxidizes saturated fatty acids (butyrate through octanoate) to acetate, and Methanospirillum hungatei, a hydrogen-utilizing methanogen. S. wolfei degrades butyrate only in coculture with H2-using bacteria, as it uses protons as the electron acceptor with H2 as the electron sink product. The removal of H2 by M. hungatei is thermodynamically essential for continued fatty acid oxidation by S. wolfei. This classic syntrophic relationship is fundamental to understanding methane production from fatty acids in anaerobic environments such as digesters, sediments, and the rumen.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Syntrophus_Benzoate_Degrader.html"
+                       class="community-card"
+                       data-id="Syntrophus_Benzoate_Degrader"
+                       data-name="syntrophus benzoate degrader"
+                       data-description="a syntrophic, obligate two-member anaerobic consortium consisting of syntrophus aciditrophicus sb, which degrades benzoate and other aromatic compounds to acetate and h2/formate, and methanospirillum hungatei, a hydrogen-utilizing methanogen. s. aciditrophicus degrades benzoate only in coculture with h2-using microorganisms, as it uses protons as the electron acceptor with h2 and formate as electron sink products. the removal of h2 by m. hungatei is thermodynamically essential for continued benzoate degradation by s. aciditrophicus. this syntrophic relationship is important for understanding aromatic compound degradation and bioremediation in anaerobic environments such as sediments and contaminated aquifers.
+"
+                       data-category="SYNTROPHY"
+                       data-state="STABLE"
+                       data-metals="IRON"
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="2">
+                        <h2>Syntrophus Benzoate Degrader</h2>
+                        <p class="description">A syntrophic, obligate two-member anaerobic consortium consisting of Syntrophus aciditrophicus SB, which degrades benzoate and other aromatic compounds to acetate and H2/formate, and Methanospirillum hungatei, a hydrogen-utilizing methanogen. S. aciditrophicus degrades benzoate only in coculture with H2-using microorganisms, as it uses protons as the electron acceptor with H2 and formate as electron sink products. The removal of H2 by M. hungatei is thermodynamically essential for continued benzoate degradation by S. aciditrophicus. This syntrophic relationship is important for understanding aromatic compound degradation and bioremediation in anaerobic environments such as sediments and contaminated aquifers.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.html"
+                       class="community-card"
+                       data-id="Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture"
+                       data-name="syntrophus-methanospirillum gentianae benzoate coculture"
+                       data-description="a defined anaerobic syntrophic coculture in which syntrophus gentianae degrades benzoate in association with the methanogen methanospirillum hungatei. the system is relevant to doe anaerobic carbon cycling, wastewater digestion, and aromatic-compound bioconversion because it links methanogenic benzoate degradation, thermodynamic thresholds, acetate inhibition, and methane formation in a tractable two-member community.
+"
+                       data-category="SYNTROPHY"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Syntrophus-Methanospirillum Gentianae Benzoate Coculture</h2>
+                        <p class="description">A defined anaerobic syntrophic coculture in which Syntrophus gentianae degrades benzoate in association with the methanogen Methanospirillum hungatei. The system is relevant to DOE anaerobic carbon cycling, wastewater digestion, and aromatic-compound bioconversion because it links methanogenic benzoate degradation, thermodynamic thresholds, acetate inhibition, and methane formation in a tractable two-member community.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/THOR_Rhizosphere_Model_Community.html"
+                       class="community-card"
+                       data-id="THOR_Rhizosphere_Model_Community"
+                       data-name="thor rhizosphere model community"
+                       data-description="the hitchhikers of the rhizosphere (thor) is a genetically tractable three-member model microbiome assembled from bacillus cereus, pseudomonas koreensis, and flavobacterium johnsoniae. the community was developed from rhizosphere-associated isolates to study microbial community assembly, competition, biofilm formation, secondary metabolism, and higher-order interactions under controlled laboratory conditions. p. koreensis produces the antibiotic koreenceine, which inhibits f. johnsoniae and drives community transcriptional responses, while b. cereus modulates antibiotic production and participates in emergent colony expansion and biofilm phenotypes.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>THOR Rhizosphere Model Community</h2>
+                        <p class="description">The Hitchhikers Of the Rhizosphere (THOR) is a genetically tractable three-member model microbiome assembled from Bacillus cereus, Pseudomonas koreensis, and Flavobacterium johnsoniae. The community was developed from rhizosphere-associated isolates to study microbial community assembly, competition, biofilm formation, secondary metabolism, and higher-order interactions under controlled laboratory conditions. P. koreensis produces the antibiotic koreenceine, which inhibits F. johnsoniae and drives community transcriptional responses, while B. cereus modulates antibiotic production and participates in emergent colony expansion and biofilm phenotypes.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/TYQ1_Nematode_Biocontrol_SynCom.html"
+                       class="community-card"
+                       data-id="TYQ1_Nematode_Biocontrol_SynCom"
+                       data-name="tyq1 nematode biocontrol syncom"
+                       data-description="an 8-member synthetic community centered on keystone species rhizobium pusense tyq1, which is enriched during root-knot nematode (meloidogyne incognita) infection of cucumber (cucumis sativus cv. zhongnong 26). tyq1 recruits 7 biomarker species that enhance biofilm formation and metabolic cross-feeding, creating a tightly interconnected network for synergistic nematode suppression. the community was identified through stress-induced enrichment analysis and validated across 12 soil types, demonstrating that keystone species recruitment can guide functional microbial community assembly to synergistically enhance plant health.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="8">
+                        <h2>TYQ1 Nematode Biocontrol SynCom</h2>
+                        <p class="description">An 8-member synthetic community centered on keystone species Rhizobium pusense TYQ1, which is enriched during root-knot nematode (Meloidogyne incognita) infection of cucumber (Cucumis sativus cv. Zhongnong 26). TYQ1 recruits 7 biomarker species that enhance biofilm formation and metabolic cross-feeding, creating a tightly interconnected network for synergistic nematode suppression. The community was identified through stress-induced enrichment analysis and validated across 12 soil types, demonstrating that keystone species recruitment can guide functional microbial community assembly to synergistically enhance plant health.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    8
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Teosinte_Maize_Biofertilizer_SynCom7.html"
+                       class="community-card"
+                       data-id="Teosinte_Maize_Biofertilizer_SynCom7"
+                       data-name="teosinte-derived maize biofertilizer syncom7"
+                       data-description="a seven-strain teosinte-derived bacterial syncom tested as a maize biofertilizer under conventional and precision fertilization strategies."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Teosinte-Derived Maize Biofertilizer SynCom7</h2>
+                        <p class="description">A seven-strain teosinte-derived bacterial SynCom tested as a maize biofertilizer under conventional and precision fertilization strategies.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.html"
+                       class="community-card"
+                       data-id="Thalassiosira_Marinobacter_Marine_Snow_Coculture"
+                       data-name="thalassiosira-marinobacter marine snow coculture"
+                       data-description="a defined marine diatom-bacterium coculture pairing the centric diatom thalassiosira weissflogii, currently represented in ncbi taxonomy as conticribra weissflogii, with the diatom-attaching heterotrophic bacterium marinobacter adhaerens hp15. the system is used to study phycosphere attachment, transparent exopolymer particle formation, aggregate formation, and sinking-particle processes relevant to the marine biological carbon pump. multiple publications use the same exact diatom-bacterium model, including studies of aggregation requirements, chemotaxis-mediated attachment, and temperature/pco2 perturbations.
+"
+                       data-category="PHYTOPLANKTON"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Thalassiosira-Marinobacter Marine Snow Coculture</h2>
+                        <p class="description">A defined marine diatom-bacterium coculture pairing the centric diatom Thalassiosira weissflogii, currently represented in NCBI Taxonomy as Conticribra weissflogii, with the diatom-attaching heterotrophic bacterium Marinobacter adhaerens HP15. The system is used to study phycosphere attachment, transparent exopolymer particle formation, aggregate formation, and sinking-particle processes relevant to the marine biological carbon pump. Multiple publications use the same exact diatom-bacterium model, including studies of aggregation requirements, chemotaxis-mediated attachment, and temperature/pCO2 perturbations.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">PHYTOPLANKTON</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.html"
+                       class="community-card"
+                       data-id="Thalassiosira_Ruegeria_Phycosphere_Coculture"
+                       data-name="thalassiosira-ruegeria phycosphere coculture"
+                       data-description="a defined two-member marine phytoplankton-bacterium model community composed of the diatom thalassiosira pseudonana ccmp1335 and the heterotrophic roseobacter ruegeria pomeroyi dss-3. the coculture is used to study bacterial recognition by a diatom, phytoplankton-derived metabolite transfer, and bacterial use of recent photosynthate in a controlled marine algal medium.
+"
+                       data-category="PHYTOPLANKTON"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Thalassiosira-Ruegeria Phycosphere Coculture</h2>
+                        <p class="description">A defined two-member marine phytoplankton-bacterium model community composed of the diatom Thalassiosira pseudonana CCMP1335 and the heterotrophic roseobacter Ruegeria pomeroyi DSS-3. The coculture is used to study bacterial recognition by a diatom, phytoplankton-derived metabolite transfer, and bacterial use of recent photosynthate in a controlled marine algal medium.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">PHYTOPLANKTON</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.html"
+                       class="community-card"
+                       data-id="Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture"
+                       data-name="thermacetogenium-methanothermobacter acetate oxidation coculture"
+                       data-description="a defined thermophilic anaerobic two-member syntrophic coculture in which thermacetogenium phaeum strain pb oxidizes acetate using the reversible wood-ljungdahl/co dehydrogenase-acetyl-coa pathway, while methanothermobacter thermautotrophicus strain tm consumes reduced products through hydrogenotrophic methanogenesis. this model system is relevant to anaerobic digestion and methane cycling because acetate oxidation is coupled to methane formation under low hydrogen partial pressure.
+"
+                       data-category="METHANOGENESIS"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Thermacetogenium-Methanothermobacter Acetate Oxidation Coculture</h2>
+                        <p class="description">A defined thermophilic anaerobic two-member syntrophic coculture in which Thermacetogenium phaeum strain PB oxidizes acetate using the reversible Wood-Ljungdahl/CO dehydrogenase-acetyl-CoA pathway, while Methanothermobacter thermautotrophicus strain TM consumes reduced products through hydrogenotrophic methanogenesis. This model system is relevant to anaerobic digestion and methane cycling because acetate oxidation is coupled to methane formation under low hydrogen partial pressure.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">METHANOGENESIS</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Thermophilic_Pyrite_QS_Consortium.html"
+                       class="community-card"
+                       data-id="Thermophilic_Pyrite_QS_Consortium"
+                       data-name="thermophilic pyrite quorum sensing consortium"
+                       data-description="a moderately thermophilic three-species bioleaching consortium used to study the effects of quorum sensing (qs) signaling on pyrite and chalcopyrite dissolution. this acidophilic community consists of leptospirillum ferriphilum dsm 14647, acidithiobacillus caldus dsm 8584, and sulfobacillus thermosulfidooxidans dsm 9293, operating at ph 2.0-2.5 and 40°c. the consortium demonstrates coordinated microbial behavior mediated by diffusible signal factor (dsf) and n-acyl-homoserine lactone (ahl) quorum sensing systems. treatment with dsf-family compounds (dsf and bdsf at 2 μm each) reduced pyrite and chalcopyrite dissolution via inhibitory effects on iron oxidation and mineral colonization. dsf compounds induced a. caldus motility and dispersion from pyrite with concomitant expansion of l. ferriphilum on mineral surfaces, while ahl-mediated signaling (c12-ahl, c14-ahl, 3-oh-c12-ahl, 3-oh-c14-ahl at 5 μm each) repressed l. ferriphilum motility. the consortium was subjected to rna-seq transcriptomics (12 samples, 271 gbases) to elucidate gene expression changes in response to qs molecules (ncbi bioproject prjna1259591). this system represents the first comprehensive study of quorum sensing regulation in moderately thermophilic biomining bacteria, revealing that qs molecules change planktonic/mineral subpopulation distributions and modulate leaching efficiency through control of cell attachment and iron oxidation rates.
+"
+                       data-category="BIOMINING"
+                       data-state="ENGINEERED"
+                       data-metals="COPPER,IRON"
+                       data-ree=""
+                       data-relevance="PRIMARY"
+                       data-member-count="3">
+                        <h2>Thermophilic Pyrite Quorum Sensing Consortium</h2>
+                        <p class="description">A moderately thermophilic three-species bioleaching consortium used to study the effects of quorum sensing (QS) signaling on pyrite and chalcopyrite dissolution. This acidophilic community consists of Leptospirillum ferriphilum DSM 14647, Acidithiobacillus caldus DSM 8584, and Sulfobacillus thermosulfidooxidans DSM 9293, operating at pH 2.0-2.5 and 40°C. The consortium demonstrates coordinated microbial behavior mediated by diffusible signal factor (DSF) and N-acyl-homoserine lactone (AHL) quorum sensing systems. Treatment with DSF-family compounds (DSF and BDSF at 2 μM each) reduced pyrite and chalcopyrite dissolution via inhibitory effects on iron oxidation and mineral colonization. DSF compounds induced A. caldus motility and dispersion from pyrite with concomitant expansion of L. ferriphilum on mineral surfaces, while AHL-mediated signaling (C12-AHL, C14-AHL, 3-OH-C12-AHL, 3-OH-C14-AHL at 5 μM each) repressed L. ferriphilum motility. The consortium was subjected to RNA-seq transcriptomics (12 samples, 271 Gbases) to elucidate gene expression changes in response to QS molecules (NCBI BioProject PRJNA1259591). This system represents the first comprehensive study of quorum sensing regulation in moderately thermophilic biomining bacteria, revealing that QS molecules change planktonic/mineral subpopulation distributions and modulate leaching efficiency through control of cell attachment and iron oxidation rates.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOMINING</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.html"
+                       class="community-card"
+                       data-id="Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy"
+                       data-name="thermotoga-methanocaldococcus hyperthermophilic syntrophy"
+                       data-description="a defined hyperthermophilic bacterial-archaeal coculture in which thermotoga maritima msb8 ferments organic substrates and transfers hydrogen to the hydrogenotrophic methanogen historically reported as methanococcus jannaschii, now represented by ncbi as methanocaldococcus jannaschii dsm 2661. the coculture is relevant to doe bioenergy and subsurface biogeochemistry because it links high-temperature fermentation, interspecies hydrogen transfer, cell aggregation, and methane formation in an experimentally tractable system.
+"
+                       data-category="SYNTROPHY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Thermotoga-Methanocaldococcus Hyperthermophilic Syntrophy</h2>
+                        <p class="description">A defined hyperthermophilic bacterial-archaeal coculture in which Thermotoga maritima MSB8 ferments organic substrates and transfers hydrogen to the hydrogenotrophic methanogen historically reported as Methanococcus jannaschii, now represented by NCBI as Methanocaldococcus jannaschii DSM 2661. The coculture is relevant to DOE bioenergy and subsurface biogeochemistry because it links high-temperature fermentation, interspecies hydrogen transfer, cell aggregation, and methane formation in an experimentally tractable system.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.html"
+                       class="community-card"
+                       data-id="Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community"
+                       data-name="thiocyanate-degrading afipia and thiobacillus bioreactor community"
+                       data-description="a laboratory bioreactor microbial community derived from consortia used to treat thiocyanate-contaminated water, perturbed by systematically increased scn- input loading and the presence or absence of molasses as organic carbon. five experiments over 790 days with genome-resolved metagenomics showed that a single thiobacillus strain proliferated in all reactors at high scn- loading, while a single afipia variant dominated the molasses- free reactor at moderate loadings. the afipia variant is predicted to degrade scn- via a novel thiocyanate desulfurase, oxidize the resulting reduced sulfur, degrade the cyanate product to ammonia and co2 via cyanate hydratase, and fix co2 via the calvin-benson-bassham cycle. removal of molasses reproducibly selects for this autotrophic strain, although molasses-free reactors did not sustain high-loading scn- degradation, possibly due to loss of biofilm-associated niche diversity.
+"
+                       data-category="BIOREMEDIATION"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Thiocyanate-Degrading Afipia and Thiobacillus Bioreactor Community</h2>
+                        <p class="description">A laboratory bioreactor microbial community derived from consortia used to treat thiocyanate-contaminated water, perturbed by systematically increased SCN- input loading and the presence or absence of molasses as organic carbon. Five experiments over 790 days with genome-resolved metagenomics showed that a single Thiobacillus strain proliferated in all reactors at high SCN- loading, while a single Afipia variant dominated the molasses- free reactor at moderate loadings. The Afipia variant is predicted to degrade SCN- via a novel thiocyanate desulfurase, oxidize the resulting reduced sulfur, degrade the cyanate product to ammonia and CO2 via cyanate hydratase, and fix CO2 via the Calvin-Benson-Bassham cycle. Removal of molasses reproducibly selects for this autotrophic strain, although molasses-free reactors did not sustain high-loading SCN- degradation, possibly due to loss of biofilm-associated niche diversity.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Tinto_River_Iron_Cycling_Community.html"
+                       class="community-card"
+                       data-id="Tinto_River_Iron_Cycling_Community"
+                       data-name="tinto river iron cycling community"
+                       data-description="a natural acidic iron-cycling microbial community from the rio tinto river in southwestern spain, distinguished by exceptional eukaryotic diversity (&gt;65% of total biomass) in an extremely acidic environment (mean ph 2.2). while prokaryotic diversity is low with 80% of bacteria belonging to three iron-cycling genera (leptospirillum, acidithiobacillus, acidiphilium), eukaryotic diversity is remarkably high including algae (diatoms, chlorophyta, euglenozoa, rhodophyta), fungi (hortaea, acidomyces), and diverse protists (ciliates, amoebae, heliozoans, cercomonads, stramenopiles). the river has constant acidic ph (mean 2.2, range 1.0-2.5) and high metal concentrations (fe 2.3 g/l, cu 0.11 g/l, zn 0.22 g/l) throughout its 100 km length, driven by natural oxidation of massive sulfide deposits in the iberian pyrite belt. the prokaryotic community drives iron cycling through fe²⁺ oxidation (leptospirillum, acidithiobacillus) and heterotrophic carbon cycling (acidiphilium), creating stromatolite-like iron oxide precipitates. eukaryotes contribute primary production (photosynthetic algae), heterotrophic consumption (protists, fungi), and trophic structure (ciliate predators, heliozoan top predators). the ecosystem represents a natural analog for early earth conditions and extraterrestrial iron-rich acidic environments, supporting astrobiology research. rio tinto demonstrates that complex food webs with eukaryotic dominance can thrive in extreme acid-metal conditions, challenging assumptions about habitability limits.
+"
+                       data-category="AMD"
+                       data-state="STABLE"
+                       data-metals="IRON"
+                       data-ree=""
+                       data-relevance="PRIMARY"
+                       data-member-count="6">
+                        <h2>Tinto River Iron Cycling Community</h2>
+                        <p class="description">A natural acidic iron-cycling microbial community from the Rio Tinto River in southwestern Spain, distinguished by exceptional eukaryotic diversity (&gt;65% of total biomass) in an extremely acidic environment (mean pH 2.2). While prokaryotic diversity is low with 80% of bacteria belonging to three iron-cycling genera (Leptospirillum, Acidithiobacillus, Acidiphilium), eukaryotic diversity is remarkably high including algae (diatoms, Chlorophyta, Euglenozoa, Rhodophyta), fungi (Hortaea, Acidomyces), and diverse protists (ciliates, amoebae, heliozoans, cercomonads, stramenopiles). The river has constant acidic pH (mean 2.2, range 1.0-2.5) and high metal concentrations (Fe 2.3 g/L, Cu 0.11 g/L, Zn 0.22 g/L) throughout its 100 km length, driven by natural oxidation of massive sulfide deposits in the Iberian Pyrite Belt. The prokaryotic community drives iron cycling through Fe²⁺ oxidation (Leptospirillum, Acidithiobacillus) and heterotrophic carbon cycling (Acidiphilium), creating stromatolite-like iron oxide precipitates. Eukaryotes contribute primary production (photosynthetic algae), heterotrophic consumption (protists, fungi), and trophic structure (ciliate predators, heliozoan top predators). The ecosystem represents a natural analog for early Earth conditions and extraterrestrial iron-rich acidic environments, supporting astrobiology research. Rio Tinto demonstrates that complex food webs with eukaryotic dominance can thrive in extreme acid-metal conditions, challenging assumptions about habitability limits.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    6
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">AMD</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Tobacco_Chemotactic_Biocontrol_SynCom.html"
+                       class="community-card"
+                       data-id="Tobacco_Chemotactic_Biocontrol_SynCom"
+                       data-name="tobacco chemotactic biocontrol syncom"
+                       data-description="a chemotactic three-member syncom in bioorganic fertilizer for suppressing ralstonia solanacearum in tobacco fields."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Tobacco Chemotactic Biocontrol SynCom</h2>
+                        <p class="description">A chemotactic three-member SynCom in bioorganic fertilizer for suppressing Ralstonia solanacearum in tobacco fields.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Tomato_Oxylipin_SynCom3.html"
+                       class="community-card"
+                       data-id="Tomato_Oxylipin_SynCom3"
+                       data-name="tomato oxylipin-protective syncom3"
+                       data-description="a three-species simplified tomato rhizosphere syncom that steers oxylipin pathways and protects against botrytis cinerea."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Tomato Oxylipin-Protective SynCom3</h2>
+                        <p class="description">A three-species simplified tomato rhizosphere SynCom that steers oxylipin pathways and protects against Botrytis cinerea.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.html"
+                       class="community-card"
+                       data-id="Tribromophenol_Anaerobic_Bioremediation_SynCom"
+                       data-name="tribromophenol anaerobic bioremediation syncom"
+                       data-description="a synthetic anaerobic community with clostridium, dehalobacter, and desulfatiglans functions for 2,4,6-tribromophenol mineralization."
+                       data-category="BIOREMEDIATION"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Tribromophenol Anaerobic Bioremediation SynCom</h2>
+                        <p class="description">A synthetic anaerobic community with Clostridium, Dehalobacter, and Desulfatiglans functions for 2,4,6-tribromophenol mineralization.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.html"
+                       class="community-card"
+                       data-id="Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture"
+                       data-name="trichococcus-syntrophomonas-methanospirillum butyrate coculture"
+                       data-description="a defined anaerobic three-member coculture in which fermentative trichococcus flocculiformis strain es5 stimulates the syntrophic butyrate-oxidizing partnership between syntrophomonas wolfei and methanospirillum hungatei. the system extends the classic two-member fatty-acid syntrophy model by adding a fermentative bacterium that increases butyrate consumption and methane production and aggregates with the syntrophic partners. it is relevant to doe anaerobic carbon cycling, wastewater treatment bioreactors, and engineered methanogenic consortia.
+"
+                       data-category="SYNTROPHY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Trichococcus-Syntrophomonas-Methanospirillum Butyrate Coculture</h2>
+                        <p class="description">A defined anaerobic three-member coculture in which fermentative Trichococcus flocculiformis strain ES5 stimulates the syntrophic butyrate-oxidizing partnership between Syntrophomonas wolfei and Methanospirillum hungatei. The system extends the classic two-member fatty-acid syntrophy model by adding a fermentative bacterium that increases butyrate consumption and methane production and aggregates with the syntrophic partners. It is relevant to DOE anaerobic carbon cycling, wastewater treatment bioreactors, and engineered methanogenic consortia.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">SYNTROPHY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.html"
+                       class="community-card"
+                       data-id="Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture"
+                       data-name="trichoderma-e. coli cellulosic isobutanol coculture"
+                       data-description="a synthetic fungal-bacterial consortium designed for direct conversion of cellulosic biomass to isobutanol. the community divides labor between trichoderma reesei, which secretes cellulases that hydrolyze lignocellulosic biomass into soluble saccharides, and escherichia coli, which metabolizes those saccharides into the target biofuel product. the study demonstrated conversion of microcrystalline cellulose and pretreated corn stover to isobutanol, making the system relevant to doe lignocellulosic biofuel and consolidated bioprocessing goals.
+"
+                       data-category="LIGNOCELLULOSE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Trichoderma-E. coli Cellulosic Isobutanol Coculture</h2>
+                        <p class="description">A synthetic fungal-bacterial consortium designed for direct conversion of cellulosic biomass to isobutanol. The community divides labor between Trichoderma reesei, which secretes cellulases that hydrolyze lignocellulosic biomass into soluble saccharides, and Escherichia coli, which metabolizes those saccharides into the target biofuel product. The study demonstrated conversion of microcrystalline cellulose and pretreated corn stover to isobutanol, making the system relevant to DOE lignocellulosic biofuel and consolidated bioprocessing goals.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Trichoderma_Lactate_Platform.html"
+                       class="community-card"
+                       data-id="Trichoderma_Lactate_Platform"
+                       data-name="trichoderma lactate platform for scfa production"
+                       data-description="a heterogeneous 3-member consortium for direct conversion of lignocellulose to short-chain fatty acids (scfas), specifically butyric acid. the platform consists of trichoderma reesei rut-c30 (aerobic fungus producing cellulases), lactobacillus pentosus (facultative anaerobic lactic acid bacterium), and clostridium tyrobutyricum (obligate anaerobic butyrate producer). sequential inoculation creates an oxygen gradient allowing coexistence of all members. t. reesei degrades cellulose to sugars, lab converts sugars to lactate and creates anaerobic conditions, and c. tyrobutyricum ferments lactate to butyrate, achieving 196 kg butyric acid per metric ton of beechwood.
+"
+                       data-category="LIGNOCELLULOSE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="INCIDENTAL"
+                       data-member-count="3">
+                        <h2>Trichoderma Lactate Platform for SCFA Production</h2>
+                        <p class="description">A heterogeneous 3-member consortium for direct conversion of lignocellulose to short-chain fatty acids (SCFAs), specifically butyric acid. The platform consists of Trichoderma reesei Rut-C30 (aerobic fungus producing cellulases), Lactobacillus pentosus (facultative anaerobic lactic acid bacterium), and Clostridium tyrobutyricum (obligate anaerobic butyrate producer). Sequential inoculation creates an oxygen gradient allowing coexistence of all members. T. reesei degrades cellulose to sugars, LAB converts sugars to lactate and creates anaerobic conditions, and C. tyrobutyricum ferments lactate to butyrate, achieving 196 kg butyric acid per metric ton of beechwood.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.html"
+                       class="community-card"
+                       data-id="Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture"
+                       data-name="trichoderma-streptomyces filamentous cellulose coculture"
+                       data-description="a synthetic filamentous coculture pairing the cellulolytic fungus trichoderma reesei rut-c30 with the noncellulolytic bacterium streptomyces coelicolor a3(2). the coculture was designed to use cellulose as the carbon source, making s. coelicolor dependent on hydrolysate sugars released by t. reesei cellulases. the system is doe-relevant as a controllable model for lignocellulose-oriented coculture bioprocessing, where population dynamics, cellulase formation, and secondary-metabolite/pigment production can be tuned through inoculation ratio and abiotic process parameters.
+"
+                       data-category="LIGNOCELLULOSE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Trichoderma-Streptomyces Filamentous Cellulose Coculture</h2>
+                        <p class="description">A synthetic filamentous coculture pairing the cellulolytic fungus Trichoderma reesei RUT-C30 with the noncellulolytic bacterium Streptomyces coelicolor A3(2). The coculture was designed to use cellulose as the carbon source, making S. coelicolor dependent on hydrolysate sugars released by T. reesei cellulases. The system is DOE-relevant as a controllable model for lignocellulose-oriented coculture bioprocessing, where population dynamics, cellulase formation, and secondary-metabolite/pigment production can be tuned through inoculation ratio and abiotic process parameters.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Trichodesmium_Alteromonas_Marine_Consortium.html"
+                       class="community-card"
+                       data-id="Trichodesmium_Alteromonas_Marine_Consortium"
+                       data-name="trichodesmium-alteromonas marine consortium"
+                       data-description="a marine cyanobacterial colony consortium centered on the nitrogen-fixing photoautotroph trichodesmium erythraeum ims101 and conserved heterotrophic partners, especially alteromonas macleodii. multi-omics studies support recurring trichodesmium-associated bacterial consortia in cultures and natural colonies, with potential interactions involving iron and phosphorus acquisition, vitamin b12 exchange, small-carbon compound catabolism, reactive oxygen detoxification, and coordinated diel resource cycling.
+"
+                       data-category="PHYTOPLANKTON"
+                       data-state="STABLE"
+                       data-metals="IRON"
+                       data-ree=""
+                       data-relevance="SIGNIFICANT"
+                       data-member-count="3">
+                        <h2>Trichodesmium-Alteromonas Marine Consortium</h2>
+                        <p class="description">A marine cyanobacterial colony consortium centered on the nitrogen-fixing photoautotroph Trichodesmium erythraeum IMS101 and conserved heterotrophic partners, especially Alteromonas macleodii. Multi-omics studies support recurring Trichodesmium-associated bacterial consortia in cultures and natural colonies, with potential interactions involving iron and phosphorus acquisition, vitamin B12 exchange, small-carbon compound catabolism, reactive oxygen detoxification, and coordinated diel resource cycling.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">PHYTOPLANKTON</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Urine_Nitrification_SynCom.html"
+                       class="community-card"
+                       data-id="Urine_Nitrification_SynCom"
+                       data-name="urine nitrification synthetic microbial community"
+                       data-description="a five-member synthetic microbial community containing nitrifiers and ureolytic heterotrophs for urine nitrification."
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="5">
+                        <h2>Urine Nitrification Synthetic Microbial Community</h2>
+                        <p class="description">A five-member synthetic microbial community containing nitrifiers and ureolytic heterotrophs for urine nitrification.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    5
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.html"
+                       class="community-card"
+                       data-id="Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm"
+                       data-name="variovorax-cryptococcus vitamin cross-feeding microcosm"
+                       data-description="a two-member vitamin cross-feeding microcosm derived from mine tailings laboratory microbial consortia, in which a variovorax species produces thiamine (vitamin b1) as a community hub for correlated thiamine auxotrophs and a cryptococcus yeast supplies pantothenate (vitamin b5) required by variovorax. co-culture of the two members yielded a 90-130 fold fitness increase for both organisms, supporting the bidirectional vitamin-dependent mutualism predicted from metagenome-informed abundance correlation networks of mine-tailings-derived consortia grown under dozens of conditions.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Variovorax-Cryptococcus Vitamin Cross-Feeding Microcosm</h2>
+                        <p class="description">A two-member vitamin cross-feeding microcosm derived from mine tailings laboratory microbial consortia, in which a Variovorax species produces thiamine (vitamin B1) as a community hub for correlated thiamine auxotrophs and a Cryptococcus yeast supplies pantothenate (vitamin B5) required by Variovorax. Co-culture of the two members yielded a 90-130 fold fitness increase for both organisms, supporting the bidirectional vitamin-dependent mutualism predicted from metagenome-informed abundance correlation networks of mine-tailings-derived consortia grown under dozens of conditions.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Watermelon_Rhizosphere_Fusarium_SynCom8.html"
+                       class="community-card"
+                       data-id="Watermelon_Rhizosphere_Fusarium_SynCom8"
+                       data-name="watermelon rhizosphere fusarium-protective syncom8"
+                       data-description="a simplified eight-member watermelon rhizosphere syncom derived from an initial 16-member grafted-watermelon core community."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Watermelon Rhizosphere Fusarium-Protective SynCom8</h2>
+                        <p class="description">A simplified eight-member watermelon rhizosphere SynCom derived from an initial 16-member grafted-watermelon core community.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.html"
+                       class="community-card"
+                       data-id="Wetland_Oxygen_Sulfate_GHG_Microcosm_Community"
+                       data-name="wetland oxygen-sulfate greenhouse gas microcosm community"
+                       data-description="freshwater wetland soil microbial microcosms incubated under anoxic non-sulfate, anoxic sulfate-addition, oxic non-sulfate, and oxic sulfate-addition conditions to resolve how climate-linked oxygen and sulfate exposures alter methane and carbon dioxide emissions. the study integrated geochemical measurements, proteogenomics, metaproteomics, and stoichiometric modeling to identify altered microbial guilds and metabolic processes driving ch4 and co2 emissions. sulfate exposure reduced methane production, oxygen shifted greenhouse gas emissions from ch4 toward co2, and the combined exposure resembled oxygen exposure alone.
+"
+                       data-category="METHANOGENESIS"
+                       data-state="PERTURBED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Wetland Oxygen-Sulfate Greenhouse Gas Microcosm Community</h2>
+                        <p class="description">Freshwater wetland soil microbial microcosms incubated under anoxic non-sulfate, anoxic sulfate-addition, oxic non-sulfate, and oxic sulfate-addition conditions to resolve how climate-linked oxygen and sulfate exposures alter methane and carbon dioxide emissions. The study integrated geochemical measurements, proteogenomics, metaproteomics, and stoichiometric modeling to identify altered microbial guilds and metabolic processes driving CH4 and CO2 emissions. Sulfate exposure reduced methane production, oxygen shifted greenhouse gas emissions from CH4 toward CO2, and the combined exposure resembled oxygen exposure alone.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-PERTURBED">PERTURBED</span>
+                            </div>
+                            <span class="badge badge-category">METHANOGENESIS</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Wheat_Consortium_C1.html"
+                       class="community-card"
+                       data-id="Wheat_Consortium_C1"
+                       data-name="wheat synthetic consortium c1"
+                       data-description="a synthetic 3-member rhizosphere consortium (c1) for biocontrol of soilborne fungal pathogens in wheat. the consortium consists of cupriavidus campinensis b20, asticcacaulis sp. b27, and an additional rhizosphere isolate. together, these bacteria suppress rhizoctonia solani ag8 through production of antimicrobial compounds, volatile organic compounds, and induced systemic resistance in wheat plants, providing effective biological control for sustainable agriculture.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="INCIDENTAL"
+                       data-member-count="3">
+                        <h2>Wheat Synthetic Consortium C1</h2>
+                        <p class="description">A synthetic 3-member rhizosphere consortium (C1) for biocontrol of soilborne fungal pathogens in wheat. The consortium consists of Cupriavidus campinensis B20, Asticcacaulis sp. B27, and an additional rhizosphere isolate. Together, these bacteria suppress Rhizoctonia solani AG8 through production of antimicrobial compounds, volatile organic compounds, and induced systemic resistance in wheat plants, providing effective biological control for sustainable agriculture.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Wheat_Consortium_C6.html"
+                       class="community-card"
+                       data-id="Wheat_Consortium_C6"
+                       data-name="wheat synthetic consortium c6"
+                       data-description="a synthetic 4-member rhizosphere consortium (c6) for biocontrol of rhizoctonia solani in wheat. the consortium includes janthinobacterium lividum bj, pseudomonas sp. p25, and two additional rhizosphere bacteria. together, they provide effective suppression of r. solani ag8, a major soilborne pathogen causing root disease in wheat, through synergistic antimicrobial activity and plant growth promotion.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="INCIDENTAL"
+                       data-member-count="3">
+                        <h2>Wheat Synthetic Consortium C6</h2>
+                        <p class="description">A synthetic 4-member rhizosphere consortium (C6) for biocontrol of Rhizoctonia solani in wheat. The consortium includes Janthinobacterium lividum BJ, Pseudomonas sp. P25, and two additional rhizosphere bacteria. Together, they provide effective suppression of R. solani AG8, a major soilborne pathogen causing root disease in wheat, through synergistic antimicrobial activity and plant growth promotion.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Wheat_Straw_Biogas_Pretreatment_SynCom.html"
+                       class="community-card"
+                       data-id="Wheat_Straw_Biogas_Pretreatment_SynCom"
+                       data-name="wheat straw biogas pretreatment syncom"
+                       data-description="a four-member bacterial-fungal synthetic microbial community that produces enzymes for wheat straw pretreatment and enhanced biogas production."
+                       data-category="LIGNOCELLULOSE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Wheat Straw Biogas Pretreatment SynCom</h2>
+                        <p class="description">A four-member bacterial-fungal synthetic microbial community that produces enzymes for wheat straw pretreatment and enhanced biogas production.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Yogurt_TwoSpecies_Starter_Culture.html"
+                       class="community-card"
+                       data-id="Yogurt_TwoSpecies_Starter_Culture"
+                       data-name="yogurt two-species starter culture"
+                       data-description="a defined thermophilic dairy fermentation community composed of streptococcus thermophilus and lactobacillus delbrueckii subsp. bulgaricus. the two lactic-acid bacteria form the canonical yogurt starter association, where metabolite exchange accelerates milk acidification: s. thermophilus provides formate, carbon dioxide, and urease-dependent ammonia/carbon dioxide effects that stimulate the lactobacillus, while proteolytic activity of l. delbrueckii subsp. bulgaricus releases peptides and amino acids that support the more weakly proteolytic streptococcus.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Yogurt Two-Species Starter Culture</h2>
+                        <p class="description">A defined thermophilic dairy fermentation community composed of Streptococcus thermophilus and Lactobacillus delbrueckii subsp. bulgaricus. The two lactic-acid bacteria form the canonical yogurt starter association, where metabolite exchange accelerates milk acidification: S. thermophilus provides formate, carbon dioxide, and urease-dependent ammonia/carbon dioxide effects that stimulate the lactobacillus, while proteolytic activity of L. delbrueckii subsp. bulgaricus releases peptides and amino acids that support the more weakly proteolytic streptococcus.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.html"
+                       class="community-card"
+                       data-id="Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism"
+                       data-name="zymomonas-e. coli exometabolomics-designed obligate mutualism"
+                       data-description="a defined synthetic obligate mutualism pairing auxotrophic zymomonas mobilis with auxotrophic escherichia coli. exometabolomics of z. mobilis spent medium identified amino acid exometabolites used to select e. coli proa, phea, and ilva auxotroph partners, while mutant fitness profiling selected a z. mobilis zmo0748 auxotroph whose rescue was linked to glutathione-related metabolites in e. coli spent medium. the system is doe-relevant because it was developed by lbnl and sandia researchers with doe ber support as a synthetic microbial ecology platform for more resilient biotechnology processes.
+"
+                       data-category="BIOTECHNOLOGY"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Zymomonas-E. coli Exometabolomics-Designed Obligate Mutualism</h2>
+                        <p class="description">A defined synthetic obligate mutualism pairing auxotrophic Zymomonas mobilis with auxotrophic Escherichia coli. Exometabolomics of Z. mobilis spent medium identified amino acid exometabolites used to select E. coli proA, pheA, and ilvA auxotroph partners, while mutant fitness profiling selected a Z. mobilis ZMO0748 auxotroph whose rescue was linked to glutathione-related metabolites in E. coli spent medium. The system is DOE-relevant because it was developed by LBNL and Sandia researchers with DOE BER support as a synthetic microbial ecology platform for more resilient biotechnology processes.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/hCom2_Complex_Gut_Microbiome.html"
+                       class="community-card"
+                       data-id="hCom2_Complex_Gut_Microbiome"
+                       data-name="hcom2 complex gut microbiome"
+                       data-description="a complex defined human gut microbiome assembled from hcom1 and iteratively augmented after fecal challenge to improve stability and colonization resistance in gnotobiotic mice."
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="1">
+                        <h2>hCom2 Complex Gut Microbiome</h2>
+                        <p class="description">A complex defined human gut microbiome assembled from hCom1 and iteratively augmented after fecal challenge to improve stability and colonization resistance in gnotobiotic mice.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    1
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/mCAFEs_Brachypodium_RCC.html"
+                       class="community-card"
+                       data-id="mCAFEs_Brachypodium_RCC"
+                       data-name="m-cafes brachypodium reduced complexity consortia"
+                       data-description="a systematic framework for assembling rhizosphere-derived reduced complexity consortia (rcc) from brachypodium distachyon roots grown in field soil from angelo coast range reserve, california. enriched co-localized microbes with carbon substrates mimicking root exudates, generating 768 enrichments. transferred every 3 or 7 days for 10 generations to develop fast and slow-growing reduced complexity communities. keystone taxa identified within these networks belong to genera with plant growth-promoting traits. tested consortia demonstrated high stability and reproducibility, assuring successful revival from glycerol stocks."
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="10">
+                        <h2>m-CAFEs Brachypodium Reduced Complexity Consortia</h2>
+                        <p class="description">A systematic framework for assembling rhizosphere-derived Reduced Complexity Consortia (RCC) from Brachypodium distachyon roots grown in field soil from Angelo Coast Range Reserve, California. Enriched co-localized microbes with carbon substrates mimicking root exudates, generating 768 enrichments. Transferred every 3 or 7 days for 10 generations to develop fast and slow-growing reduced complexity communities. Keystone taxa identified within these networks belong to genera with plant growth-promoting traits. Tested consortia demonstrated high stability and reproducibility, assuring successful revival from glycerol stocks.</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    10
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>Generated by CommunityMech | <a href="https://github.com/CultureBotAI/CommunityMech">View on GitHub</a></p>
+        </div>
+    </footer>
+
+    <script>
+        // ===== FILTERING SYSTEM =====
+
+        // Filter state
+        const filterState = {
+            searchTerm: '',
+            categories: new Set(),
+            ecologicalStates: new Set(),
+            metals: new Set(),
+            rareEarthElements: new Set(),
+            metalRelevance: new Set(),
+
+            hasActiveFilters() {
+                return this.searchTerm ||
+                       this.categories.size > 0 ||
+                       this.ecologicalStates.size > 0 ||
+                       this.metals.size > 0 ||
+                       this.rareEarthElements.size > 0 ||
+                       this.metalRelevance.size > 0;
+            },
+
+            reset() {
+                this.searchTerm = '';
+                this.categories.clear();
+                this.ecologicalStates.clear();
+                this.metals.clear();
+                this.rareEarthElements.clear();
+                this.metalRelevance.clear();
+            }
+        };
+
+        // Get all community cards
+        const allCards = Array.from(document.querySelectorAll('.community-card'));
+
+        // Initialize facets on page load
+        function initializeFacets() {
+            const categoryCounts = {};
+            const stateCounts = {};
+            const metalsCounts = {};
+            const reeCounts = {};
+            const relevanceCounts = {};
+
+            allCards.forEach(card => {
+                const category = card.dataset.category;
+                const state = card.dataset.state;
+
+                categoryCounts[category] = (categoryCounts[category] || 0) + 1;
+                stateCounts[state] = (stateCounts[state] || 0) + 1;
+
+                // Count metals
+                const metals = card.dataset.metals.split(',').filter(m => m);
+                metals.forEach(metal => {
+                    metalsCounts[metal] = (metalsCounts[metal] || 0) + 1;
+                });
+
+                // Count REE
+                const ree = card.dataset.ree.split(',').filter(r => r);
+                ree.forEach(element => {
+                    reeCounts[element] = (reeCounts[element] || 0) + 1;
+                });
+
+                // Count relevance
+                const relevance = card.dataset.relevance;
+                if (relevance && relevance !== 'NOT_APPLICABLE') {
+                    relevanceCounts[relevance] = (relevanceCounts[relevance] || 0) + 1;
+                }
+            });
+
+            // Generate category checkboxes sorted by count (descending)
+            const categoryContainer = document.getElementById('category-checkboxes');
+            Object.entries(categoryCounts)
+                .sort((a, b) => b[1] - a[1])
+                .forEach(([category, count]) => {
+                    const label = document.createElement('label');
+                    label.className = 'facet-checkbox';
+
+                    const checkbox = document.createElement('input');
+                    checkbox.type = 'checkbox';
+                    checkbox.value = category;
+                    checkbox.dataset.facet = 'category';
+                    checkbox.addEventListener('change', handleFilterChange);
+
+                    const labelSpan = document.createElement('span');
+                    labelSpan.className = 'facet-label';
+                    labelSpan.textContent = category.replace(/_/g, ' ');
+
+                    const countSpan = document.createElement('span');
+                    countSpan.className = 'facet-count';
+                    countSpan.dataset.category = category;
+                    countSpan.textContent = `(${count})`;
+
+                    label.appendChild(checkbox);
+                    label.appendChild(labelSpan);
+                    label.appendChild(countSpan);
+                    categoryContainer.appendChild(label);
+                });
+
+            // Generate ecological state checkboxes
+            const stateContainer = document.getElementById('state-checkboxes');
+            Object.entries(stateCounts)
+                .sort((a, b) => b[1] - a[1])
+                .forEach(([state, count]) => {
+                    const label = document.createElement('label');
+                    label.className = 'facet-checkbox';
+
+                    const checkbox = document.createElement('input');
+                    checkbox.type = 'checkbox';
+                    checkbox.value = state;
+                    checkbox.dataset.facet = 'ecologicalState';
+                    checkbox.addEventListener('change', handleFilterChange);
+
+                    const labelSpan = document.createElement('span');
+                    labelSpan.className = 'facet-label';
+                    labelSpan.textContent = state.replace(/_/g, ' ');
+
+                    const countSpan = document.createElement('span');
+                    countSpan.className = 'facet-count';
+                    countSpan.dataset.state = state;
+                    countSpan.textContent = `(${count})`;
+
+                    label.appendChild(checkbox);
+                    label.appendChild(labelSpan);
+                    label.appendChild(countSpan);
+                    stateContainer.appendChild(label);
+                });
+
+            // Generate metals checkboxes
+            const metalsContainer = document.getElementById('metals-checkboxes');
+            Object.entries(metalsCounts)
+                .sort((a, b) => b[1] - a[1])
+                .forEach(([metal, count]) => {
+                    const label = document.createElement('label');
+                    label.className = 'facet-checkbox';
+
+                    const checkbox = document.createElement('input');
+                    checkbox.type = 'checkbox';
+                    checkbox.value = metal;
+                    checkbox.dataset.facet = 'metals';
+                    checkbox.addEventListener('change', handleFilterChange);
+
+                    const labelSpan = document.createElement('span');
+                    labelSpan.className = 'facet-label';
+                    labelSpan.textContent = metal.replace(/_/g, ' ');
+
+                    const countSpan = document.createElement('span');
+                    countSpan.className = 'facet-count';
+                    countSpan.dataset.metal = metal;
+                    countSpan.textContent = `(${count})`;
+
+                    label.appendChild(checkbox);
+                    label.appendChild(labelSpan);
+                    label.appendChild(countSpan);
+                    metalsContainer.appendChild(label);
+                });
+
+            // Generate REE checkboxes
+            const reeContainer = document.getElementById('ree-checkboxes');
+            Object.entries(reeCounts)
+                .sort((a, b) => b[1] - a[1])
+                .forEach(([element, count]) => {
+                    const label = document.createElement('label');
+                    label.className = 'facet-checkbox';
+
+                    const checkbox = document.createElement('input');
+                    checkbox.type = 'checkbox';
+                    checkbox.value = element;
+                    checkbox.dataset.facet = 'ree';
+                    checkbox.addEventListener('change', handleFilterChange);
+
+                    const labelSpan = document.createElement('span');
+                    labelSpan.className = 'facet-label';
+                    labelSpan.textContent = element.replace(/_/g, ' ');
+
+                    const countSpan = document.createElement('span');
+                    countSpan.className = 'facet-count';
+                    countSpan.dataset.ree = element;
+                    countSpan.textContent = `(${count})`;
+
+                    label.appendChild(checkbox);
+                    label.appendChild(labelSpan);
+                    label.appendChild(countSpan);
+                    reeContainer.appendChild(label);
+                });
+
+            // Generate metal relevance checkboxes
+            const relevanceContainer = document.getElementById('relevance-checkboxes');
+            const relevanceOrder = ['PRIMARY', 'SIGNIFICANT', 'INCIDENTAL'];
+            relevanceOrder.forEach(relevance => {
+                const count = relevanceCounts[relevance];
+                if (!count) return;
+
+                const label = document.createElement('label');
+                label.className = 'facet-checkbox';
+
+                const checkbox = document.createElement('input');
+                checkbox.type = 'checkbox';
+                checkbox.value = relevance;
+                checkbox.dataset.facet = 'relevance';
+                checkbox.addEventListener('change', handleFilterChange);
+
+                const labelSpan = document.createElement('span');
+                labelSpan.className = 'facet-label';
+                labelSpan.textContent = relevance.replace(/_/g, ' ');
+
+                const countSpan = document.createElement('span');
+                countSpan.className = 'facet-count';
+                countSpan.dataset.relevance = relevance;
+                countSpan.textContent = `(${count})`;
+
+                label.appendChild(checkbox);
+                label.appendChild(labelSpan);
+                label.appendChild(countSpan);
+                relevanceContainer.appendChild(label);
+            });
+        }
+
+        // Core filtering function
+        function applyFilters() {
+            return allCards.filter(card => {
+                // Search filter (multi-field)
+                if (filterState.searchTerm) {
+                    const term = filterState.searchTerm.toLowerCase();
+                    const matches = card.dataset.name.includes(term) ||
+                                  card.dataset.description.includes(term);
+                    if (!matches) return false;
+                }
+
+                // Category filter (OR logic within facet)
+                if (filterState.categories.size > 0 &&
+                    !filterState.categories.has(card.dataset.category)) return false;
+
+                // State filter
+                if (filterState.ecologicalStates.size > 0 &&
+                    !filterState.ecologicalStates.has(card.dataset.state)) return false;
+
+                // Metal filter (OR logic within facet)
+                if (filterState.metals.size > 0) {
+                    const cardMetals = card.dataset.metals.split(',').filter(m => m);
+                    const hasMatch = cardMetals.some(m => filterState.metals.has(m));
+                    if (!hasMatch) return false;
+                }
+
+                // REE filter (OR logic within facet)
+                if (filterState.rareEarthElements.size > 0) {
+                    const cardRee = card.dataset.ree.split(',').filter(r => r);
+                    const hasMatch = cardRee.some(r => filterState.rareEarthElements.has(r));
+                    if (!hasMatch) return false;
+                }
+
+                // Metal relevance filter (OR logic)
+                if (filterState.metalRelevance.size > 0 &&
+                    !filterState.metalRelevance.has(card.dataset.relevance)) return false;
+
+                return true;
+            });
+        }
+
+        // Update visualization with filtered data
+        function updateFiltering() {
+            const filteredCards = applyFilters();
+            const filteredIds = new Set(filteredCards.map(card => card.dataset.id));
+
+            // Update card visibility
+            allCards.forEach(card => {
+                if (filteredIds.has(card.dataset.id)) {
+                    card.classList.remove('hidden');
+                } else {
+                    card.classList.add('hidden');
+                }
+            });
+
+            // Update counts
+            document.getElementById('results-count').textContent = filteredCards.length;
+            updateFilterCounts(filteredCards);
+            updateActiveFiltersSummary();
+        }
+
+        // Update facet counts based on current filters
+        function updateFilterCounts(filteredCards) {
+            const categoryCounts = {};
+            const stateCounts = {};
+            const metalsCounts = {};
+            const reeCounts = {};
+            const relevanceCounts = {};
+
+            filteredCards.forEach(card => {
+                const category = card.dataset.category;
+                const state = card.dataset.state;
+                categoryCounts[category] = (categoryCounts[category] || 0) + 1;
+                stateCounts[state] = (stateCounts[state] || 0) + 1;
+
+                // Count metals
+                const metals = card.dataset.metals.split(',').filter(m => m);
+                metals.forEach(metal => {
+                    metalsCounts[metal] = (metalsCounts[metal] || 0) + 1;
+                });
+
+                // Count REE
+                const ree = card.dataset.ree.split(',').filter(r => r);
+                ree.forEach(element => {
+                    reeCounts[element] = (reeCounts[element] || 0) + 1;
+                });
+
+                // Count relevance
+                const relevance = card.dataset.relevance;
+                if (relevance && relevance !== 'NOT_APPLICABLE') {
+                    relevanceCounts[relevance] = (relevanceCounts[relevance] || 0) + 1;
+                }
+            });
+
+            // Update category counts
+            document.querySelectorAll('.facet-count[data-category]').forEach(el => {
+                const category = el.dataset.category;
+                const count = categoryCounts[category] || 0;
+                el.textContent = `(${count})`;
+            });
+
+            // Update state counts
+            document.querySelectorAll('.facet-count[data-state]').forEach(el => {
+                const state = el.dataset.state;
+                const count = stateCounts[state] || 0;
+                el.textContent = `(${count})`;
+            });
+
+            // Update metal counts
+            document.querySelectorAll('.facet-count[data-metal]').forEach(el => {
+                const metal = el.dataset.metal;
+                const count = metalsCounts[metal] || 0;
+                el.textContent = `(${count})`;
+            });
+
+            // Update REE counts
+            document.querySelectorAll('.facet-count[data-ree]').forEach(el => {
+                const ree = el.dataset.ree;
+                const count = reeCounts[ree] || 0;
+                el.textContent = `(${count})`;
+            });
+
+            // Update relevance counts
+            document.querySelectorAll('.facet-count[data-relevance]').forEach(el => {
+                const relevance = el.dataset.relevance;
+                const count = relevanceCounts[relevance] || 0;
+                el.textContent = `(${count})`;
+            });
+        }
+
+        // Update active filters summary
+        function updateActiveFiltersSummary() {
+            const container = document.getElementById('active-filters');
+            const tagsContainer = document.getElementById('active-filter-tags');
+            tagsContainer.innerHTML = '';
+
+            if (!filterState.hasActiveFilters()) {
+                container.style.display = 'none';
+                return;
+            }
+
+            container.style.display = 'block';
+
+            // Add search tag
+            if (filterState.searchTerm) {
+                const tag = document.createElement('div');
+                tag.className = 'filter-tag';
+                tag.innerHTML = `<span>Search: "${filterState.searchTerm}"</span>`;
+
+                const remove = document.createElement('span');
+                remove.className = 'filter-tag-remove';
+                remove.textContent = '✕';
+                remove.onclick = () => {
+                    document.getElementById('search').value = '';
+                    filterState.searchTerm = '';
+                    updateFiltering();
+                };
+
+                tag.appendChild(remove);
+                tagsContainer.appendChild(tag);
+            }
+
+            // Add category tags
+            filterState.categories.forEach(cat => {
+                const tag = document.createElement('div');
+                tag.className = 'filter-tag';
+                tag.innerHTML = `<span>${cat.replace(/_/g, ' ')}</span>`;
+
+                const remove = document.createElement('span');
+                remove.className = 'filter-tag-remove';
+                remove.textContent = '✕';
+                remove.onclick = () => {
+                    filterState.categories.delete(cat);
+                    document.querySelector(`input[value="${cat}"][data-facet="category"]`).checked = false;
+                    updateFiltering();
+                };
+
+                tag.appendChild(remove);
+                tagsContainer.appendChild(tag);
+            });
+
+            // Add state tags
+            filterState.ecologicalStates.forEach(state => {
+                const tag = document.createElement('div');
+                tag.className = 'filter-tag';
+                tag.innerHTML = `<span>${state.replace(/_/g, ' ')}</span>`;
+
+                const remove = document.createElement('span');
+                remove.className = 'filter-tag-remove';
+                remove.textContent = '✕';
+                remove.onclick = () => {
+                    filterState.ecologicalStates.delete(state);
+                    document.querySelector(`input[value="${state}"][data-facet="ecologicalState"]`).checked = false;
+                    updateFiltering();
+                };
+
+                tag.appendChild(remove);
+                tagsContainer.appendChild(tag);
+            });
+
+            // Add metal tags
+            filterState.metals.forEach(metal => {
+                const tag = document.createElement('div');
+                tag.className = 'filter-tag';
+                tag.innerHTML = `<span>Metal: ${metal.replace(/_/g, ' ')}</span>`;
+
+                const remove = document.createElement('span');
+                remove.className = 'filter-tag-remove';
+                remove.textContent = '✕';
+                remove.onclick = () => {
+                    filterState.metals.delete(metal);
+                    document.querySelector(`input[value="${metal}"][data-facet="metals"]`).checked = false;
+                    updateFiltering();
+                };
+
+                tag.appendChild(remove);
+                tagsContainer.appendChild(tag);
+            });
+
+            // Add REE tags
+            filterState.rareEarthElements.forEach(element => {
+                const tag = document.createElement('div');
+                tag.className = 'filter-tag';
+                tag.innerHTML = `<span>REE: ${element.replace(/_/g, ' ')}</span>`;
+
+                const remove = document.createElement('span');
+                remove.className = 'filter-tag-remove';
+                remove.textContent = '✕';
+                remove.onclick = () => {
+                    filterState.rareEarthElements.delete(element);
+                    document.querySelector(`input[value="${element}"][data-facet="ree"]`).checked = false;
+                    updateFiltering();
+                };
+
+                tag.appendChild(remove);
+                tagsContainer.appendChild(tag);
+            });
+
+            // Add relevance tags
+            filterState.metalRelevance.forEach(relevance => {
+                const tag = document.createElement('div');
+                tag.className = 'filter-tag';
+                tag.innerHTML = `<span>Relevance: ${relevance.replace(/_/g, ' ')}</span>`;
+
+                const remove = document.createElement('span');
+                remove.className = 'filter-tag-remove';
+                remove.textContent = '✕';
+                remove.onclick = () => {
+                    filterState.metalRelevance.delete(relevance);
+                    document.querySelector(`input[value="${relevance}"][data-facet="relevance"]`).checked = false;
+                    updateFiltering();
+                };
+
+                tag.appendChild(remove);
+                tagsContainer.appendChild(tag);
+            });
+        }
+
+        // Event handlers
+        let searchTimeout;
+        document.getElementById('search').addEventListener('input', function() {
+            clearTimeout(searchTimeout);
+            searchTimeout = setTimeout(() => {
+                filterState.searchTerm = this.value.trim();
+                updateFiltering();
+            }, 150); // 150ms debounce
+        });
+
+        document.getElementById('search-clear').addEventListener('click', () => {
+            document.getElementById('search').value = '';
+            filterState.searchTerm = '';
+            updateFiltering();
+        });
+
+        function handleFilterChange(event) {
+            const checkbox = event.target;
+            const facetType = checkbox.dataset.facet;
+            const value = checkbox.value;
+
+            let setName;
+            if (facetType === 'category') {
+                setName = 'categories';
+            } else if (facetType === 'ecologicalState') {
+                setName = 'ecologicalStates';
+            } else if (facetType === 'metals') {
+                setName = 'metals';
+            } else if (facetType === 'ree') {
+                setName = 'rareEarthElements';
+            } else if (facetType === 'relevance') {
+                setName = 'metalRelevance';
+            }
+
+            if (checkbox.checked) {
+                filterState[setName].add(value);
+            } else {
+                filterState[setName].delete(value);
+            }
+
+            updateFiltering();
+        }
+
+        // Select All / Clear All buttons
+        document.querySelectorAll('.select-all').forEach(btn => {
+            btn.addEventListener('click', function() {
+                const facetType = this.dataset.facet;
+                document.querySelectorAll(`input[data-facet="${facetType}"]`).forEach(checkbox => {
+                    checkbox.checked = true;
+                    checkbox.dispatchEvent(new Event('change'));
+                });
+            });
+        });
+
+        document.querySelectorAll('.clear-all').forEach(btn => {
+            btn.addEventListener('click', function() {
+                const facetType = this.dataset.facet;
+                document.querySelectorAll(`input[data-facet="${facetType}"]`).forEach(checkbox => {
+                    checkbox.checked = false;
+                    checkbox.dispatchEvent(new Event('change'));
+                });
+            });
+        });
+
+        // Reset all filters
+        document.getElementById('reset-all').addEventListener('click', () => {
+            filterState.reset();
+            document.getElementById('search').value = '';
+            document.querySelectorAll('input[type="checkbox"]').forEach(cb => cb.checked = false);
+            updateFiltering();
+        });
+
+        // Toggle facet collapse/expand
+        function toggleFacet(facetId) {
+            const facetBody = document.getElementById(facetId);
+            const toggle = facetBody.previousElementSibling.querySelector('.facet-toggle');
+
+            if (facetBody.classList.contains('collapsed')) {
+                facetBody.classList.remove('collapsed');
+                toggle.textContent = '−';
+            } else {
+                facetBody.classList.add('collapsed');
+                toggle.textContent = '+';
+            }
+        }
+
+        // Initialize facets when page loads
+        initializeFacets();
+    </script>
+</body>
+</html>

--- a/docs/communities/AMD_Acidophile_Heterotroph_Network.html
+++ b/docs/communities/AMD_Acidophile_Heterotroph_Network.html
@@ -6,7 +6,7 @@
     <title>AMD Acidophile Heterotroph Network - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>AMD Acidophile Heterotroph Network</h1>
         </div>
     </header>

--- a/docs/communities/AMD_Nitrososphaerota_Archaeal.html
+++ b/docs/communities/AMD_Nitrososphaerota_Archaeal.html
@@ -6,7 +6,7 @@
     <title>AMD Nitrososphaerota Archaeal Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>AMD Nitrososphaerota Archaeal Community</h1>
         </div>
     </header>

--- a/docs/communities/ANME_SRB_Marine_Methane_Seep_Consortium.html
+++ b/docs/communities/ANME_SRB_Marine_Methane_Seep_Consortium.html
@@ -6,7 +6,7 @@
     <title>ANME-SRB Marine Methane Seep Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>ANME-SRB Marine Methane Seep Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Aalborg_East_Full_Scale_EBPR_Community.html
+++ b/docs/communities/Aalborg_East_Full_Scale_EBPR_Community.html
@@ -6,7 +6,7 @@
     <title>Aalborg East Full-Scale EBPR Activated Sludge Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Aalborg East Full-Scale EBPR Activated Sludge Community</h1>
         </div>
     </header>

--- a/docs/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.html
+++ b/docs/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.html
@@ -6,7 +6,7 @@
     <title>Acetobacterium woodii-Clostridium drakei CO2 Electrolysis Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Acetobacterium woodii-Clostridium drakei CO2 Electrolysis Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.html
+++ b/docs/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.html
@@ -6,7 +6,7 @@
     <title>Acetylene-Fueled Trichloroethene Dechlorination Groundwater Enrichment - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Acetylene-Fueled Trichloroethene Dechlorination Groundwater Enrichment</h1>
         </div>
     </header>

--- a/docs/communities/Aerobic_Denitrification_Disturbance_SynCom.html
+++ b/docs/communities/Aerobic_Denitrification_Disturbance_SynCom.html
@@ -6,7 +6,7 @@
     <title>Aerobic Denitrification Disturbance-Stable SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Aerobic Denitrification Disturbance-Stable SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Aerobic_Denitrification_QQ_SynCom.html
+++ b/docs/communities/Aerobic_Denitrification_QQ_SynCom.html
@@ -6,7 +6,7 @@
     <title>Aerobic Denitrification Quorum-Quenching SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Aerobic Denitrification Quorum-Quenching SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Alaska_Tundra_Permafrost_Iron_Redox_Community.html
+++ b/docs/communities/Alaska_Tundra_Permafrost_Iron_Redox_Community.html
@@ -6,7 +6,7 @@
     <title>Alaska Tundra Permafrost Iron-Redox Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Alaska Tundra Permafrost Iron-Redox Community</h1>
         </div>
     </header>

--- a/docs/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.html
+++ b/docs/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.html
@@ -6,7 +6,7 @@
     <title>Altered Schaedler Flora Gnotobiotic Mouse Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Altered Schaedler Flora Gnotobiotic Mouse Community</h1>
         </div>
     </header>

--- a/docs/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.html
+++ b/docs/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.html
@@ -6,7 +6,7 @@
     <title>Anammox Bioreactor DNRA Destabilization Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Anammox Bioreactor DNRA Destabilization Community</h1>
         </div>
     </header>

--- a/docs/communities/Anammox_Granule_Metabolic_Interaction_Community.html
+++ b/docs/communities/Anammox_Granule_Metabolic_Interaction_Community.html
@@ -6,7 +6,7 @@
     <title>Anammox Granule Metabolic Interaction Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Anammox Granule Metabolic Interaction Community</h1>
         </div>
     </header>

--- a/docs/communities/Angelarchaeales_Thermoplasmata_CuMMO_Soil_Sediment_Community.html
+++ b/docs/communities/Angelarchaeales_Thermoplasmata_CuMMO_Soil_Sediment_Community.html
@@ -6,7 +6,7 @@
     <title>Angelarchaeales Thermoplasmata CuMMO Soil and Sediment Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Angelarchaeales Thermoplasmata CuMMO Soil and Sediment Community</h1>
         </div>
     </header>

--- a/docs/communities/Arabidopsis_Coumarin_Root_SynCom.html
+++ b/docs/communities/Arabidopsis_Coumarin_Root_SynCom.html
@@ -6,7 +6,7 @@
     <title>Arabidopsis Coumarin Root SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Arabidopsis Coumarin Root SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Arabidopsis_Phyllosphere_SynCom7.html
+++ b/docs/communities/Arabidopsis_Phyllosphere_SynCom7.html
@@ -6,7 +6,7 @@
     <title>Arabidopsis Phyllosphere SynCom7 - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Arabidopsis Phyllosphere SynCom7</h1>
         </div>
     </header>

--- a/docs/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.html
+++ b/docs/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.html
@@ -6,7 +6,7 @@
     <title>Asgard Archaea Wetland Soil Methanogenesis-Substrate Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Asgard Archaea Wetland Soil Methanogenesis-Substrate Community</h1>
         </div>
     </header>

--- a/docs/communities/At_RSPHERE_SynCom.html
+++ b/docs/communities/At_RSPHERE_SynCom.html
@@ -6,7 +6,7 @@
     <title>At-RSPHERE SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>At-RSPHERE SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Australian_Lead_Zinc_Polymetallic.html
+++ b/docs/communities/Australian_Lead_Zinc_Polymetallic.html
@@ -6,7 +6,7 @@
     <title>Australian Lead Zinc Polymetallic Tailings Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Australian Lead Zinc Polymetallic Tailings Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.html
+++ b/docs/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.html
@@ -6,7 +6,7 @@
     <title>Avena Rhizosphere Cross-Kingdom 13C-SIP Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Avena Rhizosphere Cross-Kingdom 13C-SIP Community</h1>
         </div>
     </header>

--- a/docs/communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.html
+++ b/docs/communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.html
@@ -6,7 +6,7 @@
     <title>Avena Rhizosphere and Detritusphere Niche-Differentiated Decomposer Guilds - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Avena Rhizosphere and Detritusphere Niche-Differentiated Decomposer Guilds</h1>
         </div>
     </header>

--- a/docs/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.html
+++ b/docs/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.html
@@ -6,7 +6,7 @@
     <title>Bacillus-Bradyrhizobium Straw Humification SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Bacillus-Bradyrhizobium Straw Humification SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.html
+++ b/docs/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.html
@@ -6,7 +6,7 @@
     <title>Bacteroides-Eubacterium Gnotobiotic Gut Model - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Bacteroides-Eubacterium Gnotobiotic Gut Model</h1>
         </div>
     </header>

--- a/docs/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.html
+++ b/docs/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.html
@@ -6,7 +6,7 @@
     <title>Bacteroides-Methanobrevibacter Gnotobiotic Mouse Mutualism - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Bacteroides-Methanobrevibacter Gnotobiotic Mouse Mutualism</h1>
         </div>
     </header>

--- a/docs/communities/Banana_Fusarium_Biocontrol_SynCom12.html
+++ b/docs/communities/Banana_Fusarium_Biocontrol_SynCom12.html
@@ -6,7 +6,7 @@
     <title>Banana Fusarium Wilt Biocontrol SynCom1.2 - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Banana Fusarium Wilt Biocontrol SynCom1.2</h1>
         </div>
     </header>

--- a/docs/communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.html
+++ b/docs/communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.html
@@ -6,7 +6,7 @@
     <title>San Francisco Bay Area Sewage SARS-CoV-2 Metagenomic Surveillance Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>San Francisco Bay Area Sewage SARS-CoV-2 Metagenomic Surveillance Community</h1>
         </div>
     </header>

--- a/docs/communities/Bayan_Obo_REE_Tailings_Consortium.html
+++ b/docs/communities/Bayan_Obo_REE_Tailings_Consortium.html
@@ -6,7 +6,7 @@
     <title>Bayan Obo REE Tailings Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Bayan Obo REE Tailings Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.html
+++ b/docs/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.html
@@ -6,7 +6,7 @@
     <title>Bifidobacterium-Ruminococcus Infant HMO Cross-Feeding Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Bifidobacterium-Ruminococcus Infant HMO Cross-Feeding Coculture</h1>
         </div>
     </header>

--- a/docs/communities/BioModels_MODEL1806250003_Spittlebug_Sulcia_Sodalis.html
+++ b/docs/communities/BioModels_MODEL1806250003_Spittlebug_Sulcia_Sodalis.html
@@ -6,7 +6,7 @@
     <title>BioModels MODEL1806250003 Spittlebug Sulcia-Sodalis Symbiosis - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>BioModels MODEL1806250003 Spittlebug Sulcia-Sodalis Symbiosis</h1>
         </div>
     </header>

--- a/docs/communities/BioModels_MODEL1806250004_Sharpshooter_Sulcia_Baumannia.html
+++ b/docs/communities/BioModels_MODEL1806250004_Sharpshooter_Sulcia_Baumannia.html
@@ -6,7 +6,7 @@
     <title>BioModels MODEL1806250004 Sharpshooter Sulcia-Baumannia Symbiosis - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>BioModels MODEL1806250004 Sharpshooter Sulcia-Baumannia Symbiosis</h1>
         </div>
     </header>

--- a/docs/communities/BioModels_MODEL1806250005_Cicada_Sulcia_Hodgkinia.html
+++ b/docs/communities/BioModels_MODEL1806250005_Cicada_Sulcia_Hodgkinia.html
@@ -6,7 +6,7 @@
     <title>BioModels MODEL1806250005 Cicada Sulcia-Hodgkinia Symbiosis - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>BioModels MODEL1806250005 Cicada Sulcia-Hodgkinia Symbiosis</h1>
         </div>
     </header>

--- a/docs/communities/BioModels_MODEL2204300001_Kefir_Community_Model.html
+++ b/docs/communities/BioModels_MODEL2204300001_Kefir_Community_Model.html
@@ -6,7 +6,7 @@
     <title>BioModels MODEL2204300001 Kefir Community Model - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>BioModels MODEL2204300001 Kefir Community Model</h1>
         </div>
     </header>

--- a/docs/communities/BioModels_MODEL2209060002_DPigrum_SAureus_Community.html
+++ b/docs/communities/BioModels_MODEL2209060002_DPigrum_SAureus_Community.html
@@ -6,7 +6,7 @@
     <title>BioModels MODEL2209060002 D pigrum - S aureus Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>BioModels MODEL2209060002 D pigrum - S aureus Community</h1>
         </div>
     </header>

--- a/docs/communities/BioModels_MODEL2310020001_Mouse_Metaorganism_Model.html
+++ b/docs/communities/BioModels_MODEL2310020001_Mouse_Metaorganism_Model.html
@@ -6,7 +6,7 @@
     <title>BioModels MODEL2310020001 Mouse Metaorganism Model - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>BioModels MODEL2310020001 Mouse Metaorganism Model</h1>
         </div>
     </header>

--- a/docs/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.html
+++ b/docs/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.html
@@ -6,7 +6,7 @@
     <title>BioModels MODEL2405300001 Infant Gut HMO SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>BioModels MODEL2405300001 Infant Gut HMO SynCom</h1>
         </div>
     </header>

--- a/docs/communities/BioModels_MODEL2407300002_Sponge_Holobiont_Network.html
+++ b/docs/communities/BioModels_MODEL2407300002_Sponge_Holobiont_Network.html
@@ -6,7 +6,7 @@
     <title>BioModels MODEL2407300002 Sponge Holobiont Network - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>BioModels MODEL2407300002 Sponge Holobiont Network</h1>
         </div>
     </header>

--- a/docs/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.html
+++ b/docs/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.html
@@ -6,7 +6,7 @@
     <title>Brachypodium Young Root Rhizosphere EcoFAB Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Brachypodium Young Root Rhizosphere EcoFAB Community</h1>
         </div>
     </header>

--- a/docs/communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.html
+++ b/docs/communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.html
@@ -6,7 +6,7 @@
     <title>Buchnera-Serratia Cinara cedri Endosymbiont Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Buchnera-Serratia Cinara cedri Endosymbiont Consortium</h1>
         </div>
     </header>

--- a/docs/communities/CRC_Fusobacterium_Control_SynCom.html
+++ b/docs/communities/CRC_Fusobacterium_Control_SynCom.html
@@ -6,7 +6,7 @@
     <title>CRC Fusobacterium Control SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>CRC Fusobacterium Control SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.html
+++ b/docs/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.html
@@ -6,7 +6,7 @@
     <title>Cable Bacteria beneath Photosynthetic Biofilm Sediment Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Cable Bacteria beneath Photosynthetic Biofilm Sediment Community</h1>
         </div>
     </header>

--- a/docs/communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.html
+++ b/docs/communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.html
@@ -6,7 +6,7 @@
     <title>Caldibacillus-Clostridium Aerotolerant Cellulose Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Caldibacillus-Clostridium Aerotolerant Cellulose Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.html
+++ b/docs/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.html
@@ -6,7 +6,7 @@
     <title>Caldicellulosiruptor Two-Species Hydrogen Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Caldicellulosiruptor Two-Species Hydrogen Coculture</h1>
         </div>
     </header>

--- a/docs/communities/California_Grassland_Precipitation_Legacy_Soil_Community.html
+++ b/docs/communities/California_Grassland_Precipitation_Legacy_Soil_Community.html
@@ -6,7 +6,7 @@
     <title>California Grassland Precipitation Legacy Soil Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>California Grassland Precipitation Legacy Soil Community</h1>
         </div>
     </header>

--- a/docs/communities/Candida_Parapsilosis_Hospitalized_Infant_Microbiome.html
+++ b/docs/communities/Candida_Parapsilosis_Hospitalized_Infant_Microbiome.html
@@ -6,7 +6,7 @@
     <title>Candida parapsilosis Hospitalized Infant Gut Microbiome Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Candida parapsilosis Hospitalized Infant Gut Microbiome Community</h1>
         </div>
     </header>

--- a/docs/communities/CeMbio_Caenorhabditis_Elegans_Microbiome.html
+++ b/docs/communities/CeMbio_Caenorhabditis_Elegans_Microbiome.html
@@ -6,7 +6,7 @@
     <title>CeMbio Caenorhabditis elegans Microbiome - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>CeMbio Caenorhabditis elegans Microbiome</h1>
         </div>
     </header>

--- a/docs/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.html
+++ b/docs/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.html
@@ -6,7 +6,7 @@
     <title>Cellulomonas-Rhodobacter Cellulose Photohydrogen Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Cellulomonas-Rhodobacter Cellulose Photohydrogen Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Cellulose_Methane_Quad_Culture_SynCom.html
+++ b/docs/communities/Cellulose_Methane_Quad_Culture_SynCom.html
@@ -6,7 +6,7 @@
     <title>Cellulose-to-Methane Quad-Culture SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Cellulose-to-Methane Quad-Culture SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Cheese_Rind_InSitu_InVitro_Model_Community.html
+++ b/docs/communities/Cheese_Rind_InSitu_InVitro_Model_Community.html
@@ -6,7 +6,7 @@
     <title>Cheese Rind In Situ-In Vitro Model Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Cheese Rind In Situ-In Vitro Model Community</h1>
         </div>
     </header>

--- a/docs/communities/Chlamydomonas_Bacterial_H2_Consortium.html
+++ b/docs/communities/Chlamydomonas_Bacterial_H2_Consortium.html
@@ -6,7 +6,7 @@
     <title>Chlamydomonas-Bacterial Hydrogen Production Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Chlamydomonas-Bacterial Hydrogen Production Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Chlamydomonas_Methylobacterium_Mutualism.html
+++ b/docs/communities/Chlamydomonas_Methylobacterium_Mutualism.html
@@ -6,7 +6,7 @@
     <title>Chlamydomonas-Methylobacterium Mutualistic Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Chlamydomonas-Methylobacterium Mutualistic Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Chlorella_Azospirillum_Synthetic_Mutualism.html
+++ b/docs/communities/Chlorella_Azospirillum_Synthetic_Mutualism.html
@@ -6,7 +6,7 @@
     <title>Chlorella-Azospirillum Synthetic Mutualism - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Chlorella-Azospirillum Synthetic Mutualism</h1>
         </div>
     </header>

--- a/docs/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.html
+++ b/docs/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.html
@@ -6,7 +6,7 @@
     <title>Chlorella-Ecoli Mixotrophic Biofuel Precursor Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Chlorella-Ecoli Mixotrophic Biofuel Precursor Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Chlorella_Rhizobium_Bioflocculation.html
+++ b/docs/communities/Chlorella_Rhizobium_Bioflocculation.html
@@ -6,7 +6,7 @@
     <title>Chlorella-Rhizobium Bioflocculation - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Chlorella-Rhizobium Bioflocculation</h1>
         </div>
     </header>

--- a/docs/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.html
+++ b/docs/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.html
@@ -6,7 +6,7 @@
     <title>Chlorochromatium aggregatum Phototrophic Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Chlorochromatium aggregatum Phototrophic Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Chromium_Sulfur_Reduction_Enrichment.html
+++ b/docs/communities/Chromium_Sulfur_Reduction_Enrichment.html
@@ -6,7 +6,7 @@
     <title>Chromium Sulfur Reduction Enrichment - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Chromium Sulfur Reduction Enrichment</h1>
         </div>
     </header>

--- a/docs/communities/Cinnamate_Degradation_Consortium.html
+++ b/docs/communities/Cinnamate_Degradation_Consortium.html
@@ -6,7 +6,7 @@
     <title>Cinnamate β-Oxidation Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Cinnamate β-Oxidation Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.html
+++ b/docs/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.html
@@ -6,7 +6,7 @@
     <title>Clostridium autoethanogenum-Clostridium kluyveri Syngas Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Clostridium autoethanogenum-Clostridium kluyveri Syngas Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.html
+++ b/docs/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.html
@@ -6,7 +6,7 @@
     <title>Clostridium-Caldicellulosiruptor Minimal Medium Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Clostridium-Caldicellulosiruptor Minimal Medium Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.html
+++ b/docs/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.html
@@ -6,7 +6,7 @@
     <title>Clostridium carboxidivorans-Clostridium kluyveri CO Chain-Elongation Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Clostridium carboxidivorans-Clostridium kluyveri CO Chain-Elongation Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.html
+++ b/docs/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.html
@@ -6,7 +6,7 @@
     <title>Clostridium cellulolyticum-Geobacter sulfurreducens Cellulose MFC Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Clostridium cellulolyticum-Geobacter sulfurreducens Cellulose MFC Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.html
+++ b/docs/communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.html
@@ -6,7 +6,7 @@
     <title>Clostridium cellulovorans-Methanosarcina barkeri Cellulose Methane Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Clostridium cellulovorans-Methanosarcina barkeri Cellulose Methane Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.html
+++ b/docs/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.html
@@ -6,7 +6,7 @@
     <title>Clostridium cellulovorans-Rhodopseudomonas palustris Cellulose Biohydrogen Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Clostridium cellulovorans-Rhodopseudomonas palustris Cellulose Biohydrogen Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.html
+++ b/docs/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.html
@@ -6,7 +6,7 @@
     <title>Clostridium ljungdahlii-Clostridium kluyveri Syngas Alcohol Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Clostridium ljungdahlii-Clostridium kluyveri Syngas Alcohol Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.html
+++ b/docs/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.html
@@ -6,7 +6,7 @@
     <title>Clostridium phytofermentans-E. coli Cellobiose Biofilm Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Clostridium phytofermentans-E. coli Cellobiose Biofilm Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.html
+++ b/docs/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.html
@@ -6,7 +6,7 @@
     <title>Clostridium-Saccharomyces Cellulose Ethanol Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Clostridium-Saccharomyces Cellulose Ethanol Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.html
+++ b/docs/communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.html
@@ -6,7 +6,7 @@
     <title>Clostridium-Thermoanaerobacter Cellulosic Bioethanol Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Clostridium-Thermoanaerobacter Cellulosic Bioethanol Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.html
+++ b/docs/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.html
@@ -6,7 +6,7 @@
     <title>Clostridium-Thermoanaerobacterium JN4-GD17 Cellulosic Biofuel Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Clostridium-Thermoanaerobacterium JN4-GD17 Cellulosic Biofuel Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.html
+++ b/docs/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.html
@@ -6,7 +6,7 @@
     <title>Clostridium Thermocellum-Saccharoperbutylacetonicum Cellulosic Butanol Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Clostridium Thermocellum-Saccharoperbutylacetonicum Cellulosic Butanol Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.html
+++ b/docs/communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.html
@@ -6,7 +6,7 @@
     <title>Coastal Forested Wetland Seawater-Ion Microcosm Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Coastal Forested Wetland Seawater-Ion Microcosm Community</h1>
         </div>
     </header>

--- a/docs/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.html
+++ b/docs/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.html
@@ -6,7 +6,7 @@
     <title>Coniochaeta-Sphingobacterium-Citrobacter Wheat Straw Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Coniochaeta-Sphingobacterium-Citrobacter Wheat Straw Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Copper_Biomining_Heap_Leach.html
+++ b/docs/communities/Copper_Biomining_Heap_Leach.html
@@ -6,7 +6,7 @@
     <title>Copper Biomining Heap Leach Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Copper Biomining Heap Leach Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Coscinodiscus_Synthetic_Community.html
+++ b/docs/communities/Coscinodiscus_Synthetic_Community.html
@@ -6,7 +6,7 @@
     <title>Coscinodiscus Synthetic Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Coscinodiscus Synthetic Community</h1>
         </div>
     </header>

--- a/docs/communities/Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community.html
+++ b/docs/communities/Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community.html
@@ -6,7 +6,7 @@
     <title>Crystal Geyser CO2-Rich Aquifer Autotrophic CPR Lysolipid Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Crystal Geyser CO2-Rich Aquifer Autotrophic CPR Lysolipid Community</h1>
         </div>
     </header>

--- a/docs/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.html
+++ b/docs/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.html
@@ -6,7 +6,7 @@
     <title>Cyprus Copper Sulphide Bioleaching Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Cyprus Copper Sulphide Bioleaching Consortium</h1>
         </div>
     </header>

--- a/docs/communities/DVM_Triculture.html
+++ b/docs/communities/DVM_Triculture.html
@@ -6,7 +6,7 @@
     <title>DVM Tri-culture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>DVM Tri-culture</h1>
         </div>
     </header>

--- a/docs/communities/Dangl_SynComm_35.html
+++ b/docs/communities/Dangl_SynComm_35.html
@@ -6,7 +6,7 @@
     <title>Jeff Dangl&#39;s SynComm 35 - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Jeff Dangl&#39;s SynComm 35</h1>
         </div>
     </header>

--- a/docs/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.html
+++ b/docs/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.html
@@ -6,7 +6,7 @@
     <title>Deepwater Horizon Deep-Sea Oil Plume Succession - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Deepwater Horizon Deep-Sea Oil Plume Succession</h1>
         </div>
     </header>

--- a/docs/communities/Defined_Multispecies_Enamel_Caries_Model.html
+++ b/docs/communities/Defined_Multispecies_Enamel_Caries_Model.html
@@ -6,7 +6,7 @@
     <title>Defined Multispecies Enamel Caries Model - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Defined Multispecies Enamel Caries Model</h1>
         </div>
     </header>

--- a/docs/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.html
+++ b/docs/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.html
@@ -6,7 +6,7 @@
     <title>Dehalococcoides-Desulfovibrio Lactate-Fed TCE Dechlorination Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Dehalococcoides-Desulfovibrio Lactate-Fed TCE Dechlorination Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.html
+++ b/docs/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.html
@@ -6,7 +6,7 @@
     <title>Dehalococcoides-Desulfovibrio-Pelosinus Corrinoid Triculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Dehalococcoides-Desulfovibrio-Pelosinus Corrinoid Triculture</h1>
         </div>
     </header>

--- a/docs/communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.html
+++ b/docs/communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.html
@@ -6,7 +6,7 @@
     <title>Dehalococcoides-Methanosarcina DMB-Guided Cobalamin Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Dehalococcoides-Methanosarcina DMB-Guided Cobalamin Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.html
+++ b/docs/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.html
@@ -6,7 +6,7 @@
     <title>Dehalococcoides-Pelobacter Acetylene TCE Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Dehalococcoides-Pelobacter Acetylene TCE Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.html
+++ b/docs/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.html
@@ -6,7 +6,7 @@
     <title>Dehalococcoides-Syntrophomonas TCE Dechlorination Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Dehalococcoides-Syntrophomonas TCE Dechlorination Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Desert_Tomato_Salt_Stress_SynCom5.html
+++ b/docs/communities/Desert_Tomato_Salt_Stress_SynCom5.html
@@ -6,7 +6,7 @@
     <title>Desert-Derived Tomato Salt Stress SynCom5 - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Desert-Derived Tomato Salt Stress SynCom5</h1>
         </div>
     </header>

--- a/docs/communities/Desulfovibrio_Methanococcus_Syntrophy.html
+++ b/docs/communities/Desulfovibrio_Methanococcus_Syntrophy.html
@@ -6,7 +6,7 @@
     <title>Desulfovibrio-Methanococcus Syntrophic Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Desulfovibrio-Methanococcus Syntrophic Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Desulfovibrio_Methanosarcina_Lactate_Syntrophy.html
+++ b/docs/communities/Desulfovibrio_Methanosarcina_Lactate_Syntrophy.html
@@ -6,7 +6,7 @@
     <title>Desulfovibrio-Methanosarcina Lactate Syntrophy - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Desulfovibrio-Methanosarcina Lactate Syntrophy</h1>
         </div>
     </header>

--- a/docs/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.html
+++ b/docs/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.html
@@ -6,7 +6,7 @@
     <title>Drosophila Five-Species Gnotobiotic Gut Microbiota - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Drosophila Five-Species Gnotobiotic Gut Microbiota</h1>
         </div>
     </header>

--- a/docs/communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.html
+++ b/docs/communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.html
@@ -6,7 +6,7 @@
     <title>Drought-Induced Rhizosphere Iron-Enriched Actinobacteria Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Drought-Induced Rhizosphere Iron-Enriched Actinobacteria Community</h1>
         </div>
     </header>

--- a/docs/communities/ENIGMA_Denitrifying_SynCom.html
+++ b/docs/communities/ENIGMA_Denitrifying_SynCom.html
@@ -6,7 +6,7 @@
     <title>ENIGMA Denitrifying SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>ENIGMA Denitrifying SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Early_Dental_Biofilm_FiveSpecies.html
+++ b/docs/communities/Early_Dental_Biofilm_FiveSpecies.html
@@ -6,7 +6,7 @@
     <title>Early Dental Biofilm Five-Species Model - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Early Dental Biofilm Five-Species Model</h1>
         </div>
     </header>

--- a/docs/communities/East_River_Floodplain_Core_Microbiome.html
+++ b/docs/communities/East_River_Floodplain_Core_Microbiome.html
@@ -6,7 +6,7 @@
     <title>East River Floodplain Core Microbiome - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>East River Floodplain Core Microbiome</h1>
         </div>
     </header>

--- a/docs/communities/East_River_Hillslope_Riparian_Transect_Community.html
+++ b/docs/communities/East_River_Hillslope_Riparian_Transect_Community.html
@@ -6,7 +6,7 @@
     <title>East River Hillslope Riparian Transect Microbial Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>East River Hillslope Riparian Transect Microbial Community</h1>
         </div>
     </header>

--- a/docs/communities/EcoFAB_Ring_Trial_SynCom17.html
+++ b/docs/communities/EcoFAB_Ring_Trial_SynCom17.html
@@ -6,7 +6,7 @@
     <title>EcoFAB 2.0 Root Microbiome Ring Trial SynCom17 - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>EcoFAB 2.0 Root Microbiome Ring Trial SynCom17</h1>
         </div>
     </header>

--- a/docs/communities/Emiliania_Phaeobacter_Dynamic_Interaction.html
+++ b/docs/communities/Emiliania_Phaeobacter_Dynamic_Interaction.html
@@ -6,7 +6,7 @@
     <title>Emiliania huxleyi-Phaeobacter inhibens Dynamic Interaction - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Emiliania huxleyi-Phaeobacter inhibens Dynamic Interaction</h1>
         </div>
     </header>

--- a/docs/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.html
+++ b/docs/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.html
@@ -6,7 +6,7 @@
     <title>Engineered Gut Amino Acid Cross-Feeding Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Engineered Gut Amino Acid Cross-Feeding Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Episymbiotic_CPR_DPANN_Groundwater_Community.html
+++ b/docs/communities/Episymbiotic_CPR_DPANN_Groundwater_Community.html
@@ -6,7 +6,7 @@
     <title>Episymbiotic CPR Bacteria and DPANN Archaea Groundwater Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Episymbiotic CPR Bacteria and DPANN Archaea Groundwater Community</h1>
         </div>
     </header>

--- a/docs/communities/Ewaste_Bioleaching_Consortium.html
+++ b/docs/communities/Ewaste_Bioleaching_Consortium.html
@@ -6,7 +6,7 @@
     <title>E-waste Bioleaching Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>E-waste Bioleaching Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Ferroplasma_Leptospirillum_Syntrophy.html
+++ b/docs/communities/Ferroplasma_Leptospirillum_Syntrophy.html
@@ -6,7 +6,7 @@
     <title>Ferroplasma-Leptospirillum Iron-Cycling Syntrophy - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Ferroplasma-Leptospirillum Iron-Cycling Syntrophy</h1>
         </div>
     </header>

--- a/docs/communities/GLBRC_Exometabolite_Transwell_SynCom.html
+++ b/docs/communities/GLBRC_Exometabolite_Transwell_SynCom.html
@@ -6,7 +6,7 @@
     <title>GLBRC Exometabolite Transwell SynCom System - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>GLBRC Exometabolite Transwell SynCom System</h1>
         </div>
     </header>

--- a/docs/communities/GLBRC_Populus_Variovorax_SynCom28.html
+++ b/docs/communities/GLBRC_Populus_Variovorax_SynCom28.html
@@ -6,7 +6,7 @@
     <title>GLBRC Populus Variovorax SynCom28 - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>GLBRC Populus Variovorax SynCom28</h1>
         </div>
     </header>

--- a/docs/communities/GLBRC_UFMP_Fermentation_Community.html
+++ b/docs/communities/GLBRC_UFMP_Fermentation_Community.html
@@ -6,7 +6,7 @@
     <title>GLBRC Ultra-Filtered Milk Permeate Fermentation Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>GLBRC Ultra-Filtered Milk Permeate Fermentation Community</h1>
         </div>
     </header>

--- a/docs/communities/GOM_Oil_Degrading_Consortium.html
+++ b/docs/communities/GOM_Oil_Degrading_Consortium.html
@@ -6,7 +6,7 @@
     <title>Gulf of Mexico Oil-Degrading Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Gulf of Mexico Oil-Degrading Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Garlic_Pseudomonas_SynCom6.html
+++ b/docs/communities/Garlic_Pseudomonas_SynCom6.html
@@ -6,7 +6,7 @@
     <title>Garlic Rhizosphere Pseudomonas SynCom6 - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Garlic Rhizosphere Pseudomonas SynCom6</h1>
         </div>
     </header>

--- a/docs/communities/Geobacter_Clostridium_DIET.html
+++ b/docs/communities/Geobacter_Clostridium_DIET.html
@@ -6,7 +6,7 @@
     <title>Geobacter-Clostridium DIET Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Geobacter-Clostridium DIET Community</h1>
         </div>
     </header>

--- a/docs/communities/Geobacter_Methanosaeta_DIET.html
+++ b/docs/communities/Geobacter_Methanosaeta_DIET.html
@@ -6,7 +6,7 @@
     <title>Geobacter-Methanosaeta DIET Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Geobacter-Methanosaeta DIET Community</h1>
         </div>
     </header>

--- a/docs/communities/Geobacter_Methanosarcina_DIET.html
+++ b/docs/communities/Geobacter_Methanosarcina_DIET.html
@@ -6,7 +6,7 @@
     <title>Geobacter-Methanosarcina DIET Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Geobacter-Methanosarcina DIET Community</h1>
         </div>
     </header>

--- a/docs/communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.html
+++ b/docs/communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.html
@@ -6,7 +6,7 @@
     <title>Geobacter-Pseudomonas Formate-Fumarate Electroactive Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Geobacter-Pseudomonas Formate-Fumarate Electroactive Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Grassland_Soil_WetUp_Virus_Host_Community.html
+++ b/docs/communities/Grassland_Soil_WetUp_Virus_Host_Community.html
@@ -6,7 +6,7 @@
     <title>Grassland Soil Wet-Up Virus-Host Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Grassland Soil Wet-Up Virus-Host Community</h1>
         </div>
     </header>

--- a/docs/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.html
+++ b/docs/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.html
@@ -6,7 +6,7 @@
     <title>Groundwater Elusimicrobia Diverse Metabolisms Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Groundwater Elusimicrobia Diverse Metabolisms Community</h1>
         </div>
     </header>

--- a/docs/communities/Hanford_300_Area_Unconfined_Aquifer_Community.html
+++ b/docs/communities/Hanford_300_Area_Unconfined_Aquifer_Community.html
@@ -6,7 +6,7 @@
     <title>Hanford 300 Area Unconfined Aquifer Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Hanford 300 Area Unconfined Aquifer Community</h1>
         </div>
     </header>

--- a/docs/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.html
+++ b/docs/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.html
@@ -6,7 +6,7 @@
     <title>High-Solids Switchgrass Methanogenic Microbiome - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>High-Solids Switchgrass Methanogenic Microbiome</h1>
         </div>
     </header>

--- a/docs/communities/Honeybee_Core20_Defined_Microbiota.html
+++ b/docs/communities/Honeybee_Core20_Defined_Microbiota.html
@@ -6,7 +6,7 @@
     <title>Honeybee Core-20 Defined Microbiota - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Honeybee Core-20 Defined Microbiota</h1>
         </div>
     </header>

--- a/docs/communities/Horonobe_Mizunami_URL_Subsurface_Microbiome.html
+++ b/docs/communities/Horonobe_Mizunami_URL_Subsurface_Microbiome.html
@@ -6,7 +6,7 @@
     <title>Horonobe and Mizunami Underground Research Laboratory Subsurface Microbiome - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Horonobe and Mizunami Underground Research Laboratory Subsurface Microbiome</h1>
         </div>
     </header>

--- a/docs/communities/Iberian_Pit_Lake_Stratified_Community.html
+++ b/docs/communities/Iberian_Pit_Lake_Stratified_Community.html
@@ -6,7 +6,7 @@
     <title>Iberian Pit Lake Stratified Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Iberian Pit Lake Stratified Community</h1>
         </div>
     </header>

--- a/docs/communities/Industrial_Bioreactor_Consortium.html
+++ b/docs/communities/Industrial_Bioreactor_Consortium.html
@@ -6,7 +6,7 @@
     <title>Industrial Bioleaching Reactor Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Industrial Bioleaching Reactor Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.html
+++ b/docs/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.html
@@ -6,7 +6,7 @@
     <title>Industrial Milk-Line Four-Species Model Biofilm - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Industrial Milk-Line Four-Species Model Biofilm</h1>
         </div>
     </header>

--- a/docs/communities/Infant_Gut_DNA_Phage_Succession_Community.html
+++ b/docs/communities/Infant_Gut_DNA_Phage_Succession_Community.html
@@ -6,7 +6,7 @@
     <title>Infant Gut DNA Phageome Succession Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Infant Gut DNA Phageome Succession Community</h1>
         </div>
     </header>

--- a/docs/communities/Infant_Gut_Strain_Persistence_Maternal_Community.html
+++ b/docs/communities/Infant_Gut_Strain_Persistence_Maternal_Community.html
@@ -6,7 +6,7 @@
     <title>Infant Gut Strain Persistence and Maternal Seeding Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Infant Gut Strain Persistence and Maternal Seeding Community</h1>
         </div>
     </header>

--- a/docs/communities/Ion_Adsorption_REE_Indigenous_Community.html
+++ b/docs/communities/Ion_Adsorption_REE_Indigenous_Community.html
@@ -6,7 +6,7 @@
     <title>Ion-Adsorption REE Indigenous Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Ion-Adsorption REE Indigenous Community</h1>
         </div>
     </header>

--- a/docs/communities/Jala_Maize_PGPB_SynCom.html
+++ b/docs/communities/Jala_Maize_PGPB_SynCom.html
@@ -6,7 +6,7 @@
     <title>Jala Maize PGPB SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Jala Maize PGPB SynCom</h1>
         </div>
     </header>

--- a/docs/communities/KB1_Chlorinated_Ethene_Dechlorinating_Consortium.html
+++ b/docs/communities/KB1_Chlorinated_Ethene_Dechlorinating_Consortium.html
@@ -6,7 +6,7 @@
     <title>KB-1 Chlorinated Ethene Dechlorinating Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>KB-1 Chlorinated Ethene Dechlorinating Consortium</h1>
         </div>
     </header>

--- a/docs/communities/KBase_Models_for_Zahmeeth_Original_PLOS.html
+++ b/docs/communities/KBase_Models_for_Zahmeeth_Original_PLOS.html
@@ -6,7 +6,7 @@
     <title>KBase Models for Zahmeeth Original PLOS - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>KBase Models for Zahmeeth Original PLOS</h1>
         </div>
     </header>

--- a/docs/communities/KBase_ORT_Workflow_Community_Model.html
+++ b/docs/communities/KBase_ORT_Workflow_Community_Model.html
@@ -6,7 +6,7 @@
     <title>KBase ORT Workflow Community Model - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>KBase ORT Workflow Community Model</h1>
         </div>
     </header>

--- a/docs/communities/KBase_Synthetic_Bacterial_Community_R2A.html
+++ b/docs/communities/KBase_Synthetic_Bacterial_Community_R2A.html
@@ -6,7 +6,7 @@
     <title>KBase Synthetic Bacterial Community in R2A Medium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>KBase Synthetic Bacterial Community in R2A Medium</h1>
         </div>
     </header>

--- a/docs/communities/Kombucha_KMC_IMBG1_Fermentation_Community.html
+++ b/docs/communities/Kombucha_KMC_IMBG1_Fermentation_Community.html
@@ -6,7 +6,7 @@
     <title>Kombucha KMC-IMBG1 Fermentation Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Kombucha KMC-IMBG1 Fermentation Community</h1>
         </div>
     </header>

--- a/docs/communities/LBNL_Brachypodium_Drought_SynCom15.html
+++ b/docs/communities/LBNL_Brachypodium_Drought_SynCom15.html
@@ -6,7 +6,7 @@
     <title>LBNL Brachypodium Drought SynCom15 - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>LBNL Brachypodium Drought SynCom15</h1>
         </div>
     </header>

--- a/docs/communities/LBNL_Human_Gut_Interaction_SynCom.html
+++ b/docs/communities/LBNL_Human_Gut_Interaction_SynCom.html
@@ -6,7 +6,7 @@
     <title>LBNL Human Gut Interaction SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>LBNL Human Gut Interaction SynCom</h1>
         </div>
     </header>

--- a/docs/communities/LBNL_Switchgrass_Soil_SynCom16.html
+++ b/docs/communities/LBNL_Switchgrass_Soil_SynCom16.html
@@ -6,7 +6,7 @@
     <title>LBNL Switchgrass Soil SynCom16 - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>LBNL Switchgrass Soil SynCom16</h1>
         </div>
     </header>

--- a/docs/communities/Lac_Pavin_Stratified_Lake_Community.html
+++ b/docs/communities/Lac_Pavin_Stratified_Lake_Community.html
@@ -6,7 +6,7 @@
     <title>Lac Pavin Permanently Stratified Lake Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Lac Pavin Permanently Stratified Lake Community</h1>
         </div>
     </header>

--- a/docs/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.html
+++ b/docs/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.html
@@ -6,7 +6,7 @@
     <title>Lake Washington Methane-Oxygen Methylotroph Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Lake Washington Methane-Oxygen Methylotroph Community</h1>
         </div>
     </header>

--- a/docs/communities/Lotus_LjSC3.html
+++ b/docs/communities/Lotus_LjSC3.html
@@ -6,7 +6,7 @@
     <title>Lotus Lj-SC3 Synthetic Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Lotus Lj-SC3 Synthetic Community</h1>
         </div>
     </header>

--- a/docs/communities/MAMC_M48_Lignocellulose.html
+++ b/docs/communities/MAMC_M48_Lignocellulose.html
@@ -6,7 +6,7 @@
     <title>MAMC-M48 Lignocellulose-Degrading Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>MAMC-M48 Lignocellulose-Degrading Consortium</h1>
         </div>
     </header>

--- a/docs/communities/MSC1_Dominant_Core.html
+++ b/docs/communities/MSC1_Dominant_Core.html
@@ -6,7 +6,7 @@
     <title>MSC-1 Dominant Core - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>MSC-1 Dominant Core</h1>
         </div>
     </header>

--- a/docs/communities/MSC2_Model_Soil_Consortium.html
+++ b/docs/communities/MSC2_Model_Soil_Consortium.html
@@ -6,7 +6,7 @@
     <title>Model Soil Consortium-2 (MSC-2) - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Model Soil Consortium-2 (MSC-2)</h1>
         </div>
     </header>

--- a/docs/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.html
+++ b/docs/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.html
@@ -6,7 +6,7 @@
     <title>MUCC Freshwater Wetland Methane-Cycling Network Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>MUCC Freshwater Wetland Methane-Cycling Network Community</h1>
         </div>
     </header>

--- a/docs/communities/Maize_Benzoxazinoid_Metabolizing_SynComs.html
+++ b/docs/communities/Maize_Benzoxazinoid_Metabolizing_SynComs.html
@@ -6,7 +6,7 @@
     <title>Maize Benzoxazinoid-Metabolizing SynComs - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Maize Benzoxazinoid-Metabolizing SynComs</h1>
         </div>
     </header>

--- a/docs/communities/Maize_Drought_Response_SynCom.html
+++ b/docs/communities/Maize_Drought_Response_SynCom.html
@@ -6,7 +6,7 @@
     <title>Maize Drought Response SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Maize Drought Response SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Maize_Root_Simplified_Community.html
+++ b/docs/communities/Maize_Root_Simplified_Community.html
@@ -6,7 +6,7 @@
     <title>Maize Root Simplified Bacterial Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Maize Root Simplified Bacterial Community</h1>
         </div>
     </header>

--- a/docs/communities/Medicago_Nodule_Biofertilizer_SynCom.html
+++ b/docs/communities/Medicago_Nodule_Biofertilizer_SynCom.html
@@ -6,7 +6,7 @@
     <title>Medicago Nodule Biofertilizer SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Medicago Nodule Biofertilizer SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Mediterranean_Grassland_qSIP_Rainfall_Community.html
+++ b/docs/communities/Mediterranean_Grassland_qSIP_Rainfall_Community.html
@@ -6,7 +6,7 @@
     <title>Mediterranean Grassland qSIP Rainfall-Gradient Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Mediterranean Grassland qSIP Rainfall-Gradient Community</h1>
         </div>
     </header>

--- a/docs/communities/Mercury_SFA_EFPC_Sediment_Community.html
+++ b/docs/communities/Mercury_SFA_EFPC_Sediment_Community.html
@@ -6,7 +6,7 @@
     <title>Mercury SFA East Fork Poplar Creek Sediment Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Mercury SFA East Fork Poplar Creek Sediment Community</h1>
         </div>
     </header>

--- a/docs/communities/Methane_Oxidation_CrVI_Reduction_SynCom.html
+++ b/docs/communities/Methane_Oxidation_CrVI_Reduction_SynCom.html
@@ -6,7 +6,7 @@
     <title>Methane Oxidation-Cr(VI) Reduction SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Methane Oxidation-Cr(VI) Reduction SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.html
+++ b/docs/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.html
@@ -6,7 +6,7 @@
     <title>Methylacidiphilum-Galdieria Thermoacidophilic Methane Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Methylacidiphilum-Galdieria Thermoacidophilic Methane Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.html
+++ b/docs/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.html
@@ -6,7 +6,7 @@
     <title>Methylocaldum-Cupriavidus Methane Acetate Cross-Feeding Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Methylocaldum-Cupriavidus Methane Acetate Cross-Feeding Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.html
+++ b/docs/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.html
@@ -6,7 +6,7 @@
     <title>Methylocaldum-Methyloceanibacter Methane Cross-Feeding Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Methylocaldum-Methyloceanibacter Methane Cross-Feeding Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.html
+++ b/docs/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.html
@@ -6,7 +6,7 @@
     <title>Methylocystis-Rhodococcus Methane VFA PHBV Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Methylocystis-Rhodococcus Methane VFA PHBV Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.html
+++ b/docs/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.html
@@ -6,7 +6,7 @@
     <title>Methylomicrobium-Chlorella Methane Sequestration Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Methylomicrobium-Chlorella Methane Sequestration Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.html
+++ b/docs/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.html
@@ -6,7 +6,7 @@
     <title>Methylotuvimicrobium-Synechococcus Gas Feedstock Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Methylotuvimicrobium-Synechococcus Gas Feedstock Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Microcoleus_Massilia_Cyanosphere_Urea_Mutualism.html
+++ b/docs/communities/Microcoleus_Massilia_Cyanosphere_Urea_Mutualism.html
@@ -6,7 +6,7 @@
     <title>Microcoleus-Massilia Cyanosphere Urea Mutualism - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Microcoleus-Massilia Cyanosphere Urea Mutualism</h1>
         </div>
     </header>

--- a/docs/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.html
+++ b/docs/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.html
@@ -6,7 +6,7 @@
     <title>Miscanthus REE Tailings Nitrogen SynCom10 - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Miscanthus REE Tailings Nitrogen SynCom10</h1>
         </div>
     </header>

--- a/docs/communities/Mixed_Gallium_LED_Recovery_Consortium.html
+++ b/docs/communities/Mixed_Gallium_LED_Recovery_Consortium.html
@@ -6,7 +6,7 @@
     <title>Mixed Gallium LED Recovery Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Mixed Gallium LED Recovery Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.html
+++ b/docs/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.html
@@ -6,7 +6,7 @@
     <title>Model Cyanobacterial Consortia Core Microbiome - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Model Cyanobacterial Consortia Core Microbiome</h1>
         </div>
     </header>

--- a/docs/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.html
+++ b/docs/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.html
@@ -6,7 +6,7 @@
     <title>Model Lignocellulose Formaldehyde Cross-Feeding Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Model Lignocellulose Formaldehyde Cross-Feeding Community</h1>
         </div>
     </header>

--- a/docs/communities/Multiomics_Corn_Straw_Degradation_SynCom.html
+++ b/docs/communities/Multiomics_Corn_Straw_Degradation_SynCom.html
@@ -6,7 +6,7 @@
     <title>Multiomics Corn Straw Degradation SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Multiomics Corn Straw Degradation SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Mushroom_Spring_Hot_Spring_Phototrophic_Mat_Community.html
+++ b/docs/communities/Mushroom_Spring_Hot_Spring_Phototrophic_Mat_Community.html
@@ -6,7 +6,7 @@
     <title>Mushroom Spring Hot-Spring Phototrophic Mat Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Mushroom Spring Hot-Spring Phototrophic Mat Community</h1>
         </div>
     </header>

--- a/docs/communities/NCycle_Bioflocculation_Model_Consortium.html
+++ b/docs/communities/NCycle_Bioflocculation_Model_Consortium.html
@@ -6,7 +6,7 @@
     <title>N-Cycle Bioflocculation Model Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>N-Cycle Bioflocculation Model Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Naica_Deep_Subsurface_Thermophilic.html
+++ b/docs/communities/Naica_Deep_Subsurface_Thermophilic.html
@@ -6,7 +6,7 @@
     <title>Naica Deep Subsurface Thermophilic Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Naica Deep Subsurface Thermophilic Community</h1>
         </div>
     </header>

--- a/docs/communities/Neocallimastix_Methanobrevibacter_Xylan_Coculture.html
+++ b/docs/communities/Neocallimastix_Methanobrevibacter_Xylan_Coculture.html
@@ -6,7 +6,7 @@
     <title>Neocallimastix-Methanobrevibacter Xylanolytic Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Neocallimastix-Methanobrevibacter Xylanolytic Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Ngawha_Geothermal_Mercury_Cycling_Community.html
+++ b/docs/communities/Ngawha_Geothermal_Mercury_Cycling_Community.html
@@ -6,7 +6,7 @@
     <title>Ngawha Geothermal Acidic Springs Mercury Cycling Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Ngawha Geothermal Acidic Springs Mercury Cycling Community</h1>
         </div>
     </header>

--- a/docs/communities/OMM12_Gnotobiotic_Mouse_Gut_Community.html
+++ b/docs/communities/OMM12_Gnotobiotic_Mouse_Gut_Community.html
@@ -6,7 +6,7 @@
     <title>OMM12 Gnotobiotic Mouse Gut Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>OMM12 Gnotobiotic Mouse Gut Community</h1>
         </div>
     </header>

--- a/docs/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.html
+++ b/docs/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.html
@@ -6,7 +6,7 @@
     <title>ORNL Clostridium-Desulfovibrio-Geobacter Trophic Model Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>ORNL Clostridium-Desulfovibrio-Geobacter Trophic Model Community</h1>
         </div>
     </header>

--- a/docs/communities/ORNL_PMI_Populus_PD10_SynCom.html
+++ b/docs/communities/ORNL_PMI_Populus_PD10_SynCom.html
@@ -6,7 +6,7 @@
     <title>ORNL PMI Populus PD10 SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>ORNL PMI Populus PD10 SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.html
+++ b/docs/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.html
@@ -6,7 +6,7 @@
     <title>Oak Ridge FRC Uranium-Nitrate Groundwater Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Oak Ridge FRC Uranium-Nitrate Groundwater Community</h1>
         </div>
     </header>

--- a/docs/communities/Okeke_Lu_Cellulolytic_Consortium.html
+++ b/docs/communities/Okeke_Lu_Cellulolytic_Consortium.html
@@ -6,7 +6,7 @@
     <title>Okeke-Lu Cellulolytic-Xylanolytic Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Okeke-Lu Cellulolytic-Xylanolytic Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.html
+++ b/docs/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.html
@@ -6,7 +6,7 @@
     <title>Ostreococcus-Dinoroseobacter B-Vitamin Mutualism - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Ostreococcus-Dinoroseobacter B-Vitamin Mutualism</h1>
         </div>
     </header>

--- a/docs/communities/PET_Artificial_FourSpecies_Degradation_Consortium.html
+++ b/docs/communities/PET_Artificial_FourSpecies_Degradation_Consortium.html
@@ -6,7 +6,7 @@
     <title>PET Artificial Four-Species Degradation Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>PET Artificial Four-Species Degradation Consortium</h1>
         </div>
     </header>

--- a/docs/communities/PGM_Spent_Catalyst_Bioleaching.html
+++ b/docs/communities/PGM_Spent_Catalyst_Bioleaching.html
@@ -6,7 +6,7 @@
     <title>PGM Spent Catalyst Bioleaching Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>PGM Spent Catalyst Bioleaching Consortium</h1>
         </div>
     </header>

--- a/docs/communities/PMI_Variovorax_Thermotolerance_Collection.html
+++ b/docs/communities/PMI_Variovorax_Thermotolerance_Collection.html
@@ -6,7 +6,7 @@
     <title>PMI Variovorax Thermotolerance Collection - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>PMI Variovorax Thermotolerance Collection</h1>
         </div>
     </header>

--- a/docs/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.html
+++ b/docs/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.html
@@ -6,7 +6,7 @@
     <title>PSY Transgenic Rice Rhizosphere Methane-Mitigating Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>PSY Transgenic Rice Rhizosphere Methane-Mitigating Community</h1>
         </div>
     </header>

--- a/docs/communities/Panzhihua_Vanadium_Titanium_Tailings.html
+++ b/docs/communities/Panzhihua_Vanadium_Titanium_Tailings.html
@@ -6,7 +6,7 @@
     <title>Panzhihua Vanadium Titanium Tailings Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Panzhihua Vanadium Titanium Tailings Community</h1>
         </div>
     </header>

--- a/docs/communities/Peanut_Seed_Bacterial_CS_SynCom.html
+++ b/docs/communities/Peanut_Seed_Bacterial_CS_SynCom.html
@@ -6,7 +6,7 @@
     <title>Peanut Seed Bacterial CS SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Peanut Seed Bacterial CS SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.html
+++ b/docs/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.html
@@ -6,7 +6,7 @@
     <title>Pelotomaculum-Methanocella Propionate RNA-Seq Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Pelotomaculum-Methanocella Propionate RNA-Seq Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Pelotomaculum_Methanothermobacter_Syntrophy.html
+++ b/docs/communities/Pelotomaculum_Methanothermobacter_Syntrophy.html
@@ -6,7 +6,7 @@
     <title>Pelotomaculum-Methanothermobacter Syntrophic Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Pelotomaculum-Methanothermobacter Syntrophic Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Pepper_Growth_Rhizosphere_SynCom.html
+++ b/docs/communities/Pepper_Growth_Rhizosphere_SynCom.html
@@ -6,7 +6,7 @@
     <title>Pepper Growth Rhizosphere SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Pepper Growth Rhizosphere SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Pepper_Phytophthora_SynCom5.html
+++ b/docs/communities/Pepper_Phytophthora_SynCom5.html
@@ -6,7 +6,7 @@
     <title>Pepper Phytophthora-Resistance SynCom5 - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Pepper Phytophthora-Resistance SynCom5</h1>
         </div>
     </header>

--- a/docs/communities/Phenol_Carboxylation_Consortium.html
+++ b/docs/communities/Phenol_Carboxylation_Consortium.html
@@ -6,7 +6,7 @@
     <title>Phenol Carboxylation Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Phenol Carboxylation Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Phormidium_Alkaline_Consortium.html
+++ b/docs/communities/Phormidium_Alkaline_Consortium.html
@@ -6,7 +6,7 @@
     <title>Phormidium Alkaline Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Phormidium Alkaline Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Phylogenetically_Diverse_Denitrifying_SynCom.html
+++ b/docs/communities/Phylogenetically_Diverse_Denitrifying_SynCom.html
@@ -6,7 +6,7 @@
     <title>Phylogenetically Diverse Denitrifying SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Phylogenetically Diverse Denitrifying SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Polaromonas_Vanadium_Reduction_Community.html
+++ b/docs/communities/Polaromonas_Vanadium_Reduction_Community.html
@@ -6,7 +6,7 @@
     <title>Polaromonas Vanadium Reduction Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Polaromonas Vanadium Reduction Community</h1>
         </div>
     </header>

--- a/docs/communities/Populus_Salt_Tolerant_SynComs.html
+++ b/docs/communities/Populus_Salt_Tolerant_SynComs.html
@@ -6,7 +6,7 @@
     <title>Populus Salt-Tolerant Rhizosphere SynComs - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Populus Salt-Tolerant Rhizosphere SynComs</h1>
         </div>
     </header>

--- a/docs/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.html
+++ b/docs/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.html
@@ -6,7 +6,7 @@
     <title>Prairie Pothole Wetland Sulfur-Carbon Virus-Host Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Prairie Pothole Wetland Sulfur-Carbon Virus-Host Community</h1>
         </div>
     </header>

--- a/docs/communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.html
+++ b/docs/communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.html
@@ -6,7 +6,7 @@
     <title>Premature Infant Gut Escherichia In-Situ Physiological-Condition Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Premature Infant Gut Escherichia In-Situ Physiological-Condition Community</h1>
         </div>
     </header>

--- a/docs/communities/Prochlorococcus_Alteromonas_Helper_Coculture.html
+++ b/docs/communities/Prochlorococcus_Alteromonas_Helper_Coculture.html
@@ -6,7 +6,7 @@
     <title>Prochlorococcus-Alteromonas Helper Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Prochlorococcus-Alteromonas Helper Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.html
+++ b/docs/communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.html
@@ -6,7 +6,7 @@
     <title>Propanotrophic Chlorinated Ethene Cometabolism Enrichment Cultures - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Propanotrophic Chlorinated Ethene Cometabolism Enrichment Cultures</h1>
         </div>
     </header>

--- a/docs/communities/Pseudomonas_Pedobacter_Social_Spreading_Coculture.html
+++ b/docs/communities/Pseudomonas_Pedobacter_Social_Spreading_Coculture.html
@@ -6,7 +6,7 @@
     <title>Pseudomonas-Pedobacter Social Spreading Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Pseudomonas-Pedobacter Social Spreading Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Pseudomonas_Rhodococcus_Chloronitrobenzene_Coculture.html
+++ b/docs/communities/Pseudomonas_Rhodococcus_Chloronitrobenzene_Coculture.html
@@ -6,7 +6,7 @@
     <title>Pseudomonas-Rhodococcus Chloronitrobenzene Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Pseudomonas-Rhodococcus Chloronitrobenzene Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Pseudonitzschia_Sulfitobacter_Association.html
+++ b/docs/communities/Pseudonitzschia_Sulfitobacter_Association.html
@@ -6,7 +6,7 @@
     <title>Pseudo-nitzschia-Sulfitobacter Marine Association - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Pseudo-nitzschia-Sulfitobacter Marine Association</h1>
         </div>
     </header>

--- a/docs/communities/Rammelsberg_Cobalt_Nickel_Tailings.html
+++ b/docs/communities/Rammelsberg_Cobalt_Nickel_Tailings.html
@@ -6,7 +6,7 @@
     <title>Rammelsberg Cobalt-Nickel Tailings Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Rammelsberg Cobalt-Nickel Tailings Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.html
+++ b/docs/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.html
@@ -6,7 +6,7 @@
     <title>Rhodopseudomonas-E. coli Cross-Feeding Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Rhodopseudomonas-E. coli Cross-Feeding Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.html
+++ b/docs/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.html
@@ -6,7 +6,7 @@
     <title>Rhodopseudomonas-Geobacter Magnetite Redox Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Rhodopseudomonas-Geobacter Magnetite Redox Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Rice_Acid_Soil_Bioinoculant_SynCom.html
+++ b/docs/communities/Rice_Acid_Soil_Bioinoculant_SynCom.html
@@ -6,7 +6,7 @@
     <title>Rice Acid Soil Bioinoculant SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Rice Acid Soil Bioinoculant SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Rice_Duckweed_Bacillus_SynCom.html
+++ b/docs/communities/Rice_Duckweed_Bacillus_SynCom.html
@@ -6,7 +6,7 @@
     <title>Rice-Duckweed Bacillus Biocontrol SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Rice-Duckweed Bacillus Biocontrol SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Rice_P_Uptake_Intercropping_SynCom4.html
+++ b/docs/communities/Rice_P_Uptake_Intercropping_SynCom4.html
@@ -6,7 +6,7 @@
     <title>Rice Phosphorus Uptake Intercropping SynCom4 - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Rice Phosphorus Uptake Intercropping SynCom4</h1>
         </div>
     </header>

--- a/docs/communities/Richmond_Mine_AMD_Biofilm.html
+++ b/docs/communities/Richmond_Mine_AMD_Biofilm.html
@@ -6,7 +6,7 @@
     <title>Richmond Mine AMD Biofilm - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Richmond Mine AMD Biofilm</h1>
         </div>
     </header>

--- a/docs/communities/Rifle_Aquifer_Bioanode_EET_Community.html
+++ b/docs/communities/Rifle_Aquifer_Bioanode_EET_Community.html
@@ -6,7 +6,7 @@
     <title>Rifle Aquifer Bioanode Extracellular Electron Transfer Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Rifle Aquifer Bioanode Extracellular Electron Transfer Community</h1>
         </div>
     </header>

--- a/docs/communities/Rifle_Uranium_Reducing_Community.html
+++ b/docs/communities/Rifle_Uranium_Reducing_Community.html
@@ -6,7 +6,7 @@
     <title>Rifle Uranium-Reducing Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Rifle Uranium-Reducing Community</h1>
         </div>
     </header>

--- a/docs/communities/SF356_Cellulose_Degrader.html
+++ b/docs/communities/SF356_Cellulose_Degrader.html
@@ -6,7 +6,7 @@
     <title>SF356 Thermophilic Cellulose-Degrading Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>SF356 Thermophilic Cellulose-Degrading Community</h1>
         </div>
     </header>

--- a/docs/communities/SIHUMIx_Human_Intestinal_Model_Community.html
+++ b/docs/communities/SIHUMIx_Human_Intestinal_Model_Community.html
@@ -6,7 +6,7 @@
     <title>SIHUMIx Human Intestinal Model Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>SIHUMIx Human Intestinal Model Community</h1>
         </div>
     </header>

--- a/docs/communities/SMutans_CAlbicans_ECC_Biofilm.html
+++ b/docs/communities/SMutans_CAlbicans_ECC_Biofilm.html
@@ -6,7 +6,7 @@
     <title>Streptococcus mutans - Candida albicans ECC Biofilm Model - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Streptococcus mutans - Candida albicans ECC Biofilm Model</h1>
         </div>
     </header>

--- a/docs/communities/SMutans_SSputigena_ECC_Pathobiont.html
+++ b/docs/communities/SMutans_SSputigena_ECC_Pathobiont.html
@@ -6,7 +6,7 @@
     <title>Streptococcus mutans - Selenomonas sputigena ECC Pathobiont Model - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Streptococcus mutans - Selenomonas sputigena ECC Pathobiont Model</h1>
         </div>
     </header>

--- a/docs/communities/SMutans_VParvula_ASC_Biofilm.html
+++ b/docs/communities/SMutans_VParvula_ASC_Biofilm.html
@@ -6,7 +6,7 @@
     <title>Streptococcus mutans - Veillonella parvula Adult Severe Caries Model - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Streptococcus mutans - Veillonella parvula Adult Severe Caries Model</h1>
         </div>
     </header>

--- a/docs/communities/SPRUCE_Peatland_Methane_Cycling_Community.html
+++ b/docs/communities/SPRUCE_Peatland_Methane_Cycling_Community.html
@@ -6,7 +6,7 @@
     <title>SPRUCE Peatland Methane-Cycling Microbial Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>SPRUCE Peatland Methane-Cycling Microbial Community</h1>
         </div>
     </header>

--- a/docs/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.html
+++ b/docs/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.html
@@ -6,7 +6,7 @@
     <title>Saanich Inlet Oxygen Minimum Zone Redox-Gradient Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Saanich Inlet Oxygen Minimum Zone Redox-Gradient Community</h1>
         </div>
     </header>

--- a/docs/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.html
+++ b/docs/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.html
@@ -6,7 +6,7 @@
     <title>Saccharomyces-Acinetobacter Lignocellulose Hydrolysate Detoxification Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Saccharomyces-Acinetobacter Lignocellulose Hydrolysate Detoxification Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Saccharomyces_Chlamydomonas_Fungal_Algal_Mutualism.html
+++ b/docs/communities/Saccharomyces_Chlamydomonas_Fungal_Algal_Mutualism.html
@@ -6,7 +6,7 @@
     <title>Saccharomyces-Chlamydomonas Fungal-Algal Mutualism - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Saccharomyces-Chlamydomonas Fungal-Algal Mutualism</h1>
         </div>
     </header>

--- a/docs/communities/Salar_Atacama_Lithium_Brine_Community.html
+++ b/docs/communities/Salar_Atacama_Lithium_Brine_Community.html
@@ -6,7 +6,7 @@
     <title>Salar de Atacama Lithium Brine Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Salar de Atacama Lithium Brine Community</h1>
         </div>
     </header>

--- a/docs/communities/Shewanella_Denitrifying_Richness_SynComs.html
+++ b/docs/communities/Shewanella_Denitrifying_Richness_SynComs.html
@@ -6,7 +6,7 @@
     <title>Shewanella Denitrifying Richness SynComs - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Shewanella Denitrifying Richness SynComs</h1>
         </div>
     </header>

--- a/docs/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.html
+++ b/docs/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.html
@@ -6,7 +6,7 @@
     <title>Shewanella-Geobacter Three-Species Exoelectrogenic Biofilm Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Shewanella-Geobacter Three-Species Exoelectrogenic Biofilm Community</h1>
         </div>
     </header>

--- a/docs/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.html
+++ b/docs/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.html
@@ -6,7 +6,7 @@
     <title>Shewanella-Streptococcus Starch-Fueled Microbial Fuel Cell Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Shewanella-Streptococcus Starch-Fueled Microbial Fuel Cell Coculture</h1>
         </div>
     </header>

--- a/docs/communities/SkinCom_Synthetic_Skin_Community.html
+++ b/docs/communities/SkinCom_Synthetic_Skin_Community.html
@@ -6,7 +6,7 @@
     <title>SkinCom Synthetic Skin Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>SkinCom Synthetic Skin Community</h1>
         </div>
     </header>

--- a/docs/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.html
+++ b/docs/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.html
@@ -6,7 +6,7 @@
     <title>Soil Biosynthetic Gene Cluster Phylum-Depth-Vegetation Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Soil Biosynthetic Gene Cluster Phylum-Depth-Vegetation Community</h1>
         </div>
     </header>

--- a/docs/communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.html
+++ b/docs/communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.html
@@ -6,7 +6,7 @@
     <title>Soil CPR Bacteria and Nanoarchaea Rare-Biosphere Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Soil CPR Bacteria and Nanoarchaea Rare-Biosphere Community</h1>
         </div>
     </header>

--- a/docs/communities/Soil_Corrinoid_B12_Reservoir_Community.html
+++ b/docs/communities/Soil_Corrinoid_B12_Reservoir_Community.html
@@ -6,7 +6,7 @@
     <title>Soil Corrinoid Reservoir Microbial Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Soil Corrinoid Reservoir Microbial Community</h1>
         </div>
     </header>

--- a/docs/communities/Sorghum_SRC1_Subset.html
+++ b/docs/communities/Sorghum_SRC1_Subset.html
@@ -6,7 +6,7 @@
     <title>Sorghum SRC1 Subset Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Sorghum SRC1 Subset Community</h1>
         </div>
     </header>

--- a/docs/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.html
+++ b/docs/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.html
@@ -6,7 +6,7 @@
     <title>South Bay Salt Pond Methane Restoration Microbial Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>South Bay Salt Pond Methane Restoration Microbial Community</h1>
         </div>
     </header>

--- a/docs/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.html
+++ b/docs/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.html
@@ -6,7 +6,7 @@
     <title>Soybean Chlorophyll-Selected Biofertilizer SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Soybean Chlorophyll-Selected Biofertilizer SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Soybean_N_Fixation_sfSynCom.html
+++ b/docs/communities/Soybean_N_Fixation_sfSynCom.html
@@ -6,7 +6,7 @@
     <title>Soybean N-Fixation Simplified SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Soybean N-Fixation Simplified SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Sphingobium_Rhodococcus_Lignin_Dimer_Valorization_Coculture.html
+++ b/docs/communities/Sphingobium_Rhodococcus_Lignin_Dimer_Valorization_Coculture.html
@@ -6,7 +6,7 @@
     <title>Sphingobium-Rhodococcus Lignin-Dimer Valorization Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Sphingobium-Rhodococcus Lignin-Dimer Valorization Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.html
+++ b/docs/communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.html
@@ -6,7 +6,7 @@
     <title>Stordalen Mire Methylotrophic Methanogenesis Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Stordalen Mire Methylotrophic Methanogenesis Community</h1>
         </div>
     </header>

--- a/docs/communities/Subsurface_Carboxydocella_CO_Aquifer_Community.html
+++ b/docs/communities/Subsurface_Carboxydocella_CO_Aquifer_Community.html
@@ -6,7 +6,7 @@
     <title>Subsurface Carboxydocella CO-Oxidation Aquifer Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Subsurface Carboxydocella CO-Oxidation Aquifer Community</h1>
         </div>
     </header>

--- a/docs/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.html
+++ b/docs/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.html
@@ -6,7 +6,7 @@
     <title>Sulfide Spring Autotrophic CPR-Hosting Biofilm - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Sulfide Spring Autotrophic CPR-Hosting Biofilm</h1>
         </div>
     </header>

--- a/docs/communities/SynComBac10_Chicken_Intestinal_SynCom.html
+++ b/docs/communities/SynComBac10_Chicken_Intestinal_SynCom.html
@@ -6,7 +6,7 @@
     <title>SynComBac10 Chicken Intestinal SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>SynComBac10 Chicken Intestinal SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.html
+++ b/docs/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.html
@@ -6,7 +6,7 @@
     <title>Synechococcus-Azotobacter Photoproduction Mutualism - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Synechococcus-Azotobacter Photoproduction Mutualism</h1>
         </div>
     </header>

--- a/docs/communities/Synechococcus_Bacillus_SPC.html
+++ b/docs/communities/Synechococcus_Bacillus_SPC.html
@@ -6,7 +6,7 @@
     <title>Synechococcus-Bacillus Synthetic Photosynthetic Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Synechococcus-Bacillus Synthetic Photosynthetic Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Synechococcus_Ecoli_SPC.html
+++ b/docs/communities/Synechococcus_Ecoli_SPC.html
@@ -6,7 +6,7 @@
     <title>Synechococcus-E.coli Synthetic Photosynthetic Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Synechococcus-E.coli Synthetic Photosynthetic Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.html
+++ b/docs/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.html
@@ -6,7 +6,7 @@
     <title>Synechococcus-Halomonas Light-Driven PHB Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Synechococcus-Halomonas Light-Driven PHB Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.html
+++ b/docs/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.html
@@ -6,7 +6,7 @@
     <title>Synechococcus-Pseudomonas Phototrophic PHA and DNT Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Synechococcus-Pseudomonas Phototrophic PHA and DNT Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.html
+++ b/docs/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.html
@@ -6,7 +6,7 @@
     <title>Synechococcus-Shewanella D-Lactate Biophotovoltaic Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Synechococcus-Shewanella D-Lactate Biophotovoltaic Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Synechococcus_Yarrowia_SPC.html
+++ b/docs/communities/Synechococcus_Yarrowia_SPC.html
@@ -6,7 +6,7 @@
     <title>Synechococcus-Yarrowia Synthetic Photosynthetic Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Synechococcus-Yarrowia Synthetic Photosynthetic Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.html
+++ b/docs/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.html
@@ -6,7 +6,7 @@
     <title>Synthetic Lichen Synechococcus-Rhodotorula Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Synthetic Lichen Synechococcus-Rhodotorula Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Synthetic_Periphyton_Freshwater_Biofilm.html
+++ b/docs/communities/Synthetic_Periphyton_Freshwater_Biofilm.html
@@ -6,7 +6,7 @@
     <title>Synthetic Periphyton Freshwater Biofilm - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Synthetic Periphyton Freshwater Biofilm</h1>
         </div>
     </header>

--- a/docs/communities/Syntrophobacter_Methanobacterium_Syntrophy.html
+++ b/docs/communities/Syntrophobacter_Methanobacterium_Syntrophy.html
@@ -6,7 +6,7 @@
     <title>Syntrophobacter-Methanobacterium Syntrophic Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Syntrophobacter-Methanobacterium Syntrophic Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Syntrophobacter_Methanospirillum_Syntrophy.html
+++ b/docs/communities/Syntrophobacter_Methanospirillum_Syntrophy.html
@@ -6,7 +6,7 @@
     <title>Syntrophobacter-Methanospirillum Syntrophic Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Syntrophobacter-Methanospirillum Syntrophic Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.html
+++ b/docs/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.html
@@ -6,7 +6,7 @@
     <title>Syntrophomonas-Methanococcus Butyrate Growth Coordination Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Syntrophomonas-Methanococcus Butyrate Growth Coordination Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Syntrophomonas_Methanospirillum_Syntrophy.html
+++ b/docs/communities/Syntrophomonas_Methanospirillum_Syntrophy.html
@@ -6,7 +6,7 @@
     <title>Syntrophomonas-Methanospirillum Syntrophic Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Syntrophomonas-Methanospirillum Syntrophic Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Syntrophus_Benzoate_Degrader.html
+++ b/docs/communities/Syntrophus_Benzoate_Degrader.html
@@ -6,7 +6,7 @@
     <title>Syntrophus Benzoate Degrader - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Syntrophus Benzoate Degrader</h1>
         </div>
     </header>

--- a/docs/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.html
+++ b/docs/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.html
@@ -6,7 +6,7 @@
     <title>Syntrophus-Methanospirillum Gentianae Benzoate Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Syntrophus-Methanospirillum Gentianae Benzoate Coculture</h1>
         </div>
     </header>

--- a/docs/communities/THOR_Rhizosphere_Model_Community.html
+++ b/docs/communities/THOR_Rhizosphere_Model_Community.html
@@ -6,7 +6,7 @@
     <title>THOR Rhizosphere Model Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>THOR Rhizosphere Model Community</h1>
         </div>
     </header>

--- a/docs/communities/TYQ1_Nematode_Biocontrol_SynCom.html
+++ b/docs/communities/TYQ1_Nematode_Biocontrol_SynCom.html
@@ -6,7 +6,7 @@
     <title>TYQ1 Nematode Biocontrol SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>TYQ1 Nematode Biocontrol SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Teosinte_Maize_Biofertilizer_SynCom7.html
+++ b/docs/communities/Teosinte_Maize_Biofertilizer_SynCom7.html
@@ -6,7 +6,7 @@
     <title>Teosinte-Derived Maize Biofertilizer SynCom7 - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Teosinte-Derived Maize Biofertilizer SynCom7</h1>
         </div>
     </header>

--- a/docs/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.html
+++ b/docs/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.html
@@ -6,7 +6,7 @@
     <title>Thalassiosira-Marinobacter Marine Snow Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Thalassiosira-Marinobacter Marine Snow Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.html
+++ b/docs/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.html
@@ -6,7 +6,7 @@
     <title>Thalassiosira-Ruegeria Phycosphere Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Thalassiosira-Ruegeria Phycosphere Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.html
+++ b/docs/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.html
@@ -6,7 +6,7 @@
     <title>Thermacetogenium-Methanothermobacter Acetate Oxidation Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Thermacetogenium-Methanothermobacter Acetate Oxidation Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Thermophilic_Pyrite_QS_Consortium.html
+++ b/docs/communities/Thermophilic_Pyrite_QS_Consortium.html
@@ -6,7 +6,7 @@
     <title>Thermophilic Pyrite Quorum Sensing Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Thermophilic Pyrite Quorum Sensing Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.html
+++ b/docs/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.html
@@ -6,7 +6,7 @@
     <title>Thermotoga-Methanocaldococcus Hyperthermophilic Syntrophy - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Thermotoga-Methanocaldococcus Hyperthermophilic Syntrophy</h1>
         </div>
     </header>

--- a/docs/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.html
+++ b/docs/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.html
@@ -6,7 +6,7 @@
     <title>Thiocyanate-Degrading Afipia and Thiobacillus Bioreactor Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Thiocyanate-Degrading Afipia and Thiobacillus Bioreactor Community</h1>
         </div>
     </header>

--- a/docs/communities/Tinto_River_Iron_Cycling_Community.html
+++ b/docs/communities/Tinto_River_Iron_Cycling_Community.html
@@ -6,7 +6,7 @@
     <title>Tinto River Iron Cycling Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Tinto River Iron Cycling Community</h1>
         </div>
     </header>

--- a/docs/communities/Tobacco_Chemotactic_Biocontrol_SynCom.html
+++ b/docs/communities/Tobacco_Chemotactic_Biocontrol_SynCom.html
@@ -6,7 +6,7 @@
     <title>Tobacco Chemotactic Biocontrol SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Tobacco Chemotactic Biocontrol SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Tomato_Oxylipin_SynCom3.html
+++ b/docs/communities/Tomato_Oxylipin_SynCom3.html
@@ -6,7 +6,7 @@
     <title>Tomato Oxylipin-Protective SynCom3 - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Tomato Oxylipin-Protective SynCom3</h1>
         </div>
     </header>

--- a/docs/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.html
+++ b/docs/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.html
@@ -6,7 +6,7 @@
     <title>Tribromophenol Anaerobic Bioremediation SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Tribromophenol Anaerobic Bioremediation SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.html
+++ b/docs/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.html
@@ -6,7 +6,7 @@
     <title>Trichococcus-Syntrophomonas-Methanospirillum Butyrate Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Trichococcus-Syntrophomonas-Methanospirillum Butyrate Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.html
+++ b/docs/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.html
@@ -6,7 +6,7 @@
     <title>Trichoderma-E. coli Cellulosic Isobutanol Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Trichoderma-E. coli Cellulosic Isobutanol Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Trichoderma_Lactate_Platform.html
+++ b/docs/communities/Trichoderma_Lactate_Platform.html
@@ -6,7 +6,7 @@
     <title>Trichoderma Lactate Platform for SCFA Production - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Trichoderma Lactate Platform for SCFA Production</h1>
         </div>
     </header>

--- a/docs/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.html
+++ b/docs/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.html
@@ -6,7 +6,7 @@
     <title>Trichoderma-Streptomyces Filamentous Cellulose Coculture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Trichoderma-Streptomyces Filamentous Cellulose Coculture</h1>
         </div>
     </header>

--- a/docs/communities/Trichodesmium_Alteromonas_Marine_Consortium.html
+++ b/docs/communities/Trichodesmium_Alteromonas_Marine_Consortium.html
@@ -6,7 +6,7 @@
     <title>Trichodesmium-Alteromonas Marine Consortium - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Trichodesmium-Alteromonas Marine Consortium</h1>
         </div>
     </header>

--- a/docs/communities/Urine_Nitrification_SynCom.html
+++ b/docs/communities/Urine_Nitrification_SynCom.html
@@ -6,7 +6,7 @@
     <title>Urine Nitrification Synthetic Microbial Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Urine Nitrification Synthetic Microbial Community</h1>
         </div>
     </header>

--- a/docs/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.html
+++ b/docs/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.html
@@ -6,7 +6,7 @@
     <title>Variovorax-Cryptococcus Vitamin Cross-Feeding Microcosm - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Variovorax-Cryptococcus Vitamin Cross-Feeding Microcosm</h1>
         </div>
     </header>

--- a/docs/communities/Watermelon_Rhizosphere_Fusarium_SynCom8.html
+++ b/docs/communities/Watermelon_Rhizosphere_Fusarium_SynCom8.html
@@ -6,7 +6,7 @@
     <title>Watermelon Rhizosphere Fusarium-Protective SynCom8 - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Watermelon Rhizosphere Fusarium-Protective SynCom8</h1>
         </div>
     </header>

--- a/docs/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.html
+++ b/docs/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.html
@@ -6,7 +6,7 @@
     <title>Wetland Oxygen-Sulfate Greenhouse Gas Microcosm Community - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Wetland Oxygen-Sulfate Greenhouse Gas Microcosm Community</h1>
         </div>
     </header>

--- a/docs/communities/Wheat_Consortium_C1.html
+++ b/docs/communities/Wheat_Consortium_C1.html
@@ -6,7 +6,7 @@
     <title>Wheat Synthetic Consortium C1 - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Wheat Synthetic Consortium C1</h1>
         </div>
     </header>

--- a/docs/communities/Wheat_Consortium_C6.html
+++ b/docs/communities/Wheat_Consortium_C6.html
@@ -6,7 +6,7 @@
     <title>Wheat Synthetic Consortium C6 - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Wheat Synthetic Consortium C6</h1>
         </div>
     </header>

--- a/docs/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.html
+++ b/docs/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.html
@@ -6,7 +6,7 @@
     <title>Wheat Straw Biogas Pretreatment SynCom - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Wheat Straw Biogas Pretreatment SynCom</h1>
         </div>
     </header>

--- a/docs/communities/Yogurt_TwoSpecies_Starter_Culture.html
+++ b/docs/communities/Yogurt_TwoSpecies_Starter_Culture.html
@@ -6,7 +6,7 @@
     <title>Yogurt Two-Species Starter Culture - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Yogurt Two-Species Starter Culture</h1>
         </div>
     </header>

--- a/docs/communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.html
+++ b/docs/communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.html
@@ -6,7 +6,7 @@
     <title>Zymomonas-E. coli Exometabolomics-Designed Obligate Mutualism - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>Zymomonas-E. coli Exometabolomics-Designed Obligate Mutualism</h1>
         </div>
     </header>

--- a/docs/communities/hCom2_Complex_Gut_Microbiome.html
+++ b/docs/communities/hCom2_Complex_Gut_Microbiome.html
@@ -6,7 +6,7 @@
     <title>hCom2 Complex Gut Microbiome - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>hCom2 Complex Gut Microbiome</h1>
         </div>
     </header>

--- a/docs/communities/mCAFEs_Brachypodium_RCC.html
+++ b/docs/communities/mCAFEs_Brachypodium_RCC.html
@@ -6,7 +6,7 @@
     <title>m-CAFEs Brachypodium Reduced Complexity Consortia - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>m-CAFEs Brachypodium Reduced Complexity Consortia</h1>
         </div>
     </header>

--- a/docs/community_umap.html
+++ b/docs/community_umap.html
@@ -6,8 +6,8 @@
     <title>Community Embedding Space - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
-            --primary-dark: #1e40af;
+            --primary: #3D7DD6;
+            --primary-dark: #2f63ac;
             --secondary: #64748b;
             --background: #ffffff;
             --surface: #f8fafc;

--- a/src/communitymech/render.py
+++ b/src/communitymech/render.py
@@ -128,19 +128,26 @@ class CommunityRenderer:
                     }
                 )
 
-        # Load index template
-        template = self.env.get_template("index.html")
+        # Render the faceted browser (templates/index.html) to docs/browser.html
+        browser_template = self.env.get_template("index.html")
+        browser_html = browser_template.render(communities=communities)
 
-        # Render index page
-        index_html = template.render(communities=communities)
+        browser_path = output_dir.parent / "browser.html"  # docs/browser.html
+        browser_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(browser_path, "w") as f:
+            f.write(browser_html)
 
-        # Write to file
+        print(f"  ✓ Generated browser at {browser_path}")
+
+        # Render the landing page (templates/landing.html) to docs/index.html
+        landing_template = self.env.get_template("landing.html")
+        landing_html = landing_template.render(num_communities=len(communities))
+
         index_path = output_dir.parent / "index.html"  # docs/index.html
-        index_path.parent.mkdir(parents=True, exist_ok=True)
         with open(index_path, "w") as f:
-            f.write(index_html)
+            f.write(landing_html)
 
-        print(f"  ✓ Generated index at {index_path}")
+        print(f"  ✓ Generated landing at {index_path}")
 
 
 def main():

--- a/src/communitymech/templates/community.html
+++ b/src/communitymech/templates/community.html
@@ -6,7 +6,7 @@
     <title>{{ community.name }} - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
+            --primary: #3D7DD6;
             --secondary: #64748b;
             --background: #f8fafc;
             --card: #ffffff;
@@ -37,8 +37,8 @@
         }
 
         header {
-            background: var(--card);
-            border-bottom: 2px solid var(--primary);
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 1.5rem 0;
             margin-bottom: 2rem;
         }
@@ -347,7 +347,7 @@
 <body>
     <header>
         <div class="container">
-            <a href="../index.html" class="back-link">← Back to Communities</a>
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
             <h1>{{ community.name }}</h1>
         </div>
     </header>

--- a/src/communitymech/templates/community.html.j2
+++ b/src/communitymech/templates/community.html.j2
@@ -14,7 +14,7 @@
 
 <nav class="breadcrumb">
   <a href="../index.html">CommunityMech</a> &rsaquo;
-  <a href="index.html">communities</a> &rsaquo;
+  <a href="../browser.html">communities</a> &rsaquo;
   <span>{{ community.id }}</span>
 </nav>
 

--- a/src/communitymech/templates/community_umap.html
+++ b/src/communitymech/templates/community_umap.html
@@ -6,8 +6,8 @@
     <title>Community Embedding Space - CommunityMech</title>
     <style>
         :root {
-            --primary: #2563eb;
-            --primary-dark: #1e40af;
+            --primary: #3D7DD6;
+            --primary-dark: #2f63ac;
             --secondary: #64748b;
             --background: #ffffff;
             --surface: #f8fafc;

--- a/src/communitymech/templates/index.html
+++ b/src/communitymech/templates/index.html
@@ -14,7 +14,7 @@
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
             background: #f8fafc;
-            color: #1e293b;
+            color: #1a1a1a;
             line-height: 1.6;
         }
 
@@ -25,14 +25,27 @@
         }
 
         header {
-            background: white;
-            border-bottom: 2px solid #2563eb;
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
             padding: 2rem 0;
             margin-bottom: 2rem;
         }
 
+        header .home-link {
+            display: inline-block;
+            margin-bottom: 0.75rem;
+            color: #3D7DD6;
+            text-decoration: none;
+            font-weight: 600;
+            font-size: 0.95rem;
+        }
+
+        header .home-link:hover {
+            text-decoration: underline;
+        }
+
         h1 {
-            color: #2563eb;
+            color: #1a1a1a;
             font-size: 2.5rem;
             margin-bottom: 0.5rem;
         }
@@ -260,11 +273,11 @@
             padding: 1.5rem;
             background: white;
             border-radius: 8px;
-            border: 2px solid #2563eb;
+            border: 2px solid #3D7DD6;
         }
 
         .umap-link h2 {
-            color: #2563eb;
+            color: #3D7DD6;
             font-size: 1.25rem;
             margin-bottom: 0.5rem;
         }
@@ -277,7 +290,7 @@
         .umap-link a {
             display: inline-block;
             padding: 0.75rem 1.5rem;
-            background: #2563eb;
+            background: #3D7DD6;
             color: white;
             text-decoration: none;
             border-radius: 6px;
@@ -286,7 +299,7 @@
         }
 
         .umap-link a:hover {
-            background: #1e40af;
+            background: #2f63ac;
         }
 
         .community-grid {
@@ -313,7 +326,7 @@
         }
 
         .community-card h2 {
-            color: #2563eb;
+            color: #3D7DD6;
             font-size: 1.25rem;
             margin-bottom: 0.5rem;
         }
@@ -405,6 +418,7 @@
 <body>
     <header>
         <div class="container">
+            <a href="index.html" class="home-link">← Home</a>
             <h1>CommunityMech</h1>
             <p class="subtitle">Microbial Community Knowledge Base</p>
         </div>

--- a/src/communitymech/templates/landing.html
+++ b/src/communitymech/templates/landing.html
@@ -52,7 +52,7 @@
     <h1>CommunityMech</h1>
     <p class="tagline">Microbial community knowledge base — curated, evidence-backed interaction networks.</p>
     <div class="stats">
-      <div class="stat"><b>265</b><span>communities</span></div>
+      <div class="stat"><b>{{ num_communities }}</b><span>communities</span></div>
       <div class="stat"><b>16</b><span>categories</span></div>
       <div class="stat"><b>512-D</b><span>v3 embeddings</span></div>
     </div>

--- a/src/communitymech/templates/style.css
+++ b/src/communitymech/templates/style.css
@@ -3,7 +3,7 @@
   --muted: #666;
   --line: #e5e7eb;
   --bg-soft: #f6f8fa;
-  --accent: #0969da;
+  --accent: #3D7DD6;
   --pass: #2c8a3a;
   --warn: #d68f00;
   --fail: #b8302c;


### PR DESCRIPTION
Restyles the site: the main page is now a clean landing (branded hero + summary stats + three cards → record browser, embedding/UMAP browser, GitHub) with a footer cross-linking the other Mechs, kg-microbe, and METPO. **No facets on the main page** — the faceted record browser lives on its own page. Site-wide pastel **pink/blue** theme with a common black body font.

Part of the cross-Mech web redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)