### PR TITLE
GTDB-ground all remaining records (24 → 231/295)

### DIFF
--- a/kb/communities/AMD_Acidophile_Heterotroph_Network.yaml
+++ b/kb/communities/AMD_Acidophile_Heterotroph_Network.yaml
@@ -42,6 +42,14 @@ taxonomy:
     term:
       id: NCBITaxon:62140
       label: Acidiphilium multivorum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidiphilium_multivorum
+      gtdb_taxon: Acidiphilium multivorum
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acidiphilium;s__Acidiphilium multivorum
+      ncbi_source_id: NCBITaxon:62140
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Facultative anaerobic acidophilic heterotroph isolated from pyritic acid mine drainage. This
       α-proteobacterium couples Fe(III) reduction to organic carbon oxidation under anaerobic conditions
       and performs aerobic heterotrophy when oxygen is available. It completely oxidizes sugars (glucose,
@@ -78,6 +86,14 @@ taxonomy:
     term:
       id: NCBITaxon:121039
       label: Ferrimicrobium acidiphilum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Ferrimicrobium_acidiphilum
+      gtdb_taxon: Ferrimicrobium acidiphilum
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Acidimicrobiia;o__Acidimicrobiales;f__Acidimicrobiaceae;g__Ferrimicrobium;s__Ferrimicrobium acidiphilum
+      ncbi_source_id: NCBITaxon:121039
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Obligately heterotrophic iron-oxidizing actinobacterium from the subclass Acidimicrobidae.
       Unlike most heterotrophs, F. acidiphilum catalyzes both dissimilatory oxidation and reduction of
       soluble iron while requiring organic carbon for growth. This dual capability makes it unique among
@@ -113,6 +129,14 @@ taxonomy:
     term:
       id: NCBITaxon:524
       label: Acidiphilium cryptum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidiphilium_multivorum
+      gtdb_taxon: Acidiphilium multivorum
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acidiphilium;s__Acidiphilium multivorum
+      ncbi_source_id: NCBITaxon:524
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Facultative anaerobic acidophile capable of coupling complete oxidation of organic substrates
       to Fe(III) reduction at pH 3-5. This organism demonstrates metabolic versatility by performing aerobic
       respiration with oxygen, anaerobic respiration with ferric iron, or fermentation. It oxidizes a
@@ -147,6 +171,14 @@ taxonomy:
     term:
       id: NCBITaxon:525
       label: Acidocella facilis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidocella_facilis
+      gtdb_taxon: Acidocella facilis
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acidocella;s__Acidocella facilis
+      ncbi_source_id: NCBITaxon:525
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Obligately aerobic heterotrophic α-proteobacterium with strict respiratory metabolism. Unlike
       facultative anaerobes in the genus Acidiphilium, A. facilis requires oxygen as terminal electron
       acceptor and cannot perform Fe(III) reduction. It degrades organic compounds using dissolved oxygen
@@ -178,6 +210,14 @@ taxonomy:
     term:
       id: NCBITaxon:50715
       label: Acidisphaera rubrifaciens
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidisphaera_rubrifaciens
+      gtdb_taxon: Acidisphaera rubrifaciens
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acidisphaera;s__Acidisphaera rubrifaciens
+      ncbi_source_id: NCBITaxon:50715
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Aerobic photoheterotrophic α-proteobacterium that produces bacteriochlorophyll a and carotenoids
       under aerobic conditions. This unique organism combines heterotrophic carbon metabolism with light-harvesting
       capability, allowing it to supplement energy from organic carbon oxidation with photosynthetic light

--- a/kb/communities/AMD_Nitrososphaerota_Archaeal.yaml
+++ b/kb/communities/AMD_Nitrososphaerota_Archaeal.yaml
@@ -45,6 +45,14 @@ taxonomy:
     term:
       id: NCBITaxon:1078905
       label: Nitrosotalea devaniterrae
+    gtdb_classification:
+      gtdb_id: GTDB:s__Nitrosotalea_devanaterra
+      gtdb_taxon: Nitrosotalea devanaterra
+      gtdb_lineage: d__Archaea;p__Thermoproteota;c__Nitrososphaeria;o__Nitrososphaerales;f__Nitrosopumilaceae;g__Nitrosotalea;s__Nitrosotalea devanaterra
+      ncbi_source_id: NCBITaxon:1078905
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Obligately acidophilic ammonia-oxidizing archaeon from the phylum Nitrososphaerota, class
       Nitrososphaeria. This chemolithoautotrophic organism represents the first cultivated acidophilic
       AOA, isolated from acidic agricultural soil (pH 4.5). Grows optimally at pH 4.0-5.5 with extraordinary
@@ -94,6 +102,14 @@ taxonomy:
     term:
       id: NCBITaxon:497726
       label: Nitrososphaera
+    gtdb_classification:
+      gtdb_id: GTDB:g__Nitrososphaera
+      gtdb_taxon: Nitrososphaera
+      gtdb_lineage: d__Archaea;p__Thermoproteota;c__Nitrososphaeria;o__Nitrososphaerales;f__Nitrososphaeraceae;g__Nitrososphaera
+      ncbi_source_id: NCBITaxon:497726
+      majority_fraction: 0.833
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Mesophilic ammonia-oxidizing archaea related to Nitrososphaera viennensis but adapted to acidic
       conditions (pH 3.5-5.0). Detected in AMD-impacted sediments through 16S rRNA and amoA gene sequencing,
       with OTUs clustering with acidic soil- associated Nitrososphaera lineages. These archaea possess
@@ -131,6 +147,14 @@ taxonomy:
     term:
       id: NCBITaxon:74969
       label: Ferroplasma acidiphilum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Ferroplasma_acidarmanus
+      gtdb_taxon: Ferroplasma acidarmanus
+      gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales;f__Thermoplasmataceae;g__Ferroplasma;s__Ferroplasma acidarmanus
+      ncbi_source_id: NCBITaxon:74969
+      majority_fraction: 0.91
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Cell wall-lacking archaeon (Thermoplasmatales, Thermoplasmata) found in acid mine drainage
       alongside Nitrososphaerota AOA. Grows chemomixotrophically, oxidizing ferrous iron for energy while
       consuming organic matter. In the context of the archaeal nitrifying community, Ferroplasma plays

--- a/kb/communities/ANME_SRB_Marine_Methane_Seep_Consortium.yaml
+++ b/kb/communities/ANME_SRB_Marine_Methane_Seep_Consortium.yaml
@@ -42,6 +42,14 @@ taxonomy:
     term:
       id: NCBITaxon:213118
       label: Desulfobacterales
+    gtdb_classification:
+      gtdb_id: GTDB:o__Desulfobacterales
+      gtdb_taxon: Desulfobacterales
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfobacteria;o__Desulfobacterales
+      ncbi_source_id: NCBITaxon:213118
+      majority_fraction: 0.81
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at o__ rank; 5 GTDB taxa under the NCBI taxon]
     notes: Desulfobacterales is used as a conservative NCBI-grounded representation for common marine
       sulfate-reducing bacterial partners of ANME aggregates.
   functional_role:

--- a/kb/communities/Aalborg_East_Full_Scale_EBPR_Community.yaml
+++ b/kb/communities/Aalborg_East_Full_Scale_EBPR_Community.yaml
@@ -39,6 +39,14 @@ taxonomy:
     term:
       id: NCBITaxon:28216
       label: Betaproteobacteria
+    gtdb_classification:
+      gtdb_id: GTDB:c__Gammaproteobacteria
+      gtdb_taxon: Gammaproteobacteria
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria
+      ncbi_source_id: NCBITaxon:28216
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at c__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Accumulibacter is represented with the validated Betaproteobacteria class term because the record
       captures the full-scale community and clade-level microdiversity rather than a cultured isolate.
   functional_role:
@@ -66,6 +74,14 @@ taxonomy:
     term:
       id: NCBITaxon:201174
       label: Actinomycetota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Actinomycetota
+      gtdb_taxon: Actinomycetota
+      gtdb_lineage: d__Bacteria;p__Actinomycetota
+      ncbi_source_id: NCBITaxon:201174
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 6 GTDB taxa under the NCBI taxon]
     notes: Tetrasphaera-related Actinobacteria were abundant by qFISH but underrepresented in the metagenome,
       likely because of DNA extraction bias against gram-positive bacteria.
   functional_role:
@@ -92,6 +108,14 @@ taxonomy:
     term:
       id: NCBITaxon:976
       label: Bacteroidota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Bacteroidota
+      gtdb_taxon: Bacteroidota
+      gtdb_lineage: d__Bacteria;p__Bacteroidota
+      ncbi_source_id: NCBITaxon:976
+      majority_fraction: 0.999
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 8 GTDB taxa under the NCBI taxon]
     notes: Bacteroidetes-related Saprospiraceae and other flanking bacteria contribute to biomass processing
       and were prominent in metagenomic assignments.
   functional_role:

--- a/kb/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.yaml
+++ b/kb/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.yaml
@@ -48,6 +48,14 @@ taxonomy:
     term:
       id: NCBITaxon:33952
       label: Acetobacterium woodii
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acetobacterium_woodii
+      gtdb_taxon: Acetobacterium woodii
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Eubacteriales;f__Eubacteriaceae;g__Acetobacterium;s__Acetobacterium woodii
+      ncbi_source_id: NCBITaxon:33952
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Recombinant lactate-producing A. woodii mutant used as the acetogenic CO2/H2-converting
       partner.
   abundance_level: ABUNDANT
@@ -70,6 +78,14 @@ taxonomy:
     term:
       id: NCBITaxon:332101
       label: Clostridium drakei
+    gtdb_classification:
+      gtdb_id: GTDB:s__Clostridium_AM_drakei
+      gtdb_taxon: Clostridium_AM drakei
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_AM;s__Clostridium_AM drakei
+      ncbi_source_id: NCBITaxon:332101
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Wild-type chain-elongating partner that converts lactate-derived intermediates toward
       caproic acid.
   abundance_level: ABUNDANT

--- a/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
+++ b/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
@@ -48,6 +48,14 @@ taxonomy:
     term:
       id: NCBITaxon:201174
       label: Actinomycetota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Actinomycetota
+      gtdb_taxon: Actinomycetota
+      gtdb_lineage: d__Bacteria;p__Actinomycetota
+      ncbi_source_id: NCBITaxon:201174
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 6 GTDB taxa under the NCBI taxon]
     notes: A novel anaerobic acetylenotroph in the phylum Actinobacteria was
       identified by metagenomic analysis of the stable enrichment.
   functional_role:

--- a/kb/communities/Aerobic_Denitrification_Disturbance_SynCom.yaml
+++ b/kb/communities/Aerobic_Denitrification_Disturbance_SynCom.yaml
@@ -37,6 +37,14 @@ taxonomy:
     term:
       id: NCBITaxon:287
       label: Pseudomonas aeruginosa
+    gtdb_classification:
+      gtdb_id: GTDB:s__Pseudomonas_aeruginosa
+      gtdb_taxon: Pseudomonas aeruginosa
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas;s__Pseudomonas aeruginosa
+      ncbi_source_id: NCBITaxon:287
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -46,6 +54,14 @@ taxonomy:
     term:
       id: NCBITaxon:470
       label: Acinetobacter baumannii
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acinetobacter_baumannii
+      gtdb_taxon: Acinetobacter baumannii
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Moraxellaceae;g__Acinetobacter;s__Acinetobacter baumannii
+      ncbi_source_id: NCBITaxon:470
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -55,6 +71,14 @@ taxonomy:
     term:
       id: NCBITaxon:644
       label: Aeromonas hydrophila
+    gtdb_classification:
+      gtdb_id: GTDB:s__Aeromonas_hydrophila
+      gtdb_taxon: Aeromonas hydrophila
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Aeromonadaceae;g__Aeromonas;s__Aeromonas hydrophila
+      ncbi_source_id: NCBITaxon:644
+      majority_fraction: 0.96
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Aerobic_Denitrification_QQ_SynCom.yaml
+++ b/kb/communities/Aerobic_Denitrification_QQ_SynCom.yaml
@@ -36,6 +36,14 @@ taxonomy:
     term:
       id: NCBITaxon:470
       label: Acinetobacter baumannii
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acinetobacter_baumannii
+      gtdb_taxon: Acinetobacter baumannii
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Moraxellaceae;g__Acinetobacter;s__Acinetobacter baumannii
+      ncbi_source_id: NCBITaxon:470
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -45,6 +53,14 @@ taxonomy:
     term:
       id: NCBITaxon:287
       label: Pseudomonas aeruginosa
+    gtdb_classification:
+      gtdb_id: GTDB:s__Pseudomonas_aeruginosa
+      gtdb_taxon: Pseudomonas aeruginosa
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas;s__Pseudomonas aeruginosa
+      ncbi_source_id: NCBITaxon:287
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -54,6 +70,14 @@ taxonomy:
     term:
       id: NCBITaxon:644
       label: Aeromonas hydrophila
+    gtdb_classification:
+      gtdb_id: GTDB:s__Aeromonas_hydrophila
+      gtdb_taxon: Aeromonas hydrophila
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Aeromonadaceae;g__Aeromonas;s__Aeromonas hydrophila
+      ncbi_source_id: NCBITaxon:644
+      majority_fraction: 0.96
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Alaska_Tundra_Permafrost_Iron_Redox_Community.yaml
+++ b/kb/communities/Alaska_Tundra_Permafrost_Iron_Redox_Community.yaml
@@ -31,6 +31,14 @@ taxonomy:
     term:
       id: NCBITaxon:28065
       label: Rhodoferax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Rhodoferax
+      gtdb_taxon: Rhodoferax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Rhodoferax
+      ncbi_source_id: NCBITaxon:28065
+      majority_fraction: 0.718
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Iron-cycling Gammaproteobacteria-lineage Rhodoferax sp. that
       becomes numerically dominant in transition-zone and permafrost
       microbiomes following extended anaerobic thaw.
@@ -53,6 +61,14 @@ taxonomy:
     term:
       id: NCBITaxon:96
       label: Gallionella
+    gtdb_classification:
+      gtdb_id: GTDB:g__Gallionella
+      gtdb_taxon: Gallionella
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Gallionellaceae;g__Gallionella
+      ncbi_source_id: NCBITaxon:96
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Iron-cycling Gammaproteobacteria-lineage Gallionella sp. that, with
       Rhodoferax sp., accounts for 65% of community abundance in the
       transition-zone and permafrost depths after extended thaw.
@@ -73,6 +89,14 @@ taxonomy:
     term:
       id: NCBITaxon:224756
       label: Methanomicrobia
+    gtdb_classification:
+      gtdb_id: GTDB:c__Methanosarcinia
+      gtdb_taxon: Methanosarcinia
+      gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanosarcinia
+      ncbi_source_id: NCBITaxon:224756
+      majority_fraction: 0.617
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at c__ rank; 9 GTDB taxa under the NCBI taxon]
     notes: Co-resident acetoclastic methanogenic archaea whose CH4-metabolism
       gene abundance decreased during extended thaw, consistent with competitive
       suppression by Fe(III) reduction. Methanomicrobia is used as the closest

--- a/kb/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.yaml
+++ b/kb/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.yaml
@@ -36,6 +36,14 @@ taxonomy:
     term:
       id: NCBITaxon:1239
       label: Bacillota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Bacillota_A
+      gtdb_taxon: Bacillota_A
+      gtdb_lineage: d__Bacteria;p__Bacillota_A
+      ncbi_source_id: NCBITaxon:1239
+      majority_fraction: 0.556
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 21 GTDB taxa under the NCBI taxon]
     notes: Represents ASF356 Clostridium sp., ASF492 Eubacterium plexicaudatum, ASF500 Firmicutes bacterium,
       and ASF502 Clostridium sp. as a grouped firmicute guild.
   functional_role:
@@ -58,6 +66,14 @@ taxonomy:
     term:
       id: NCBITaxon:1578
       label: Lactobacillus
+    gtdb_classification:
+      gtdb_id: GTDB:g__Lactobacillus
+      gtdb_taxon: Lactobacillus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactobacillus
+      ncbi_source_id: NCBITaxon:1578
+      majority_fraction: 0.971
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 16 GTDB taxa under the NCBI taxon]
     notes: Represents ASF360 Lactobacillus sp. and ASF361 Lactobacillus murinus.
   functional_role:
   - PRIMARY_DEGRADER
@@ -78,6 +94,14 @@ taxonomy:
     term:
       id: NCBITaxon:1379858
       label: Mucispirillum schaedleri ASF457
+    gtdb_classification:
+      gtdb_id: GTDB:s__Mucispirillum_schaedleri
+      gtdb_taxon: Mucispirillum schaedleri
+      gtdb_lineage: d__Bacteria;p__Deferribacterota;c__Deferribacteres;o__Deferribacterales;f__Mucispirillaceae;g__Mucispirillum;s__Mucispirillum schaedleri
+      ncbi_source_id: NCBITaxon:1379858
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Spiral, mucus-associated member of the ASF.
   functional_role:
   - SECONDARY_FERMENTER
@@ -93,6 +117,14 @@ taxonomy:
     term:
       id: NCBITaxon:375288
       label: Parabacteroides
+    gtdb_classification:
+      gtdb_id: GTDB:g__Parabacteroides
+      gtdb_taxon: Parabacteroides
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Tannerellaceae;g__Parabacteroides
+      ncbi_source_id: NCBITaxon:375288
+      majority_fraction: 0.997
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 9 GTDB taxa under the NCBI taxon]
     notes: Bacteroidetes/Tannerellaceae member of the ASF, represented at genus level because the genome
       paper table identifies it as Parabacteroides sp.
   functional_role:

--- a/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
+++ b/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
@@ -48,6 +48,14 @@ taxonomy:
     term:
       id: NCBITaxon:203682
       label: Planctomycetota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Planctomycetota
+      gtdb_taxon: Planctomycetota
+      gtdb_lineage: d__Bacteria;p__Planctomycetota
+      ncbi_source_id: NCBITaxon:203682
+      majority_fraction: 0.995
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Anaerobic ammonium-oxidizing bacterium that drives nitrogen removal
       in the bioreactor; outcompeted during destabilization.
   abundance_level: DOMINANT

--- a/kb/communities/Anammox_Granule_Metabolic_Interaction_Community.yaml
+++ b/kb/communities/Anammox_Granule_Metabolic_Interaction_Community.yaml
@@ -39,6 +39,14 @@ taxonomy:
     term:
       id: NCBITaxon:795830
       label: Candidatus Brocadia sinica
+    gtdb_classification:
+      gtdb_id: GTDB:s__Brocadia_sinica
+      gtdb_taxon: Brocadia sinica
+      gtdb_lineage: d__Bacteria;p__Planctomycetota;c__Brocadiia;o__Brocadiales;f__Brocadiaceae;g__Brocadia;s__Brocadia sinica
+      ncbi_source_id: NCBITaxon:795830
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: AMX1 was reported as a Brocadia-affiliated anammox MAG closely related to named Brocadia species.
       The NCBI term is used as the closest named representative for the Brocadia-like anammox population.
   functional_role:
@@ -61,6 +69,14 @@ taxonomy:
     term:
       id: NCBITaxon:1090
       label: Chlorobiota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Bacteroidota
+      gtdb_taxon: Bacteroidota
+      gtdb_lineage: d__Bacteria;p__Bacteroidota
+      ncbi_source_id: NCBITaxon:1090
+      majority_fraction: 0.989
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Chlorobi-affiliated MAGs, especially CHB1 and CHB2, were inferred as active protein and peptide
       degraders in the EPS matrix.
   functional_role:

--- a/kb/communities/Angelarchaeales_Thermoplasmata_CuMMO_Soil_Sediment_Community.yaml
+++ b/kb/communities/Angelarchaeales_Thermoplasmata_CuMMO_Soil_Sediment_Community.yaml
@@ -29,6 +29,14 @@ taxonomy:
     term:
       id: NCBITaxon:2283796
       label: Thermoplasmatota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Thermoplasmatota
+      gtdb_taxon: Thermoplasmatota
+      gtdb_lineage: d__Archaea;p__Thermoplasmatota
+      ncbi_source_id: NCBITaxon:2283796
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Newly defined Thermoplasmatota archaeal order encoding divergent
       CuMMO sequences across 20 species-level genomes.
   abundance_level: ABUNDANT

--- a/kb/communities/At_RSPHERE_SynCom.yaml
+++ b/kb/communities/At_RSPHERE_SynCom.yaml
@@ -89,6 +89,14 @@ taxonomy:
     term:
       id: NCBITaxon:1827
       label: Rhodococcus <high G+C Gram-positive bacteria>
+    gtdb_classification:
+      gtdb_id: GTDB:g__Rhodococcus
+      gtdb_taxon: Rhodococcus
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Rhodococcus
+      ncbi_source_id: NCBITaxon:1827
+      majority_fraction: 0.996
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Australian_Lead_Zinc_Polymetallic.yaml
+++ b/kb/communities/Australian_Lead_Zinc_Polymetallic.yaml
@@ -50,6 +50,14 @@ taxonomy:
     term:
       id: NCBITaxon:920
       label: Acidithiobacillus ferrooxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidithiobacillus_ferrooxidans
+      gtdb_taxon: Acidithiobacillus ferrooxidans
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
+      ncbi_source_id: NCBITaxon:920
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Metabolically versatile chemolithoautotrophic γ-proteobacterium that dominates the upper oxidized
       layer of the tailings, capable of oxidizing both ferrous iron (Fe²⁺ → Fe³⁺) and reduced sulfur compounds
       (sulfide, elemental sulfur, thiosulfate) to sulfuric acid. At. ferrooxidans thrives at pH 1.5-2.5
@@ -95,6 +103,14 @@ taxonomy:
     term:
       id: NCBITaxon:178606
       label: Leptospirillum ferriphilum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Leptospirillum_A_rubarum
+      gtdb_taxon: Leptospirillum_A rubarum
+      gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
+      ncbi_source_id: NCBITaxon:178606
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Highly specialized chemolithoautotrophic iron-oxidizing bacterium (phylum Nitrospirae) that
       thrives in extremely acidic environments (pH 1.3-2.5) within the oxidized tailings layer. Unlike
       At. ferrooxidans, L. ferriphilum oxidizes only ferrous iron and does not utilize reduced sulfur
@@ -134,6 +150,14 @@ taxonomy:
     term:
       id: NCBITaxon:97393
       label: Ferroplasma acidarmanus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Ferroplasma_acidarmanus
+      gtdb_taxon: Ferroplasma acidarmanus
+      gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales;f__Thermoplasmataceae;g__Ferroplasma;s__Ferroplasma acidarmanus
+      ncbi_source_id: NCBITaxon:97393
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Extremely acidophilic archaeon (order Thermoplasmatales) that dominates the most acidic microhabitats
       within the tailings (pH 0-2.0), filling ecological niches too extreme for bacterial acidophiles.
       Ferroplasma is a pleomorphic, cell wall-lacking organism adapted to extraordinarily low pH while
@@ -176,6 +200,14 @@ taxonomy:
     term:
       id: NCBITaxon:28232
       label: Geobacter metallireducens
+    gtdb_classification:
+      gtdb_id: GTDB:s__Geobacter_metallireducens
+      gtdb_taxon: Geobacter metallireducens
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
+      ncbi_source_id: NCBITaxon:28232
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Obligately anaerobic δ-proteobacterium specialized for dissimilatory metal reduction, inhabiting
       the deeper sediment layers (>3m depth) of the stratified tailings where anoxic conditions prevail.
       Geobacter reduces ferric iron [Fe(III)] to ferrous iron [Fe(II)] using organic carbon as electron
@@ -217,6 +249,14 @@ taxonomy:
     term:
       id: NCBITaxon:28034
       label: Sulfobacillus thermosulfidooxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Sulfobacillus_thermosulfidooxidans
+      gtdb_taxon: Sulfobacillus thermosulfidooxidans
+      gtdb_lineage: d__Bacteria;p__Bacillota_E;c__Sulfobacillia;o__Sulfobacillales;f__Sulfobacillaceae;g__Sulfobacillus;s__Sulfobacillus thermosulfidooxidans
+      ncbi_source_id: NCBITaxon:28034
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Moderately thermophilic facultatively chemolithoautotrophic bacterium (Firmicutes) present
       in warmer microniches within the tailings that experience solar heating in the arid Australian climate.
       Sulfobacillus can oxidize both iron and reduced sulfur compounds and exhibits mixotrophic metabolism,
@@ -255,6 +295,14 @@ taxonomy:
     term:
       id: NCBITaxon:524
       label: Acidiphilium cryptum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidiphilium_multivorum
+      gtdb_taxon: Acidiphilium multivorum
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acidiphilium;s__Acidiphilium multivorum
+      ncbi_source_id: NCBITaxon:524
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Heterotrophic acidophilic α-proteobacterium that scavenges organic carbon in the acidic tailings
       environment, occupying a distinct trophic niche from chemolithoautotrophic iron and sulfur oxidizers.
       Acidiphilium thrives at pH 2-6, bridging highly acidic surface layers and less acidic deeper zones.

--- a/kb/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.yaml
+++ b/kb/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.yaml
@@ -76,6 +76,14 @@ taxonomy:
     term:
       id: NCBITaxon:80840
       label: Burkholderiales
+    gtdb_classification:
+      gtdb_id: GTDB:o__Burkholderiales
+      gtdb_taxon: Burkholderiales
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales
+      ncbi_source_id: NCBITaxon:80840
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at o__ rank; 7 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -89,6 +97,14 @@ taxonomy:
     term:
       id: NCBITaxon:414878
       label: Catenulispora
+    gtdb_classification:
+      gtdb_id: GTDB:g__Catenulispora
+      gtdb_taxon: Catenulispora
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Streptomycetales;f__Catenulisporaceae;g__Catenulispora
+      ncbi_source_id: NCBITaxon:414878
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_DEGRADER
   evidence:

--- a/kb/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.yaml
+++ b/kb/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.yaml
@@ -37,6 +37,14 @@ taxonomy:
     term:
       id: NCBITaxon:659243
       label: Bacillus siamensis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Bacillus_siamensis
+      gtdb_taxon: Bacillus siamensis
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus siamensis
+      ncbi_source_id: NCBITaxon:659243
+      majority_fraction: 0.85
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - PRIMARY_DEGRADER
   evidence:

--- a/kb/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.yaml
+++ b/kb/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.yaml
@@ -42,6 +42,14 @@ taxonomy:
     term:
       id: NCBITaxon:226186
       label: Bacteroides thetaiotaomicron VPI-5482
+    gtdb_classification:
+      gtdb_id: GTDB:s__Bacteroides_thetaiotaomicron
+      gtdb_taxon: Bacteroides thetaiotaomicron
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides;s__Bacteroides thetaiotaomicron
+      ncbi_source_id: NCBITaxon:226186
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Human gut Bacteroidetes member used as the polysaccharide-foraging partner.
   strain_designation:
     strain_name: VPI-5482
@@ -71,6 +79,14 @@ taxonomy:
     term:
       id: NCBITaxon:515619
       label: Agathobacter rectalis ATCC 33656
+    gtdb_classification:
+      gtdb_id: GTDB:s__Agathobacter_rectalis
+      gtdb_taxon: Agathobacter rectalis
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Agathobacter;s__Agathobacter rectalis
+      ncbi_source_id: NCBITaxon:515619
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Literature name retained in preferred_term; NCBI currently labels the strain as Agathobacter
       rectalis ATCC 33656 and lists Eubacterium rectale ATCC 33656 as an equivalent name.
   strain_designation:

--- a/kb/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.yaml
+++ b/kb/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.yaml
@@ -39,6 +39,14 @@ taxonomy:
     term:
       id: NCBITaxon:818
       label: Bacteroides thetaiotaomicron
+    gtdb_classification:
+      gtdb_id: GTDB:s__Bacteroides_thetaiotaomicron
+      gtdb_taxon: Bacteroides thetaiotaomicron
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides;s__Bacteroides thetaiotaomicron
+      ncbi_source_id: NCBITaxon:818
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Saccharolytic bacterial forager in the defined gnotobiotic community.
   functional_role:
   - PRIMARY_DEGRADER
@@ -74,6 +82,14 @@ taxonomy:
     term:
       id: NCBITaxon:901
       label: Desulfovibrio piger
+    gtdb_classification:
+      gtdb_id: GTDB:s__Desulfovibrio_piger
+      gtdb_taxon: Desulfovibrio piger
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Desulfovibrio;s__Desulfovibrio piger
+      ncbi_source_id: NCBITaxon:901
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Sulfate-reducing comparator organism used to distinguish M. smithii-specific effects.
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Banana_Fusarium_Biocontrol_SynCom12.yaml
+++ b/kb/communities/Banana_Fusarium_Biocontrol_SynCom12.yaml
@@ -45,6 +45,14 @@ taxonomy:
     term:
       id: NCBITaxon:492670
       label: Bacillus velezensis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Bacillus_velezensis
+      gtdb_taxon: Bacillus velezensis
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus velezensis
+      ncbi_source_id: NCBITaxon:492670
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Bayan_Obo_REE_Tailings_Consortium.yaml
+++ b/kb/communities/Bayan_Obo_REE_Tailings_Consortium.yaml
@@ -62,6 +62,14 @@ taxonomy:
     term:
       id: NCBITaxon:920
       label: Acidithiobacillus ferrooxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidithiobacillus_ferrooxidans
+      gtdb_taxon: Acidithiobacillus ferrooxidans
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
+      ncbi_source_id: NCBITaxon:920
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Autotrophic chemolithotrophic acidophile that oxidizes ferrous iron and reduced sulfur compounds
       to generate sulfuric acid. In the Bayan Obo REE bioleaching consortium, At. ferrooxidans plays a
       primary role in acidification of the tailings slurry, lowering pH to facilitate REE dissolution
@@ -102,6 +110,14 @@ taxonomy:
     term:
       id: NCBITaxon:524
       label: Acidiphilium cryptum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidiphilium_multivorum
+      gtdb_taxon: Acidiphilium multivorum
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acidiphilium;s__Acidiphilium multivorum
+      ncbi_source_id: NCBITaxon:524
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Heterotrophic acidophilic bacterium that produces high concentrations of organic acids critical
       for REE complexation and mobilization. Acidiphilium cryptum achieves maximum organic acid production
       (13.8 mM) when cultured in advance and then co-cultured with Acidithiobacillus ferrooxidans in a
@@ -123,6 +139,14 @@ taxonomy:
     term:
       id: NCBITaxon:1883
       label: Streptomyces
+    gtdb_classification:
+      gtdb_id: GTDB:g__Streptomyces
+      gtdb_taxon: Streptomyces
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Streptomycetales;f__Streptomycetaceae;g__Streptomyces
+      ncbi_source_id: NCBITaxon:1883
+      majority_fraction: 0.973
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 14 GTDB taxa under the NCBI taxon]
     notes: 'Actinobacterial genus capable of bioleaching rare earth elements from bastnaesite-bearing
       rock through secretion of organic acids (lactic, oxalic, pyruvic), siderophores, and complexing
       ligands. A Streptomyces sp. strain demonstrated growth in oligotrophic medium in the presence of

--- a/kb/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.yaml
+++ b/kb/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.yaml
@@ -53,6 +53,14 @@ taxonomy:
     term:
       id: NCBITaxon:1685
       label: Bifidobacterium breve
+    gtdb_classification:
+      gtdb_id: GTDB:s__Bifidobacterium_breve
+      gtdb_taxon: Bifidobacterium breve
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium breve
+      ncbi_source_id: NCBITaxon:1685
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: ABUNDANT
   functional_role:
   - CROSS_FEEDER
@@ -68,6 +76,14 @@ taxonomy:
     term:
       id: NCBITaxon:33038
       label: Mediterraneibacter gnavus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Ruminococcus_B_gnavus
+      gtdb_taxon: Ruminococcus_B gnavus
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Ruminococcus_B;s__Ruminococcus_B gnavus
+      ncbi_source_id: NCBITaxon:33038
+      majority_fraction: 0.99
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   abundance_level: ABUNDANT
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
+++ b/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
@@ -32,6 +32,14 @@ taxonomy:
     term:
       id: NCBITaxon:267818
       label: Lactobacillus kefiranofaciens
+    gtdb_classification:
+      gtdb_id: GTDB:s__Lactobacillus_kefiranofaciens
+      gtdb_taxon: Lactobacillus kefiranofaciens
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactobacillus;s__Lactobacillus kefiranofaciens
+      ncbi_source_id: NCBITaxon:267818
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - PRIMARY_DEGRADER
   abundance_level: DOMINANT
@@ -46,6 +54,14 @@ taxonomy:
     term:
       id: NCBITaxon:1358
       label: Lactococcus lactis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Lactococcus_lactis
+      gtdb_taxon: Lactococcus lactis
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Lactococcus;s__Lactococcus lactis
+      ncbi_source_id: NCBITaxon:1358
+      majority_fraction: 0.92
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -61,6 +77,14 @@ taxonomy:
     term:
       id: NCBITaxon:1245
       label: Leuconostoc mesenteroides
+    gtdb_classification:
+      gtdb_id: GTDB:s__Leuconostoc_mesenteroides
+      gtdb_taxon: Leuconostoc mesenteroides
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Leuconostoc;s__Leuconostoc mesenteroides
+      ncbi_source_id: NCBITaxon:1245
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - SECONDARY_FERMENTER
   evidence:
@@ -76,6 +100,14 @@ taxonomy:
     term:
       id: NCBITaxon:33962
       label: Lentilactobacillus kefiri
+    gtdb_classification:
+      gtdb_id: GTDB:s__Lentilactobacillus_kefiri
+      gtdb_taxon: Lentilactobacillus kefiri
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lentilactobacillus;s__Lentilactobacillus kefiri
+      ncbi_source_id: NCBITaxon:33962
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - SECONDARY_FERMENTER
   evidence:
@@ -91,6 +123,14 @@ taxonomy:
     term:
       id: NCBITaxon:483199
       label: Acetobacter fabarum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acetobacter_fabarum
+      gtdb_taxon: Acetobacter fabarum
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acetobacter;s__Acetobacter fabarum
+      ncbi_source_id: NCBITaxon:483199
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/BioModels_MODEL2209060002_DPigrum_SAureus_Community.yaml
+++ b/kb/communities/BioModels_MODEL2209060002_DPigrum_SAureus_Community.yaml
@@ -32,6 +32,14 @@ taxonomy:
     term:
       id: NCBITaxon:29394
       label: Dolosigranulum pigrum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Dolosigranulum_pigrum
+      gtdb_taxon: Dolosigranulum pigrum
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Carnobacteriaceae;g__Dolosigranulum;s__Dolosigranulum pigrum
+      ncbi_source_id: NCBITaxon:29394
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - CROSS_FEEDER
 - taxon_term:
@@ -39,6 +47,14 @@ taxonomy:
     term:
       id: NCBITaxon:1280
       label: Staphylococcus aureus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Staphylococcus_aureus
+      gtdb_taxon: Staphylococcus aureus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus;s__Staphylococcus aureus
+      ncbi_source_id: NCBITaxon:1280
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - CROSS_FEEDER
 ecological_interactions:

--- a/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
+++ b/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
@@ -32,6 +32,14 @@ taxonomy:
     term:
       id: NCBITaxon:1682
       label: Bifidobacterium longum subsp. infantis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Bifidobacterium_infantis
+      gtdb_taxon: Bifidobacterium infantis
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium infantis
+      ncbi_source_id: NCBITaxon:1682
+      majority_fraction: 0.94
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   strain_designation:
     strain_name: ATCC15697
   functional_role:
@@ -48,6 +56,14 @@ taxonomy:
     term:
       id: NCBITaxon:1681
       label: Bifidobacterium bifidum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Bifidobacterium_bifidum
+      gtdb_taxon: Bifidobacterium bifidum
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium bifidum
+      ncbi_source_id: NCBITaxon:1681
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   strain_designation:
     strain_name: JCM1254
   functional_role:
@@ -63,6 +79,14 @@ taxonomy:
     term:
       id: NCBITaxon:1685
       label: Bifidobacterium breve
+    gtdb_classification:
+      gtdb_id: GTDB:s__Bifidobacterium_breve
+      gtdb_taxon: Bifidobacterium breve
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium breve
+      ncbi_source_id: NCBITaxon:1685
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:
     strain_name: ATCC15700
   functional_role:
@@ -81,6 +105,14 @@ taxonomy:
     term:
       id: NCBITaxon:821
       label: Phocaeicola vulgatus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Phocaeicola_vulgatus
+      gtdb_taxon: Phocaeicola vulgatus
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Phocaeicola;s__Phocaeicola vulgatus
+      ncbi_source_id: NCBITaxon:821
+      majority_fraction: 0.86
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   strain_designation:
     strain_name: ATCC8482
   functional_role:
@@ -99,6 +131,14 @@ taxonomy:
     term:
       id: NCBITaxon:29466
       label: Veillonella parvula
+    gtdb_classification:
+      gtdb_id: GTDB:s__Veillonella_parvula_A
+      gtdb_taxon: Veillonella parvula_A
+      gtdb_lineage: d__Bacteria;p__Bacillota_C;c__Negativicutes;o__Veillonellales;f__Veillonellaceae;g__Veillonella;s__Veillonella parvula_A
+      ncbi_source_id: NCBITaxon:29466
+      majority_fraction: 0.95
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   strain_designation:
     strain_name: ATCC10790
   functional_role:
@@ -108,6 +148,14 @@ taxonomy:
     term:
       id: NCBITaxon:33038
       label: Mediterraneibacter gnavus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Ruminococcus_B_gnavus
+      gtdb_taxon: Ruminococcus_B gnavus
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Ruminococcus_B;s__Ruminococcus_B gnavus
+      ncbi_source_id: NCBITaxon:33038
+      majority_fraction: 0.99
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   strain_designation:
     strain_name: ATCC29149
   functional_role:
@@ -117,6 +165,14 @@ taxonomy:
     term:
       id: NCBITaxon:83333
       label: Escherichia coli K-12
+    gtdb_classification:
+      gtdb_id: GTDB:s__Escherichia_coli
+      gtdb_taxon: Escherichia coli
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
+      ncbi_source_id: NCBITaxon:83333
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   strain_designation:
     strain_name: MG1655
   functional_role:
@@ -126,6 +182,14 @@ taxonomy:
     term:
       id: NCBITaxon:47715
       label: Lacticaseibacillus rhamnosus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Lacticaseibacillus_rhamnosus
+      gtdb_taxon: Lacticaseibacillus rhamnosus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lacticaseibacillus;s__Lacticaseibacillus rhamnosus
+      ncbi_source_id: NCBITaxon:47715
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   strain_designation:
     strain_name: GG
   functional_role:
@@ -135,6 +199,14 @@ taxonomy:
     term:
       id: NCBITaxon:1351
       label: Enterococcus faecalis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Enterococcus_faecalis
+      gtdb_taxon: Enterococcus faecalis
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Enterococcaceae;g__Enterococcus;s__Enterococcus faecalis
+      ncbi_source_id: NCBITaxon:1351
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   strain_designation:
     strain_name: ATCC19433
   functional_role:
@@ -144,6 +216,14 @@ taxonomy:
     term:
       id: NCBITaxon:1308
       label: Streptococcus thermophilus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Streptococcus_thermophilus
+      gtdb_taxon: Streptococcus thermophilus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Streptococcus;s__Streptococcus thermophilus
+      ncbi_source_id: NCBITaxon:1308
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   strain_designation:
     strain_name: ATCC19258
   functional_role:
@@ -153,6 +233,14 @@ taxonomy:
     term:
       id: NCBITaxon:33035
       label: Blautia producta
+    gtdb_classification:
+      gtdb_id: GTDB:s__Blautia_coccoides
+      gtdb_taxon: Blautia coccoides
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Blautia;s__Blautia coccoides
+      ncbi_source_id: NCBITaxon:33035
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:
     strain_name: JCM1471
   functional_role:

--- a/kb/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.yaml
+++ b/kb/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.yaml
@@ -29,6 +29,14 @@ taxonomy:
     term:
       id: NCBITaxon:201174
       label: Actinomycetota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Actinomycetota
+      gtdb_taxon: Actinomycetota
+      gtdb_lineage: d__Bacteria;p__Actinomycetota
+      ncbi_source_id: NCBITaxon:201174
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 6 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -43,6 +51,14 @@ taxonomy:
     term:
       id: NCBITaxon:976
       label: Bacteroidota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Bacteroidota
+      gtdb_taxon: Bacteroidota
+      gtdb_lineage: d__Bacteria;p__Bacteroidota
+      ncbi_source_id: NCBITaxon:976
+      majority_fraction: 0.999
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 8 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -56,6 +72,14 @@ taxonomy:
     term:
       id: NCBITaxon:1239
       label: Bacillota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Bacillota_A
+      gtdb_taxon: Bacillota_A
+      gtdb_lineage: d__Bacteria;p__Bacillota_A
+      ncbi_source_id: NCBITaxon:1239
+      majority_fraction: 0.55
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 21 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -69,6 +93,14 @@ taxonomy:
     term:
       id: NCBITaxon:1224
       label: Pseudomonadota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Pseudomonadota
+      gtdb_taxon: Pseudomonadota
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota
+      ncbi_source_id: NCBITaxon:1224
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 14 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_DEGRADER
   evidence:

--- a/kb/communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.yaml
+++ b/kb/communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.yaml
@@ -22,6 +22,14 @@ taxonomy:
     term:
       id: NCBITaxon:372461
       label: Buchnera aphidicola BCc
+    gtdb_classification:
+      gtdb_id: GTDB:s__Buchnera_aphidicola_F
+      gtdb_taxon: Buchnera aphidicola_F
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae_A;g__Buchnera;s__Buchnera aphidicola_F
+      ncbi_source_id: NCBITaxon:372461
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Reduced-genome primary aphid endosymbiont from Cinara cedri.
   functional_role:
   - CROSS_FEEDER

--- a/kb/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.yaml
+++ b/kb/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.yaml
@@ -21,6 +21,14 @@ taxonomy:
     term:
       id: NCBITaxon:213121
       label: Desulfobulbaceae
+    gtdb_classification:
+      gtdb_id: GTDB:f__Desulfobulbaceae
+      gtdb_taxon: Desulfobulbaceae
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfobulbia;o__Desulfobulbales;f__Desulfobulbaceae
+      ncbi_source_id: NCBITaxon:213121
+      majority_fraction: 0.529
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at f__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Long multicellular filamentous bacteria mediating electrogenic sulfur oxidation in sediment.
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.yaml
+++ b/kb/communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.yaml
@@ -50,6 +50,14 @@ taxonomy:
     term:
       id: NCBITaxon:1515
       label: Acetivibrio thermocellus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Hungateiclostridium_thermocellum
+      gtdb_taxon: Hungateiclostridium thermocellum
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__Acetivibrionaceae;g__Hungateiclostridium;s__Hungateiclostridium thermocellum
+      ncbi_source_id: NCBITaxon:1515
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Cellulolytic anaerobic partner in the designed coculture.
   functional_role:
   - PRIMARY_DEGRADER
@@ -65,6 +73,14 @@ taxonomy:
     term:
       id: NCBITaxon:301148
       label: Caldibacillus debilis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Caldibacillus_debilis
+      gtdb_taxon: Caldibacillus debilis
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales_B;f__Caldibacillaceae;g__Caldibacillus;s__Caldibacillus debilis
+      ncbi_source_id: NCBITaxon:301148
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Noncellulolytic facultative anaerobe isolated from the air-tolerant cellulolytic enrichment
       and used as the respiratory-protection partner.
   strain_designation:

--- a/kb/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.yaml
+++ b/kb/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.yaml
@@ -52,6 +52,14 @@ taxonomy:
     term:
       id: NCBITaxon:351627
       label: Caldicellulosiruptor saccharolyticus DSM 8903
+    gtdb_classification:
+      gtdb_id: GTDB:s__Caldicellulosiruptor_saccharolyticus
+      gtdb_taxon: Caldicellulosiruptor saccharolyticus
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Thermoanaerobacteria;o__Caldicellulosiruptorales;f__Caldicellulosiruptoraceae;g__Caldicellulosiruptor;s__Caldicellulosiruptor saccharolyticus
+      ncbi_source_id: NCBITaxon:351627
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Extreme thermophilic anaerobe used as one hydrogen-producing member of the defined coculture.
   strain_designation:
     strain_name: DSM 8903
@@ -76,6 +84,14 @@ taxonomy:
     term:
       id: NCBITaxon:632335
       label: Caldicellulosiruptor acetigenus I77R1B
+    gtdb_classification:
+      gtdb_id: GTDB:s__Caldicellulosiruptor_acetigenus
+      gtdb_taxon: Caldicellulosiruptor acetigenus
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Thermoanaerobacteria;o__Caldicellulosiruptorales;f__Caldicellulosiruptoraceae;g__Caldicellulosiruptor;s__Caldicellulosiruptor acetigenus
+      ncbi_source_id: NCBITaxon:632335
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: >
       The primary paper reports this member as C. kristjanssonii DSM 12137.
       NCBI currently records the sequenced strain as Caldicellulosiruptor

--- a/kb/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.yaml
+++ b/kb/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.yaml
@@ -54,6 +54,14 @@ taxonomy:
     term:
       id: NCBITaxon:1707
       label: Cellulomonas
+    gtdb_classification:
+      gtdb_id: GTDB:g__Cellulomonas
+      gtdb_taxon: Cellulomonas
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Cellulomonadaceae;g__Cellulomonas
+      ncbi_source_id: NCBITaxon:1707
+      majority_fraction: 0.858
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
     notes: >
       The source identifies the cellulolytic member as Cellulomonas sp. strain
       ATCC 21399; curated at the genus level because the publication does not
@@ -78,6 +86,14 @@ taxonomy:
     term:
       id: NCBITaxon:1061
       label: Rhodobacter capsulatus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Rhodobacter_capsulatus_B
+      gtdb_taxon: Rhodobacter capsulatus_B
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhodobacterales;f__Rhodobacteraceae;g__Rhodobacter;s__Rhodobacter capsulatus_B
+      ncbi_source_id: NCBITaxon:1061
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: >
       The publication uses Rhodopseudomonas capsulata; NCBI Taxonomy now
       records this organism as Rhodobacter capsulatus.

--- a/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
+++ b/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
@@ -38,6 +38,14 @@ taxonomy:
     term:
       id: NCBITaxon:1521
       label: Ruminiclostridium cellulolyticum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Ruminiclostridium_cellulolyticum
+      gtdb_taxon: Ruminiclostridium cellulolyticum
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__DSM-27016;g__Ruminiclostridium;s__Ruminiclostridium cellulolyticum
+      ncbi_source_id: NCBITaxon:1521
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -47,6 +55,14 @@ taxonomy:
     term:
       id: NCBITaxon:323259
       label: Methanospirillum hungatei JF-1
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methanospirillum_hungatei
+      gtdb_taxon: Methanospirillum hungatei
+      gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanospirillum;s__Methanospirillum hungatei
+      ncbi_source_id: NCBITaxon:323259
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:
@@ -56,6 +72,14 @@ taxonomy:
     term:
       id: NCBITaxon:2223
       label: Methanothrix soehngenii
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methanothrix_soehngenii
+      gtdb_taxon: Methanothrix soehngenii
+      gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanosarcinia;o__Methanotrichales;f__Methanotrichaceae;g__Methanothrix;s__Methanothrix soehngenii
+      ncbi_source_id: NCBITaxon:2223
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:
@@ -65,6 +89,14 @@ taxonomy:
     term:
       id: NCBITaxon:881
       label: Nitratidesulfovibrio vulgaris
+    gtdb_classification:
+      gtdb_id: GTDB:s__Nitratidesulfovibrio_vulgaris
+      gtdb_taxon: Nitratidesulfovibrio vulgaris
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Nitratidesulfovibrio;s__Nitratidesulfovibrio vulgaris
+      ncbi_source_id: NCBITaxon:881
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:

--- a/kb/communities/Cheese_Rind_InSitu_InVitro_Model_Community.yaml
+++ b/kb/communities/Cheese_Rind_InSitu_InVitro_Model_Community.yaml
@@ -41,6 +41,14 @@ taxonomy:
     term:
       id: NCBITaxon:1279
       label: Staphylococcus
+    gtdb_classification:
+      gtdb_id: GTDB:g__Staphylococcus
+      gtdb_taxon: Staphylococcus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus
+      ncbi_source_id: NCBITaxon:1279
+      majority_fraction: 0.993
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Genus-level taxon used because the source record reports community members primarily at genus
       level in amplicon and reconstruction analyses.
   abundance_level: DOMINANT
@@ -55,6 +63,14 @@ taxonomy:
     term:
       id: NCBITaxon:1696
       label: Brevibacterium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Brevibacterium
+      gtdb_taxon: Brevibacterium
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Brevibacteriaceae;g__Brevibacterium
+      ncbi_source_id: NCBITaxon:1696
+      majority_fraction: 0.987
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Genus-level taxon used because the source reports Brevibacterium as a mature-rind genus in
       the natural-rind succession and in vitro reconstruction.
   abundance_level: ABUNDANT

--- a/kb/communities/Chlamydomonas_Bacterial_H2_Consortium.yaml
+++ b/kb/communities/Chlamydomonas_Bacterial_H2_Consortium.yaml
@@ -82,6 +82,14 @@ taxonomy:
     term:
       id: NCBITaxon:40323
       label: Stenotrophomonas
+    gtdb_classification:
+      gtdb_id: GTDB:g__Stenotrophomonas
+      gtdb_taxon: Stenotrophomonas
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Xanthomonadaceae;g__Stenotrophomonas
+      ncbi_source_id: NCBITaxon:40323
+      majority_fraction: 0.987
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Chlorella_Azospirillum_Synthetic_Mutualism.yaml
+++ b/kb/communities/Chlorella_Azospirillum_Synthetic_Mutualism.yaml
@@ -85,6 +85,14 @@ taxonomy:
     term:
       id: NCBITaxon:192
       label: Azospirillum brasilense
+    gtdb_classification:
+      gtdb_id: GTDB:s__Azospirillum_brasilense
+      gtdb_taxon: Azospirillum brasilense
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Azospirillales;f__Azospirillaceae;g__Azospirillum;s__Azospirillum brasilense
+      ncbi_source_id: NCBITaxon:192
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: >
       Source publications identify strain Cd; ontology grounding is
       species-level because the stable NCBI Taxonomy term used here is

--- a/kb/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.yaml
+++ b/kb/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.yaml
@@ -77,6 +77,14 @@ taxonomy:
     term:
       id: NCBITaxon:562
       label: Escherichia coli
+    gtdb_classification:
+      gtdb_id: GTDB:s__Escherichia_coli
+      gtdb_taxon: Escherichia coli
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
+      ncbi_source_id: NCBITaxon:562
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Bacterial partner in the mixotrophic algal-bacterial coculture.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml
+++ b/kb/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml
@@ -21,6 +21,14 @@ taxonomy:
     term:
       id: NCBITaxon:340177
       label: Chlorobium chlorochromatii CaD3
+    gtdb_classification:
+      gtdb_id: null
+      gtdb_taxon: null
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Chlorobiia;o__Chlorobiales;f__Chlorobiaceae;g__Chlorobium
+      ncbi_source_id: NCBITaxon:340177
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Photolithoautotrophic green sulfur bacterial epibiont that surrounds the central bacterium.
   strain_designation:
     strain_name: CaD3
@@ -45,6 +53,14 @@ taxonomy:
     term:
       id: NCBITaxon:1436290
       label: Candidatus Symbiobacter mobilis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Symbiobacter_mobilis
+      gtdb_taxon: Symbiobacter mobilis
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Symbiobacter;s__Symbiobacter mobilis
+      ncbi_source_id: NCBITaxon:1436290
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Central non-pigmented motile heterotroph in the barrel-shaped phototrophic consortium.
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Chromium_Sulfur_Reduction_Enrichment.yaml
+++ b/kb/communities/Chromium_Sulfur_Reduction_Enrichment.yaml
@@ -64,6 +64,14 @@ taxonomy:
     term:
       id: NCBITaxon:85021
       label: Intrasporangiaceae
+    gtdb_classification:
+      gtdb_id: GTDB:f__Dermatophilaceae
+      gtdb_taxon: Dermatophilaceae
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Dermatophilaceae
+      ncbi_source_id: NCBITaxon:85021
+      majority_fraction: 0.997
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at f__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive actinobacterium of the Intrasporangiaceae family, isolated as the dominant chromium-reducing
       organism in sulfur-oxidizing enrichment cultures. The SOCrRB (Sulfur-Oxidizing Chromium-Reducing
       Bacterium) strain exhibits the novel capability to couple Cr(VI) reduction with oxidation of reduced
@@ -110,6 +118,14 @@ taxonomy:
     term:
       id: NCBITaxon:286
       label: Pseudomonas
+    gtdb_classification:
+      gtdb_id: GTDB:g__Pseudomonas
+      gtdb_taxon: Pseudomonas
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
+      ncbi_source_id: NCBITaxon:286
+      majority_fraction: 0.596
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 17 GTDB taxa under the NCBI taxon]
     notes: 'Gram-negative gammaproteobacteria contributing to sulfur oxidation, chromium reduction, and
       biofilm formation in the enrichment culture. Pseudomonas species comprise 15-20% of the community
       and perform facultative chemolithotrophic sulfur oxidation, oxidizing thiosulfate, sulfide, and
@@ -151,6 +167,14 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_classification:
+      gtdb_id: GTDB:g__Bacillus
+      gtdb_taxon: Bacillus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
+      ncbi_source_id: NCBITaxon:1386
+      majority_fraction: 0.508
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive, spore-forming bacteria (Firmicutes phylum) performing Cr(VI) reduction, metal
       biosorption, and organic matter degradation. Bacillus species comprise 10-15% of the enrichment
       community and exhibit broad pH tolerance (6.0-9.0), enabling activity across environmental gradients

--- a/kb/communities/Cinnamate_Degradation_Consortium.yaml
+++ b/kb/communities/Cinnamate_Degradation_Consortium.yaml
@@ -21,6 +21,14 @@ taxonomy:
     term:
       id: NCBITaxon:100176
       label: Papillibacter cinnamivorans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Papillibacter_cinnamivorans
+      gtdb_taxon: Papillibacter cinnamivorans
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Oscillospirales;f__Oscillospiraceae;g__Papillibacter;s__Papillibacter cinnamivorans
+      ncbi_source_id: NCBITaxon:100176
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -37,6 +45,14 @@ taxonomy:
     term:
       id: NCBITaxon:43773
       label: Syntrophus <bacteria>
+    gtdb_classification:
+      gtdb_id: GTDB:g__Syntrophus
+      gtdb_taxon: Syntrophus
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Syntrophia;o__Syntrophales;f__Syntrophaceae;g__Syntrophus
+      ncbi_source_id: NCBITaxon:43773
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -53,6 +69,14 @@ taxonomy:
     term:
       id: NCBITaxon:2162
       label: Methanobacterium formicicum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methanobacterium_formicicum
+      gtdb_taxon: Methanobacterium formicicum
+      gtdb_lineage: d__Archaea;p__Methanobacteriota;c__Methanobacteria;o__Methanobacteriales;f__Methanobacteriaceae;g__Methanobacterium;s__Methanobacterium formicicum
+      ncbi_source_id: NCBITaxon:2162
+      majority_fraction: 0.94
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.yaml
+++ b/kb/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.yaml
@@ -49,6 +49,14 @@ taxonomy:
     term:
       id: NCBITaxon:84023
       label: Clostridium autoethanogenum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Clostridium_B_ljungdahlii
+      gtdb_taxon: Clostridium_B ljungdahlii
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_B;s__Clostridium_B ljungdahlii
+      ncbi_source_id: NCBITaxon:84023
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Acetogenic syngas-fermenting partner in the defined coculture.
   abundance_level: ABUNDANT
   functional_role:
@@ -69,6 +77,14 @@ taxonomy:
     term:
       id: NCBITaxon:1534
       label: Clostridium kluyveri
+    gtdb_classification:
+      gtdb_id: GTDB:s__Clostridium_B_kluyveri
+      gtdb_taxon: Clostridium_B kluyveri
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_B;s__Clostridium_B kluyveri
+      ncbi_source_id: NCBITaxon:1534
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Chain-elongating partner that consumes acetogen products in the defined coculture.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.yaml
+++ b/kb/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.yaml
@@ -49,6 +49,14 @@ taxonomy:
     term:
       id: NCBITaxon:203119
       label: Acetivibrio thermocellus ATCC 27405
+    gtdb_classification:
+      gtdb_id: GTDB:s__Hungateiclostridium_thermocellum
+      gtdb_taxon: Hungateiclostridium thermocellum
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__Acetivibrionaceae;g__Hungateiclostridium;s__Hungateiclostridium thermocellum
+      ncbi_source_id: NCBITaxon:203119
+      majority_fraction: 0.93
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: The primary publication uses Clostridium thermocellum ATCC 27405;
       NCBI currently records the strain under Acetivibrio thermocellus ATCC
       27405 with Clostridium thermocellum ATCC 27405 as a homotypic synonym.
@@ -80,6 +88,14 @@ taxonomy:
     term:
       id: NCBITaxon:521460
       label: Caldicellulosiruptor bescii DSM 6725
+    gtdb_classification:
+      gtdb_id: GTDB:s__Caldicellulosiruptor_bescii
+      gtdb_taxon: Caldicellulosiruptor bescii
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Thermoanaerobacteria;o__Caldicellulosiruptorales;f__Caldicellulosiruptoraceae;g__Caldicellulosiruptor;s__Caldicellulosiruptor bescii
+      ncbi_source_id: NCBITaxon:521460
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Type strain DSM 6725 is also available as ATCC BAA-1888 and was
       previously reported as Anaerocellum thermophilum DSM 6725.
   strain_designation:

--- a/kb/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.yaml
+++ b/kb/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.yaml
@@ -55,6 +55,14 @@ taxonomy:
     term:
       id: NCBITaxon:217159
       label: Clostridium carboxidivorans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Clostridium_AM_carboxidivorans
+      gtdb_taxon: Clostridium_AM carboxidivorans
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_AM;s__Clostridium_AM carboxidivorans
+      ncbi_source_id: NCBITaxon:217159
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Autotrophic acetogenic/solventogenic partner that reduces C. kluyveri-derived organic acids to alcohols.
   abundance_level: ABUNDANT
   functional_role:
@@ -76,6 +84,14 @@ taxonomy:
     term:
       id: NCBITaxon:1534
       label: Clostridium kluyveri
+    gtdb_classification:
+      gtdb_id: GTDB:s__Clostridium_B_kluyveri
+      gtdb_taxon: Clostridium_B kluyveri
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_B;s__Clostridium_B kluyveri
+      ncbi_source_id: NCBITaxon:1534
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Chain-elongating partner that generates organic acids from C2 substrates in the coculture.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.yaml
+++ b/kb/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.yaml
@@ -53,6 +53,14 @@ taxonomy:
     term:
       id: NCBITaxon:1521
       label: Ruminiclostridium cellulolyticum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Ruminiclostridium_cellulolyticum
+      gtdb_taxon: Ruminiclostridium cellulolyticum
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__DSM-27016;g__Ruminiclostridium;s__Ruminiclostridium cellulolyticum
+      ncbi_source_id: NCBITaxon:1521
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: NCBI Taxonomy treats Clostridium cellulolyticum as the basionym/synonym of Ruminiclostridium
       cellulolyticum; the publications used the historical C. cellulolyticum name.
   abundance_level: ABUNDANT
@@ -75,6 +83,14 @@ taxonomy:
     term:
       id: NCBITaxon:35554
       label: Geobacter sulfurreducens
+    gtdb_classification:
+      gtdb_id: GTDB:s__Geobacter_sulfurreducens
+      gtdb_taxon: Geobacter sulfurreducens
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter sulfurreducens
+      ncbi_source_id: NCBITaxon:35554
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Electrochemically active partner that occupies the anode-attached fraction in particulate
       cellulose-fed MFCs.
   abundance_level: ABUNDANT

--- a/kb/communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.yaml
+++ b/kb/communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.yaml
@@ -50,6 +50,14 @@ taxonomy:
     term:
       id: NCBITaxon:573061
       label: Clostridium cellulovorans 743B
+    gtdb_classification:
+      gtdb_id: GTDB:s__Clostridium_K_cellulovorans
+      gtdb_taxon: Clostridium_K cellulovorans
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_K;s__Clostridium_K cellulovorans
+      ncbi_source_id: NCBITaxon:573061
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: ATCC 35296 cellulolytic fermenter that supplies H2, formate, acetate, and other VFAs
       from cellulose degradation.
   abundance_level: ABUNDANT
@@ -72,6 +80,14 @@ taxonomy:
     term:
       id: NCBITaxon:269797
       label: Methanosarcina barkeri str. Fusaro
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methanosarcina_barkeri_B
+      gtdb_taxon: Methanosarcina barkeri_B
+      gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanosarcinia;o__Methanosarcinales;f__Methanosarcinaceae;g__Methanosarcina;s__Methanosarcina barkeri_B
+      ncbi_source_id: NCBITaxon:269797
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: DSM 804 methanogen able to use H2, formate, and acetate-linked metabolism in the
       C. cellulovorans coculture.
   abundance_level: ABUNDANT

--- a/kb/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.yaml
+++ b/kb/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.yaml
@@ -58,6 +58,14 @@ taxonomy:
     term:
       id: NCBITaxon:573061
       label: Clostridium cellulovorans 743B
+    gtdb_classification:
+      gtdb_id: GTDB:s__Clostridium_K_cellulovorans
+      gtdb_taxon: Clostridium_K cellulovorans
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_K;s__Clostridium_K cellulovorans
+      ncbi_source_id: NCBITaxon:573061
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Cellulolytic dark-fermentative bacterium that degrades cellulose and produces volatile fatty acids.
   abundance_level: ABUNDANT
   functional_role:
@@ -79,6 +87,14 @@ taxonomy:
     term:
       id: NCBITaxon:258594
       label: Rhodopseudomonas palustris CGA009
+    gtdb_classification:
+      gtdb_id: GTDB:s__Rhodopseudomonas_palustris_F
+      gtdb_taxon: Rhodopseudomonas palustris_F
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Rhodopseudomonas;s__Rhodopseudomonas palustris_F
+      ncbi_source_id: NCBITaxon:258594
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Purple nonsulfur phototroph that consumes fermentation products and contributes to hydrogen production.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.yaml
+++ b/kb/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.yaml
@@ -53,6 +53,14 @@ taxonomy:
     term:
       id: NCBITaxon:1538
       label: Clostridium ljungdahlii
+    gtdb_classification:
+      gtdb_id: GTDB:s__Clostridium_B_ljungdahlii
+      gtdb_taxon: Clostridium_B ljungdahlii
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_B;s__Clostridium_B ljungdahlii
+      ncbi_source_id: NCBITaxon:1538
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Acetogenic carboxydotroph that produces ethanol and acetate from syngas in the coculture.
   abundance_level: ABUNDANT
   functional_role:
@@ -74,6 +82,14 @@ taxonomy:
     term:
       id: NCBITaxon:1534
       label: Clostridium kluyveri
+    gtdb_classification:
+      gtdb_id: GTDB:s__Clostridium_B_kluyveri
+      gtdb_taxon: Clostridium_B kluyveri
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_B;s__Clostridium_B kluyveri
+      ncbi_source_id: NCBITaxon:1534
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Chain-elongating partner that consumes ethanol and produces butyrate and caproate.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.yaml
+++ b/kb/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.yaml
@@ -59,6 +59,14 @@ taxonomy:
     term:
       id: NCBITaxon:357809
       label: Lachnoclostridium phytofermentans ISDg
+    gtdb_classification:
+      gtdb_id: GTDB:s__Lachnoclostridium_phytofermentans
+      gtdb_taxon: Lachnoclostridium phytofermentans
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Lachnoclostridium;s__Lachnoclostridium phytofermentans
+      ncbi_source_id: NCBITaxon:357809
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: The paper uses the name C. phytofermentans; NCBI currently places strain ISDg under
       Lachnoclostridium phytofermentans.
   strain_designation:
@@ -91,6 +99,14 @@ taxonomy:
     term:
       id: NCBITaxon:511145
       label: Escherichia coli str. K-12 substr. MG1655
+    gtdb_classification:
+      gtdb_id: GTDB:s__Escherichia_coli
+      gtdb_taxon: Escherichia coli
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
+      ncbi_source_id: NCBITaxon:511145
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Facultative anaerobic secondary-resource specialist in the artificial consortium.
   strain_designation:
     strain_name: K-12 MG1655

--- a/kb/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.yaml
@@ -52,6 +52,14 @@ taxonomy:
     term:
       id: NCBITaxon:357809
       label: Lachnoclostridium phytofermentans ISDg
+    gtdb_classification:
+      gtdb_id: GTDB:s__Lachnoclostridium_phytofermentans
+      gtdb_taxon: Lachnoclostridium phytofermentans
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Lachnoclostridium;s__Lachnoclostridium phytofermentans
+      ncbi_source_id: NCBITaxon:357809
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: The source uses the name C. phytofermentans; NCBI currently represents
       the strain as Lachnoclostridium phytofermentans ISDg.
   strain_designation:

--- a/kb/communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.yaml
@@ -46,6 +46,14 @@ taxonomy:
     term:
       id: NCBITaxon:572545
       label: Acetivibrio thermocellus DSM 2360
+    gtdb_classification:
+      gtdb_id: GTDB:s__Hungateiclostridium_thermocellum
+      gtdb_taxon: Hungateiclostridium thermocellum
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__Acetivibrionaceae;g__Hungateiclostridium;s__Hungateiclostridium thermocellum
+      ncbi_source_id: NCBITaxon:572545
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: The publications use Clostridium thermocellum LQRI; NCBI and JGI records place DSM 2360/LQRI
       under Acetivibrio thermocellus.
   strain_designation:
@@ -73,6 +81,14 @@ taxonomy:
     term:
       id: NCBITaxon:399726
       label: Thermoanaerobacter sp. X514
+    gtdb_classification:
+      gtdb_id: GTDB:s__Thermoanaerobacter_pseudethanolicus
+      gtdb_taxon: Thermoanaerobacter pseudethanolicus
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Thermoanaerobacteria;o__Thermoanaerobacterales;f__Thermoanaerobacteraceae;g__Thermoanaerobacter;s__Thermoanaerobacter pseudethanolicus
+      ncbi_source_id: NCBITaxon:399726
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: The cyclic fed-batch paper names Thermoanaerobacter pseudethanolicus strain X514; NCBI records
       the sequenced strain as Thermoanaerobacter sp. X514.
   strain_designation:

--- a/kb/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.yaml
+++ b/kb/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.yaml
@@ -51,6 +51,14 @@ taxonomy:
     term:
       id: NCBITaxon:1515
       label: Acetivibrio thermocellus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Hungateiclostridium_thermocellum
+      gtdb_taxon: Hungateiclostridium thermocellum
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__Acetivibrionaceae;g__Hungateiclostridium;s__Hungateiclostridium thermocellum
+      ncbi_source_id: NCBITaxon:1515
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Cellulolytic member that releases glucose or cellobiose from lignocellulosic substrates.
   strain_designation:
     strain_name: JN4
@@ -68,6 +76,14 @@ taxonomy:
     term:
       id: NCBITaxon:1517
       label: Thermoanaerobacterium thermosaccharolyticum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Thermoanaerobacterium_thermosaccharolyticum
+      gtdb_taxon: Thermoanaerobacterium thermosaccharolyticum
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Thermoanaerobacteria;o__Thermoanaerobacterales;f__Thermoanaerobacteraceae;g__Thermoanaerobacterium;s__Thermoanaerobacterium thermosaccharolyticum
+      ncbi_source_id: NCBITaxon:1517
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Non-cellulolytic fermentative partner with a competitive metabolic advantage in glucose
       or cellobiose conversion.
   strain_designation:

--- a/kb/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.yaml
@@ -47,6 +47,14 @@ taxonomy:
     term:
       id: NCBITaxon:203119
       label: Acetivibrio thermocellus ATCC 27405
+    gtdb_classification:
+      gtdb_id: GTDB:s__Hungateiclostridium_thermocellum
+      gtdb_taxon: Hungateiclostridium thermocellum
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__Acetivibrionaceae;g__Hungateiclostridium;s__Hungateiclostridium thermocellum
+      ncbi_source_id: NCBITaxon:203119
+      majority_fraction: 0.93
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: The primary paper uses Clostridium thermocellum; NCBI currently represents ATCC 27405 as
       Acetivibrio thermocellus ATCC 27405.
   strain_designation:

--- a/kb/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.yaml
+++ b/kb/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.yaml
@@ -73,6 +73,14 @@ taxonomy:
     term:
       id: NCBITaxon:2886510
       label: Sphingobacterium paramultivorum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Sphingobacterium_paramultivorum
+      gtdb_taxon: Sphingobacterium paramultivorum
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Sphingobacteriales;f__Sphingobacteriaceae;g__Sphingobacterium;s__Sphingobacterium paramultivorum
+      ncbi_source_id: NCBITaxon:2886510
+      majority_fraction: 0.88
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: The 2020 consortium paper reports this member as Sphingobacterium multivorum w15;
       later taxonomic analysis proposed renaming strain w15 as Sphingobacterium paramultivorum.
   strain_designation:

--- a/kb/communities/Copper_Biomining_Heap_Leach.yaml
+++ b/kb/communities/Copper_Biomining_Heap_Leach.yaml
@@ -56,6 +56,14 @@ taxonomy:
     term:
       id: NCBITaxon:920
       label: Acidithiobacillus ferrooxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidithiobacillus_ferrooxidans
+      gtdb_taxon: Acidithiobacillus ferrooxidans
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
+      ncbi_source_id: NCBITaxon:920
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Gram-negative γ-proteobacterium that oxidizes both ferrous iron (Fe²⁺) and reduced sulfur
       compounds. Dominates early stages of heap leaching when pH values are over 2 and iron concentrations
       remain low. Reaches peak abundance of ~10⁷ copies/ml around 200 days of operation. As the most abundant
@@ -88,6 +96,14 @@ taxonomy:
     term:
       id: NCBITaxon:178606
       label: Leptospirillum ferriphilum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Leptospirillum_A_rubarum
+      gtdb_taxon: Leptospirillum_A rubarum
+      gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
+      ncbi_source_id: NCBITaxon:178606
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Iron-oxidizing bacterium (Nitrospirae phylum) that becomes dominant in aged copper bioleaching
       heaps as pH drops and Fe³⁺ concentrations increase. Leptospirillum species predominate in sulfide
       mineral-containing environments and are effective primary mineral colonizers. L. ferriphilum oxidizes
@@ -122,6 +138,14 @@ taxonomy:
     term:
       id: NCBITaxon:930
       label: Acidithiobacillus thiooxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidithiobacillus_thiooxidans
+      gtdb_taxon: Acidithiobacillus thiooxidans
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus thiooxidans
+      ncbi_source_id: NCBITaxon:930
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Gram-negative γ-proteobacterium specialized for oxidizing elemental sulfur (S⁰) and reduced
       inorganic sulfur compounds to sulfuric acid. Unlike At. ferrooxidans, At. thiooxidans does not oxidize
       iron and focuses exclusively on sulfur metabolism. Maintains constant copy numbers (10⁵ copies/ml)
@@ -153,6 +177,14 @@ taxonomy:
     term:
       id: NCBITaxon:74969
       label: Ferroplasma acidiphilum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Ferroplasma_acidarmanus
+      gtdb_taxon: Ferroplasma acidarmanus
+      gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales;f__Thermoplasmataceae;g__Ferroplasma;s__Ferroplasma acidarmanus
+      ncbi_source_id: NCBITaxon:74969
+      majority_fraction: 0.91
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Cell wall-lacking archaeon (Thermoplasmatales) that oxidizes ferrous iron in extremely acidic
       environments. Increases with heap age alongside Leptospirillum, reaching ~10⁵ copies/ml in heaps
       >250 days old. Thrives at pH 1.67-1.83 and high Fe³⁺ concentrations (1.86-1.9 g/L) where it fills
@@ -178,6 +210,14 @@ taxonomy:
     term:
       id: NCBITaxon:28034
       label: Sulfobacillus thermosulfidooxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Sulfobacillus_thermosulfidooxidans
+      gtdb_taxon: Sulfobacillus thermosulfidooxidans
+      gtdb_lineage: d__Bacteria;p__Bacillota_E;c__Sulfobacillia;o__Sulfobacillales;f__Sulfobacillaceae;g__Sulfobacillus;s__Sulfobacillus thermosulfidooxidans
+      ncbi_source_id: NCBITaxon:28034
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Gram-positive, spore-forming, moderately thermophilic bacterium (optimum 50-55°C) that oxidizes
       both ferrous iron and reduced sulfur compounds. Sulfobacillus is facultatively autotrophic, capable
       of mixotrophic growth on organic compounds plus Fe²⁺ or S⁰. Displays considerable tolerance of high

--- a/kb/communities/Coscinodiscus_Synthetic_Community.yaml
+++ b/kb/communities/Coscinodiscus_Synthetic_Community.yaml
@@ -70,6 +70,14 @@ taxonomy:
     term:
       id: NCBITaxon:1434019
       label: Mameliella
+    gtdb_classification:
+      gtdb_id: GTDB:g__Mameliella
+      gtdb_taxon: Mameliella
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhodobacterales;f__Rhodobacteraceae;g__Mameliella
+      ncbi_source_id: NCBITaxon:1434019
+      majority_fraction: 0.905
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Roseobacteraceae member that extended the diatom''s stationary phase and reduced dead algal
       cells in later culture stages. CS4 possessed complete genes for DMSP metabolism via both demethylation
       and cleavage pathways, indicating capacity for processing diatom-derived organic sulfur compounds.
@@ -93,6 +101,14 @@ taxonomy:
     term:
       id: NCBITaxon:74030
       label: Roseovarius
+    gtdb_classification:
+      gtdb_id: GTDB:g__Roseovarius
+      gtdb_taxon: Roseovarius
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhodobacterales;f__Rhodobacteraceae;g__Roseovarius
+      ncbi_source_id: NCBITaxon:74030
+      majority_fraction: 0.971
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: 'Roseobacteraceae member that promoted diatom survival during late growth phases. Rose1 showed
       no significant influence on bacterial growth rates but was capable of both DMSP demethylation and
       cleavage, suggesting a role in sulfur cycling in this marine community.
@@ -116,6 +132,14 @@ taxonomy:
     term:
       id: NCBITaxon:216431
       label: Croceibacter
+    gtdb_classification:
+      gtdb_id: GTDB:g__Croceibacter
+      gtdb_taxon: Croceibacter
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Flavobacteriales;f__Flavobacteriaceae;g__Croceibacter
+      ncbi_source_id: NCBITaxon:216431
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Flavobacterium that consistently inhibited C. radiatus throughout all growth phases. Crocei1
       was heavily dependent on diatom presence for growth and failed to thrive in nutrient-poor medium
       alone. Lacked genes for DMSP catabolism and showed the highest auxotrophic requirements among the
@@ -140,6 +164,14 @@ taxonomy:
     term:
       id: NCBITaxon:2742
       label: Marinobacter
+    gtdb_classification:
+      gtdb_id: GTDB:g__Marinobacter
+      gtdb_taxon: Marinobacter
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Oleiphilaceae;g__Marinobacter
+      ncbi_source_id: NCBITaxon:2742
+      majority_fraction: 0.964
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: 'Gammaproteobacterium that initially suppressed algal growth but enabled recovery by day nine,
       demonstrating dynamic temporal effects. CS1 grew well independently using HEPES buffer as a carbon
       source and was partially deficient in DMSP demethylation pathways.

--- a/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
+++ b/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
@@ -58,6 +58,14 @@ taxonomy:
     term:
       id: NCBITaxon:119977
       label: Acidithiobacillus
+    gtdb_classification:
+      gtdb_id: GTDB:g__Acidithiobacillus
+      gtdb_taxon: Acidithiobacillus
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus
+      ncbi_source_id: NCBITaxon:119977
+      majority_fraction: 0.724
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Acidithiobacillus species and strains dominated the enrichments on
       both chalcopyrite and chalcocite.
   abundance_level: DOMINANT
@@ -90,6 +98,14 @@ taxonomy:
     term:
       id: NCBITaxon:204441
       label: Rhodospirillales
+    gtdb_classification:
+      gtdb_id: GTDB:o__RF32
+      gtdb_taxon: RF32
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__RF32
+      ncbi_source_id: NCBITaxon:204441
+      majority_fraction: 0.636
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at o__ rank; 30 GTDB taxa under the NCBI taxon]
   abundance_level: ABUNDANT
   evidence:
   - reference: PMID:41381092
@@ -102,6 +118,14 @@ taxonomy:
     term:
       id: NCBITaxon:2301
       label: Thermoplasmatales
+    gtdb_classification:
+      gtdb_id: GTDB:o__Thermoplasmatales
+      gtdb_taxon: Thermoplasmatales
+      gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales
+      ncbi_source_id: NCBITaxon:2301
+      majority_fraction: 0.903
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at o__ rank; 9 GTDB taxa under the NCBI taxon]
   abundance_level: ABUNDANT
   evidence:
   - reference: PMID:41381092

--- a/kb/communities/DVM_Triculture.yaml
+++ b/kb/communities/DVM_Triculture.yaml
@@ -33,6 +33,14 @@ taxonomy:
     term:
       id: NCBITaxon:881
       label: Nitratidesulfovibrio vulgaris
+    gtdb_classification:
+      gtdb_id: GTDB:s__Nitratidesulfovibrio_vulgaris
+      gtdb_taxon: Nitratidesulfovibrio vulgaris
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Nitratidesulfovibrio;s__Nitratidesulfovibrio vulgaris
+      ncbi_source_id: NCBITaxon:881
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Sulfate-reducing bacterium that serves as the keystone species in this tri-culture. D. vulgaris
       oxidizes lactate to acetate, CO2, and H2. In the absence of sulfate, it grows syntrophically with
       methanogens by transferring H2 and acetate, relying on the methanogens to maintain low H2 partial
@@ -59,6 +67,14 @@ taxonomy:
     term:
       id: NCBITaxon:39152
       label: Methanococcus maripaludis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methanococcus_maripaludis
+      gtdb_taxon: Methanococcus maripaludis
+      gtdb_lineage: d__Archaea;p__Methanobacteriota_A;c__Methanococci;o__Methanococcales;f__Methanococcaceae;g__Methanococcus;s__Methanococcus maripaludis
+      ncbi_source_id: NCBITaxon:39152
+      majority_fraction: 0.93
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Hydrogenotrophic methanogen that consumes H2 and CO2 to produce methane. M. maripaludis serves
       as a syntrophic partner by maintaining low H2 partial pressure, enabling thermodynamically favorable
       lactate oxidation by D. vulgaris. Its growth is affected by sulfate availability - as sulfate levels

--- a/kb/communities/Dangl_SynComm_35.yaml
+++ b/kb/communities/Dangl_SynComm_35.yaml
@@ -62,6 +62,14 @@ taxonomy:
     term:
       id: NCBITaxon:231455
       label: Dyella japonica
+    gtdb_classification:
+      gtdb_id: GTDB:s__Dyella_marensis
+      gtdb_taxon: Dyella marensis
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Rhodanobacteraceae;g__Dyella;s__Dyella marensis
+      ncbi_source_id: NCBITaxon:231455
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -77,6 +85,14 @@ taxonomy:
     term:
       id: NCBITaxon:135614
       label: Lysobacterales
+    gtdb_classification:
+      gtdb_id: GTDB:o__Xanthomonadales
+      gtdb_taxon: Xanthomonadales
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales
+      ncbi_source_id: NCBITaxon:135614
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at o__ rank; 3 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -92,6 +108,14 @@ taxonomy:
     term:
       id: NCBITaxon:286
       label: Pseudomonas
+    gtdb_classification:
+      gtdb_id: GTDB:g__Pseudomonas
+      gtdb_taxon: Pseudomonas
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
+      ncbi_source_id: NCBITaxon:286
+      majority_fraction: 0.596
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 17 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -106,6 +130,14 @@ taxonomy:
     term:
       id: NCBITaxon:237
       label: Flavobacterium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Flavobacterium
+      gtdb_taxon: Flavobacterium
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Flavobacteriales;f__Flavobacteriaceae;g__Flavobacterium
+      ncbi_source_id: NCBITaxon:237
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 9 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -121,6 +153,14 @@ taxonomy:
     term:
       id: NCBITaxon:40323
       label: Stenotrophomonas
+    gtdb_classification:
+      gtdb_id: GTDB:g__Stenotrophomonas
+      gtdb_taxon: Stenotrophomonas
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Xanthomonadaceae;g__Stenotrophomonas
+      ncbi_source_id: NCBITaxon:40323
+      majority_fraction: 0.987
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -129,6 +169,14 @@ taxonomy:
     term:
       id: NCBITaxon:33882
       label: Microbacterium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Microbacterium
+      gtdb_taxon: Microbacterium
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Microbacteriaceae;g__Microbacterium
+      ncbi_source_id: NCBITaxon:33882
+      majority_fraction: 0.995
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 6 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -137,6 +185,14 @@ taxonomy:
     term:
       id: NCBITaxon:668369
       label: Escherichia coli DH5[alpha]
+    gtdb_classification:
+      gtdb_id: GTDB:s__Escherichia_coli
+      gtdb_taxon: Escherichia coli
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
+      ncbi_source_id: NCBITaxon:668369
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   abundance_level: COMMON
   functional_role:
   - CROSS_FEEDER

--- a/kb/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.yaml
+++ b/kb/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.yaml
@@ -22,6 +22,14 @@ taxonomy:
     term:
       id: NCBITaxon:135619
       label: Oceanospirillales
+    gtdb_classification:
+      gtdb_id: GTDB:o__Pseudomonadales
+      gtdb_taxon: Pseudomonadales
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales
+      ncbi_source_id: NCBITaxon:135619
+      majority_fraction: 0.968
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at o__ rank; 7 GTDB taxa under the NCBI taxon]
     notes: Early deep-plume bloom related to known petroleum-degrading Oceanospirillales.
   abundance_level: DOMINANT
   functional_role:
@@ -62,6 +70,14 @@ taxonomy:
     term:
       id: NCBITaxon:34067
       label: Cycloclasticus
+    gtdb_classification:
+      gtdb_id: GTDB:g__Cycloclasticus
+      gtdb_taxon: Cycloclasticus
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Cycloclasticaceae;g__Cycloclasticus
+      ncbi_source_id: NCBITaxon:34067
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Aromatic-hydrocarbon-associated genus reported in DWH plume succession studies.
   functional_role:
   - PRIMARY_DEGRADER
@@ -76,6 +92,14 @@ taxonomy:
     term:
       id: NCBITaxon:40222
       label: Methylophaga
+    gtdb_classification:
+      gtdb_id: GTDB:g__Methylophaga
+      gtdb_taxon: Methylophaga
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Nitrosococcales;f__Methylophagaceae;g__Methylophaga
+      ncbi_source_id: NCBITaxon:40222
+      majority_fraction: 0.967
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Methylotrophic bacteria implicated in later plume-water hydrocarbon processing.
   functional_role:
   - PRIMARY_DEGRADER
@@ -90,6 +114,14 @@ taxonomy:
     term:
       id: NCBITaxon:2742
       label: Marinobacter
+    gtdb_classification:
+      gtdb_id: GTDB:g__Marinobacter
+      gtdb_taxon: Marinobacter
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Oleiphilaceae;g__Marinobacter
+      ncbi_source_id: NCBITaxon:2742
+      majority_fraction: 0.964
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Alkane-degrading genus enriched in stable-isotope probing experiments with DWH spill samples.
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/Defined_Multispecies_Enamel_Caries_Model.yaml
+++ b/kb/communities/Defined_Multispecies_Enamel_Caries_Model.yaml
@@ -49,6 +49,14 @@ taxonomy:
     term:
       id: NCBITaxon:1582
       label: Lacticaseibacillus casei
+    gtdb_classification:
+      gtdb_id: GTDB:s__Lacticaseibacillus_paracasei
+      gtdb_taxon: Lacticaseibacillus paracasei
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lacticaseibacillus;s__Lacticaseibacillus paracasei
+      ncbi_source_id: NCBITaxon:1582
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Study uses the historical name Lactobacillus casei.
   evidence:
   - reference: PMID:23446436
@@ -64,6 +72,14 @@ taxonomy:
     term:
       id: NCBITaxon:1309
       label: Streptococcus mutans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Streptococcus_mutans
+      gtdb_taxon: Streptococcus mutans
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Streptococcus;s__Streptococcus mutans
+      ncbi_source_id: NCBITaxon:1309
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   evidence:
   - reference: PMID:23446436
     supports: SUPPORT

--- a/kb/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.yaml
+++ b/kb/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.yaml
@@ -51,6 +51,14 @@ taxonomy:
     term:
       id: NCBITaxon:243164
       label: Dehalococcoides mccartyi 195
+    gtdb_classification:
+      gtdb_id: GTDB:s__Dehalococcoides_mccartyi
+      gtdb_taxon: Dehalococcoides mccartyi
+      gtdb_lineage: d__Bacteria;p__Chloroflexota;c__Dehalococcoidia;o__Dehalococcoidales;f__Dehalococcoidaceae;g__Dehalococcoides;s__Dehalococcoides mccartyi
+      ncbi_source_id: NCBITaxon:243164
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: The main 2011 publication uses the historical name Dehalococcoides
       ethenogenes strain 195; this record uses the current NCBI strain taxon.
   strain_designation:
@@ -83,6 +91,14 @@ taxonomy:
     term:
       id: NCBITaxon:882
       label: Nitratidesulfovibrio vulgaris str. Hildenborough
+    gtdb_classification:
+      gtdb_id: GTDB:s__Nitratidesulfovibrio_vulgaris
+      gtdb_taxon: Nitratidesulfovibrio vulgaris
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Nitratidesulfovibrio;s__Nitratidesulfovibrio vulgaris
+      ncbi_source_id: NCBITaxon:882
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: The publications use Desulfovibrio vulgaris Hildenborough or DvH; NCBI
       currently represents the strain as Nitratidesulfovibrio vulgaris str.
       Hildenborough.

--- a/kb/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.yaml
+++ b/kb/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.yaml
@@ -53,6 +53,14 @@ taxonomy:
     term:
       id: NCBITaxon:243164
       label: Dehalococcoides mccartyi 195
+    gtdb_classification:
+      gtdb_id: GTDB:s__Dehalococcoides_mccartyi
+      gtdb_taxon: Dehalococcoides mccartyi
+      gtdb_lineage: d__Bacteria;p__Chloroflexota;c__Dehalococcoidia;o__Dehalococcoidales;f__Dehalococcoidaceae;g__Dehalococcoides;s__Dehalococcoides mccartyi
+      ncbi_source_id: NCBITaxon:243164
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Organohalide-respiring strain that depends on partner-supplied hydrogen,
       acetate, vitamins, and corrinoids in simplified dechlorinating consortia.
   strain_designation:
@@ -85,6 +93,14 @@ taxonomy:
     term:
       id: NCBITaxon:882
       label: Nitratidesulfovibrio vulgaris str. Hildenborough
+    gtdb_classification:
+      gtdb_id: GTDB:s__Nitratidesulfovibrio_vulgaris
+      gtdb_taxon: Nitratidesulfovibrio vulgaris
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Nitratidesulfovibrio;s__Nitratidesulfovibrio vulgaris
+      ncbi_source_id: NCBITaxon:882
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: The source uses Desulfovibrio vulgaris Hildenborough or DvH; NCBI
       currently represents the strain as Nitratidesulfovibrio vulgaris str.
       Hildenborough.
@@ -116,6 +132,14 @@ taxonomy:
     term:
       id: NCBITaxon:1122947
       label: Pelosinus fermentans DSM 17108
+    gtdb_classification:
+      gtdb_id: GTDB:s__Pelosinus_fermentans
+      gtdb_taxon: Pelosinus fermentans
+      gtdb_lineage: d__Bacteria;p__Bacillota_C;c__Negativicutes;o__DSM-13327;f__DSM-13327;g__Pelosinus;s__Pelosinus fermentans
+      ncbi_source_id: NCBITaxon:1122947
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: The source uses Pelosinus fermentans R7 or PfR7; NCBI represents the
       strain as Pelosinus fermentans DSM 17108 and lists Pelosinus fermentans R7
       as a synonym.

--- a/kb/communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.yaml
@@ -49,6 +49,14 @@ taxonomy:
     term:
       id: NCBITaxon:216389
       label: Dehalococcoides mccartyi BAV1
+    gtdb_classification:
+      gtdb_id: GTDB:s__Dehalococcoides_mccartyi_B
+      gtdb_taxon: Dehalococcoides mccartyi_B
+      gtdb_lineage: d__Bacteria;p__Chloroflexota;c__Dehalococcoidia;o__Dehalococcoidales;f__Dehalococcoidaceae;g__Dehalococcoides;s__Dehalococcoides mccartyi_B
+      ncbi_source_id: NCBITaxon:216389
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Strain BAV1 is curated as the organohalide-respiring Dehalococcoides member.
   strain_designation:
     strain_name: BAV1
@@ -70,6 +78,14 @@ taxonomy:
     term:
       id: NCBITaxon:269797
       label: Methanosarcina barkeri str. Fusaro
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methanosarcina_barkeri_B
+      gtdb_taxon: Methanosarcina barkeri_B
+      gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanosarcinia;o__Methanosarcinales;f__Methanosarcinaceae;g__Methanosarcina;s__Methanosarcina barkeri_B
+      ncbi_source_id: NCBITaxon:269797
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Methanogenic partner population tested for cobamide production and DMB-guided cobalamin support.
   strain_designation:
     strain_name: Fusaro

--- a/kb/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml
@@ -53,6 +53,14 @@ taxonomy:
     term:
       id: NCBITaxon:243164
       label: Dehalococcoides mccartyi 195
+    gtdb_classification:
+      gtdb_id: GTDB:s__Dehalococcoides_mccartyi
+      gtdb_taxon: Dehalococcoides mccartyi
+      gtdb_lineage: d__Bacteria;p__Chloroflexota;c__Dehalococcoidia;o__Dehalococcoidales;f__Dehalococcoidaceae;g__Dehalococcoides;s__Dehalococcoides mccartyi
+      ncbi_source_id: NCBITaxon:243164
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Organohalide-respiring partner used for TCE reductive dechlorination in the defined
       SFB93 coculture.
   strain_designation:
@@ -78,6 +86,14 @@ taxonomy:
     term:
       id: NCBITaxon:18
       label: Pelobacter
+    gtdb_classification:
+      gtdb_id: GTDB:g__Syntrophotalea
+      gtdb_taxon: Syntrophotalea
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Desulfuromonadales;f__Syntrophotaleaceae;g__Syntrophotalea
+      ncbi_source_id: NCBITaxon:18
+      majority_fraction: 0.5
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Source literature identifies the acetylene-fermenting partner as Pelobacter strain
       SFB93; current resources also associate SFB93 with Syntrophotalea acetylenivorans.
   strain_designation:

--- a/kb/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.yaml
@@ -59,6 +59,14 @@ taxonomy:
     term:
       id: NCBITaxon:243164
       label: Dehalococcoides mccartyi 195
+    gtdb_classification:
+      gtdb_id: GTDB:s__Dehalococcoides_mccartyi
+      gtdb_taxon: Dehalococcoides mccartyi
+      gtdb_lineage: d__Bacteria;p__Chloroflexota;c__Dehalococcoidia;o__Dehalococcoidales;f__Dehalococcoidaceae;g__Dehalococcoides;s__Dehalococcoides mccartyi
+      ncbi_source_id: NCBITaxon:243164
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Organohalide-respiring bacterium that uses hydrogen as the electron donor for reductive
       dechlorination of TCE in the coculture.
   strain_designation:

--- a/kb/communities/Desulfovibrio_Methanococcus_Syntrophy.yaml
+++ b/kb/communities/Desulfovibrio_Methanococcus_Syntrophy.yaml
@@ -31,6 +31,14 @@ taxonomy:
     term:
       id: NCBITaxon:882
       label: Nitratidesulfovibrio vulgaris str. Hildenborough
+    gtdb_classification:
+      gtdb_id: GTDB:s__Nitratidesulfovibrio_vulgaris
+      gtdb_taxon: Nitratidesulfovibrio vulgaris
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Nitratidesulfovibrio;s__Nitratidesulfovibrio vulgaris
+      ncbi_source_id: NCBITaxon:882
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Anaerobic sulfate-reducing bacterium that can also grow syntrophically in the absence of sulfate.
       When grown without sulfate, D. vulgaris oxidizes lactate to acetate, producing H2 and CO2 as electron
       sink products. This organism is a facultative syntrophic partner that preferentially uses sulfate
@@ -56,6 +64,14 @@ taxonomy:
     term:
       id: NCBITaxon:267377
       label: Methanococcus maripaludis S2
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methanococcus_maripaludis
+      gtdb_taxon: Methanococcus maripaludis
+      gtdb_lineage: d__Archaea;p__Methanobacteriota_A;c__Methanococci;o__Methanococcales;f__Methanococcaceae;g__Methanococcus;s__Methanococcus maripaludis
+      ncbi_source_id: NCBITaxon:267377
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Hydrogenotrophic methanogen that consumes H2 and CO2 to produce methane. Essential syntrophic
       partner that maintains low H2 partial pressure, enabling thermodynamically unfavorable lactate oxidation
       by D. vulgaris in the absence of sulfate. A genetically tractable model organism for studying methanogenesis

--- a/kb/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.yaml
+++ b/kb/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.yaml
@@ -42,6 +42,14 @@ taxonomy:
     term:
       id: NCBITaxon:434
       label: Acetobacter
+    gtdb_classification:
+      gtdb_id: GTDB:g__Acetobacter
+      gtdb_taxon: Acetobacter
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acetobacter
+      ncbi_source_id: NCBITaxon:434
+      majority_fraction: 0.561
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Represents Acetobacter pomorum DmelCS_004 and Acetobacter tropicalis DmelCS_006 in the defined
       five-species microbiota.
   functional_role:
@@ -64,6 +72,14 @@ taxonomy:
     term:
       id: NCBITaxon:1578
       label: Lactobacillus
+    gtdb_classification:
+      gtdb_id: GTDB:g__Lactobacillus
+      gtdb_taxon: Lactobacillus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactobacillus
+      ncbi_source_id: NCBITaxon:1578
+      majority_fraction: 0.971
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 16 GTDB taxa under the NCBI taxon]
     notes: Represents Lactobacillus brevis DmelCS_003, Lactobacillus fructivorans DmelCS_002, and
       Lactobacillus plantarum DmelCS_001, using names from the source publications.
   functional_role:

--- a/kb/communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.yaml
+++ b/kb/communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.yaml
@@ -28,6 +28,14 @@ taxonomy:
     term:
       id: NCBITaxon:201174
       label: Actinomycetota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Actinomycetota
+      gtdb_taxon: Actinomycetota
+      gtdb_lineage: d__Bacteria;p__Actinomycetota
+      ncbi_source_id: NCBITaxon:201174
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 6 GTDB taxa under the NCBI taxon]
     notes: Drought-enriched Actinobacteria lineage whose abundance is amplified
       by loss of a plant phytosiderophore iron transporter and suppressed by
       exogenous iron amendment.

--- a/kb/communities/ENIGMA_Denitrifying_SynCom.yaml
+++ b/kb/communities/ENIGMA_Denitrifying_SynCom.yaml
@@ -45,6 +45,14 @@ taxonomy:
     term:
       id: NCBITaxon:416169
       label: Rhodanobacter thiooxydans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Rhodanobacter_thiooxydans
+      gtdb_taxon: Rhodanobacter thiooxydans
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Rhodanobacteraceae;g__Rhodanobacter;s__Rhodanobacter thiooxydans
+      ncbi_source_id: NCBITaxon:416169
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:
     strain_name: FW510-R12
     isolation_source: heavily nitrate-contaminated superfund site groundwater

--- a/kb/communities/Early_Dental_Biofilm_FiveSpecies.yaml
+++ b/kb/communities/Early_Dental_Biofilm_FiveSpecies.yaml
@@ -89,6 +89,14 @@ taxonomy:
     term:
       id: NCBITaxon:1317
       label: Streptococcus downei
+    gtdb_classification:
+      gtdb_id: GTDB:s__Streptococcus_downei
+      gtdb_taxon: Streptococcus downei
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Streptococcus;s__Streptococcus downei
+      ncbi_source_id: NCBITaxon:1317
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   evidence:
   - reference: PMID:21966490
     supports: SUPPORT
@@ -103,6 +111,14 @@ taxonomy:
     term:
       id: NCBITaxon:1655
       label: Actinomyces naeslundii
+    gtdb_classification:
+      gtdb_id: GTDB:s__Actinomyces_naeslundii
+      gtdb_taxon: Actinomyces naeslundii
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Actinomycetaceae;g__Actinomyces;s__Actinomyces naeslundii
+      ncbi_source_id: NCBITaxon:1655
+      majority_fraction: 0.96
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   evidence:
   - reference: PMID:21966490
     supports: SUPPORT

--- a/kb/communities/East_River_Floodplain_Core_Microbiome.yaml
+++ b/kb/communities/East_River_Floodplain_Core_Microbiome.yaml
@@ -22,6 +22,14 @@ taxonomy:
     term:
       id: NCBITaxon:28216
       label: Betaproteobacteria
+    gtdb_classification:
+      gtdb_id: GTDB:c__Gammaproteobacteria
+      gtdb_taxon: Gammaproteobacteria
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria
+      ncbi_source_id: NCBITaxon:28216
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at c__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Betaproteobacteria had the highest number of representative genomes and dominated the operationally
       defined core floodplain microbiome.
   functional_role:
@@ -63,6 +71,14 @@ taxonomy:
     term:
       id: NCBITaxon:57723
       label: Acidobacteriota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Acidobacteriota
+      gtdb_taxon: Acidobacteriota
+      gtdb_lineage: d__Bacteria;p__Acidobacteriota
+      ncbi_source_id: NCBITaxon:57723
+      majority_fraction: 0.976
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Acidobacteriota were among the abundant representative genomes reconstructed across the three
       meander-bound floodplains.
   functional_role:
@@ -79,6 +95,14 @@ taxonomy:
     term:
       id: NCBITaxon:142182
       label: Gemmatimonadota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Gemmatimonadota
+      gtdb_taxon: Gemmatimonadota
+      gtdb_lineage: d__Bacteria;p__Gemmatimonadota
+      ncbi_source_id: NCBITaxon:142182
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Gemmatimonadota were reported among abundant reconstructed taxa and among the lower-abundance
       members of the core floodplain microbiome.
   functional_role:

--- a/kb/communities/EcoFAB_Ring_Trial_SynCom17.yaml
+++ b/kb/communities/EcoFAB_Ring_Trial_SynCom17.yaml
@@ -53,6 +53,14 @@ taxonomy:
     term:
       id: NCBITaxon:1822464
       label: Paraburkholderia
+    gtdb_classification:
+      gtdb_id: GTDB:g__Paraburkholderia
+      gtdb_taxon: Paraburkholderia
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Paraburkholderia
+      ncbi_source_id: NCBITaxon:1822464
+      majority_fraction: 0.988
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: 'Dominant root colonizer in SynCom17 (~98% relative abundance across all 5 labs). Uniquely
       possesses a Type 3 Secretion System (T3SS), acid resistance genes (glutamate/arginine transporters
       and decarboxylases), and highest motility at 24h among all SynCom members. Formerly classified as
@@ -81,6 +89,14 @@ taxonomy:
     term:
       id: NCBITaxon:1827
       label: Rhodococcus <high G+C Gram-positive bacteria>
+    gtdb_classification:
+      gtdb_id: GTDB:g__Rhodococcus
+      gtdb_taxon: Rhodococcus
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Rhodococcus
+      ncbi_source_id: NCBITaxon:1827
+      majority_fraction: 0.996
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: 'Dominant in SynCom16 (without Paraburkholderia) at ~68% relative abundance. Fast growth and
       high motility similar to Paraburkholderia.
 
@@ -104,6 +120,14 @@ taxonomy:
     term:
       id: NCBITaxon:1763
       label: Mycobacterium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Mycobacterium
+      gtdb_taxon: Mycobacterium
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Mycobacterium
+      ncbi_source_id: NCBITaxon:1763
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: High relative abundance in SynCom16 roots (~14%).
   strain_designation:
     strain_name: OAE908
@@ -122,6 +146,14 @@ taxonomy:
     term:
       id: NCBITaxon:407
       label: Methylobacterium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Methylobacterium
+      gtdb_taxon: Methylobacterium
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Methylobacterium
+      ncbi_source_id: NCBITaxon:407
+      majority_fraction: 0.992
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: High relative abundance in SynCom16 roots (~15%).
   strain_designation:
     strain_name: OAE515
@@ -140,6 +172,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OAS795
     isolation_source: Switchgrass rhizosphere soil
@@ -155,6 +195,14 @@ taxonomy:
     term:
       id: NCBITaxon:379
       label: Rhizobium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Rhizobium
+      gtdb_taxon: Rhizobium
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Rhizobium
+      ncbi_source_id: NCBITaxon:379
+      majority_fraction: 0.723
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 16 GTDB taxa under the NCBI taxon]
     notes: Most closely related to R. endophyticum.
   strain_designation:
     strain_name: OAE497
@@ -171,6 +219,14 @@ taxonomy:
     term:
       id: NCBITaxon:169215
       label: Bosea
+    gtdb_classification:
+      gtdb_id: GTDB:g__Bosea
+      gtdb_taxon: Bosea
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Bosea
+      ncbi_source_id: NCBITaxon:169215
+      majority_fraction: 0.981
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OAE506
     isolation_source: Switchgrass rhizosphere soil
@@ -186,6 +242,14 @@ taxonomy:
     term:
       id: NCBITaxon:374
       label: Bradyrhizobium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Bradyrhizobium
+      gtdb_taxon: Bradyrhizobium
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Bradyrhizobium
+      ncbi_source_id: NCBITaxon:374
+      majority_fraction: 0.982
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 8 GTDB taxa under the NCBI taxon]
     notes: Grown in 1/10 R2A medium (unlike other members grown in R2A).
   strain_designation:
     strain_name: OAE829
@@ -202,6 +266,14 @@ taxonomy:
     term:
       id: NCBITaxon:68
       label: Lysobacter
+    gtdb_classification:
+      gtdb_id: GTDB:g__Lysobacter
+      gtdb_taxon: Lysobacter
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Xanthomonadaceae;g__Lysobacter
+      ncbi_source_id: NCBITaxon:68
+      majority_fraction: 0.748
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 8 GTDB taxa under the NCBI taxon]
     notes: Enriched in rhizosphere at 21 DPI (order Xanthomonadales).
   strain_designation:
     strain_name: OAE881
@@ -236,6 +308,14 @@ taxonomy:
     term:
       id: NCBITaxon:86795
       label: Marmoricola
+    gtdb_classification:
+      gtdb_id: GTDB:g__Marmoricola
+      gtdb_taxon: Marmoricola
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Propionibacteriales;f__Nocardioidaceae;g__Marmoricola
+      ncbi_source_id: NCBITaxon:86795
+      majority_fraction: 0.923
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OAE513
     isolation_source: Switchgrass rhizosphere soil
@@ -251,6 +331,14 @@ taxonomy:
     term:
       id: NCBITaxon:79328
       label: Chitinophaga
+    gtdb_classification:
+      gtdb_id: GTDB:g__Chitinophaga
+      gtdb_taxon: Chitinophaga
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Chitinophagales;f__Chitinophagaceae;g__Chitinophaga
+      ncbi_source_id: NCBITaxon:79328
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OAE865
     isolation_source: Switchgrass rhizosphere soil
@@ -266,6 +354,14 @@ taxonomy:
     term:
       id: NCBITaxon:423349
       label: Mucilaginibacter
+    gtdb_classification:
+      gtdb_id: GTDB:g__Mucilaginibacter
+      gtdb_taxon: Mucilaginibacter
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Sphingobacteriales;f__Sphingobacteriaceae;g__Mucilaginibacter
+      ncbi_source_id: NCBITaxon:423349
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OAE612
     isolation_source: Switchgrass rhizosphere soil
@@ -281,6 +377,14 @@ taxonomy:
     term:
       id: NCBITaxon:354354
       label: Niastella
+    gtdb_classification:
+      gtdb_id: GTDB:g__Niastella
+      gtdb_taxon: Niastella
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Chitinophagales;f__Chitinophagaceae;g__Niastella
+      ncbi_source_id: NCBITaxon:354354
+      majority_fraction: 0.917
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OAS944
     isolation_source: Switchgrass rhizosphere soil
@@ -296,6 +400,14 @@ taxonomy:
     term:
       id: NCBITaxon:2837503
       label: Gottfriedia
+    gtdb_classification:
+      gtdb_id: GTDB:g__Gottfriedia
+      gtdb_taxon: Gottfriedia
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae_G;g__Gottfriedia
+      ncbi_source_id: NCBITaxon:2837503
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Formerly classified as Bacillus sp. OAE603.
   strain_designation:
     strain_name: OAE603
@@ -312,6 +424,14 @@ taxonomy:
     term:
       id: NCBITaxon:55080
       label: Brevibacillus
+    gtdb_classification:
+      gtdb_id: GTDB:g__Brevibacillus
+      gtdb_taxon: Brevibacillus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Brevibacillales;f__Brevibacillaceae;g__Brevibacillus
+      ncbi_source_id: NCBITaxon:55080
+      majority_fraction: 0.816
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 6 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OAP136
     isolation_source: Switchgrass rhizosphere soil

--- a/kb/communities/Emiliania_Phaeobacter_Dynamic_Interaction.yaml
+++ b/kb/communities/Emiliania_Phaeobacter_Dynamic_Interaction.yaml
@@ -57,6 +57,14 @@ taxonomy:
     term:
       id: NCBITaxon:391619
       label: Phaeobacter inhibens DSM 17395
+    gtdb_classification:
+      gtdb_id: GTDB:s__Phaeobacter_inhibens
+      gtdb_taxon: Phaeobacter inhibens
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhodobacterales;f__Rhodobacteraceae;g__Phaeobacter;s__Phaeobacter inhibens
+      ncbi_source_id: NCBITaxon:391619
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Heterotrophic Roseobacter-group bacterium that attaches to E. huxleyi and produces IAA.
   strain_designation:
     strain_name: DSM 17395

--- a/kb/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.yaml
+++ b/kb/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.yaml
@@ -43,6 +43,14 @@ taxonomy:
     term:
       id: NCBITaxon:562
       label: Escherichia coli
+    gtdb_classification:
+      gtdb_id: GTDB:s__Escherichia_coli
+      gtdb_taxon: Escherichia coli
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
+      ncbi_source_id: NCBITaxon:562
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Engineered gut-associated Enterobacteriaceae member in the four-species consortium.
   functional_role:
   - CROSS_FEEDER
@@ -57,6 +65,14 @@ taxonomy:
     term:
       id: NCBITaxon:90371
       label: Salmonella enterica subsp. enterica serovar Typhimurium
+    gtdb_classification:
+      gtdb_id: GTDB:s__Salmonella_enterica
+      gtdb_taxon: Salmonella enterica
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Salmonella;s__Salmonella enterica
+      ncbi_source_id: NCBITaxon:90371
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Engineered Salmonella member used as a genetically tractable gut-associated strain.
   functional_role:
   - CROSS_FEEDER
@@ -71,6 +87,14 @@ taxonomy:
     term:
       id: NCBITaxon:818
       label: Bacteroides thetaiotaomicron
+    gtdb_classification:
+      gtdb_id: GTDB:s__Bacteroides_thetaiotaomicron
+      gtdb_taxon: Bacteroides thetaiotaomicron
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides;s__Bacteroides thetaiotaomicron
+      ncbi_source_id: NCBITaxon:818
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Engineered Bacteroides member of the consortium; Bacteroides taxa were described as more
       mucosally associated and complex-carbohydrate utilizing.
   functional_role:

--- a/kb/communities/Ewaste_Bioleaching_Consortium.yaml
+++ b/kb/communities/Ewaste_Bioleaching_Consortium.yaml
@@ -56,6 +56,14 @@ taxonomy:
     term:
       id: NCBITaxon:178606
       label: Leptospirillum ferriphilum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Leptospirillum_A_rubarum
+      gtdb_taxon: Leptospirillum_A rubarum
+      gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
+      ncbi_source_id: NCBITaxon:178606
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Dominant iron-oxidizing bacterium in the e-waste bioleaching consortium. Leptospirillum can
       potentially thrive in bioleaching environments as they have greater capacity for iron oxidation
       activity than other iron-oxidizing bacteria (FeOB). This obligate chemolithoautotroph oxidizes Fe²⁺
@@ -87,6 +95,14 @@ taxonomy:
     term:
       id: NCBITaxon:453960
       label: Sulfobacillus benefaciens
+    gtdb_classification:
+      gtdb_id: GTDB:s__Sulfobacillus_benefaciens
+      gtdb_taxon: Sulfobacillus benefaciens
+      gtdb_lineage: d__Bacteria;p__Bacillota_E;c__Sulfobacillia;o__Sulfobacillales;f__Sulfobacillaceae;g__Sulfobacillus;s__Sulfobacillus benefaciens
+      ncbi_source_id: NCBITaxon:453960
+      majority_fraction: 0.96
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Gram-positive, moderately thermophilic, facultatively autotrophic bacterium co-occurring with
       Leptospirillum in the e-waste consortium. Sulfobacillus species oxidize both iron and reduced sulfur
       compounds and can grow mixotrophically on organic compounds. S. benefaciens contributes to iron
@@ -113,6 +129,14 @@ taxonomy:
     term:
       id: NCBITaxon:920
       label: Acidithiobacillus ferrooxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidithiobacillus_ferrooxidans
+      gtdb_taxon: Acidithiobacillus ferrooxidans
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
+      ncbi_source_id: NCBITaxon:920
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Mesophilic γ-proteobacterium that oxidizes both ferrous iron and reduced sulfur compounds.
       Widely used in PCB bioleaching research, achieving >94% copper recovery and 90% zinc recovery in
       4-10 days at PCB concentrations of 10-50 g/L. This chemolithoautotroph fixes CO₂ and nitrogen, thriving
@@ -146,6 +170,14 @@ taxonomy:
     term:
       id: NCBITaxon:930
       label: Acidithiobacillus thiooxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidithiobacillus_thiooxidans
+      gtdb_taxon: Acidithiobacillus thiooxidans
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus thiooxidans
+      ncbi_source_id: NCBITaxon:930
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Sulfur-oxidizing bacterium that generates sulfuric acid from elemental sulfur and reduced
       inorganic sulfur compounds. In e-waste bioleaching, At. thiooxidans maintains the extremely low
       pH (1.2-2.0) required for metal solubilization and prevents precipitation of dissolved metals as
@@ -175,6 +207,14 @@ taxonomy:
     term:
       id: NCBITaxon:160808
       label: Acidithiobacillus ferrivorans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidithiobacillus_ferrivorans
+      gtdb_taxon: Acidithiobacillus ferrivorans
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrivorans
+      ncbi_source_id: NCBITaxon:160808
+      majority_fraction: 0.95
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Facultatively anaerobic, psychrotolerant iron- and sulfur-oxidizing acidophile. Used in two-step
       e-waste bioleaching processes for PCB metal recovery. This diazotrophic bacterium fixes nitrogen,
       reducing nutrient requirements. A. ferrivorans tolerates lower temperatures than At. ferrooxidans,

--- a/kb/communities/Ferroplasma_Leptospirillum_Syntrophy.yaml
+++ b/kb/communities/Ferroplasma_Leptospirillum_Syntrophy.yaml
@@ -39,6 +39,14 @@ taxonomy:
     term:
       id: NCBITaxon:178606
       label: Leptospirillum ferriphilum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Leptospirillum_A_rubarum
+      gtdb_taxon: Leptospirillum_A rubarum
+      gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
+      ncbi_source_id: NCBITaxon:178606
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Chemolithoautotrophic iron-oxidizing bacterium (Nitrospirae phylum) that oxidizes Fe²⁺ to
       Fe³⁺ as sole energy source while fixing CO₂. Secretes organic matter during growth (cell lysis products,
       extracellular polymeric substances, metabolic byproducts) that accumulates to toxic levels in pure
@@ -79,6 +87,14 @@ taxonomy:
     term:
       id: NCBITaxon:74969
       label: Ferroplasma acidiphilum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Ferroplasma_acidarmanus
+      gtdb_taxon: Ferroplasma acidarmanus
+      gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales;f__Thermoplasmataceae;g__Ferroplasma;s__Ferroplasma acidarmanus
+      ncbi_source_id: NCBITaxon:74969
+      majority_fraction: 0.91
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Cell wall-lacking archaeon (Thermoplasmatales) that grows chemomixotrophically, oxidizing
       ferrous iron while utilizing organic compounds for carbon. In syntrophic partnership with Leptospirillum,
       F. acidiphilum consumes organic matter secreted by the bacterium, maintaining low organic compound

--- a/kb/communities/GLBRC_Populus_Variovorax_SynCom28.yaml
+++ b/kb/communities/GLBRC_Populus_Variovorax_SynCom28.yaml
@@ -45,6 +45,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: BK119
     isolation_source: Populus deltoides root

--- a/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
+++ b/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
@@ -57,6 +57,14 @@ taxonomy:
     term:
       id: NCBITaxon:133926
       label: Olsenella uli
+    gtdb_classification:
+      gtdb_id: GTDB:s__Olsenella_uli
+      gtdb_taxon: Olsenella uli
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Coriobacteriia;o__Coriobacteriales;f__Atopobiaceae;g__Olsenella;s__Olsenella uli
+      ncbi_source_id: NCBITaxon:133926
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Dominant Actinobacteriota member (up to 61.5% relative abundance). Degrades lactose via the
       Leloir pathway, producing acetic and lactic acids.
 
@@ -108,6 +116,14 @@ taxonomy:
     term:
       id: NCBITaxon:2740557
       label: Pauljensenia
+    gtdb_classification:
+      gtdb_id: GTDB:g__Pauljensenia
+      gtdb_taxon: Pauljensenia
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Actinomycetaceae;g__Pauljensenia
+      ncbi_source_id: NCBITaxon:2740557
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Actinobacteriota member (up to 29.6% relative abundance). Produces succinic acid from lactose.
 
       '
@@ -132,6 +148,14 @@ taxonomy:
     term:
       id: NCBITaxon:1766253
       label: Agathobacter
+    gtdb_classification:
+      gtdb_id: GTDB:g__Agathobacter
+      gtdb_taxon: Agathobacter
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Agathobacter
+      ncbi_source_id: NCBITaxon:1766253
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Firmicutes member (up to 18.7% relative abundance). Performs lactose-based chain elongation
       to medium-chain fatty acids.
 
@@ -158,6 +182,14 @@ taxonomy:
     term:
       id: NCBITaxon:1678
       label: Bifidobacterium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Bifidobacterium
+      gtdb_taxon: Bifidobacterium
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium
+      ncbi_source_id: NCBITaxon:1678
+      majority_fraction: 0.998
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Actinobacteriota member (up to 17.4% relative abundance). Ferments lactose via the bifid shunt
       pathway.
 
@@ -183,6 +215,14 @@ taxonomy:
     term:
       id: NCBITaxon:203691
       label: Spirochaetota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Spirochaetota
+      gtdb_taxon: Spirochaetota
+      gtdb_lineage: d__Bacteria;p__Spirochaetota
+      ncbi_source_id: NCBITaxon:203691
+      majority_fraction: 0.995
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 5 GTDB taxa under the NCBI taxon]
     notes: 'Spirochaetota member (up to 16.1% relative abundance). Produces ethanol which serves as substrate
       for chain elongation by Firmicutes.
 
@@ -258,6 +298,14 @@ taxonomy:
     term:
       id: NCBITaxon:33905
       label: Bifidobacterium thermophilum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Bifidobacterium_thermacidophilum
+      gtdb_taxon: Bifidobacterium thermacidophilum
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium thermacidophilum
+      ncbi_source_id: NCBITaxon:33905
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Third Bifidobacterium MAG (up to 11.4% relative abundance). Lactose fermentation.
 
       '
@@ -282,6 +330,14 @@ taxonomy:
     term:
       id: NCBITaxon:904
       label: Acidaminococcus
+    gtdb_classification:
+      gtdb_id: GTDB:g__Acidaminococcus
+      gtdb_taxon: Acidaminococcus
+      gtdb_lineage: d__Bacteria;p__Bacillota_C;c__Negativicutes;o__Acidaminococcales;f__Acidaminococcaceae;g__Acidaminococcus
+      ncbi_source_id: NCBITaxon:904
+      majority_fraction: 0.991
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: 'Firmicutes member (up to 10.2% relative abundance). Possible ethanol-based chain elongation.
 
       '

--- a/kb/communities/GOM_Oil_Degrading_Consortium.yaml
+++ b/kb/communities/GOM_Oil_Degrading_Consortium.yaml
@@ -36,6 +36,14 @@ taxonomy:
     term:
       id: NCBITaxon:857252
       label: Halopseudomonas aestusnigri
+    gtdb_classification:
+      gtdb_id: GTDB:s__Halopseudomonas_aestusnigri
+      gtdb_taxon: Halopseudomonas aestusnigri
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Halopseudomonas;s__Halopseudomonas aestusnigri
+      ncbi_source_id: NCBITaxon:857252
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -50,6 +58,14 @@ taxonomy:
     term:
       id: NCBITaxon:2782567
       label: Paenarthrobacter sp. GOM3
+    gtdb_classification:
+      gtdb_id: GTDB:s__Arthrobacter_sp018215265
+      gtdb_taxon: Arthrobacter sp018215265
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Micrococcaceae;g__Arthrobacter;s__Arthrobacter sp018215265
+      ncbi_source_id: NCBITaxon:2782567
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/Geobacter_Clostridium_DIET.yaml
+++ b/kb/communities/Geobacter_Clostridium_DIET.yaml
@@ -36,6 +36,14 @@ taxonomy:
     term:
       id: NCBITaxon:35554
       label: Geobacter sulfurreducens
+    gtdb_classification:
+      gtdb_id: GTDB:s__Geobacter_sulfurreducens
+      gtdb_taxon: Geobacter sulfurreducens
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter sulfurreducens
+      ncbi_source_id: NCBITaxon:35554
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Anaerobic bacterium serving as an exoelectrogen in this DIET partnership.
       G. sulfurreducens (strain DSM 12127) oxidizes acetate and transfers electrons
       to C. pasteurianum via electrically conductive pili (nanowires). These pili
@@ -69,6 +77,14 @@ taxonomy:
     term:
       id: NCBITaxon:1501
       label: Clostridium pasteurianum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Clostridium_I_pasteurianum
+      gtdb_taxon: Clostridium_I pasteurianum
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_I;s__Clostridium_I pasteurianum
+      ncbi_source_id: NCBITaxon:1501
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Saccharolytic, nitrogen-fixing, spore-forming Gram-positive obligate anaerobe
       that serves as the electron acceptor in this DIET partnership. C. pasteurianum
       (strain DSM 525 = ATCC 6013) ferments glycerol, and when receiving electrons

--- a/kb/communities/Geobacter_Methanosaeta_DIET.yaml
+++ b/kb/communities/Geobacter_Methanosaeta_DIET.yaml
@@ -34,6 +34,14 @@ taxonomy:
     term:
       id: NCBITaxon:28232
       label: Geobacter metallireducens
+    gtdb_classification:
+      gtdb_id: GTDB:s__Geobacter_metallireducens
+      gtdb_taxon: Geobacter metallireducens
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
+      ncbi_source_id: NCBITaxon:28232
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Anaerobic bacterium capable of oxidizing organic compounds (including
       ethanol) and transferring electrons to metal oxides or other microorganisms.
       In DIET cocultures, G. metallireducens uses electrically conductive pili (e-pili)
@@ -61,6 +69,14 @@ taxonomy:
     term:
       id: NCBITaxon:301375
       label: Methanothrix harundinacea
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methanocrinis_harundinaceus
+      gtdb_taxon: Methanocrinis harundinaceus
+      gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanosarcinia;o__Methanotrichales;f__Methanotrichaceae;g__Methanocrinis;s__Methanocrinis harundinaceus
+      ncbi_source_id: NCBITaxon:301375
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Obligate acetoclastic methanogenic archaeon capable of accepting electrons
       via DIET and using them for CO2 reduction to methane. M. harundinacea is unique
       among acetoclastic methanogens in its ability to participate in DIET, accepting

--- a/kb/communities/Geobacter_Methanosarcina_DIET.yaml
+++ b/kb/communities/Geobacter_Methanosarcina_DIET.yaml
@@ -33,6 +33,14 @@ taxonomy:
     term:
       id: NCBITaxon:28232
       label: Geobacter metallireducens
+    gtdb_classification:
+      gtdb_id: GTDB:s__Geobacter_metallireducens
+      gtdb_taxon: Geobacter metallireducens
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
+      ncbi_source_id: NCBITaxon:28232
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Anaerobic bacterium capable of oxidizing organic compounds (including
       ethanol) and transferring electrons to metal oxides or other microorganisms.
       In DIET cocultures, G. metallireducens uses electrically conductive pili (e-pili)

--- a/kb/communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.yaml
+++ b/kb/communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.yaml
@@ -55,6 +55,14 @@ taxonomy:
     term:
       id: NCBITaxon:35554
       label: Geobacter sulfurreducens
+    gtdb_classification:
+      gtdb_id: GTDB:s__Geobacter_sulfurreducens
+      gtdb_taxon: Geobacter sulfurreducens
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter sulfurreducens
+      ncbi_source_id: NCBITaxon:35554
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Species-level member of the defined Geobacter-Pseudomonas coculture.
   abundance_level: DOMINANT
   abundance_value: Geobacter became dominant during serially adapted cocultures.
@@ -77,6 +85,14 @@ taxonomy:
     term:
       id: NCBITaxon:287
       label: Pseudomonas aeruginosa
+    gtdb_classification:
+      gtdb_id: GTDB:s__Pseudomonas_aeruginosa
+      gtdb_taxon: Pseudomonas aeruginosa
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas;s__Pseudomonas aeruginosa
+      ncbi_source_id: NCBITaxon:287
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Species-level member of the defined Geobacter-Pseudomonas coculture.
   abundance_level: COMMON
   functional_role:

--- a/kb/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.yaml
+++ b/kb/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.yaml
@@ -32,6 +32,14 @@ taxonomy:
     term:
       id: NCBITaxon:641853
       label: Elusimicrobia
+    gtdb_classification:
+      gtdb_id: GTDB:c__Elusimicrobia
+      gtdb_taxon: Elusimicrobia
+      gtdb_lineage: d__Bacteria;p__Elusimicrobiota;c__Elusimicrobia
+      ncbi_source_id: NCBITaxon:641853
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at c__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Groundwater Elusimicrobia clades with diverse metabolic strategies
       including aerobic and anaerobic respiration and Rnf-dependent acetogenesis.
   functional_role:

--- a/kb/communities/Hanford_300_Area_Unconfined_Aquifer_Community.yaml
+++ b/kb/communities/Hanford_300_Area_Unconfined_Aquifer_Community.yaml
@@ -23,6 +23,14 @@ taxonomy:
     term:
       id: NCBITaxon:1224
       label: Pseudomonadota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Pseudomonadota
+      gtdb_taxon: Pseudomonadota
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota
+      ncbi_source_id: NCBITaxon:1224
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 14 GTDB taxa under the NCBI taxon]
     notes: Proteobacteria comprised half of the recovered sequences in the Hanford unconfined aquifer
       groundwater study.
   functional_role:
@@ -41,6 +49,14 @@ taxonomy:
     term:
       id: NCBITaxon:976
       label: Bacteroidota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Bacteroidota
+      gtdb_taxon: Bacteroidota
+      gtdb_lineage: d__Bacteria;p__Bacteroidota
+      ncbi_source_id: NCBITaxon:976
+      majority_fraction: 0.999
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 8 GTDB taxa under the NCBI taxon]
     notes: Bacteroidetes were the second most abundant phylum in the recovered 16S rRNA gene sequences.
   functional_role:
   - PRIMARY_DEGRADER
@@ -58,6 +74,14 @@ taxonomy:
     term:
       id: NCBITaxon:201174
       label: Actinomycetota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Actinomycetota
+      gtdb_taxon: Actinomycetota
+      gtdb_lineage: d__Bacteria;p__Actinomycetota
+      ncbi_source_id: NCBITaxon:201174
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 6 GTDB taxa under the NCBI taxon]
     notes: Actinobacterial ACK-M1 and CL500-29 groups appeared during river-water intrusion and became
       abundant at high water level.
   functional_role:

--- a/kb/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.yaml
+++ b/kb/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.yaml
@@ -52,6 +52,14 @@ taxonomy:
     term:
       id: NCBITaxon:186801
       label: Clostridia
+    gtdb_classification:
+      gtdb_id: GTDB:c__Clostridia
+      gtdb_taxon: Clostridia
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia
+      ncbi_source_id: NCBITaxon:186801
+      majority_fraction: 0.974
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at c__ rank; 39 GTDB taxa under the NCBI taxon]
     notes: The source reports Clostridia within Firmicutes as dominant contributors of measured CAZymes.
   abundance_level: DOMINANT
   functional_role:
@@ -68,6 +76,14 @@ taxonomy:
     term:
       id: NCBITaxon:91061
       label: Bacilli
+    gtdb_classification:
+      gtdb_id: GTDB:c__Bacilli
+      gtdb_taxon: Bacilli
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli
+      ncbi_source_id: NCBITaxon:91061
+      majority_fraction: 0.996
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at c__ rank; 8 GTDB taxa under the NCBI taxon]
     notes: The paper describes Bacillus/Bacilli-lineage Firmicutes among dominant CAZyme contributors.
   abundance_level: ABUNDANT
   functional_role:
@@ -84,6 +100,14 @@ taxonomy:
     term:
       id: NCBITaxon:200795
       label: Chloroflexota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Chloroflexota
+      gtdb_taxon: Chloroflexota
+      gtdb_lineage: d__Bacteria;p__Chloroflexota
+      ncbi_source_id: NCBITaxon:200795
+      majority_fraction: 0.998
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: The publication uses the historical phylum name Chloroflexi and reports fraction-specific
       prevalence of Chloroflexi-derived CAZymes.
   abundance_level: COMMON
@@ -101,6 +125,14 @@ taxonomy:
     term:
       id: NCBITaxon:200918
       label: Thermotogota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Thermotogota
+      gtdb_taxon: Thermotogota
+      gtdb_lineage: d__Bacteria;p__Thermotogota
+      ncbi_source_id: NCBITaxon:200918
+      majority_fraction: 0.997
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: The publication uses the historical phylum name Thermotogae and reports Thermotogae-derived
       enzymes in supernatant and substrate-bound fractions.
   abundance_level: COMMON

--- a/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
+++ b/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
@@ -44,6 +44,14 @@ taxonomy:
     term:
       id: NCBITaxon:179
       label: Leptospirillum
+    gtdb_classification:
+      gtdb_id: GTDB:g__Leptospirillum
+      gtdb_taxon: Leptospirillum
+      gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum
+      ncbi_source_id: NCBITaxon:179
+      majority_fraction: 0.575
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: 'Iron-oxidizing chemolithoautotroph present in the chemocline and upper layers of stratified
       pit lakes. Leptospirillum oxidizes ferrous iron (Fe²⁺) to ferric iron (Fe³⁺) for energy at extremely
       low pH (1.5-3.0), fixing CO₂ autotrophically via the Calvin-Benson-Bassham cycle. In the chemocline,
@@ -77,6 +85,14 @@ taxonomy:
     term:
       id: NCBITaxon:920
       label: Acidithiobacillus ferrooxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidithiobacillus_ferrooxidans
+      gtdb_taxon: Acidithiobacillus ferrooxidans
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
+      ncbi_source_id: NCBITaxon:920
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Metabolically versatile chemolithoautotroph capable of both iron and sulfur oxidation in the
       oxic layers of stratified pit lakes. At. ferrooxidans oxidizes Fe²⁺ to Fe³⁺ and reduced sulfur compounds
       (sulfide, elemental sulfur, thiosulfate) to sulfuric acid, contributing to acidification and metal
@@ -102,6 +118,14 @@ taxonomy:
     term:
       id: NCBITaxon:522
       label: Acidiphilium
+    gtdb_classification:
+      gtdb_id: GTDB:g__UBA10281
+      gtdb_taxon: UBA10281
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Christensenellales;f__Borkfalkiaceae;g__UBA10281
+      ncbi_source_id: NCBITaxon:522
+      majority_fraction: 0.633
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Facultatively heterotrophic acidophilic bacterium that consumes algal-derived organic carbon
       in the oxic surface layers of stratified pit lakes. Acidiphilium is a mixotrophic genus capable
       of both aerobic respiration on organic compounds and facultative iron reduction under microaerobic
@@ -132,6 +156,14 @@ taxonomy:
     term:
       id: NCBITaxon:2357
       label: Desulfomonile
+    gtdb_classification:
+      gtdb_id: GTDB:g__Desulfomonile
+      gtdb_taxon: Desulfomonile
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfomonilia;o__Desulfomonilales;f__Desulfomonilaceae;g__Desulfomonile
+      ncbi_source_id: NCBITaxon:2357
+      majority_fraction: 0.667
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Dominant sulfate-reducing bacterium in the chemocline (~11m depth), representing 43% of amplicon
       sequence variants in this critical transition zone. Desulfomonile performs dissimilatory sulfate
       reduction coupled to organic carbon oxidation, producing hydrogen sulfide (peak concentration 120
@@ -198,6 +230,14 @@ taxonomy:
     term:
       id: NCBITaxon:2301
       label: Thermoplasmatales
+    gtdb_classification:
+      gtdb_id: GTDB:o__Thermoplasmatales
+      gtdb_taxon: Thermoplasmatales
+      gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales
+      ncbi_source_id: NCBITaxon:2301
+      majority_fraction: 0.903
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at o__ rank; 9 GTDB taxa under the NCBI taxon]
     notes: 'Dominant archaeal heterotrophs in the deep anoxic monimolimnion, representing 46% ± 2.5% of
       total sequences and serving as the primary carbon scavengers in this extreme environment (pH 3.0-4.5,
       no oxygen, high metals). Thermoplasmatales utilize organic carbon that settles from upper layers,
@@ -237,6 +277,14 @@ taxonomy:
     term:
       id: NCBITaxon:2172
       label: Methanobrevibacter
+    gtdb_classification:
+      gtdb_id: GTDB:g__Methanobrevibacter_A
+      gtdb_taxon: Methanobrevibacter_A
+      gtdb_lineage: d__Archaea;p__Methanobacteriota;c__Methanobacteria;o__Methanobacteriales;f__Methanobacteriaceae;g__Methanobrevibacter_A
+      ncbi_source_id: NCBITaxon:2172
+      majority_fraction: 0.955
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 8 GTDB taxa under the NCBI taxon]
     notes: 'Hydrogenotrophic methanogen detected in the deep anoxic monimolimnion and subsurface sediments
       of Iberian Pyrite Belt systems. Methanobrevibacter belongs to the class Methanobacteria and produces
       methane from H₂ and CO₂ (4H₂ + CO₂ → CH₄ + 2H₂O) under strictly anaerobic conditions. While detected

--- a/kb/communities/Industrial_Bioreactor_Consortium.yaml
+++ b/kb/communities/Industrial_Bioreactor_Consortium.yaml
@@ -63,6 +63,14 @@ taxonomy:
     term:
       id: NCBITaxon:33059
       label: Acidithiobacillus caldus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidithiobacillus_A_caldus
+      gtdb_taxon: Acidithiobacillus_A caldus
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus_A;s__Acidithiobacillus_A caldus
+      ncbi_source_id: NCBITaxon:33059
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Moderately thermophilic chemolithoautotrophic bacterium that oxidizes ferrous iron (Fe²⁺)
       and reduced inorganic sulfur compounds (RISCs) including elemental sulfur, thiosulfate, tetrathionate,
       and sulfide. Optimum temperature 40-50°C with activity up to 52°C, significantly higher than mesophilic
@@ -109,6 +117,14 @@ taxonomy:
     term:
       id: NCBITaxon:74969
       label: Ferroplasma acidiphilum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Ferroplasma_acidarmanus
+      gtdb_taxon: Ferroplasma acidarmanus
+      gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales;f__Thermoplasmataceae;g__Ferroplasma;s__Ferroplasma acidarmanus
+      ncbi_source_id: NCBITaxon:74969
+      majority_fraction: 0.91
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Extremely acidophilic, cell wall-lacking archaeon (Thermoplasmatales, Ferroplasmaceae) that
       oxidizes ferrous iron at pH as low as 1.0-1.5. This pleomorphic organism thrives in late-stage reactor
       conditions when pH drops below 2.0 and Fe³⁺ concentrations increase to >15 g/L. Ferroplasma species
@@ -288,6 +304,14 @@ taxonomy:
     term:
       id: NCBITaxon:453960
       label: Sulfobacillus benefaciens
+    gtdb_classification:
+      gtdb_id: GTDB:s__Sulfobacillus_benefaciens
+      gtdb_taxon: Sulfobacillus benefaciens
+      gtdb_lineage: d__Bacteria;p__Bacillota_E;c__Sulfobacillia;o__Sulfobacillales;f__Sulfobacillaceae;g__Sulfobacillus;s__Sulfobacillus benefaciens
+      ncbi_source_id: NCBITaxon:453960
+      majority_fraction: 0.96
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Gram-positive, moderately thermophilic (optimum 45-50°C), facultatively autotrophic bacterium
       that oxidizes both ferrous iron and reduced sulfur compounds. Spore-forming capability provides
       resilience to environmental stress, toxic metals, and nutrient limitation. Grows mixotrophically
@@ -318,6 +342,14 @@ taxonomy:
     term:
       id: NCBITaxon:178606
       label: Leptospirillum ferriphilum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Leptospirillum_A_rubarum
+      gtdb_taxon: Leptospirillum_A rubarum
+      gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
+      ncbi_source_id: NCBITaxon:178606
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Obligate chemolithoautotrophic iron-oxidizing bacterium (Nitrospirae) specialized for extremely
       acidic environments. Highly efficient at colonizing sulfide mineral surfaces and oxidizing Fe²⁺
       at pH approaching 1.5. In moderate thermophilic bioleaching, L. ferriphilum is sensitive to elevated

--- a/kb/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.yaml
+++ b/kb/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.yaml
@@ -41,6 +41,14 @@ taxonomy:
     term:
       id: NCBITaxon:1064
       label: Rhodocyclus
+    gtdb_classification:
+      gtdb_id: GTDB:g__Rhodocyclus
+      gtdb_taxon: Rhodocyclus
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Rhodocyclaceae;g__Rhodocyclus
+      ncbi_source_id: NCBITaxon:1064
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Source strain CCL5 was identified to genus level as Rhodocyclus sp.; genus-level taxonomy is
       used because the source did not assign a species.
   strain_designation:

--- a/kb/communities/Infant_Gut_DNA_Phage_Succession_Community.yaml
+++ b/kb/communities/Infant_Gut_DNA_Phage_Succession_Community.yaml
@@ -44,6 +44,14 @@ taxonomy:
     term:
       id: NCBITaxon:816
       label: Bacteroides
+    gtdb_classification:
+      gtdb_id: GTDB:g__Bacteroides
+      gtdb_taxon: Bacteroides
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides
+      ncbi_source_id: NCBITaxon:816
+      majority_fraction: 0.953
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 19 GTDB taxa under the NCBI taxon]
   evidence:
   - reference: PMID:38096814
     supports: SUPPORT

--- a/kb/communities/Infant_Gut_Strain_Persistence_Maternal_Community.yaml
+++ b/kb/communities/Infant_Gut_Strain_Persistence_Maternal_Community.yaml
@@ -26,6 +26,14 @@ taxonomy:
     term:
       id: NCBITaxon:816
       label: Bacteroides
+    gtdb_classification:
+      gtdb_id: GTDB:g__Bacteroides
+      gtdb_taxon: Bacteroides
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides
+      ncbi_source_id: NCBITaxon:816
+      majority_fraction: 0.953
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 19 GTDB taxa under the NCBI taxon]
     notes: Bacteroides is one of the two main genera among ~11 percent of
       early colonizers that persist through the first year of life.
   abundance_level: ABUNDANT
@@ -44,6 +52,14 @@ taxonomy:
     term:
       id: NCBITaxon:1678
       label: Bifidobacterium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Bifidobacterium
+      gtdb_taxon: Bifidobacterium
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium
+      ncbi_source_id: NCBITaxon:1678
+      majority_fraction: 0.998
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Bifidobacterium is the second main genus among ~11 percent of
       persistent early colonizers.
   abundance_level: ABUNDANT

--- a/kb/communities/Ion_Adsorption_REE_Indigenous_Community.yaml
+++ b/kb/communities/Ion_Adsorption_REE_Indigenous_Community.yaml
@@ -44,6 +44,14 @@ taxonomy:
     term:
       id: NCBITaxon:1224
       label: Pseudomonadota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Pseudomonadota
+      gtdb_taxon: Pseudomonadota
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota
+      ncbi_source_id: NCBITaxon:1224
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 14 GTDB taxa under the NCBI taxon]
     notes: 'Dominant bacterial phylum (46.9% average abundance) present along the entire weathering profile.
       Proteobacteria members include REE-dissolving genera such as Acinetobacter (5.06%) and Pseudomonas
       (1.25%) that facilitate bioweathering of REE-bearing minerals through organic acid production and
@@ -74,6 +82,14 @@ taxonomy:
     term:
       id: NCBITaxon:57723
       label: Acidobacteriota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Acidobacteriota
+      gtdb_taxon: Acidobacteriota
+      gtdb_lineage: d__Bacteria;p__Acidobacteriota
+      ncbi_source_id: NCBITaxon:57723
+      majority_fraction: 0.976
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: 'Second most abundant bacterial phylum (14.6%) exhibiting oligotrophic K-strategist lifestyle
       adaptations for survival in low-nutrient weathering environments. Acidobacteria are slow-growing
       specialists that thrive in nutrient-depleted regolith-hosted deposits, contributing to long-term
@@ -107,6 +123,14 @@ taxonomy:
     term:
       id: NCBITaxon:201174
       label: Actinomycetota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Actinomycetota
+      gtdb_taxon: Actinomycetota
+      gtdb_lineage: d__Bacteria;p__Actinomycetota
+      ncbi_source_id: NCBITaxon:201174
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 6 GTDB taxa under the NCBI taxon]
     notes: 'Third most abundant bacterial phylum (9.0%) contributing to bioweathering and REE mobilization
       through organic acid secretion and mineral dissolution. Actinobacteria are well-known producers
       of diverse secondary metabolites, organic acids, and extracellular enzymes that facilitate rock
@@ -131,6 +155,14 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_classification:
+      gtdb_id: GTDB:g__Bacillus
+      gtdb_taxon: Bacillus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
+      ncbi_source_id: NCBITaxon:1386
+      majority_fraction: 0.508
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive Firmicutes genus demonstrating exceptional HREE selectivity through teichoic
       acid binding. Bacillus pumilus exhibited 77.6% REE adsorption efficiency with preferential HREE
       uptake (82.9%) versus LREE (69.8%), showing a characteristic "leftward-inclined curve" favoring
@@ -170,6 +202,14 @@ taxonomy:
     term:
       id: NCBITaxon:1269
       label: Micrococcus
+    gtdb_classification:
+      gtdb_id: GTDB:g__Micrococcus
+      gtdb_taxon: Micrococcus
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Micrococcaceae;g__Micrococcus
+      ncbi_source_id: NCBITaxon:1269
+      majority_fraction: 0.997
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive Actinobacteria genus exhibiting the highest HREE selectivity among tested strains.
       Micrococcus sp. achieved 82.4% overall REE adsorption efficiency with 85.1% HREE uptake versus 78.2%
       LREE, demonstrating stronger HREE preference than even Bacillus. Like Bacillus, Micrococcus cell

--- a/kb/communities/Jala_Maize_PGPB_SynCom.yaml
+++ b/kb/communities/Jala_Maize_PGPB_SynCom.yaml
@@ -35,6 +35,14 @@ taxonomy:
     term:
       id: NCBITaxon:380021
       label: Pseudomonas protegens
+    gtdb_classification:
+      gtdb_id: GTDB:s__Pseudomonas_E_protegens
+      gtdb_taxon: Pseudomonas_E protegens
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas_E;s__Pseudomonas_E protegens
+      ncbi_source_id: NCBITaxon:380021
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -44,6 +52,14 @@ taxonomy:
     term:
       id: NCBITaxon:553
       label: Pantoea ananatis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Pantoea_ananatis
+      gtdb_taxon: Pantoea ananatis
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Pantoea;s__Pantoea ananatis
+      ncbi_source_id: NCBITaxon:553
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -53,6 +69,14 @@ taxonomy:
     term:
       id: NCBITaxon:244366
       label: Klebsiella variicola
+    gtdb_classification:
+      gtdb_id: GTDB:s__Klebsiella_variicola
+      gtdb_taxon: Klebsiella variicola
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Klebsiella;s__Klebsiella variicola
+      ncbi_source_id: NCBITaxon:244366
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -62,6 +86,14 @@ taxonomy:
     term:
       id: NCBITaxon:32008
       label: Burkholderia
+    gtdb_classification:
+      gtdb_id: GTDB:g__Burkholderia
+      gtdb_taxon: Burkholderia
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Burkholderia
+      ncbi_source_id: NCBITaxon:32008
+      majority_fraction: 0.985
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/KB1_Chlorinated_Ethene_Dechlorinating_Consortium.yaml
+++ b/kb/communities/KB1_Chlorinated_Ethene_Dechlorinating_Consortium.yaml
@@ -38,6 +38,14 @@ taxonomy:
     term:
       id: NCBITaxon:61434
       label: Dehalococcoides
+    gtdb_classification:
+      gtdb_id: GTDB:g__Dehalococcoides
+      gtdb_taxon: Dehalococcoides
+      gtdb_lineage: d__Bacteria;p__Chloroflexota;c__Dehalococcoidia;o__Dehalococcoidales;f__Dehalococcoidaceae;g__Dehalococcoides
+      ncbi_source_id: NCBITaxon:61434
+      majority_fraction: 0.909
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Organohalide-respiring bacteria responsible for dechlorination beyond cis-DCE to ethene.
   functional_role:
   - PRIMARY_DEGRADER
@@ -57,6 +65,14 @@ taxonomy:
     term:
       id: NCBITaxon:33952
       label: Acetobacterium woodii
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acetobacterium_woodii
+      gtdb_taxon: Acetobacterium woodii
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Eubacteriales;f__Eubacteriaceae;g__Acetobacterium;s__Acetobacterium woodii
+      ncbi_source_id: NCBITaxon:33952
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Dominant acetogen in KB-1 low-pH and vitamin-perturbation experiments; supports cobamide availability.
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -71,6 +87,14 @@ taxonomy:
     term:
       id: NCBITaxon:2375
       label: Sporomusa
+    gtdb_classification:
+      gtdb_id: GTDB:g__Sporomusa
+      gtdb_taxon: Sporomusa
+      gtdb_lineage: d__Bacteria;p__Bacillota_C;c__Negativicutes;o__Sporomusales;f__Sporomusaceae;g__Sporomusa
+      ncbi_source_id: NCBITaxon:2375
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Acetogenic KB-1 member reported with Acetobacterium in cultures lacking exogenous vitamins.
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/KBase_Models_for_Zahmeeth_Original_PLOS.yaml
+++ b/kb/communities/KBase_Models_for_Zahmeeth_Original_PLOS.yaml
@@ -44,6 +44,14 @@ taxonomy:
     term:
       id: NCBITaxon:562
       label: Escherichia coli
+    gtdb_classification:
+      gtdb_id: GTDB:s__Escherichia_coli
+      gtdb_taxon: Escherichia coli
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
+      ncbi_source_id: NCBITaxon:562
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -70,6 +78,14 @@ taxonomy:
     term:
       id: NCBITaxon:818
       label: Bacteroides thetaiotaomicron
+    gtdb_classification:
+      gtdb_id: GTDB:s__Bacteroides_thetaiotaomicron
+      gtdb_taxon: Bacteroides thetaiotaomicron
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides;s__Bacteroides thetaiotaomicron
+      ncbi_source_id: NCBITaxon:818
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:
@@ -83,6 +99,14 @@ taxonomy:
     term:
       id: NCBITaxon:570
       label: Klebsiella
+    gtdb_classification:
+      gtdb_id: GTDB:g__Klebsiella
+      gtdb_taxon: Klebsiella
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Klebsiella
+      ncbi_source_id: NCBITaxon:570
+      majority_fraction: 0.999
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/KBase_ORT_Workflow_Community_Model.yaml
+++ b/kb/communities/KBase_ORT_Workflow_Community_Model.yaml
@@ -62,6 +62,14 @@ taxonomy:
     term:
       id: NCBITaxon:1236
       label: Gammaproteobacteria
+    gtdb_classification:
+      gtdb_id: GTDB:c__Gammaproteobacteria
+      gtdb_taxon: Gammaproteobacteria
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria
+      ncbi_source_id: NCBITaxon:1236
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at c__ rank; 7 GTDB taxa under the NCBI taxon]
     notes: Bacterial member of Nitrospiraceae family from Columbia River sediments. Functions as nitrite
       oxidizer in the nitrogen cycle.
   functional_role:

--- a/kb/communities/KBase_Synthetic_Bacterial_Community_R2A.yaml
+++ b/kb/communities/KBase_Synthetic_Bacterial_Community_R2A.yaml
@@ -33,6 +33,14 @@ taxonomy:
     term:
       id: NCBITaxon:53335
       label: Pantoea
+    gtdb_classification:
+      gtdb_id: GTDB:g__Pantoea
+      gtdb_taxon: Pantoea
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Pantoea
+      ncbi_source_id: NCBITaxon:53335
+      majority_fraction: 0.961
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 15 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: YR343
   abundance_level: DOMINANT
@@ -52,6 +60,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: CF313
   functional_role:

--- a/kb/communities/Kombucha_KMC_IMBG1_Fermentation_Community.yaml
+++ b/kb/communities/Kombucha_KMC_IMBG1_Fermentation_Community.yaml
@@ -22,6 +22,14 @@ taxonomy:
     term:
       id: NCBITaxon:1434011
       label: Komagataeibacter
+    gtdb_classification:
+      gtdb_id: GTDB:g__Komagataeibacter
+      gtdb_taxon: Komagataeibacter
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Komagataeibacter
+      ncbi_source_id: NCBITaxon:1434011
+      majority_fraction: 0.973
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Acetobacterial core member reported as the current genus name for former Gluconacetobacter
       isolates in KMC-IMBG1.
   abundance_level: DOMINANT
@@ -38,6 +46,14 @@ taxonomy:
     term:
       id: NCBITaxon:441
       label: Gluconobacter
+    gtdb_classification:
+      gtdb_id: GTDB:g__Gluconobacter
+      gtdb_taxon: Gluconobacter
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Gluconobacter
+      ncbi_source_id: NCBITaxon:441
+      majority_fraction: 0.71
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Acetobacterial core member of the KMC-IMBG1 kombucha culture.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml
+++ b/kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml
@@ -81,6 +81,14 @@ taxonomy:
     term:
       id: NCBITaxon:403
       label: Methylococcaceae
+    gtdb_classification:
+      gtdb_id: GTDB:f__Methylococcaceae
+      gtdb_taxon: Methylococcaceae
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylococcaceae
+      ncbi_source_id: NCBITaxon:403
+      majority_fraction: 0.505
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at f__ rank; 6 GTDB taxa under the NCBI taxon]
     notes: >
       Type I methanotroph family represented in methane-consuming Lake
       Washington sediment microcosms; includes oxygen-dependent genera such as
@@ -104,6 +112,14 @@ taxonomy:
     term:
       id: NCBITaxon:32011
       label: Methylophilaceae
+    gtdb_classification:
+      gtdb_id: GTDB:f__Methylophilaceae
+      gtdb_taxon: Methylophilaceae
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Methylophilaceae
+      ncbi_source_id: NCBITaxon:32011
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at f__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: >
       Non-methane-oxidizing methylotrophic family that co-enriches with
       Methylococcaceae in methane-fed Lake Washington sediment microcosms.
@@ -126,6 +142,14 @@ taxonomy:
     term:
       id: NCBITaxon:429
       label: Methylobacter
+    gtdb_classification:
+      gtdb_id: GTDB:g__Methylobacter_A
+      gtdb_taxon: Methylobacter_A
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylomonadaceae;g__Methylobacter_A
+      ncbi_source_id: NCBITaxon:429
+      majority_fraction: 0.662
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Low-oxygen methanotrophic genus in Lake Washington methane-fed microcosms.
   functional_role:
   - PRIMARY_DEGRADER
@@ -146,6 +170,14 @@ taxonomy:
     term:
       id: NCBITaxon:359407
       label: Methylotenera
+    gtdb_classification:
+      gtdb_id: GTDB:g__Methylotenera
+      gtdb_taxon: Methylotenera
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Methylophilaceae;g__Methylotenera
+      ncbi_source_id: NCBITaxon:359407
+      majority_fraction: 0.676
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Low-oxygen non-methanotrophic methylotroph genus partnered with Methylobacter.
   functional_role:
   - CROSS_FEEDER
@@ -168,6 +200,14 @@ taxonomy:
     term:
       id: NCBITaxon:416
       label: Methylomonas
+    gtdb_classification:
+      gtdb_id: GTDB:g__Methylomonas
+      gtdb_taxon: Methylomonas
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylomonadaceae;g__Methylomonas
+      ncbi_source_id: NCBITaxon:416
+      majority_fraction: 0.948
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Methanotrophic genus included in genome-scale modeling of the Lake Washington methane-cycling community.
   functional_role:
   - PRIMARY_DEGRADER
@@ -182,6 +222,14 @@ taxonomy:
     term:
       id: NCBITaxon:105972
       label: Methylosarcina fibrata
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methylosarcina_fibrata
+      gtdb_taxon: Methylosarcina fibrata
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylomonadaceae;g__Methylosarcina;s__Methylosarcina fibrata
+      ncbi_source_id: NCBITaxon:105972
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Higher-oxygen methanotrophic genus in Lake Washington methane-fed microcosms.
   functional_role:
   - PRIMARY_DEGRADER
@@ -196,6 +244,14 @@ taxonomy:
     term:
       id: NCBITaxon:16
       label: Methylophilus
+    gtdb_classification:
+      gtdb_id: GTDB:g__Methylophilus
+      gtdb_taxon: Methylophilus
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Methylophilaceae;g__Methylophilus
+      ncbi_source_id: NCBITaxon:16
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Higher-oxygen non-methanotrophic methylotroph genus partnered with Methylosarcina.
   functional_role:
   - CROSS_FEEDER

--- a/kb/communities/Lotus_LjSC3.yaml
+++ b/kb/communities/Lotus_LjSC3.yaml
@@ -47,6 +47,14 @@ taxonomy:
     term:
       id: NCBITaxon:68287
       label: Mesorhizobium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Mesorhizobium
+      gtdb_taxon: Mesorhizobium
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Mesorhizobium
+      ncbi_source_id: NCBITaxon:68287
+      majority_fraction: 0.97
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 17 GTDB taxa under the NCBI taxon]
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_PRODUCER
@@ -140,6 +148,14 @@ taxonomy:
     term:
       id: NCBITaxon:75682
       label: Oxalobacteraceae
+    gtdb_classification:
+      gtdb_id: GTDB:f__Burkholderiaceae
+      gtdb_taxon: Burkholderiaceae
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae
+      ncbi_source_id: NCBITaxon:75682
+      majority_fraction: 0.995
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at f__ rank; 3 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/MAMC_M48_Lignocellulose.yaml
+++ b/kb/communities/MAMC_M48_Lignocellulose.yaml
@@ -83,6 +83,14 @@ taxonomy:
     term:
       id: NCBITaxon:363331
       label: Chryseobacterium taiwanense
+    gtdb_classification:
+      gtdb_id: GTDB:s__Chryseobacterium_taiwanense
+      gtdb_taxon: Chryseobacterium taiwanense
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Flavobacteriales;f__Weeksellaceae;g__Chryseobacterium;s__Chryseobacterium taiwanense
+      ncbi_source_id: NCBITaxon:363331
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/MSC1_Dominant_Core.yaml
+++ b/kb/communities/MSC1_Dominant_Core.yaml
@@ -22,6 +22,14 @@ taxonomy:
     term:
       id: NCBITaxon:1827
       label: Rhodococcus <high G+C Gram-positive bacteria>
+    gtdb_classification:
+      gtdb_id: GTDB:g__Rhodococcus
+      gtdb_taxon: Rhodococcus
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Rhodococcus
+      ncbi_source_id: NCBITaxon:1827
+      majority_fraction: 0.996
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -50,6 +58,14 @@ taxonomy:
     term:
       id: NCBITaxon:1914288
       label: Dyadobacter sp.
+    gtdb_classification:
+      gtdb_id: GTDB:s__Dyadobacter_sp017744695
+      gtdb_taxon: Dyadobacter sp017744695
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Cytophagales;f__Spirosomataceae;g__Dyadobacter;s__Dyadobacter sp017744695
+      ncbi_source_id: NCBITaxon:1914288
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -78,6 +94,14 @@ taxonomy:
     term:
       id: NCBITaxon:169215
       label: Bosea
+    gtdb_classification:
+      gtdb_id: GTDB:g__Bosea
+      gtdb_taxon: Bosea
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Bosea
+      ncbi_source_id: NCBITaxon:169215
+      majority_fraction: 0.981
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -92,6 +116,14 @@ taxonomy:
     term:
       id: NCBITaxon:1911909
       label: Neorhizobium sp.
+    gtdb_classification:
+      gtdb_id: GTDB:s__Neorhizobium_sp028283725
+      gtdb_taxon: Neorhizobium sp028283725
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Neorhizobium;s__Neorhizobium sp028283725
+      ncbi_source_id: NCBITaxon:1911909
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -149,6 +181,14 @@ taxonomy:
     term:
       id: NCBITaxon:42445
       label: Sinorhizobium sp.
+    gtdb_classification:
+      gtdb_id: GTDB:s__Sinorhizobium_sp031178305
+      gtdb_taxon: Sinorhizobium sp031178305
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Sinorhizobium;s__Sinorhizobium sp031178305
+      ncbi_source_id: NCBITaxon:42445
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -177,6 +217,14 @@ taxonomy:
     term:
       id: NCBITaxon:201174
       label: Actinomycetota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Actinomycetota
+      gtdb_taxon: Actinomycetota
+      gtdb_lineage: d__Bacteria;p__Actinomycetota
+      ncbi_source_id: NCBITaxon:201174
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 6 GTDB taxa under the NCBI taxon]
   abundance_level: RARE
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -192,6 +240,14 @@ taxonomy:
     term:
       id: NCBITaxon:976
       label: Bacteroidota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Bacteroidota
+      gtdb_taxon: Bacteroidota
+      gtdb_lineage: d__Bacteria;p__Bacteroidota
+      ncbi_source_id: NCBITaxon:976
+      majority_fraction: 0.999
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 8 GTDB taxa under the NCBI taxon]
   abundance_level: RARE
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/MSC2_Model_Soil_Consortium.yaml
+++ b/kb/communities/MSC2_Model_Soil_Consortium.yaml
@@ -58,6 +58,14 @@ taxonomy:
     term:
       id: NCBITaxon:2093828
       label: Neorhizobium tomejilense
+    gtdb_classification:
+      gtdb_id: GTDB:s__Neorhizobium_tomejilense
+      gtdb_taxon: Neorhizobium tomejilense
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Neorhizobium;s__Neorhizobium tomejilense
+      ncbi_source_id: NCBITaxon:2093828
+      majority_fraction: 0.9
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   strain_designation:
     strain_name: MSC1_005
     genome_accession: GCA_023667605.1
@@ -69,6 +77,14 @@ taxonomy:
     term:
       id: NCBITaxon:1914288
       label: Dyadobacter sp.
+    gtdb_classification:
+      gtdb_id: GTDB:s__Dyadobacter_sp017744695
+      gtdb_taxon: Dyadobacter sp017744695
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Cytophagales;f__Spirosomataceae;g__Dyadobacter;s__Dyadobacter sp017744695
+      ncbi_source_id: NCBITaxon:1914288
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   strain_designation:
     strain_name: MSC1_007
     genome_accession: GCA_023667495.1
@@ -91,6 +107,14 @@ taxonomy:
     term:
       id: NCBITaxon:106592
       label: Ensifer adhaerens
+    gtdb_classification:
+      gtdb_id: GTDB:s__Ensifer_canadensis
+      gtdb_taxon: Ensifer canadensis
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Ensifer;s__Ensifer canadensis
+      ncbi_source_id: NCBITaxon:106592
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:
     strain_name: MSC1_011
     genome_accession: GCA_023667555.1
@@ -114,6 +138,14 @@ taxonomy:
     term:
       id: NCBITaxon:382
       label: Sinorhizobium meliloti
+    gtdb_classification:
+      gtdb_id: GTDB:s__Sinorhizobium_meliloti
+      gtdb_taxon: Sinorhizobium meliloti
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Sinorhizobium;s__Sinorhizobium meliloti
+      ncbi_source_id: NCBITaxon:382
+      majority_fraction: 0.97
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   strain_designation:
     strain_name: MSC1_014
     genome_accession: GCA_023197145.1
@@ -125,6 +157,14 @@ taxonomy:
     term:
       id: NCBITaxon:1827
       label: Rhodococcus <high G+C Gram-positive bacteria>
+    gtdb_classification:
+      gtdb_id: GTDB:g__Rhodococcus
+      gtdb_taxon: Rhodococcus
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Rhodococcus
+      ncbi_source_id: NCBITaxon:1827
+      majority_fraction: 0.996
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: MSC1_016
     genome_accession: GCA_023667485.1

--- a/kb/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.yaml
+++ b/kb/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.yaml
@@ -74,6 +74,14 @@ taxonomy:
     term:
       id: NCBITaxon:395331
       label: Methanoregula
+    gtdb_classification:
+      gtdb_id: GTDB:g__Methanoregula
+      gtdb_taxon: Methanoregula
+      gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanoregula
+      ncbi_source_id: NCBITaxon:395331
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Methanoregula is curated at genus level because the study reports it
       as a hub methanogen across networks and a predictor of methane flux.
   functional_role:

--- a/kb/communities/Maize_Root_Simplified_Community.yaml
+++ b/kb/communities/Maize_Root_Simplified_Community.yaml
@@ -122,6 +122,14 @@ taxonomy:
     term:
       id: NCBITaxon:92645
       label: Herbaspirillum frisingense
+    gtdb_classification:
+      gtdb_id: GTDB:s__Herbaspirillum_frisingense
+      gtdb_taxon: Herbaspirillum frisingense
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Herbaspirillum;s__Herbaspirillum frisingense
+      ncbi_source_id: NCBITaxon:92645
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -146,6 +154,14 @@ taxonomy:
     term:
       id: NCBITaxon:253
       label: Chryseobacterium indologenes
+    gtdb_classification:
+      gtdb_id: GTDB:s__Chryseobacterium_indologenes
+      gtdb_taxon: Chryseobacterium indologenes
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Flavobacteriales;f__Weeksellaceae;g__Chryseobacterium;s__Chryseobacterium indologenes
+      ncbi_source_id: NCBITaxon:253
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Medicago_Nodule_Biofertilizer_SynCom.yaml
+++ b/kb/communities/Medicago_Nodule_Biofertilizer_SynCom.yaml
@@ -38,6 +38,14 @@ taxonomy:
     term:
       id: NCBITaxon:106591
       label: Ensifer
+    gtdb_classification:
+      gtdb_id: GTDB:g__Ensifer
+      gtdb_taxon: Ensifer
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Ensifer
+      ncbi_source_id: NCBITaxon:106591
+      majority_fraction: 0.745
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
+++ b/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
@@ -32,6 +32,14 @@ taxonomy:
     term:
       id: NCBITaxon:1224
       label: Pseudomonadota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Pseudomonadota
+      gtdb_taxon: Pseudomonadota
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota
+      ncbi_source_id: NCBITaxon:1224
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 14 GTDB taxa under the NCBI taxon]
     notes: 'Multiple MAGs representing Proteobacteria were reconstructed from EFPC sediment metagenomes.
       Several contained heavy metal resistance genes.
 
@@ -53,6 +61,14 @@ taxonomy:
     term:
       id: NCBITaxon:57723
       label: Acidobacteriota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Acidobacteriota
+      gtdb_taxon: Acidobacteriota
+      gtdb_lineage: d__Bacteria;p__Acidobacteriota
+      ncbi_source_id: NCBITaxon:57723
+      majority_fraction: 0.976
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: MAGs from this phylum were recovered from EFPC sediment metagenomes.
   functional_role:
   - PRIMARY_DEGRADER
@@ -71,6 +87,14 @@ taxonomy:
     term:
       id: NCBITaxon:201174
       label: Actinomycetota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Actinomycetota
+      gtdb_taxon: Actinomycetota
+      gtdb_lineage: d__Bacteria;p__Actinomycetota
+      ncbi_source_id: NCBITaxon:201174
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 6 GTDB taxa under the NCBI taxon]
     notes: MAGs from this phylum were recovered from EFPC sediment metagenomes.
   functional_role:
   - PRIMARY_DEGRADER
@@ -89,6 +113,14 @@ taxonomy:
     term:
       id: NCBITaxon:142182
       label: Gemmatimonadota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Gemmatimonadota
+      gtdb_taxon: Gemmatimonadota
+      gtdb_lineage: d__Bacteria;p__Gemmatimonadota
+      ncbi_source_id: NCBITaxon:142182
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: MAGs from this phylum were recovered from EFPC sediment metagenomes.
   functional_role:
   - PRIMARY_DEGRADER
@@ -124,6 +156,14 @@ taxonomy:
     term:
       id: NCBITaxon:2818505
       label: Myxococcota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Myxococcota
+      gtdb_taxon: Myxococcota
+      gtdb_lineage: d__Bacteria;p__Myxococcota
+      ncbi_source_id: NCBITaxon:2818505
+      majority_fraction: 0.903
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: MAGs from this phylum were recovered from EFPC sediment metagenomes.
   functional_role:
   - PRIMARY_DEGRADER
@@ -142,6 +182,14 @@ taxonomy:
     term:
       id: NCBITaxon:28889
       label: Thermoproteota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Thermoproteota
+      gtdb_taxon: Thermoproteota
+      gtdb_lineage: d__Archaea;p__Thermoproteota
+      ncbi_source_id: NCBITaxon:28889
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Archaeal MAGs recovered from EFPC sediment metagenomes.
   functional_role:
   - PRIMARY_DEGRADER
@@ -181,6 +229,14 @@ taxonomy:
     term:
       id: NCBITaxon:71518
       label: Methanocorpusculum bavaricum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methanocorpusculum_parvum
+      gtdb_taxon: Methanocorpusculum parvum
+      gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanocorpusculaceae;g__Methanocorpusculum;s__Methanocorpusculum parvum
+      ncbi_source_id: NCBITaxon:71518
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Confirmed hgcAB+ mercury methylator. Demonstrated methylmercury production in pure culture.
 
       '
@@ -201,6 +257,14 @@ taxonomy:
     term:
       id: NCBITaxon:2201
       label: Methanofollis liminatans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methanofollis_liminatans
+      gtdb_taxon: Methanofollis liminatans
+      gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanofollaceae;g__Methanofollis;s__Methanofollis liminatans
+      ncbi_source_id: NCBITaxon:2201
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Confirmed hgcAB+ mercury methylator. Demonstrated methylmercury production in pure culture.
 
       '
@@ -221,6 +285,14 @@ taxonomy:
     term:
       id: NCBITaxon:475088
       label: Methanosphaerula palustris
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methanosphaerula_palustris
+      gtdb_taxon: Methanosphaerula palustris
+      gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanosphaerula;s__Methanosphaerula palustris
+      ncbi_source_id: NCBITaxon:475088
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Confirmed hgcAB+ mercury methylator. Demonstrated methylmercury production in pure culture.
 
       '

--- a/kb/communities/Methane_Oxidation_CrVI_Reduction_SynCom.yaml
+++ b/kb/communities/Methane_Oxidation_CrVI_Reduction_SynCom.yaml
@@ -35,6 +35,14 @@ taxonomy:
     term:
       id: NCBITaxon:133
       label: Methylocystis
+    gtdb_classification:
+      gtdb_id: GTDB:g__Methylocystis
+      gtdb_taxon: Methylocystis
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Methylocystis
+      ncbi_source_id: NCBITaxon:133
+      majority_fraction: 0.952
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -53,6 +61,14 @@ taxonomy:
     term:
       id: NCBITaxon:919
       label: Thiobacillus
+    gtdb_classification:
+      gtdb_id: GTDB:g__Thiobacillus
+      gtdb_taxon: Thiobacillus
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Thiobacillaceae;g__Thiobacillus
+      ncbi_source_id: NCBITaxon:919
+      majority_fraction: 0.714
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.yaml
+++ b/kb/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.yaml
@@ -48,6 +48,14 @@ taxonomy:
     term:
       id: NCBITaxon:511746
       label: Candidatus Methylacidiphilum infernorum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methylacidiphilum_infernorum
+      gtdb_taxon: Methylacidiphilum infernorum
+      gtdb_lineage: d__Bacteria;p__Verrucomicrobiota;c__Verrucomicrobiae;o__Methylacidiphilales;f__Methylacidiphilaceae;g__Methylacidiphilum;s__Methylacidiphilum infernorum
+      ncbi_source_id: NCBITaxon:511746
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: NCBI Taxonomy lists Methylacidiphilum sp. RTK17.1 under Candidatus Methylacidiphilum
       infernorum.
   strain_designation:

--- a/kb/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.yaml
+++ b/kb/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.yaml
@@ -48,6 +48,14 @@ taxonomy:
     term:
       id: NCBITaxon:1432792
       label: Methylocaldum marinum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methylocaldum_marinum
+      gtdb_taxon: Methylocaldum marinum
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylococcaceae;g__Methylocaldum;s__Methylocaldum marinum
+      ncbi_source_id: NCBITaxon:1432792
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Marine methanotroph S8 that excretes acetate under both microaerobic and aerobic conditions.
   strain_designation:
     strain_name: S8
@@ -76,6 +84,14 @@ taxonomy:
     term:
       id: NCBITaxon:1218105
       label: Cupriavidus necator NBRC 102504
+    gtdb_classification:
+      gtdb_id: GTDB:s__Cupriavidus_necator_D
+      gtdb_taxon: Cupriavidus necator_D
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Cupriavidus;s__Cupriavidus necator_D
+      ncbi_source_id: NCBITaxon:1218105
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Non-methylotrophic acetate-utilizing partner selected for bioproduction relevance.
   strain_designation:
     strain_name: NBRC 102504

--- a/kb/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.yaml
+++ b/kb/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.yaml
@@ -45,6 +45,14 @@ taxonomy:
     term:
       id: NCBITaxon:1432792
       label: Methylocaldum marinum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methylocaldum_marinum
+      gtdb_taxon: Methylocaldum marinum
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylococcaceae;g__Methylocaldum;s__Methylocaldum marinum
+      ncbi_source_id: NCBITaxon:1432792
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Marine thermotolerant methane-oxidizing bacterium; type strain S8 is also listed by DSM and
       NBRC culture collections.
   strain_designation:
@@ -73,6 +81,14 @@ taxonomy:
     term:
       id: NCBITaxon:1384459
       label: Methyloceanibacter caenitepidi
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methyloceanibacter_caenitepidi
+      gtdb_taxon: Methyloceanibacter caenitepidi
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Methyloligellaceae;g__Methyloceanibacter;s__Methyloceanibacter caenitepidi
+      ncbi_source_id: NCBITaxon:1384459
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Facultative methylotroph isolated from marine sediment near a hydrothermal vent.
   strain_designation:
     strain_name: Gela4

--- a/kb/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.yaml
+++ b/kb/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.yaml
@@ -43,6 +43,14 @@ taxonomy:
     term:
       id: NCBITaxon:134
       label: Methylocystis parvus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methylocystis_parva
+      gtdb_taxon: Methylocystis parva
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Methylocystis;s__Methylocystis parva
+      ncbi_source_id: NCBITaxon:134
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: NCBI Taxonomy lists Methylocystis parvus at taxon 134; the PHBV study used
       M. parvus as the methanotrophic PHA-producing member.
   abundance_level: ABUNDANT

--- a/kb/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.yaml
+++ b/kb/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.yaml
@@ -56,6 +56,14 @@ taxonomy:
     term:
       id: NCBITaxon:1091494
       label: Methylotuvimicrobium alcaliphilum 20Z
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methylotuvimicrobium_alcaliphilum
+      gtdb_taxon: Methylotuvimicrobium alcaliphilum
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylomonadaceae;g__Methylotuvimicrobium;s__Methylotuvimicrobium alcaliphilum
+      ncbi_source_id: NCBITaxon:1091494
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: >
       The source publication uses Methylomicrobium alcaliphilum 20Z; NCBI
       Taxonomy records the strain as Methylotuvimicrobium alcaliphilum 20Z and

--- a/kb/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.yaml
+++ b/kb/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.yaml
@@ -47,6 +47,14 @@ taxonomy:
     term:
       id: NCBITaxon:1091494
       label: Methylotuvimicrobium alcaliphilum 20Z
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methylotuvimicrobium_alcaliphilum
+      gtdb_taxon: Methylotuvimicrobium alcaliphilum
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylomonadaceae;g__Methylotuvimicrobium;s__Methylotuvimicrobium alcaliphilum
+      ncbi_source_id: NCBITaxon:1091494
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Source publications use Methylomicrobium alcaliphilum 20z or 20ZR; NCBI Taxonomy
       records the strain under Methylotuvimicrobium alcaliphilum 20Z.
   strain_designation:
@@ -77,6 +85,14 @@ taxonomy:
     term:
       id: NCBITaxon:32049
       label: Picosynechococcus sp. PCC 7002
+    gtdb_classification:
+      gtdb_id: GTDB:s__Limnothrix_sp001693275
+      gtdb_taxon: Limnothrix sp001693275
+      gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Cyanobacteriales;f__MRBY01;g__Limnothrix;s__Limnothrix sp001693275
+      ncbi_source_id: NCBITaxon:32049
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Source publications use Synechococcus PCC 7002 or Synechococcus sp. PCC7002; NCBI
       currently labels taxon 32049 as Picosynechococcus sp. PCC 7002.
   strain_designation:

--- a/kb/communities/Microcoleus_Massilia_Cyanosphere_Urea_Mutualism.yaml
+++ b/kb/communities/Microcoleus_Massilia_Cyanosphere_Urea_Mutualism.yaml
@@ -69,6 +69,14 @@ taxonomy:
     term:
       id: NCBITaxon:149698
       label: Massilia
+    gtdb_classification:
+      gtdb_id: GTDB:g__Telluria
+      gtdb_taxon: Telluria
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Telluria
+      ncbi_source_id: NCBITaxon:149698
+      majority_fraction: 0.905
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Heterotrophic cyanosphere isolate METH4; curated at genus level because the papers report the
       isolate as Massilia sp. METH4.
   strain_designation:

--- a/kb/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.yaml
+++ b/kb/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.yaml
@@ -37,6 +37,14 @@ taxonomy:
     term:
       id: NCBITaxon:32008
       label: Burkholderia
+    gtdb_classification:
+      gtdb_id: GTDB:g__Burkholderia
+      gtdb_taxon: Burkholderia
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Burkholderia
+      ncbi_source_id: NCBITaxon:32008
+      majority_fraction: 0.985
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -46,6 +54,14 @@ taxonomy:
     term:
       id: NCBITaxon:1822464
       label: Paraburkholderia
+    gtdb_classification:
+      gtdb_id: GTDB:g__Paraburkholderia
+      gtdb_taxon: Paraburkholderia
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Paraburkholderia
+      ncbi_source_id: NCBITaxon:1822464
+      majority_fraction: 0.988
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -55,6 +71,14 @@ taxonomy:
     term:
       id: NCBITaxon:2034
       label: Curtobacterium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Curtobacterium
+      gtdb_taxon: Curtobacterium
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Microbacteriaceae;g__Curtobacterium
+      ncbi_source_id: NCBITaxon:2034
+      majority_fraction: 0.993
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -64,6 +88,14 @@ taxonomy:
     term:
       id: NCBITaxon:110932
       label: Leifsonia
+    gtdb_classification:
+      gtdb_id: GTDB:g__Leifsonia
+      gtdb_taxon: Leifsonia
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Microbacteriaceae;g__Leifsonia
+      ncbi_source_id: NCBITaxon:110932
+      majority_fraction: 0.75
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Mixed_Gallium_LED_Recovery_Consortium.yaml
+++ b/kb/communities/Mixed_Gallium_LED_Recovery_Consortium.yaml
@@ -62,6 +62,14 @@ taxonomy:
     term:
       id: NCBITaxon:930
       label: Acidithiobacillus thiooxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidithiobacillus_thiooxidans
+      gtdb_taxon: Acidithiobacillus thiooxidans
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus thiooxidans
+      ncbi_source_id: NCBITaxon:930
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Gram-negative γ-proteobacterium specialized for oxidizing elemental sulfur (S⁰) and reduced
       inorganic sulfur compounds to sulfuric acid. In this consortium, At. thiooxidans is present at equal
       ratio (1:1:1) with At. ferrooxidans and L. ferrooxidans, contributing to the generation of biogenic
@@ -101,6 +109,14 @@ taxonomy:
     term:
       id: NCBITaxon:920
       label: Acidithiobacillus ferrooxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidithiobacillus_ferrooxidans
+      gtdb_taxon: Acidithiobacillus ferrooxidans
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
+      ncbi_source_id: NCBITaxon:920
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Mesophilic γ-proteobacterium that oxidizes both ferrous iron (Fe²⁺) and reduced sulfur compounds.
       Present at equal ratio (1:1:1) in the mixed consortium, At. ferrooxidans generates ferric iron (Fe³⁺)
       that serves as a secondary oxidant for gallium mobilization from LED materials. This chemolithoautotroph
@@ -140,6 +156,14 @@ taxonomy:
     term:
       id: NCBITaxon:180
       label: Leptospirillum ferrooxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Leptospirillum_ferrooxidans
+      gtdb_taxon: Leptospirillum ferrooxidans
+      gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum;s__Leptospirillum ferrooxidans
+      ncbi_source_id: NCBITaxon:180
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Obligate iron-oxidizing bacterium (Nitrospirae phylum) specialized for Fe²⁺ oxidation at extremely
       low pH. Present at equal ratio (1:1:1) in the consortium, L. ferrooxidans contributes to ferric
       iron generation for gallium and base metal leaching from waste LEDs. This organism excels at operating

--- a/kb/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.yaml
+++ b/kb/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.yaml
@@ -56,6 +56,14 @@ taxonomy:
     term:
       id: NCBITaxon:1117
       label: Cyanobacteriota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Cyanobacteriota
+      gtdb_taxon: Cyanobacteriota
+      gtdb_lineage: d__Bacteria;p__Cyanobacteriota
+      ncbi_source_id: NCBITaxon:1117
+      majority_fraction: 0.998
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 5 GTDB taxa under the NCBI taxon]
     notes: Five well-characterized model cyanobacterial strains served as the
       phototrophic hosts; specific strain identities are not enumerated in the
       abstract.

--- a/kb/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.yaml
+++ b/kb/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.yaml
@@ -67,6 +67,14 @@ taxonomy:
     term:
       id: NCBITaxon:1708
       label: Cellulomonas fimi
+    gtdb_classification:
+      gtdb_id: GTDB:s__Cellulomonas_fimi
+      gtdb_taxon: Cellulomonas fimi
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Cellulomonadaceae;g__Cellulomonas;s__Cellulomonas fimi
+      ncbi_source_id: NCBITaxon:1708
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Source describes C. fimi as the cellulose degrader and formaldehyde-sensitive member.
   abundance_level: ABUNDANT
   functional_role:
@@ -87,6 +95,14 @@ taxonomy:
     term:
       id: NCBITaxon:408
       label: Methylorubrum extorquens
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methylobacterium_extorquens
+      gtdb_taxon: Methylobacterium extorquens
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Methylobacterium;s__Methylobacterium extorquens
+      ncbi_source_id: NCBITaxon:408
+      majority_fraction: 0.88
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Methylotrophic partner included to consume formaldehyde generated during aromatic-substrate
       breakdown.
   abundance_level: ABUNDANT

--- a/kb/communities/Mushroom_Spring_Hot_Spring_Phototrophic_Mat_Community.yaml
+++ b/kb/communities/Mushroom_Spring_Hot_Spring_Phototrophic_Mat_Community.yaml
@@ -48,6 +48,14 @@ taxonomy:
     term:
       id: NCBITaxon:120961
       label: Roseiflexus
+    gtdb_classification:
+      gtdb_id: GTDB:g__Roseiflexus
+      gtdb_taxon: Roseiflexus
+      gtdb_lineage: d__Bacteria;p__Chloroflexota;c__Chloroflexia;o__Chloroflexales;f__Roseiflexaceae;g__Roseiflexus
+      ncbi_source_id: NCBITaxon:120961
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: >
       Filamentous anoxygenic phototrophic Chloroflexi that dominate parts of
       the Mushroom Spring undermat and participate in diel carbon and energy
@@ -72,6 +80,14 @@ taxonomy:
     term:
       id: NCBITaxon:1107
       label: Chloroflexus
+    gtdb_classification:
+      gtdb_id: GTDB:g__Chloroflexus
+      gtdb_taxon: Chloroflexus
+      gtdb_lineage: d__Bacteria;p__Chloroflexota;c__Chloroflexia;o__Chloroflexales;f__Chloroflexaceae;g__Chloroflexus
+      ncbi_source_id: NCBITaxon:1107
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Filamentous anoxygenic phototrophs in the Mushroom Spring phototrophic mat.
   functional_role:
   - PRIMARY_PRODUCER
@@ -92,6 +108,14 @@ taxonomy:
     term:
       id: NCBITaxon:28261
       label: Thermodesulfovibrio
+    gtdb_classification:
+      gtdb_id: GTDB:g__Thermodesulfovibrio
+      gtdb_taxon: Thermodesulfovibrio
+      gtdb_lineage: d__Bacteria;p__Nitrospirota;c__Thermodesulfovibrionia;o__Thermodesulfovibrionales;f__Thermodesulfovibrionaceae;g__Thermodesulfovibrio
+      ncbi_source_id: NCBITaxon:28261
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: >
       Thermophilic sulfate-reducing bacterial lineage detected in the Mushroom
       Spring undermat, where nitrogen fixation potential was inferred from

--- a/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
+++ b/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
@@ -42,6 +42,14 @@ taxonomy:
     term:
       id: NCBITaxon:651137
       label: Nitrososphaerota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Thermoproteota
+      gtdb_taxon: Thermoproteota
+      gtdb_lineage: d__Archaea;p__Thermoproteota
+      ncbi_source_id: NCBITaxon:651137
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Dominant archaeal lineage representing basal Thaumarchaeota clades adapted to deep subsurface
       thermophilic conditions. Naica Thaumarchaeota possess archaeal ammonia monooxygenase (amoA) genes,
       demonstrating their role in autotrophic ammonia oxidation coupled to CO₂ fixation. High GC content
@@ -80,6 +88,14 @@ taxonomy:
     term:
       id: NCBITaxon:2301
       label: Thermoplasmatales
+    gtdb_classification:
+      gtdb_id: GTDB:o__Thermoplasmatales
+      gtdb_taxon: Thermoplasmatales
+      gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales
+      ncbi_source_id: NCBITaxon:2301
+      majority_fraction: 0.903
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at o__ rank; 9 GTDB taxa under the NCBI taxon]
     notes: 'Euryarchaeota belonging to a large clade of environmental sequences branching as a sister
       group to the order Thermoplasmatales. This archaeal lineage is distinct from cultured Thermoplasmatales
       (Thermoplasma, Ferroplasma, Picrophilus) but shares physiological characteristics of cell wall-lacking
@@ -141,6 +157,14 @@ taxonomy:
     term:
       id: NCBITaxon:1239
       label: Bacillota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Bacillota_A
+      gtdb_taxon: Bacillota_A
+      gtdb_lineage: d__Bacteria;p__Bacillota_A
+      ncbi_source_id: NCBITaxon:1239
+      majority_fraction: 0.55
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 21 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive bacteria detected in Naica subsurface waters, likely representing thermophilic
       spore-forming genera adapted to oligotrophic deep biosphere conditions. Firmicutes in analogous
       geothermal subsurface systems include thermophilic fermenters (Thermoanaerobacter, Moorella) and
@@ -166,6 +190,14 @@ taxonomy:
     term:
       id: NCBITaxon:28211
       label: Alphaproteobacteria
+    gtdb_classification:
+      gtdb_id: GTDB:c__Alphaproteobacteria
+      gtdb_taxon: Alphaproteobacteria
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria
+      ncbi_source_id: NCBITaxon:28211
+      majority_fraction: 0.996
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at c__ rank; 8 GTDB taxa under the NCBI taxon]
     notes: 'Alpha-proteobacteria detected in Naica representing oligotrophic heterotrophs or mixotrophs
       adapted to extremely low carbon availability. In deep subsurface environments, Alphaproteobacteria
       perform diverse metabolisms including methylotrophy, sulfur oxidation, and organic acid utilization.
@@ -190,6 +222,14 @@ taxonomy:
     term:
       id: NCBITaxon:28216
       label: Betaproteobacteria
+    gtdb_classification:
+      gtdb_id: GTDB:c__Gammaproteobacteria
+      gtdb_taxon: Gammaproteobacteria
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria
+      ncbi_source_id: NCBITaxon:28216
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at c__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: 'Beta-proteobacteria present in Naica subsurface waters, potentially representing autotrophic
       sulfur oxidizers or denitrifiers. In oligotrophic subsurface aquifers, Betaproteobacteria include
       chemolithoautotrophs such as Thiobacillus (sulfur oxidation coupled to denitrification) and heterotrophic

--- a/kb/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.yaml
+++ b/kb/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.yaml
@@ -53,6 +53,14 @@ taxonomy:
     term:
       id: NCBITaxon:1521
       label: Ruminiclostridium cellulolyticum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Ruminiclostridium_cellulolyticum
+      gtdb_taxon: Ruminiclostridium cellulolyticum
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__DSM-27016;g__Ruminiclostridium;s__Ruminiclostridium cellulolyticum
+      ncbi_source_id: NCBITaxon:1521
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: The primary abstract identifies C. cellulolyticum as the fermentative member.
   abundance_level: DOMINANT
   abundance_value: qPCR monitoring identified C. cellulolyticum as dominant.
@@ -75,6 +83,14 @@ taxonomy:
     term:
       id: NCBITaxon:882
       label: Nitratidesulfovibrio vulgaris str. Hildenborough
+    gtdb_classification:
+      gtdb_id: GTDB:s__Nitratidesulfovibrio_vulgaris
+      gtdb_taxon: Nitratidesulfovibrio vulgaris
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Nitratidesulfovibrio;s__Nitratidesulfovibrio vulgaris
+      ncbi_source_id: NCBITaxon:882
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: The source uses the historical Desulfovibrio vulgaris Hildenborough name; NCBI
       currently represents this taxon as Nitratidesulfovibrio vulgaris str. Hildenborough.
   abundance_level: COMMON
@@ -98,6 +114,14 @@ taxonomy:
     term:
       id: NCBITaxon:35554
       label: Geobacter sulfurreducens
+    gtdb_classification:
+      gtdb_id: GTDB:s__Geobacter_sulfurreducens
+      gtdb_taxon: Geobacter sulfurreducens
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter sulfurreducens
+      ncbi_source_id: NCBITaxon:35554
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: The primary abstract identifies G. sulfurreducens as the partner supplied with fumarate
       as electron acceptor.
   abundance_level: COMMON

--- a/kb/communities/ORNL_PMI_Populus_PD10_SynCom.yaml
+++ b/kb/communities/ORNL_PMI_Populus_PD10_SynCom.yaml
@@ -47,6 +47,14 @@ taxonomy:
     term:
       id: NCBITaxon:53335
       label: Pantoea
+    gtdb_classification:
+      gtdb_id: GTDB:g__Pantoea
+      gtdb_taxon: Pantoea
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Pantoea
+      ncbi_source_id: NCBITaxon:53335
+      majority_fraction: 0.961
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 15 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: YR343
     isolation_source: Populus deltoides rhizosphere
@@ -87,6 +95,14 @@ taxonomy:
     term:
       id: NCBITaxon:165695
       label: Sphingobium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Sphingobium
+      gtdb_taxon: Sphingobium
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Sphingobium
+      ncbi_source_id: NCBITaxon:165695
+      majority_fraction: 0.993
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: AP49
     isolation_source: Populus deltoides rhizosphere
@@ -104,6 +120,14 @@ taxonomy:
     term:
       id: NCBITaxon:379
       label: Rhizobium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Rhizobium
+      gtdb_taxon: Rhizobium
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Rhizobium
+      ncbi_source_id: NCBITaxon:379
+      majority_fraction: 0.723
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 16 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: CF142
     isolation_source: Populus deltoides rhizosphere
@@ -121,6 +145,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: CF313
     isolation_source: Populus deltoides rhizosphere
@@ -138,6 +170,14 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_classification:
+      gtdb_id: GTDB:g__Bacillus
+      gtdb_taxon: Bacillus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
+      ncbi_source_id: NCBITaxon:1386
+      majority_fraction: 0.508
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: BC15
     isolation_source: Populus deltoides rhizosphere
@@ -155,6 +195,14 @@ taxonomy:
     term:
       id: NCBITaxon:75
       label: Caulobacter
+    gtdb_classification:
+      gtdb_id: GTDB:g__Caulobacter
+      gtdb_taxon: Caulobacter
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Caulobacterales;f__Caulobacteraceae;g__Caulobacter
+      ncbi_source_id: NCBITaxon:75
+      majority_fraction: 0.837
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: AP07
     isolation_source: Populus deltoides rhizosphere
@@ -172,6 +220,14 @@ taxonomy:
     term:
       id: NCBITaxon:75654
       label: Duganella
+    gtdb_classification:
+      gtdb_id: GTDB:g__Duganella
+      gtdb_taxon: Duganella
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Duganella
+      ncbi_source_id: NCBITaxon:75654
+      majority_fraction: 0.886
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: CF402
     isolation_source: Populus deltoides rhizosphere
@@ -206,6 +262,14 @@ taxonomy:
     term:
       id: NCBITaxon:1822464
       label: Paraburkholderia
+    gtdb_classification:
+      gtdb_id: GTDB:g__Paraburkholderia
+      gtdb_taxon: Paraburkholderia
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Paraburkholderia
+      ncbi_source_id: NCBITaxon:1822464
+      majority_fraction: 0.988
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: BT03
     isolation_source: Populus deltoides rhizosphere

--- a/kb/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.yaml
+++ b/kb/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.yaml
@@ -46,6 +46,14 @@ taxonomy:
     term:
       id: NCBITaxon:286
       label: Pseudomonas
+    gtdb_classification:
+      gtdb_id: GTDB:g__Pseudomonas
+      gtdb_taxon: Pseudomonas
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
+      ncbi_source_id: NCBITaxon:286
+      majority_fraction: 0.596
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 17 GTDB taxa under the NCBI taxon]
     notes: Pseudomonas was reported among organisms stimulated in the highly contaminated well FW113-47
       and associated with uranium and nitrate reduction potential.
   functional_role:
@@ -63,6 +71,14 @@ taxonomy:
     term:
       id: NCBITaxon:22
       label: Shewanella
+    gtdb_classification:
+      gtdb_id: GTDB:g__Shewanella
+      gtdb_taxon: Shewanella
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella
+      ncbi_source_id: NCBITaxon:22
+      majority_fraction: 0.996
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Shewanella was reported as a uranium-reducing organism stimulated in the highly contaminated
       Oak Ridge FRC well FW113-47.
   functional_role:
@@ -80,6 +96,14 @@ taxonomy:
     term:
       id: NCBITaxon:40323
       label: Stenotrophomonas
+    gtdb_classification:
+      gtdb_id: GTDB:g__Stenotrophomonas
+      gtdb_taxon: Stenotrophomonas
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Xanthomonadaceae;g__Stenotrophomonas
+      ncbi_source_id: NCBITaxon:40323
+      majority_fraction: 0.987
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
     notes: Stenotrophomonas was reported among organisms stimulated in the highly contaminated well FW113-47
       and associated with iron reduction potential.
   functional_role:

--- a/kb/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.yaml
+++ b/kb/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.yaml
@@ -56,6 +56,14 @@ taxonomy:
     term:
       id: NCBITaxon:215813
       label: Dinoroseobacter shibae
+    gtdb_classification:
+      gtdb_id: GTDB:s__Dinoroseobacter_shibae
+      gtdb_taxon: Dinoroseobacter shibae
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhodobacterales;f__Rhodobacteraceae;g__Dinoroseobacter;s__Dinoroseobacter shibae
+      ncbi_source_id: NCBITaxon:215813
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: DF-12 strain used as the heterotrophic bacterial partner.
   abundance_level: COMMON
   functional_role:

--- a/kb/communities/PET_Artificial_FourSpecies_Degradation_Consortium.yaml
+++ b/kb/communities/PET_Artificial_FourSpecies_Degradation_Consortium.yaml
@@ -47,6 +47,14 @@ taxonomy:
     term:
       id: NCBITaxon:1423
       label: Bacillus subtilis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Bacillus_subtilis
+      gtdb_taxon: Bacillus subtilis
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
+      ncbi_source_id: NCBITaxon:1423
+      majority_fraction: 0.91
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Engineered B. subtilis 168 strain carrying pHP13-P43-LipB-PETase; represented at species level
       for ontology stability.
   abundance_value: Engineered PETase-secretion module in the consortium.
@@ -89,6 +97,14 @@ taxonomy:
     term:
       id: NCBITaxon:101510
       label: Rhodococcus jostii RHA1
+    gtdb_classification:
+      gtdb_id: GTDB:s__Rhodococcus_jostii_A
+      gtdb_taxon: Rhodococcus jostii_A
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Rhodococcus;s__Rhodococcus jostii_A
+      ncbi_source_id: NCBITaxon:101510
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Wild-type R. jostii RHA1 added as the terephthalic-acid utilization module.
   abundance_value: TPA-utilization member of the consortium.
   functional_role:
@@ -110,6 +126,14 @@ taxonomy:
     term:
       id: NCBITaxon:160488
       label: Pseudomonas putida KT2440
+    gtdb_classification:
+      gtdb_id: GTDB:s__Pseudomonas_E_alloputida
+      gtdb_taxon: Pseudomonas_E alloputida
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas_E;s__Pseudomonas_E alloputida
+      ncbi_source_id: NCBITaxon:160488
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Wild-type P. putida KT2440 added as the ethylene-glycol utilization module.
   abundance_value: EG-utilization member of the consortium.
   functional_role:

--- a/kb/communities/PGM_Spent_Catalyst_Bioleaching.yaml
+++ b/kb/communities/PGM_Spent_Catalyst_Bioleaching.yaml
@@ -62,6 +62,14 @@ taxonomy:
     term:
       id: NCBITaxon:930
       label: Acidithiobacillus thiooxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidithiobacillus_thiooxidans
+      gtdb_taxon: Acidithiobacillus thiooxidans
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus thiooxidans
+      ncbi_source_id: NCBITaxon:930
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Primary sulfur-oxidizing bacterium responsible for both alumina dissolution and thiosulfate
       generation in spent catalyst bioleaching. This gram-negative chemolithoautotroph oxidizes elemental
       sulfur (S⁰) and reduced inorganic sulfur compounds (RISC) to sulfuric acid, which dissolves the
@@ -117,6 +125,14 @@ taxonomy:
     term:
       id: NCBITaxon:920
       label: Acidithiobacillus ferrooxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidithiobacillus_ferrooxidans
+      gtdb_taxon: Acidithiobacillus ferrooxidans
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
+      ncbi_source_id: NCBITaxon:920
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Supporting acidophilic bacterium that contributes to bioleaching through dual iron and sulfur
       oxidation capabilities. At. ferrooxidans oxidizes both ferrous iron (Fe²⁺ → Fe³⁺) and reduced sulfur
       compounds, providing supplementary acid generation and metabolic versatility. In spent catalyst
@@ -152,6 +168,14 @@ taxonomy:
     term:
       id: NCBITaxon:28034
       label: Sulfobacillus thermosulfidooxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Sulfobacillus_thermosulfidooxidans
+      gtdb_taxon: Sulfobacillus thermosulfidooxidans
+      gtdb_lineage: d__Bacteria;p__Bacillota_E;c__Sulfobacillia;o__Sulfobacillales;f__Sulfobacillaceae;g__Sulfobacillus;s__Sulfobacillus thermosulfidooxidans
+      ncbi_source_id: NCBITaxon:28034
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Moderately thermophilic, facultatively autotrophic bacterium contributing to sulfur and iron
       oxidation in catalyst bioleaching systems. Sulfobacillus species oxidize reduced sulfur compounds
       and Fe²⁺, providing metabolic redundancy with Acidithiobacillus. The facultative autotrophy enables
@@ -188,6 +212,14 @@ taxonomy:
     term:
       id: NCBITaxon:931
       label: Thiobacillus thioparus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Thiobacillus_thioparus
+      gtdb_taxon: Thiobacillus thioparus
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Thiobacillaceae;g__Thiobacillus;s__Thiobacillus thioparus
+      ncbi_source_id: NCBITaxon:931
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Neutrophilic to slightly acidophilic sulfur-oxidizing bacterium that produces thiosulfate
       as a key metabolic intermediate. While At. thiooxidans operates at extremely low pH (1.5-3.0), T.
       thioparus thrives at pH 5.0-8.0 and contributes to biogenic thiosulfate production under less acidic

--- a/kb/communities/PMI_Variovorax_Thermotolerance_Collection.yaml
+++ b/kb/communities/PMI_Variovorax_Thermotolerance_Collection.yaml
@@ -45,6 +45,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: CF313
     isolation_source: Populus root

--- a/kb/communities/Panzhihua_Vanadium_Titanium_Tailings.yaml
+++ b/kb/communities/Panzhihua_Vanadium_Titanium_Tailings.yaml
@@ -152,6 +152,14 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_classification:
+      gtdb_id: GTDB:g__Bacillus
+      gtdb_taxon: Bacillus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
+      ncbi_source_id: NCBITaxon:1386
+      majority_fraction: 0.508
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive spore-forming bacteria representing the most abundant genus (79 of 136 isolates,
       58%) in V-Ti magnetite mine tailing soil from Panzhihua. Bacillus species demonstrate exceptional
       heavy metal resistance and diverse plant growth-promoting activities including IAA production (67%
@@ -189,6 +197,14 @@ taxonomy:
     term:
       id: NCBITaxon:94625
       label: Brucella intermedia
+    gtdb_classification:
+      gtdb_id: GTDB:s__Ochrobactrum_intermedium
+      gtdb_taxon: Ochrobactrum intermedium
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Ochrobactrum;s__Ochrobactrum intermedium
+      ncbi_source_id: NCBITaxon:94625
+      majority_fraction: 0.99
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Alphaproteobacterium (13 isolates) with exceptional heavy metal tolerance and plant growth-promoting
       capabilities in V-Ti tailings. Four Ochrobactrum isolates from P. pinnata nodules were initially
       identified as O. anthropi, closely related to O. intermedium. Ochrobactrum species are known for
@@ -226,6 +242,14 @@ taxonomy:
     term:
       id: NCBITaxon:52972
       label: Polaromonas
+    gtdb_classification:
+      gtdb_id: GTDB:g__Polaromonas
+      gtdb_taxon: Polaromonas
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Polaromonas
+      ncbi_source_id: NCBITaxon:52972
+      majority_fraction: 0.959
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Betaproteobacteria capable of dissimilatory vanadium reduction in contaminated mine environments.
       While not specifically reported in the Panzhihua tailings studies reviewed, Polaromonas is a well-established
       V(V)-reducing organism in circumneutral pH vanadium mine tailings in northern China and likely present

--- a/kb/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.yaml
+++ b/kb/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.yaml
@@ -55,6 +55,14 @@ taxonomy:
     term:
       id: NCBITaxon:110500
       label: Pelotomaculum thermopropionicum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Pelotomaculum_thermopropionicum
+      gtdb_taxon: Pelotomaculum thermopropionicum
+      gtdb_lineage: d__Bacteria;p__Bacillota_B;c__Desulfotomaculia;o__Desulfotomaculales;f__Pelotomaculaceae;g__Pelotomaculum;s__Pelotomaculum thermopropionicum
+      ncbi_source_id: NCBITaxon:110500
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Propionate-oxidizing bacterial syntroph in the two-member RNA-seq coculture.
   functional_role:
   - PRIMARY_DEGRADER
@@ -75,6 +83,14 @@ taxonomy:
     term:
       id: NCBITaxon:1175444
       label: Methanocella conradii
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methanocella_conradii
+      gtdb_taxon: Methanocella conradii
+      gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanocellia;o__Methanocellales;f__Methanocellaceae;g__Methanocella;s__Methanocella conradii
+      ncbi_source_id: NCBITaxon:1175444
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Hydrogenotrophic methanogenic archaeal partner in the two-member RNA-seq coculture.
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Pelotomaculum_Methanothermobacter_Syntrophy.yaml
+++ b/kb/communities/Pelotomaculum_Methanothermobacter_Syntrophy.yaml
@@ -31,6 +31,14 @@ taxonomy:
     term:
       id: NCBITaxon:110500
       label: Pelotomaculum thermopropionicum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Pelotomaculum_thermopropionicum
+      gtdb_taxon: Pelotomaculum thermopropionicum
+      gtdb_lineage: d__Bacteria;p__Bacillota_B;c__Desulfotomaculia;o__Desulfotomaculales;f__Pelotomaculaceae;g__Pelotomaculum;s__Pelotomaculum thermopropionicum
+      ncbi_source_id: NCBITaxon:110500
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Thermophilic, anaerobic, syntrophic, propionate-oxidizing bacterium that oxidizes propionate,
       ethanol, lactate, and various alcohols (1-butanol, 1-pentanol, 1-propanol, 1,3-propanediol, ethylene
       glycol) to acetate, CO2, and H2 in co-culture with hydrogenotrophic methanogens. Cannot grow on
@@ -57,6 +65,14 @@ taxonomy:
     term:
       id: NCBITaxon:145262
       label: Methanothermobacter thermautotrophicus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methanothermobacter_thermautotrophicus
+      gtdb_taxon: Methanothermobacter thermautotrophicus
+      gtdb_lineage: d__Archaea;p__Methanobacteriota;c__Methanobacteria;o__Methanobacteriales;f__Methanothermobacteraceae;g__Methanothermobacter;s__Methanothermobacter thermautotrophicus
+      ncbi_source_id: NCBITaxon:145262
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Thermophilic hydrogen-utilizing methanogen that consumes H2 and CO2 to produce methane. Essential
       syntrophic partner that maintains low H2 partial pressure, enabling thermodynamically unfavorable
       propionate oxidation by P. thermopropionicum. Operates optimally at thermophilic temperatures (55-65°C).

--- a/kb/communities/Pepper_Phytophthora_SynCom5.yaml
+++ b/kb/communities/Pepper_Phytophthora_SynCom5.yaml
@@ -37,6 +37,14 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_classification:
+      gtdb_id: GTDB:g__Bacillus
+      gtdb_taxon: Bacillus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
+      ncbi_source_id: NCBITaxon:1386
+      majority_fraction: 0.508
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -46,6 +54,14 @@ taxonomy:
     term:
       id: NCBITaxon:237
       label: Flavobacterium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Flavobacterium
+      gtdb_taxon: Flavobacterium
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Flavobacteriales;f__Flavobacteriaceae;g__Flavobacterium
+      ncbi_source_id: NCBITaxon:237
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 9 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Phormidium_Alkaline_Consortium.yaml
+++ b/kb/communities/Phormidium_Alkaline_Consortium.yaml
@@ -79,6 +79,14 @@ taxonomy:
     term:
       id: NCBITaxon:976
       label: Bacteroidota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Bacteroidota
+      gtdb_taxon: Bacteroidota
+      gtdb_lineage: d__Bacteria;p__Bacteroidota
+      ncbi_source_id: NCBITaxon:976
+      majority_fraction: 0.999
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 8 GTDB taxa under the NCBI taxon]
     notes: 'Multiple heterotrophic Bacteroidota species present in the consortium. These organisms contribute
       to organic matter degradation, polysaccharide utilization, and nutrient cycling. They occupy ecological
       niches related to fermentation product utilization and compatible solute metabolism.
@@ -101,6 +109,14 @@ taxonomy:
     term:
       id: NCBITaxon:28211
       label: Alphaproteobacteria
+    gtdb_classification:
+      gtdb_id: GTDB:c__Alphaproteobacteria
+      gtdb_taxon: Alphaproteobacteria
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria
+      ncbi_source_id: NCBITaxon:28211
+      majority_fraction: 0.996
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at c__ rank; 8 GTDB taxa under the NCBI taxon]
     notes: 'Diverse alphaproteobacterial species in the consortium that likely contribute to vitamin production,
       siderophore synthesis for iron solubilization, and aerobic metabolism of cyanobacterial exudates.
 
@@ -122,6 +138,14 @@ taxonomy:
     term:
       id: NCBITaxon:74201
       label: Verrucomicrobiota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Verrucomicrobiota
+      gtdb_taxon: Verrucomicrobiota
+      gtdb_lineage: d__Bacteria;p__Verrucomicrobiota
+      ncbi_source_id: NCBITaxon:74201
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Verrucomicrobial species equipped with glycoside hydrolases for degradation of sulfated polysaccharides
       and cell wall components from cyanobacteria. These organisms specialize in degrading complex polymers.
 
@@ -142,6 +166,14 @@ taxonomy:
     term:
       id: NCBITaxon:203682
       label: Planctomycetota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Planctomycetota
+      gtdb_taxon: Planctomycetota
+      gtdb_lineage: d__Bacteria;p__Planctomycetota
+      ncbi_source_id: NCBITaxon:203682
+      majority_fraction: 0.995
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: 'Planctomycete species with glycoside hydrolases capable of degrading cyanobacterial cell wall
       polysaccharides and other complex sulfated polymers. They play a key role in recycling cyanobacterial
       biomass.

--- a/kb/communities/Phylogenetically_Diverse_Denitrifying_SynCom.yaml
+++ b/kb/communities/Phylogenetically_Diverse_Denitrifying_SynCom.yaml
@@ -36,6 +36,14 @@ taxonomy:
     term:
       id: NCBITaxon:22
       label: Shewanella
+    gtdb_classification:
+      gtdb_id: GTDB:g__Shewanella
+      gtdb_taxon: Shewanella
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella
+      ncbi_source_id: NCBITaxon:22
+      majority_fraction: 0.996
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Polaromonas_Vanadium_Reduction_Community.yaml
+++ b/kb/communities/Polaromonas_Vanadium_Reduction_Community.yaml
@@ -43,6 +43,14 @@ taxonomy:
     term:
       id: NCBITaxon:52972
       label: Polaromonas
+    gtdb_classification:
+      gtdb_id: GTDB:g__Polaromonas
+      gtdb_taxon: Polaromonas
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Polaromonas
+      ncbi_source_id: NCBITaxon:52972
+      majority_fraction: 0.959
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Gram-negative betaproteobacteria (Burkholderiaceae family) dominating the vanadium-contaminated
       tailings community, reaching up to 46% relative abundance in enrichment cultures and 18-24% in natural
       tailings. Polaromonas species are psychrotolerant, facultatively anaerobic bacteria capable of dissimilatory
@@ -79,6 +87,14 @@ taxonomy:
     term:
       id: NCBITaxon:872
       label: Desulfovibrio
+    gtdb_classification:
+      gtdb_id: GTDB:g__Desulfovibrio
+      gtdb_taxon: Desulfovibrio
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Desulfovibrio
+      ncbi_source_id: NCBITaxon:872
+      majority_fraction: 0.871
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 16 GTDB taxa under the NCBI taxon]
     notes: 'Gram-negative deltaproteobacteria performing dissimilatory sulfate reduction in the vanadium
       tailings. Desulfovibrio oxidizes organic acids (lactate, pyruvate, formate) and hydrogen coupled
       to sulfate reduction, producing hydrogen sulfide (H₂S) that chemically reduces V(V) to V(IV) and
@@ -118,6 +134,14 @@ taxonomy:
     term:
       id: NCBITaxon:28232
       label: Geobacter metallireducens
+    gtdb_classification:
+      gtdb_id: GTDB:s__Geobacter_metallireducens
+      gtdb_taxon: Geobacter metallireducens
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
+      ncbi_source_id: NCBITaxon:28232
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Deltaproteobacteria specialized in dissimilatory metal reduction, present at 5-8% relative
       abundance in vanadium tailings. Geobacter oxidizes acetate and other organic acids coupled to reduction
       of Fe(III), Mn(IV), and V(V). This genus possesses extensive arrays of c-type cytochromes enabling
@@ -158,6 +182,14 @@ taxonomy:
     term:
       id: NCBITaxon:36853
       label: Desulfitobacterium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Desulfitobacterium
+      gtdb_taxon: Desulfitobacterium
+      gtdb_lineage: d__Bacteria;p__Bacillota_B;c__Desulfitobacteriia;o__Desulfitobacteriales;f__Desulfitobacteriaceae;g__Desulfitobacterium
+      ncbi_source_id: NCBITaxon:36853
+      majority_fraction: 0.946
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive, spore-forming bacteria (Firmicutes phylum) capable of organohalide respiration
       and metal reduction. Desulfitobacterium species comprise 3-6% of the tailings community and perform
       dissimilatory reduction of V(V), Cr(VI), and arsenate using respiratory reductases. This genus couples

--- a/kb/communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.yaml
+++ b/kb/communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.yaml
@@ -30,6 +30,14 @@ taxonomy:
     term:
       id: NCBITaxon:561
       label: Escherichia
+    gtdb_classification:
+      gtdb_id: GTDB:g__Escherichia
+      gtdb_taxon: Escherichia
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia
+      ncbi_source_id: NCBITaxon:561
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
     notes: Escherichia spp. whose in situ physiological conditions were
       probed via metagenomic and metatranscriptomic sequencing.
   functional_role:

--- a/kb/communities/Prochlorococcus_Alteromonas_Helper_Coculture.yaml
+++ b/kb/communities/Prochlorococcus_Alteromonas_Helper_Coculture.yaml
@@ -61,6 +61,14 @@ taxonomy:
     term:
       id: NCBITaxon:28108
       label: Alteromonas macleodii
+    gtdb_classification:
+      gtdb_id: GTDB:s__Alteromonas_macleodii
+      gtdb_taxon: Alteromonas macleodii
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Alteromonadaceae;g__Alteromonas;s__Alteromonas macleodii
+      ncbi_source_id: NCBITaxon:28108
+      majority_fraction: 0.9
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Heterotrophic helper bacterium that removes hydrogen peroxide and modifies Prochlorococcus oxidative
       stress exposure.
   strain_designation:

--- a/kb/communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.yaml
+++ b/kb/communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.yaml
@@ -108,6 +108,14 @@ taxonomy:
     term:
       id: NCBITaxon:1866885
       label: Mycolicibacterium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Mycobacterium
+      gtdb_taxon: Mycobacterium
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Mycobacterium
+      ncbi_source_id: NCBITaxon:1866885
+      majority_fraction: 0.998
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Dominant genus across all four cDCE-amended enrichments and the
       most abundant in the TCE-amended enrichment from impacted-site sediment
       by community-composition analysis. MAG-level propane monooxygenase
@@ -130,6 +138,14 @@ taxonomy:
     term:
       id: NCBITaxon:1763
       label: Mycobacterium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Mycobacterium
+      gtdb_taxon: Mycobacterium
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Mycobacterium
+      ncbi_source_id: NCBITaxon:1763
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Second dominant genus in cDCE-amended enrichments after
       Mycolicibacterium; multiple Mycobacterium MAGs from cDCE-amended
       cultures carry propane monooxygenase operons with prmACDB ordering
@@ -149,6 +165,14 @@ taxonomy:
     term:
       id: NCBITaxon:1847
       label: Pseudonocardia
+    gtdb_classification:
+      gtdb_id: GTDB:g__Pseudonocardia
+      gtdb_taxon: Pseudonocardia
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Pseudonocardiaceae;g__Pseudonocardia
+      ncbi_source_id: NCBITaxon:1847
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Dominant genus in 1,1-DCE-degrading enrichments after re-selection
       on 1,1-DCE; the associated MAG carries a truncated propane monooxygenase
       alpha subunit, indicating that other enzymes likely catalyze 1,1-DCE
@@ -171,6 +195,14 @@ taxonomy:
     term:
       id: NCBITaxon:2736640
       label: Pseudonocardia broussonetiae
+    gtdb_classification:
+      gtdb_id: GTDB:s__Pseudonocardia_broussonetiae
+      gtdb_taxon: Pseudonocardia broussonetiae
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Pseudonocardiaceae;g__Pseudonocardia;s__Pseudonocardia broussonetiae
+      ncbi_source_id: NCBITaxon:2736640
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Species-level MAGs recovered from the impacted-site (Site 1)
       TCE-amended enrichments only; carry propane monooxygenase operons.
   functional_role:
@@ -189,6 +221,14 @@ taxonomy:
     term:
       id: NCBITaxon:316612
       label: Methylibium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Methylibium
+      gtdb_taxon: Methylibium
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Methylibium
+      ncbi_source_id: NCBITaxon:316612
+      majority_fraction: 0.607
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
     notes: One of two non-actinobacterial MAGs containing the propane
       monooxygenase operon, recovered from cDCE-amended T3 enrichments.
   functional_role:
@@ -207,6 +247,14 @@ taxonomy:
     term:
       id: NCBITaxon:119060
       label: Burkholderiaceae
+    gtdb_classification:
+      gtdb_id: GTDB:f__Burkholderiaceae
+      gtdb_taxon: Burkholderiaceae
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae
+      ncbi_source_id: NCBITaxon:119060
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at f__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: One of two non-actinobacterial MAGs containing the propane
       monooxygenase operon, recovered from cDCE-amended T4 enrichments;
       taxon resolved only to family level.

--- a/kb/communities/Pseudomonas_Pedobacter_Social_Spreading_Coculture.yaml
+++ b/kb/communities/Pseudomonas_Pedobacter_Social_Spreading_Coculture.yaml
@@ -60,6 +60,14 @@ taxonomy:
     term:
       id: NCBITaxon:84567
       label: Pedobacter
+    gtdb_classification:
+      gtdb_id: GTDB:g__Pedobacter
+      gtdb_taxon: Pedobacter
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Sphingobacteriales;f__Sphingobacteriaceae;g__Pedobacter
+      ncbi_source_id: NCBITaxon:84567
+      majority_fraction: 0.924
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
     notes: Soil-associated Pedobacter isolate V48; represented at genus level because the publication names
       the strain as Pedobacter sp. V48.
   functional_role:

--- a/kb/communities/Pseudomonas_Rhodococcus_Chloronitrobenzene_Coculture.yaml
+++ b/kb/communities/Pseudomonas_Rhodococcus_Chloronitrobenzene_Coculture.yaml
@@ -73,6 +73,14 @@ taxonomy:
     term:
       id: NCBITaxon:1827
       label: Rhodococcus <high G+C Gram-positive bacteria>
+    gtdb_classification:
+      gtdb_id: GTDB:g__Rhodococcus
+      gtdb_taxon: Rhodococcus
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Rhodococcus
+      ncbi_source_id: NCBITaxon:1827
+      majority_fraction: 0.996
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Chlorohydroxyacetanilide-degrading partner paired with P. putida HS12 for complete
       chloronitrobenzene mineralization.
   strain_designation:

--- a/kb/communities/Rammelsberg_Cobalt_Nickel_Tailings.yaml
+++ b/kb/communities/Rammelsberg_Cobalt_Nickel_Tailings.yaml
@@ -59,6 +59,14 @@ taxonomy:
     term:
       id: NCBITaxon:920
       label: Acidithiobacillus ferrooxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidithiobacillus_ferrooxidans
+      gtdb_taxon: Acidithiobacillus ferrooxidans
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
+      ncbi_source_id: NCBITaxon:920
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Mesophilic chemolithoautotrophic iron-oxidizing bacterium that obtains energy from oxidation
       of ferrous iron (Fe²⁺) to ferric iron (Fe³⁺) and reduced sulfur compounds. This organism is one
       of the two dominant members of the Rammelsberg bioleaching consortium and plays a critical role
@@ -95,6 +103,14 @@ taxonomy:
     term:
       id: NCBITaxon:930
       label: Acidithiobacillus thiooxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidithiobacillus_thiooxidans
+      gtdb_taxon: Acidithiobacillus thiooxidans
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus thiooxidans
+      ncbi_source_id: NCBITaxon:930
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Mesophilic chemolithoautotrophic sulfur-oxidizing bacterium that derives energy from oxidation
       of elemental sulfur, sulfide, and other reduced sulfur compounds to sulfuric acid. This organism
       is the second dominant member of the Rammelsberg bioleaching consortium and plays an essential complementary

--- a/kb/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.yaml
+++ b/kb/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.yaml
@@ -45,6 +45,14 @@ taxonomy:
     term:
       id: NCBITaxon:562
       label: Escherichia coli
+    gtdb_classification:
+      gtdb_id: GTDB:s__Escherichia_coli
+      gtdb_taxon: Escherichia coli
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
+      ncbi_source_id: NCBITaxon:562
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.yaml
+++ b/kb/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.yaml
@@ -54,6 +54,14 @@ taxonomy:
     term:
       id: NCBITaxon:395960
       label: Rhodopseudomonas palustris TIE-1
+    gtdb_classification:
+      gtdb_id: GTDB:s__Rhodopseudomonas_palustris_F
+      gtdb_taxon: Rhodopseudomonas palustris_F
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Rhodopseudomonas;s__Rhodopseudomonas palustris_F
+      ncbi_source_id: NCBITaxon:395960
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Phototrophic Fe(II)-oxidizing member of the coculture.
   abundance_level: ABUNDANT
   functional_role:
@@ -75,6 +83,14 @@ taxonomy:
     term:
       id: NCBITaxon:35554
       label: Geobacter sulfurreducens
+    gtdb_classification:
+      gtdb_id: GTDB:s__Geobacter_sulfurreducens
+      gtdb_taxon: Geobacter sulfurreducens
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter sulfurreducens
+      ncbi_source_id: NCBITaxon:35554
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Anaerobic Fe(III)-reducing member of the coculture.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Rice_Duckweed_Bacillus_SynCom.yaml
+++ b/kb/communities/Rice_Duckweed_Bacillus_SynCom.yaml
@@ -45,6 +45,14 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_classification:
+      gtdb_id: GTDB:g__Bacillus
+      gtdb_taxon: Bacillus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
+      ncbi_source_id: NCBITaxon:1386
+      majority_fraction: 0.508
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
     notes: Auxin (IAA)-producing specialist within the 8-member SynCom. Division-of-labor member contributing
       to rice growth promotion through indole-3-acetic acid biosynthesis. 8 members total; strain-level
       identifiers available in supplementary data.

--- a/kb/communities/Rice_P_Uptake_Intercropping_SynCom4.yaml
+++ b/kb/communities/Rice_P_Uptake_Intercropping_SynCom4.yaml
@@ -46,6 +46,14 @@ taxonomy:
     term:
       id: NCBITaxon:48936
       label: Novosphingobium subterraneum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Novosphingobium_subterraneum
+      gtdb_taxon: Novosphingobium subterraneum
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Novosphingobium;s__Novosphingobium subterraneum
+      ncbi_source_id: NCBITaxon:48936
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -55,6 +63,14 @@ taxonomy:
     term:
       id: NCBITaxon:47421
       label: Hydrogenophaga pseudoflava
+    gtdb_classification:
+      gtdb_id: GTDB:s__Hydrogenophaga_pseudoflava
+      gtdb_taxon: Hydrogenophaga pseudoflava
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Hydrogenophaga;s__Hydrogenophaga pseudoflava
+      ncbi_source_id: NCBITaxon:47421
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -64,6 +80,14 @@ taxonomy:
     term:
       id: NCBITaxon:12916
       label: Acidovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Acidovorax
+      gtdb_taxon: Acidovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Acidovorax
+      ncbi_source_id: NCBITaxon:12916
+      majority_fraction: 0.867
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 9 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
+++ b/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
@@ -69,6 +69,14 @@ taxonomy:
     term:
       id: NCBITaxon:97393
       label: Ferroplasma acidarmanus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Ferroplasma_acidarmanus
+      gtdb_taxon: Ferroplasma acidarmanus
+      gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales;f__Thermoplasmataceae;g__Ferroplasma;s__Ferroplasma acidarmanus
+      ncbi_source_id: NCBITaxon:97393
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Cell wall-lacking archaeon (Thermoplasmatales order) adapted to extremely
       acidic conditions. Ferroplasma acidarmanus reaches up to 85% of cells in the
       most acidic microniches (pH approaching 0.5). This microaerophilic organism
@@ -136,6 +144,14 @@ taxonomy:
     term:
       id: NCBITaxon:920
       label: Acidithiobacillus ferrooxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidithiobacillus_ferrooxidans
+      gtdb_taxon: Acidithiobacillus ferrooxidans
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
+      ncbi_source_id: NCBITaxon:920
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Gram-negative γ-proteobacterium that oxidizes both iron and reduced sulfur
       compounds. At Richmond Mine, A. ferrooxidans is restricted to higher pH environments
       (pH >1.0) such as the Red Pool (pH 1.4), where it can outcompete Leptospirillum

--- a/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
+++ b/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
@@ -68,6 +68,14 @@ taxonomy:
     term:
       id: NCBITaxon:201174
       label: Actinomycetota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Actinomycetota
+      gtdb_taxon: Actinomycetota
+      gtdb_lineage: d__Bacteria;p__Actinomycetota
+      ncbi_source_id: NCBITaxon:201174
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 6 GTDB taxa under the NCBI taxon]
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:
@@ -83,6 +91,14 @@ taxonomy:
     term:
       id: NCBITaxon:1134404
       label: Ignavibacteriota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Bacteroidota
+      gtdb_taxon: Bacteroidota
+      gtdb_lineage: d__Bacteria;p__Bacteroidota
+      ncbi_source_id: NCBITaxon:1134404
+      majority_fraction: 0.987
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:
@@ -96,6 +112,14 @@ taxonomy:
     term:
       id: NCBITaxon:200795
       label: Chloroflexota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Chloroflexota
+      gtdb_taxon: Chloroflexota
+      gtdb_lineage: d__Bacteria;p__Chloroflexota
+      ncbi_source_id: NCBITaxon:200795
+      majority_fraction: 0.998
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 4 GTDB taxa under the NCBI taxon]
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:
@@ -109,6 +133,14 @@ taxonomy:
     term:
       id: NCBITaxon:57723
       label: Acidobacteriota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Acidobacteriota
+      gtdb_taxon: Acidobacteriota
+      gtdb_lineage: d__Bacteria;p__Acidobacteriota
+      ncbi_source_id: NCBITaxon:57723
+      majority_fraction: 0.976
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 4 GTDB taxa under the NCBI taxon]
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:
@@ -122,6 +154,14 @@ taxonomy:
     term:
       id: NCBITaxon:1239
       label: Bacillota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Bacillota_A
+      gtdb_taxon: Bacillota_A
+      gtdb_lineage: d__Bacteria;p__Bacillota_A
+      ncbi_source_id: NCBITaxon:1239
+      majority_fraction: 0.55
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 21 GTDB taxa under the NCBI taxon]
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:
@@ -135,6 +175,14 @@ taxonomy:
     term:
       id: NCBITaxon:1224
       label: Pseudomonadota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Pseudomonadota
+      gtdb_taxon: Pseudomonadota
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota
+      ncbi_source_id: NCBITaxon:1224
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 14 GTDB taxa under the NCBI taxon]
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:

--- a/kb/communities/Rifle_Uranium_Reducing_Community.yaml
+++ b/kb/communities/Rifle_Uranium_Reducing_Community.yaml
@@ -37,6 +37,14 @@ taxonomy:
     term:
       id: NCBITaxon:28232
       label: Geobacter metallireducens
+    gtdb_classification:
+      gtdb_id: GTDB:s__Geobacter_metallireducens
+      gtdb_taxon: Geobacter metallireducens
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
+      ncbi_source_id: NCBITaxon:28232
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Geobacter species, primarily G. metallireducens, dominate Phase I of uranium bioremediation
       (days 0-50). Geobacteraceae reach 89% of the groundwater microbial community by day 17, with Geobacter
       genus comprising 83% of Geobacteraceae sequences. These deltaproteobacteria oxidize acetate coupled
@@ -100,6 +108,14 @@ taxonomy:
     term:
       id: NCBITaxon:881
       label: Nitratidesulfovibrio vulgaris
+    gtdb_classification:
+      gtdb_id: GTDB:s__Nitratidesulfovibrio_vulgaris
+      gtdb_taxon: Nitratidesulfovibrio vulgaris
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Nitratidesulfovibrio;s__Nitratidesulfovibrio vulgaris
+      ncbi_source_id: NCBITaxon:881
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Sulfate-reducing bacterium that contributes to uranium reduction through enzymatic pathways
       and production of hydrogen sulfide (H₂S), which can chemically reduce U(VI). While Desulfovibrio
       was not dominant in initial Rifle studies (unlike Geobacter), it was later isolated from uranium-reducing
@@ -125,6 +141,14 @@ taxonomy:
     term:
       id: NCBITaxon:79206
       label: Desulfosporosinus
+    gtdb_classification:
+      gtdb_id: GTDB:g__Desulfosporosinus
+      gtdb_taxon: Desulfosporosinus
+      gtdb_lineage: d__Bacteria;p__Bacillota_B;c__Desulfitobacteriia;o__Desulfitobacteriales;f__Desulfitobacteriaceae;g__Desulfosporosinus
+      ncbi_source_id: NCBITaxon:79206
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive, spore-forming, sulfate-reducing bacteria detected during later phases of uranium
       biostimulation at Rifle. Desulfosporosinus species reduce U(VI) via enzymatic pathways distinct
       from Desulfovibrio, lacking certain cytochromes used by other sulfate reducers. This genus becomes
@@ -161,6 +185,14 @@ taxonomy:
     term:
       id: NCBITaxon:213118
       label: Desulfobacterales
+    gtdb_classification:
+      gtdb_id: GTDB:o__Desulfobacterales
+      gtdb_taxon: Desulfobacterales
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfobacteria;o__Desulfobacterales
+      ncbi_source_id: NCBITaxon:213118
+      majority_fraction: 0.81
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at o__ rank; 5 GTDB taxa under the NCBI taxon]
     notes: 'Family of sulfate-reducing bacteria that becomes dominant during Phase II of uranium biostimulation
       at Rifle (>50 days). By day 80, Desulfobacteraceae comprise 45% of the groundwater microbial community,
       replacing Geobacter as Fe(III) is depleted. This family includes diverse sulfate reducers that oxidize

--- a/kb/communities/SF356_Cellulose_Degrader.yaml
+++ b/kb/communities/SF356_Cellulose_Degrader.yaml
@@ -23,6 +23,14 @@ taxonomy:
     term:
       id: NCBITaxon:253314
       label: Acetivibrio straminisolvens
+    gtdb_classification:
+      gtdb_id: GTDB:s__Hungateiclostridium_straminisolvens
+      gtdb_taxon: Hungateiclostridium straminisolvens
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__Acetivibrionaceae;g__Hungateiclostridium;s__Hungateiclostridium straminisolvens
+      ncbi_source_id: NCBITaxon:253314
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -74,6 +82,14 @@ taxonomy:
     term:
       id: NCBITaxon:55080
       label: Brevibacillus
+    gtdb_classification:
+      gtdb_id: GTDB:g__Brevibacillus
+      gtdb_taxon: Brevibacillus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Brevibacillales;f__Brevibacillaceae;g__Brevibacillus
+      ncbi_source_id: NCBITaxon:55080
+      majority_fraction: 0.816
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 6 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/SIHUMIx_Human_Intestinal_Model_Community.yaml
+++ b/kb/communities/SIHUMIx_Human_Intestinal_Model_Community.yaml
@@ -41,6 +41,14 @@ taxonomy:
     term:
       id: NCBITaxon:105841
       label: Anaerostipes caccae
+    gtdb_classification:
+      gtdb_id: GTDB:s__Anaerostipes_caccae
+      gtdb_taxon: Anaerostipes caccae
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Anaerostipes;s__Anaerostipes caccae
+      ncbi_source_id: NCBITaxon:105841
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Human intestinal anaerobe included in SIHUMIx.
   strain_designation:
     strain_name: DSMZ 14662
@@ -61,6 +69,14 @@ taxonomy:
     term:
       id: NCBITaxon:818
       label: Bacteroides thetaiotaomicron
+    gtdb_classification:
+      gtdb_id: GTDB:s__Bacteroides_thetaiotaomicron
+      gtdb_taxon: Bacteroides thetaiotaomicron
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides;s__Bacteroides thetaiotaomicron
+      ncbi_source_id: NCBITaxon:818
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Gut Bacteroides member and dominant SIHUMIx constituent in bioreactor studies.
   strain_designation:
     strain_name: DSMZ 2079
@@ -98,6 +114,14 @@ taxonomy:
     term:
       id: NCBITaxon:33035
       label: Blautia producta
+    gtdb_classification:
+      gtdb_id: GTDB:s__Blautia_coccoides
+      gtdb_taxon: Blautia coccoides
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Blautia;s__Blautia coccoides
+      ncbi_source_id: NCBITaxon:33035
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Anaerobic gut member included in SIHUMIx.
   strain_designation:
     strain_name: DSMZ 2950
@@ -118,6 +142,14 @@ taxonomy:
     term:
       id: NCBITaxon:1492
       label: Clostridium butyricum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Clostridium_butyricum
+      gtdb_taxon: Clostridium butyricum
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium;s__Clostridium butyricum
+      ncbi_source_id: NCBITaxon:1492
+      majority_fraction: 0.97
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Butyrate-associated clostridial member added in the extended SIHUMIx community.
   strain_designation:
     strain_name: DSMZ 10702
@@ -138,6 +170,14 @@ taxonomy:
     term:
       id: NCBITaxon:1547
       label: Thomasclavelia ramosa
+    gtdb_classification:
+      gtdb_id: GTDB:s__Thomasclavelia_ramosa
+      gtdb_taxon: Thomasclavelia ramosa
+      gtdb_lineage: d__Bacteria;p__Bacillota_I;c__Bacilli_A;o__Erysipelotrichales;f__Coprobacillaceae;g__Thomasclavelia;s__Thomasclavelia ramosa
+      ncbi_source_id: NCBITaxon:1547
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Literature name retained as preferred term; this organism is also encountered under updated
       clostridial taxonomy in some resources.
   strain_designation:
@@ -159,6 +199,14 @@ taxonomy:
     term:
       id: NCBITaxon:511145
       label: Escherichia coli str. K-12 substr. MG1655
+    gtdb_classification:
+      gtdb_id: GTDB:s__Escherichia_coli
+      gtdb_taxon: Escherichia coli
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
+      ncbi_source_id: NCBITaxon:511145
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Facultative anaerobic Proteobacteria member of SIHUMIx.
   strain_designation:
     strain_name: MG1655
@@ -176,6 +224,14 @@ taxonomy:
     term:
       id: NCBITaxon:1590
       label: Lactiplantibacillus plantarum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Lactiplantibacillus_plantarum
+      gtdb_taxon: Lactiplantibacillus plantarum
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactiplantibacillus;s__Lactiplantibacillus plantarum
+      ncbi_source_id: NCBITaxon:1590
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Literature name retained in preferred_term; current NCBI label reflects Lactobacillus
       reclassification.
   strain_designation:

--- a/kb/communities/SMutans_CAlbicans_ECC_Biofilm.yaml
+++ b/kb/communities/SMutans_CAlbicans_ECC_Biofilm.yaml
@@ -48,6 +48,14 @@ taxonomy:
     term:
       id: NCBITaxon:1309
       label: Streptococcus mutans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Streptococcus_mutans
+      gtdb_taxon: Streptococcus mutans
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Streptococcus;s__Streptococcus mutans
+      ncbi_source_id: NCBITaxon:1309
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   evidence:
   - reference: PMID:24566629
     supports: SUPPORT

--- a/kb/communities/SMutans_SSputigena_ECC_Pathobiont.yaml
+++ b/kb/communities/SMutans_SSputigena_ECC_Pathobiont.yaml
@@ -52,6 +52,14 @@ taxonomy:
     term:
       id: NCBITaxon:1309
       label: Streptococcus mutans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Streptococcus_mutans
+      gtdb_taxon: Streptococcus mutans
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Streptococcus;s__Streptococcus mutans
+      ncbi_source_id: NCBITaxon:1309
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   evidence:
   - reference: PMID:37217495
     supports: SUPPORT
@@ -65,6 +73,14 @@ taxonomy:
     term:
       id: NCBITaxon:69823
       label: Selenomonas sputigena
+    gtdb_classification:
+      gtdb_id: GTDB:s__Selenomonas_sp905372355
+      gtdb_taxon: Selenomonas sp905372355
+      gtdb_lineage: d__Bacteria;p__Bacillota_C;c__Negativicutes;o__Selenomonadales;f__Selenomonadaceae;g__Selenomonas;s__Selenomonas sp905372355
+      ncbi_source_id: NCBITaxon:69823
+      majority_fraction: 0.86
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   evidence:
   - reference: PMID:37217495
     supports: SUPPORT

--- a/kb/communities/SMutans_VParvula_ASC_Biofilm.yaml
+++ b/kb/communities/SMutans_VParvula_ASC_Biofilm.yaml
@@ -52,6 +52,14 @@ taxonomy:
     term:
       id: NCBITaxon:1309
       label: Streptococcus mutans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Streptococcus_mutans
+      gtdb_taxon: Streptococcus mutans
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Streptococcus;s__Streptococcus mutans
+      ncbi_source_id: NCBITaxon:1309
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   evidence:
   - reference: PMID:39345197
     supports: SUPPORT
@@ -66,6 +74,14 @@ taxonomy:
     term:
       id: NCBITaxon:29466
       label: Veillonella parvula
+    gtdb_classification:
+      gtdb_id: GTDB:s__Veillonella_parvula_A
+      gtdb_taxon: Veillonella parvula_A
+      gtdb_lineage: d__Bacteria;p__Bacillota_C;c__Negativicutes;o__Veillonellales;f__Veillonellaceae;g__Veillonella;s__Veillonella parvula_A
+      ncbi_source_id: NCBITaxon:29466
+      majority_fraction: 0.95
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   abundance_level: DOMINANT
   evidence:
   - reference: PMID:39345197

--- a/kb/communities/SPRUCE_Peatland_Methane_Cycling_Community.yaml
+++ b/kb/communities/SPRUCE_Peatland_Methane_Cycling_Community.yaml
@@ -40,6 +40,14 @@ taxonomy:
     term:
       id: NCBITaxon:57723
       label: Acidobacteriota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Acidobacteriota
+      gtdb_taxon: Acidobacteriota
+      gtdb_lineage: d__Bacteria;p__Acidobacteriota
+      ncbi_source_id: NCBITaxon:57723
+      majority_fraction: 0.976
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Acidobacteriota MAGs contribute to anaerobic peat carbon turnover and sulfur-linked respiratory
       potential in the SPRUCE MAG collection.
   functional_role:

--- a/kb/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.yaml
+++ b/kb/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.yaml
@@ -92,6 +92,14 @@ taxonomy:
     term:
       id: NCBITaxon:1236
       label: Gammaproteobacteria
+    gtdb_classification:
+      gtdb_id: GTDB:c__Gammaproteobacteria
+      gtdb_taxon: Gammaproteobacteria
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria
+      ncbi_source_id: NCBITaxon:1236
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at c__ rank; 7 GTDB taxa under the NCBI taxon]
     notes: SUP05 Gammaproteobacteria are represented at class level and described as the dominant denitrifier
       guild in Saanich Inlet.
   functional_role:

--- a/kb/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.yaml
+++ b/kb/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.yaml
@@ -70,6 +70,14 @@ taxonomy:
     term:
       id: NCBITaxon:202950
       label: Acinetobacter baylyi
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acinetobacter_baylyi
+      gtdb_taxon: Acinetobacter baylyi
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Moraxellaceae;g__Acinetobacter;s__Acinetobacter baylyi
+      ncbi_source_id: NCBITaxon:202950
+      majority_fraction: 0.96
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Engineered ADP1 strain that bioconverts furan aldehyde inhibitors and
       diverts residual S. cerevisiae carbon into wax esters.
   functional_role:

--- a/kb/communities/Salar_Atacama_Lithium_Brine_Community.yaml
+++ b/kb/communities/Salar_Atacama_Lithium_Brine_Community.yaml
@@ -37,6 +37,14 @@ taxonomy:
     term:
       id: NCBITaxon:1377992
       label: Halovenus
+    gtdb_classification:
+      gtdb_id: GTDB:g__Halovenus
+      gtdb_taxon: Halovenus
+      gtdb_lineage: d__Archaea;p__Halobacteriota;c__Halobacteria;o__Halobacteriales;f__Haloarculaceae;g__Halovenus
+      ncbi_source_id: NCBITaxon:1377992
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Extremely halophilic archaeon of the family Halobacteriaceae. This genus is the most abundant
       archaeal taxon in Salar de Atacama brines, representing 26.8% of archaeal community in natural brine
       and increasing to 41% dominance in concentrated brine. Halovenus species are adapted to chaotropic
@@ -66,6 +74,14 @@ taxonomy:
     term:
       id: NCBITaxon:63743
       label: Natronomonas
+    gtdb_classification:
+      gtdb_id: GTDB:g__Natronomonas
+      gtdb_taxon: Natronomonas
+      gtdb_lineage: d__Archaea;p__Halobacteriota;c__Halobacteria;o__Halobacteriales;f__Haloarculaceae;g__Natronomonas
+      ncbi_source_id: NCBITaxon:63743
+      majority_fraction: 0.957
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Alkaliphilic and extremely halophilic archaeon that thrives in hypersaline soda lake environments
       and lithium brines. This genus represents the second most abundant archaeal taxon (20.1%) in natural
       Atacama brines but shows reduced relative abundance in concentrated brines. Natronomonas species
@@ -90,6 +106,14 @@ taxonomy:
     term:
       id: NCBITaxon:2237
       label: Haloarcula
+    gtdb_classification:
+      gtdb_id: GTDB:g__Haloarcula
+      gtdb_taxon: Haloarcula
+      gtdb_lineage: d__Archaea;p__Halobacteriota;c__Halobacteria;o__Halobacteriales;f__Haloarculaceae;g__Haloarcula
+      ncbi_source_id: NCBITaxon:2237
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Extremely halophilic archaeon with metabolic versatility including aerobic respiration, nitrate
       reduction, and polymer degradation. Haloarcula represents 14% of archaeal community in natural brine
       and maintains presence in concentrated brine. Species in this genus can utilize diverse carbon sources
@@ -113,6 +137,14 @@ taxonomy:
     term:
       id: NCBITaxon:2239
       label: Halobacterium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Halobacterium
+      gtdb_taxon: Halobacterium
+      gtdb_lineage: d__Archaea;p__Halobacteriota;c__Halobacteria;o__Halobacteriales;f__Halobacteriaceae;g__Halobacterium
+      ncbi_source_id: NCBITaxon:2239
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Model extremely halophilic archaeon with well-characterized physiology including bacteriorhodopsin-mediated
       phototrophy, aerobic respiration, and arginine fermentation. Halobacterium comprises 13% of archaeal
       community in natural brine. This genus can generate ATP through light-driven proton pumping via
@@ -136,6 +168,14 @@ taxonomy:
     term:
       id: NCBITaxon:146918
       label: Salinibacter
+    gtdb_classification:
+      gtdb_id: GTDB:g__Salinibacter
+      gtdb_taxon: Salinibacter
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Rhodothermia;o__Rhodothermales;f__Salinibacteraceae;g__Salinibacter
+      ncbi_source_id: NCBITaxon:146918
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Extremely halophilic bacterium of the family Rhodothermaceae, representing the dominant bacterial
       taxon in natural Atacama brines. Rhodothermaceae, solely represented by Salinibacter genus, comprises
       56% of bacterial community in natural brine. Salinibacter uses the "salt-in" strategy similar to
@@ -161,6 +201,14 @@ taxonomy:
     term:
       id: NCBITaxon:90964
       label: Staphylococcaceae
+    gtdb_classification:
+      gtdb_id: GTDB:f__Staphylococcaceae
+      gtdb_taxon: Staphylococcaceae
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae
+      ncbi_source_id: NCBITaxon:90964
+      majority_fraction: 0.993
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at f__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: 'Halotolerant bacterial family present in the Atacama brine community. Members of Staphylococcaceae
       are among the most abundant bacterial families in natural brine alongside Rhodothermaceae, contributing
       to heterotrophic activity and organic matter processing in the hypersaline environment.

--- a/kb/communities/Shewanella_Denitrifying_Richness_SynComs.yaml
+++ b/kb/communities/Shewanella_Denitrifying_Richness_SynComs.yaml
@@ -35,6 +35,14 @@ taxonomy:
     term:
       id: NCBITaxon:22
       label: Shewanella
+    gtdb_classification:
+      gtdb_id: GTDB:g__Shewanella
+      gtdb_taxon: Shewanella
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella
+      ncbi_source_id: NCBITaxon:22
+      majority_fraction: 0.996
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.yaml
+++ b/kb/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.yaml
@@ -59,6 +59,14 @@ taxonomy:
     term:
       id: NCBITaxon:70863
       label: Shewanella oneidensis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Shewanella_oneidensis
+      gtdb_taxon: Shewanella oneidensis
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella oneidensis
+      ncbi_source_id: NCBITaxon:70863
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Exoelectrogenic proteobacterium in the defined anode biofilm community.
   abundance_level: ABUNDANT
   common_taxon: CommunityMech:taxon:000001
@@ -81,6 +89,14 @@ taxonomy:
     term:
       id: NCBITaxon:35554
       label: Geobacter sulfurreducens
+    gtdb_classification:
+      gtdb_id: GTDB:s__Geobacter_sulfurreducens
+      gtdb_taxon: Geobacter sulfurreducens
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter sulfurreducens
+      ncbi_source_id: NCBITaxon:35554
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Exoelectrogenic Geobacter member that was detected in the planktonic phase of mixed-culture
       reactors as well as in the anode-associated community.
   abundance_level: ABUNDANT
@@ -104,6 +120,14 @@ taxonomy:
     term:
       id: NCBITaxon:28232
       label: Geobacter metallireducens
+    gtdb_classification:
+      gtdb_id: GTDB:s__Geobacter_metallireducens
+      gtdb_taxon: Geobacter metallireducens
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
+      ncbi_source_id: NCBITaxon:28232
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Exoelectrogenic Geobacter member of the defined biofilm community.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.yaml
+++ b/kb/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.yaml
@@ -51,6 +51,14 @@ taxonomy:
     term:
       id: NCBITaxon:211586
       label: Shewanella oneidensis MR-1
+    gtdb_classification:
+      gtdb_id: GTDB:s__Shewanella_oneidensis
+      gtdb_taxon: Shewanella oneidensis
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella oneidensis
+      ncbi_source_id: NCBITaxon:211586
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Exoelectrogenic strain that generates electricity from lactic acid in the MFC.
   strain_designation:
     strain_name: MR-1

--- a/kb/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.yaml
+++ b/kb/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.yaml
@@ -28,6 +28,14 @@ taxonomy:
     term:
       id: NCBITaxon:201174
       label: Actinomycetota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Actinomycetota
+      gtdb_taxon: Actinomycetota
+      gtdb_lineage: d__Bacteria;p__Actinomycetota
+      ncbi_source_id: NCBITaxon:201174
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 6 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -42,6 +50,14 @@ taxonomy:
     term:
       id: NCBITaxon:200795
       label: Chloroflexota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Chloroflexota
+      gtdb_taxon: Chloroflexota
+      gtdb_lineage: d__Bacteria;p__Chloroflexota
+      ncbi_source_id: NCBITaxon:200795
+      majority_fraction: 0.998
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 4 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_DEGRADER
   evidence:

--- a/kb/communities/Soil_Corrinoid_B12_Reservoir_Community.yaml
+++ b/kb/communities/Soil_Corrinoid_B12_Reservoir_Community.yaml
@@ -28,6 +28,14 @@ taxonomy:
     term:
       id: NCBITaxon:28889
       label: Thermoproteota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Thermoproteota
+      gtdb_taxon: Thermoproteota
+      gtdb_lineage: d__Archaea;p__Thermoproteota
+      ncbi_source_id: NCBITaxon:28889
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_PRODUCER
   evidence:
@@ -42,6 +50,14 @@ taxonomy:
     term:
       id: NCBITaxon:201174
       label: Actinomycetota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Actinomycetota
+      gtdb_taxon: Actinomycetota
+      gtdb_lineage: d__Bacteria;p__Actinomycetota
+      ncbi_source_id: NCBITaxon:201174
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 6 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_PRODUCER
   evidence:
@@ -56,6 +72,14 @@ taxonomy:
     term:
       id: NCBITaxon:1224
       label: Pseudomonadota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Pseudomonadota
+      gtdb_taxon: Pseudomonadota
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota
+      ncbi_source_id: NCBITaxon:1224
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 14 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Sorghum_SRC1_Subset.yaml
+++ b/kb/communities/Sorghum_SRC1_Subset.yaml
@@ -57,6 +57,14 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_classification:
+      gtdb_id: GTDB:g__Bacillus
+      gtdb_taxon: Bacillus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
+      ncbi_source_id: NCBITaxon:1386
+      majority_fraction: 0.508
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -86,6 +94,14 @@ taxonomy:
     term:
       id: NCBITaxon:1889
       label: Streptomyces ambofaciens
+    gtdb_classification:
+      gtdb_id: GTDB:s__Streptomyces_ambofaciens
+      gtdb_taxon: Streptomyces ambofaciens
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Streptomycetales;f__Streptomycetaceae;g__Streptomyces;s__Streptomyces ambofaciens
+      ncbi_source_id: NCBITaxon:1889
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -101,6 +117,14 @@ taxonomy:
     term:
       id: NCBITaxon:1401
       label: Paenibacillus lautus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Paenibacillus_lautus
+      gtdb_taxon: Paenibacillus lautus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Paenibacillales;f__Paenibacillaceae;g__Paenibacillus;s__Paenibacillus lautus
+      ncbi_source_id: NCBITaxon:1401
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -116,6 +140,14 @@ taxonomy:
     term:
       id: NCBITaxon:272772
       label: Pseudomonas pudica
+    gtdb_classification:
+      gtdb_id: GTDB:s__Pseudomonas_E_pudica
+      gtdb_taxon: Pseudomonas_E pudica
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas_E;s__Pseudomonas_E pudica
+      ncbi_source_id: NCBITaxon:272772
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.yaml
+++ b/kb/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.yaml
@@ -46,6 +46,14 @@ taxonomy:
     term:
       id: NCBITaxon:374
       label: Bradyrhizobium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Bradyrhizobium
+      gtdb_taxon: Bradyrhizobium
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Bradyrhizobium
+      ncbi_source_id: NCBITaxon:374
+      majority_fraction: 0.982
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 8 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
+++ b/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
@@ -43,6 +43,14 @@ taxonomy:
     term:
       id: NCBITaxon:29448
       label: Bradyrhizobium elkanii
+    gtdb_classification:
+      gtdb_id: GTDB:s__Bradyrhizobium_elkanii
+      gtdb_taxon: Bradyrhizobium elkanii
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Bradyrhizobium;s__Bradyrhizobium elkanii
+      ncbi_source_id: NCBITaxon:29448
+      majority_fraction: 0.89
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_PRODUCER
@@ -59,6 +67,14 @@ taxonomy:
     term:
       id: NCBITaxon:53335
       label: Pantoea
+    gtdb_classification:
+      gtdb_id: GTDB:g__Pantoea
+      gtdb_taxon: Pantoea
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Pantoea
+      ncbi_source_id: NCBITaxon:53335
+      majority_fraction: 0.961
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 15 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Sphingobium_Rhodococcus_Lignin_Dimer_Valorization_Coculture.yaml
+++ b/kb/communities/Sphingobium_Rhodococcus_Lignin_Dimer_Valorization_Coculture.yaml
@@ -54,6 +54,14 @@ taxonomy:
     term:
       id: NCBITaxon:165695
       label: Sphingobium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Sphingobium
+      gtdb_taxon: Sphingobium
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Sphingobium
+      ncbi_source_id: NCBITaxon:165695
+      majority_fraction: 0.993
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: >
       The publication identifies the dimer-cleaving partner at genus level as
       Sphingobium sp.; no species name is asserted here.

--- a/kb/communities/Subsurface_Carboxydocella_CO_Aquifer_Community.yaml
+++ b/kb/communities/Subsurface_Carboxydocella_CO_Aquifer_Community.yaml
@@ -26,6 +26,14 @@ taxonomy:
     term:
       id: NCBITaxon:178898
       label: Carboxydocella
+    gtdb_classification:
+      gtdb_id: GTDB:g__Carboxydocella
+      gtdb_taxon: Carboxydocella
+      gtdb_lineage: d__Bacteria;p__Bacillota_B;c__GCA-003054495;o__Carboxydocellales;f__Carboxydocellaceae;g__Carboxydocella
+      ncbi_source_id: NCBITaxon:178898
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Native carboxydotrophic Carboxydocella whose relative abundance
       decreased post-scCO2 injection.
   functional_role:

--- a/kb/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.yaml
+++ b/kb/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.yaml
@@ -29,6 +29,14 @@ taxonomy:
     term:
       id: NCBITaxon:1031
       label: Thiothrix nivea
+    gtdb_classification:
+      gtdb_id: GTDB:s__Thiothrix_nivea
+      gtdb_taxon: Thiothrix nivea
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Thiotrichales;f__Thiotrichaceae;g__Thiothrix;s__Thiothrix nivea
+      ncbi_source_id: NCBITaxon:1031
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_PRODUCER
@@ -46,6 +54,14 @@ taxonomy:
     term:
       id: NCBITaxon:1021
       label: Beggiatoa
+    gtdb_classification:
+      gtdb_id: GTDB:g__Beggiatoa
+      gtdb_taxon: Beggiatoa
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Beggiatoales;f__Beggiatoaceae;g__Beggiatoa
+      ncbi_source_id: NCBITaxon:1021
+      majority_fraction: 0.75
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_PRODUCER

--- a/kb/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.yaml
+++ b/kb/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.yaml
@@ -48,6 +48,14 @@ taxonomy:
     term:
       id: NCBITaxon:1140
       label: Synechococcus elongatus PCC 7942 = FACHB-805
+    gtdb_classification:
+      gtdb_id: GTDB:s__Synechococcus_elongatus
+      gtdb_taxon: Synechococcus elongatus
+      gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
+      ncbi_source_id: NCBITaxon:1140
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Engineered PCC 7942 derivative expressing cscB for sucrose export.
   strain_designation:
     strain_name: PCC 7942 cscB
@@ -76,6 +84,14 @@ taxonomy:
     term:
       id: NCBITaxon:354
       label: Azotobacter vinelandii
+    gtdb_classification:
+      gtdb_id: GTDB:s__Azotobacter_vinelandii
+      gtdb_taxon: Azotobacter vinelandii
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Azotobacter;s__Azotobacter vinelandii
+      ncbi_source_id: NCBITaxon:354
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: The primary publication specifies strain AV3; NCBI Taxonomy resolves the organism at species
       level for this record.
   strain_designation:

--- a/kb/communities/Synechococcus_Bacillus_SPC.yaml
+++ b/kb/communities/Synechococcus_Bacillus_SPC.yaml
@@ -36,6 +36,14 @@ taxonomy:
     term:
       id: NCBITaxon:32046
       label: Synechococcus elongatus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Synechococcus_elongatus
+      gtdb_taxon: Synechococcus elongatus
+      gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
+      ncbi_source_id: NCBITaxon:32046
+      majority_fraction: 0.85
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_PRODUCER
@@ -56,6 +64,14 @@ taxonomy:
     term:
       id: NCBITaxon:1423
       label: Bacillus subtilis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Bacillus_subtilis
+      gtdb_taxon: Bacillus subtilis
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
+      ncbi_source_id: NCBITaxon:1423
+      majority_fraction: 0.91
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   abundance_level: ABUNDANT
   functional_role:
   - CROSS_FEEDER

--- a/kb/communities/Synechococcus_Ecoli_SPC.yaml
+++ b/kb/communities/Synechococcus_Ecoli_SPC.yaml
@@ -43,6 +43,14 @@ taxonomy:
     term:
       id: NCBITaxon:32046
       label: Synechococcus elongatus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Synechococcus_elongatus
+      gtdb_taxon: Synechococcus elongatus
+      gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
+      ncbi_source_id: NCBITaxon:32046
+      majority_fraction: 0.85
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Engineered strain expressing E. coli H+/sucrose symporter CscB to enable sucrose export. Wild-type
       strain does not secrete significant sucrose.
 
@@ -68,6 +76,14 @@ taxonomy:
     term:
       id: NCBITaxon:83333
       label: Escherichia coli K-12
+    gtdb_classification:
+      gtdb_id: GTDB:s__Escherichia_coli
+      gtdb_taxon: Escherichia coli
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
+      ncbi_source_id: NCBITaxon:83333
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Heterotrophic partner that utilizes secreted sucrose from the cyanobacterium.
 
       '

--- a/kb/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.yaml
+++ b/kb/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.yaml
@@ -48,6 +48,14 @@ taxonomy:
     term:
       id: NCBITaxon:32046
       label: Synechococcus elongatus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Synechococcus_elongatus
+      gtdb_taxon: Synechococcus elongatus
+      gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
+      ncbi_source_id: NCBITaxon:32046
+      majority_fraction: 0.85
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Engineered PCC 7942 derivative expressing cscB for sucrose export.
   strain_designation:
     strain_name: PCC 7942 cscB
@@ -76,6 +84,14 @@ taxonomy:
     term:
       id: NCBITaxon:1072583
       label: Vreelandella boliviensis LC1
+    gtdb_classification:
+      gtdb_id: GTDB:s__Vreelandella_boliviensis
+      gtdb_taxon: Vreelandella boliviensis
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Halomonadaceae;g__Vreelandella;s__Vreelandella boliviensis
+      ncbi_source_id: NCBITaxon:1072583
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: The publication and culture collections use Halomonas boliviensis LC1; NCBI Taxonomy currently
       represents the strain as Vreelandella boliviensis LC1.
   strain_designation:

--- a/kb/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.yaml
+++ b/kb/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.yaml
@@ -53,6 +53,14 @@ taxonomy:
     term:
       id: NCBITaxon:32046
       label: Synechococcus elongatus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Synechococcus_elongatus
+      gtdb_taxon: Synechococcus elongatus
+      gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
+      ncbi_source_id: NCBITaxon:32046
+      majority_fraction: 0.85
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Engineered PCC 7942 derivative expressing the heterologous CscB sucrose permease to export
       photosynthetically fixed carbon as sucrose.
   strain_designation:

--- a/kb/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.yaml
+++ b/kb/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.yaml
@@ -54,6 +54,14 @@ taxonomy:
     term:
       id: NCBITaxon:1350461
       label: Synechococcus elongatus UTEX 2973
+    gtdb_classification:
+      gtdb_id: GTDB:s__Synechococcus_elongatus
+      gtdb_taxon: Synechococcus elongatus
+      gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
+      ncbi_source_id: NCBITaxon:1350461
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Engineered Syn2973-omcS-ldh cyanobacterial charging unit that produces D-lactate.
   strain_designation:
     strain_name: UTEX 2973
@@ -76,6 +84,14 @@ taxonomy:
     term:
       id: NCBITaxon:211586
       label: Shewanella oneidensis MR-1
+    gtdb_classification:
+      gtdb_id: GTDB:s__Shewanella_oneidensis
+      gtdb_taxon: Shewanella oneidensis
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella oneidensis
+      ncbi_source_id: NCBITaxon:211586
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Engineered napA deletion discharging unit used for D-lactate oxidation and anode electron transfer.
   strain_designation:
     strain_name: MR-1

--- a/kb/communities/Synechococcus_Yarrowia_SPC.yaml
+++ b/kb/communities/Synechococcus_Yarrowia_SPC.yaml
@@ -38,6 +38,14 @@ taxonomy:
     term:
       id: NCBITaxon:32046
       label: Synechococcus elongatus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Synechococcus_elongatus
+      gtdb_taxon: Synechococcus elongatus
+      gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
+      ncbi_source_id: NCBITaxon:32046
+      majority_fraction: 0.85
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_PRODUCER

--- a/kb/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.yaml
+++ b/kb/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.yaml
@@ -38,6 +38,14 @@ taxonomy:
     term:
       id: NCBITaxon:32046
       label: Synechococcus elongatus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Synechococcus_elongatus
+      gtdb_taxon: Synechococcus elongatus
+      gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
+      ncbi_source_id: NCBITaxon:32046
+      majority_fraction: 0.85
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Engineered cyanobacterial phototroph expressing cscB to secrete sucrose.
   strain_designation:
     strain_name: PCC 7942 cscB+

--- a/kb/communities/Synthetic_Periphyton_Freshwater_Biofilm.yaml
+++ b/kb/communities/Synthetic_Periphyton_Freshwater_Biofilm.yaml
@@ -55,6 +55,14 @@ taxonomy:
     term:
       id: NCBITaxon:1117
       label: Cyanobacteriota
+    gtdb_classification:
+      gtdb_id: GTDB:p__Cyanobacteriota
+      gtdb_taxon: Cyanobacteriota
+      gtdb_lineage: d__Bacteria;p__Cyanobacteriota
+      ncbi_source_id: NCBITaxon:1117
+      majority_fraction: 0.998
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 5 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Syntrophobacter_Methanobacterium_Syntrophy.yaml
+++ b/kb/communities/Syntrophobacter_Methanobacterium_Syntrophy.yaml
@@ -30,6 +30,14 @@ taxonomy:
     term:
       id: NCBITaxon:119484
       label: Syntrophobacter fumaroxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Syntrophobacter_fumaroxidans
+      gtdb_taxon: Syntrophobacter fumaroxidans
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Syntrophobacteria;o__Syntrophobacterales;f__Syntrophobacteraceae;g__Syntrophobacter;s__Syntrophobacter fumaroxidans
+      ncbi_source_id: NCBITaxon:119484
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Anaerobic, syntrophic, propionate-oxidizing bacterium that degrades propionate to acetate
       via the methylmalonyl-CoA pathway. Cannot grow on propionate alone; requires syntrophic association
       with H2/formate-utilizing partners. Uses protons as electron acceptor, producing H2 and formate
@@ -54,6 +62,14 @@ taxonomy:
     term:
       id: NCBITaxon:2162
       label: Methanobacterium formicicum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methanobacterium_formicicum
+      gtdb_taxon: Methanobacterium formicicum
+      gtdb_lineage: d__Archaea;p__Methanobacteriota;c__Methanobacteria;o__Methanobacteriales;f__Methanobacteriaceae;g__Methanobacterium;s__Methanobacterium formicicum
+      ncbi_source_id: NCBITaxon:2162
+      majority_fraction: 0.94
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Hydrogen and formate-utilizing methanogen that consumes H2/formate and CO2 to produce methane
       via hydrogenotrophic methanogenesis. Essential syntrophic partner that maintains low H2 and formate
       partial pressure, enabling thermodynamically unfavorable propionate oxidation by S. fumaroxidans.

--- a/kb/communities/Syntrophobacter_Methanospirillum_Syntrophy.yaml
+++ b/kb/communities/Syntrophobacter_Methanospirillum_Syntrophy.yaml
@@ -30,6 +30,14 @@ taxonomy:
     term:
       id: NCBITaxon:119484
       label: Syntrophobacter fumaroxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Syntrophobacter_fumaroxidans
+      gtdb_taxon: Syntrophobacter fumaroxidans
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Syntrophobacteria;o__Syntrophobacterales;f__Syntrophobacteraceae;g__Syntrophobacter;s__Syntrophobacter fumaroxidans
+      ncbi_source_id: NCBITaxon:119484
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Anaerobic, syntrophic, propionate-oxidizing bacterium that degrades propionate to acetate
       via the methylmalonyl-CoA pathway. Cannot grow on propionate alone; requires syntrophic association
       with H2/formate-utilizing partners. Uses protons as electron acceptor, producing H2 and formate
@@ -54,6 +62,14 @@ taxonomy:
     term:
       id: NCBITaxon:2203
       label: Methanospirillum hungatei
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methanospirillum_hungatei
+      gtdb_taxon: Methanospirillum hungatei
+      gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanospirillum;s__Methanospirillum hungatei
+      ncbi_source_id: NCBITaxon:2203
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Hydrogen and formate-utilizing methanogen that consumes H2/formate and CO2 to produce methane
       via hydrogenotrophic methanogenesis. Essential syntrophic partner that maintains low H2 and formate
       partial pressure, enabling thermodynamically unfavorable propionate oxidation by S. fumaroxidans.

--- a/kb/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.yaml
+++ b/kb/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.yaml
@@ -75,6 +75,14 @@ taxonomy:
     term:
       id: NCBITaxon:39152
       label: Methanococcus maripaludis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methanococcus_maripaludis
+      gtdb_taxon: Methanococcus maripaludis
+      gtdb_lineage: d__Archaea;p__Methanobacteriota_A;c__Methanococci;o__Methanococcales;f__Methanococcaceae;g__Methanococcus;s__Methanococcus maripaludis
+      ncbi_source_id: NCBITaxon:39152
+      majority_fraction: 0.93
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Hydrogenotrophic methanogen paired with S. wolfei in the mesophilic coculture.
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Syntrophomonas_Methanospirillum_Syntrophy.yaml
+++ b/kb/communities/Syntrophomonas_Methanospirillum_Syntrophy.yaml
@@ -50,6 +50,14 @@ taxonomy:
     term:
       id: NCBITaxon:2203
       label: Methanospirillum hungatei
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methanospirillum_hungatei
+      gtdb_taxon: Methanospirillum hungatei
+      gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanospirillum;s__Methanospirillum hungatei
+      ncbi_source_id: NCBITaxon:2203
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Hydrogen-utilizing methanogen that consumes H2 and CO2 to produce methane. Essential syntrophic
       partner that maintains low H2 partial pressure, enabling thermodynamically unfavorable fatty acid
       oxidation by S. wolfei.

--- a/kb/communities/Syntrophus_Benzoate_Degrader.yaml
+++ b/kb/communities/Syntrophus_Benzoate_Degrader.yaml
@@ -30,6 +30,14 @@ taxonomy:
     term:
       id: NCBITaxon:56780
       label: Syntrophus aciditrophicus SB
+    gtdb_classification:
+      gtdb_id: GTDB:s__Syntrophus_aciditrophicus
+      gtdb_taxon: Syntrophus aciditrophicus
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Syntrophia;o__Syntrophales;f__Syntrophaceae;g__Syntrophus;s__Syntrophus aciditrophicus
+      ncbi_source_id: NCBITaxon:56780
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Anaerobic, syntrophic bacterium that degrades benzoate and other aromatic compounds to acetate,
       H2, and formate. Cannot grow on benzoate alone; requires syntrophic association with H2-utilizing
       partners. Uses protons as electron acceptor, producing H2 and formate as electron sink products.
@@ -53,6 +61,14 @@ taxonomy:
     term:
       id: NCBITaxon:2203
       label: Methanospirillum hungatei
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methanospirillum_hungatei
+      gtdb_taxon: Methanospirillum hungatei
+      gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanospirillum;s__Methanospirillum hungatei
+      ncbi_source_id: NCBITaxon:2203
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Hydrogen-utilizing methanogen that consumes H2 and CO2 to produce methane. Essential syntrophic
       partner that maintains low H2 partial pressure, enabling thermodynamically unfavorable benzoate
       degradation by S. aciditrophicus.

--- a/kb/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.yaml
+++ b/kb/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.yaml
@@ -47,6 +47,14 @@ taxonomy:
     term:
       id: NCBITaxon:43775
       label: Syntrophus gentianae
+    gtdb_classification:
+      gtdb_id: GTDB:s__Syntrophus_gentianae
+      gtdb_taxon: Syntrophus gentianae
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Syntrophia;o__Syntrophales;f__Syntrophaceae;g__Syntrophus;s__Syntrophus gentianae
+      ncbi_source_id: NCBITaxon:43775
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Anaerobic syntrophic benzoate-fermenting bacterium in the methanogenic coculture.
   strain_designation:
     strain_name: HQG1
@@ -77,6 +85,14 @@ taxonomy:
     term:
       id: NCBITaxon:2203
       label: Methanospirillum hungatei
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methanospirillum_hungatei
+      gtdb_taxon: Methanospirillum hungatei
+      gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanospirillum;s__Methanospirillum hungatei
+      ncbi_source_id: NCBITaxon:2203
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Methanogenic archaeal partner in the S. gentianae benzoate-degrading coculture.
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/THOR_Rhizosphere_Model_Community.yaml
+++ b/kb/communities/THOR_Rhizosphere_Model_Community.yaml
@@ -80,6 +80,14 @@ taxonomy:
     term:
       id: NCBITaxon:986
       label: Flavobacterium johnsoniae
+    gtdb_classification:
+      gtdb_id: GTDB:s__Flavobacterium_johnsoniae
+      gtdb_taxon: Flavobacterium johnsoniae
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Flavobacteriales;f__Flavobacteriaceae;g__Flavobacterium;s__Flavobacterium johnsoniae
+      ncbi_source_id: NCBITaxon:986
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Bacteroidetes/Flavobacteriia member whose abundance and transcriptional state are sensitive
       to P. koreensis and koreenceine.
   strain_designation:

--- a/kb/communities/TYQ1_Nematode_Biocontrol_SynCom.yaml
+++ b/kb/communities/TYQ1_Nematode_Biocontrol_SynCom.yaml
@@ -46,6 +46,14 @@ taxonomy:
     term:
       id: NCBITaxon:648995
       label: Agrobacterium pusense
+    gtdb_classification:
+      gtdb_id: GTDB:s__Agrobacterium_pusense
+      gtdb_taxon: Agrobacterium pusense
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Agrobacterium;s__Agrobacterium pusense
+      ncbi_source_id: NCBITaxon:648995
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Keystone species and central metabolic hub. Directly inhibits root-knot nematodes and coordinates
       biofilm formation across the community. Its enrichment causes restructuring of the rhizobacterial
       community, leading to recruitment of 7 biomarker species.
@@ -70,6 +78,14 @@ taxonomy:
     term:
       id: NCBITaxon:237612
       label: Sphingomonas panni
+    gtdb_classification:
+      gtdb_id: GTDB:s__Sphingomonas_panni
+      gtdb_taxon: Sphingomonas panni
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Sphingomonas;s__Sphingomonas panni
+      ncbi_source_id: NCBITaxon:237612
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Biomarker species recruited by TYQ1 enrichment (OTU2477).
   strain_designation:
     strain_name: SP
@@ -88,6 +104,14 @@ taxonomy:
     term:
       id: NCBITaxon:13687
       label: Sphingomonas
+    gtdb_classification:
+      gtdb_id: GTDB:g__Sphingomonas
+      gtdb_taxon: Sphingomonas
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Sphingomonas
+      ncbi_source_id: NCBITaxon:13687
+      majority_fraction: 0.777
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 24 GTDB taxa under the NCBI taxon]
     notes: 'Biomarker species recruited by TYQ1 enrichment (OTU1716). Genus-level NCBITaxon used as species-level
       ID not available.
 
@@ -129,6 +153,14 @@ taxonomy:
     term:
       id: NCBITaxon:12916
       label: Acidovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Acidovorax
+      gtdb_taxon: Acidovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Acidovorax
+      ncbi_source_id: NCBITaxon:12916
+      majority_fraction: 0.867
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 9 GTDB taxa under the NCBI taxon]
     notes: Biomarker species with significant nematicidal activity (OTU2649).
   strain_designation:
     strain_name: AF
@@ -146,6 +178,14 @@ taxonomy:
     term:
       id: NCBITaxon:48936
       label: Novosphingobium subterraneum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Novosphingobium_subterraneum
+      gtdb_taxon: Novosphingobium subterraneum
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Novosphingobium;s__Novosphingobium subterraneum
+      ncbi_source_id: NCBITaxon:48936
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Biomarker species recruited by TYQ1 enrichment (OTU613).
   strain_designation:
     strain_name: NS

--- a/kb/communities/Teosinte_Maize_Biofertilizer_SynCom7.yaml
+++ b/kb/communities/Teosinte_Maize_Biofertilizer_SynCom7.yaml
@@ -37,6 +37,14 @@ taxonomy:
     term:
       id: NCBITaxon:613
       label: Serratia <enterobacteria>
+    gtdb_classification:
+      gtdb_id: GTDB:g__Serratia
+      gtdb_taxon: Serratia
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Serratia
+      ncbi_source_id: NCBITaxon:613
+      majority_fraction: 0.519
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 14 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -46,6 +54,14 @@ taxonomy:
     term:
       id: NCBITaxon:244366
       label: Klebsiella variicola
+    gtdb_classification:
+      gtdb_id: GTDB:s__Klebsiella_variicola
+      gtdb_taxon: Klebsiella variicola
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Klebsiella;s__Klebsiella variicola
+      ncbi_source_id: NCBITaxon:244366
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -64,6 +80,14 @@ taxonomy:
     term:
       id: NCBITaxon:549
       label: Pantoea agglomerans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Pantoea_agglomerans
+      gtdb_taxon: Pantoea agglomerans
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Pantoea;s__Pantoea agglomerans
+      ncbi_source_id: NCBITaxon:549
+      majority_fraction: 0.9
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.yaml
+++ b/kb/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.yaml
@@ -70,6 +70,14 @@ taxonomy:
     term:
       id: NCBITaxon:225937
       label: Marinobacter adhaerens HP15
+    gtdb_classification:
+      gtdb_id: GTDB:s__Marinobacter_adhaerens
+      gtdb_taxon: Marinobacter adhaerens
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Oleiphilaceae;g__Marinobacter;s__Marinobacter adhaerens
+      ncbi_source_id: NCBITaxon:225937
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: >
       Diatom-attaching marine gammaproteobacterium originally isolated from
       marine particles in the German Wadden Sea and used as a model bacterium

--- a/kb/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.yaml
+++ b/kb/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.yaml
@@ -66,6 +66,14 @@ taxonomy:
     term:
       id: NCBITaxon:246200
       label: Ruegeria pomeroyi DSS-3
+    gtdb_classification:
+      gtdb_id: GTDB:s__Ruegeria_B_pomeroyi
+      gtdb_taxon: Ruegeria_B pomeroyi
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhodobacterales;f__Rhodobacteraceae;g__Ruegeria_B;s__Ruegeria_B pomeroyi
+      ncbi_source_id: NCBITaxon:246200
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Heterotrophic roseobacter strain DSS-3, inoculated into the diatom culture in pairwise coculture.
   abundance_value: One of two members in the defined coculture.
   functional_role:

--- a/kb/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.yaml
+++ b/kb/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.yaml
@@ -53,6 +53,14 @@ taxonomy:
     term:
       id: NCBITaxon:1089553
       label: Thermacetogenium phaeum DSM 12270
+    gtdb_classification:
+      gtdb_id: GTDB:s__Thermacetogenium_phaeum
+      gtdb_taxon: Thermacetogenium phaeum
+      gtdb_lineage: d__Bacteria;p__Bacillota_B;c__DSM-12270;o__Thermacetogeniales;f__Thermacetogeniaceae;g__Thermacetogenium;s__Thermacetogenium phaeum
+      ncbi_source_id: NCBITaxon:1089553
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Type strain PB/DSM 12270; acetate-oxidizing syntrophic bacterium in the defined coculture.
   strain_designation:
     strain_name: PB
@@ -84,6 +92,14 @@ taxonomy:
     term:
       id: NCBITaxon:145262
       label: Methanothermobacter thermautotrophicus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methanothermobacter_thermautotrophicus
+      gtdb_taxon: Methanothermobacter thermautotrophicus
+      gtdb_lineage: d__Archaea;p__Methanobacteriota;c__Methanobacteria;o__Methanobacteriales;f__Methanothermobacteraceae;g__Methanothermobacter;s__Methanothermobacter thermautotrophicus
+      ncbi_source_id: NCBITaxon:145262
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Source literature also uses the spelling Methanothermobacter thermoautotrophicus;
       this record uses the NCBI current label for the same methanogenic partner.
   strain_designation:

--- a/kb/communities/Thermophilic_Pyrite_QS_Consortium.yaml
+++ b/kb/communities/Thermophilic_Pyrite_QS_Consortium.yaml
@@ -59,6 +59,14 @@ taxonomy:
     term:
       id: NCBITaxon:178606
       label: Leptospirillum ferriphilum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Leptospirillum_A_rubarum
+      gtdb_taxon: Leptospirillum_A rubarum
+      gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
+      ncbi_source_id: NCBITaxon:178606
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Chemolithoautotrophic iron-oxidizing bacterium (Nitrospirae phylum) representing a dominant
       member of moderately thermophilic bioleaching consortia. L. ferriphilum DSM 14647 (type strain)
       oxidizes ferrous iron [Fe(II)] to ferric iron [Fe(III)] as the primary energy source for carbon
@@ -102,6 +110,14 @@ taxonomy:
     term:
       id: NCBITaxon:33059
       label: Acidithiobacillus caldus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidithiobacillus_A_caldus
+      gtdb_taxon: Acidithiobacillus_A caldus
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus_A;s__Acidithiobacillus_A caldus
+      ncbi_source_id: NCBITaxon:33059
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Gram-negative γ-proteobacterium specialized for oxidizing reduced inorganic sulfur compounds
       (RISCs) including elemental sulfur, tetrathionate, and thiosulfate to sulfuric acid. A. caldus DSM
       8584 (type strain KU) is a moderately thermophilic acidophile with temperature optimum at 45°C and
@@ -156,6 +172,14 @@ taxonomy:
     term:
       id: NCBITaxon:28034
       label: Sulfobacillus thermosulfidooxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Sulfobacillus_thermosulfidooxidans
+      gtdb_taxon: Sulfobacillus thermosulfidooxidans
+      gtdb_lineage: d__Bacteria;p__Bacillota_E;c__Sulfobacillia;o__Sulfobacillales;f__Sulfobacillaceae;g__Sulfobacillus;s__Sulfobacillus thermosulfidooxidans
+      ncbi_source_id: NCBITaxon:28034
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Gram-positive, spore-forming, moderately thermophilic bacterium (Firmicutes) that oxidizes
       both ferrous iron and reduced sulfur compounds. S. thermosulfidooxidans DSM 9293 (type strain AT-1)
       exhibits temperature optimum at 50-55°C with growth range of 20-60°C, representing the most thermophilic

--- a/kb/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.yaml
+++ b/kb/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.yaml
@@ -53,6 +53,14 @@ taxonomy:
     term:
       id: NCBITaxon:243274
       label: Thermotoga maritima MSB8
+    gtdb_classification:
+      gtdb_id: GTDB:s__Thermotoga_maritima
+      gtdb_taxon: Thermotoga maritima
+      gtdb_lineage: d__Bacteria;p__Thermotogota;c__Thermotogae;o__Thermotogales;f__Thermotogaceae;g__Thermotoga;s__Thermotoga maritima
+      ncbi_source_id: NCBITaxon:243274
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Hyperthermophilic anaerobic heterotroph and hydrogen-producing fermentative member.
   strain_designation:
     strain_name: MSB8
@@ -83,6 +91,14 @@ taxonomy:
     term:
       id: NCBITaxon:243232
       label: Methanocaldococcus jannaschii DSM 2661
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methanocaldococcus_jannaschii
+      gtdb_taxon: Methanocaldococcus jannaschii
+      gtdb_lineage: d__Archaea;p__Methanobacteriota_A;c__Methanococci;o__Methanococcales;f__Methanocaldococcaceae;g__Methanocaldococcus;s__Methanocaldococcus jannaschii
+      ncbi_source_id: NCBITaxon:243232
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: >
       Source publications use the historical name Methanococcus jannaschii.
       NCBI currently represents the DSM 2661/JAL-1 strain as Methanocaldococcus

--- a/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
+++ b/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
@@ -54,6 +54,14 @@ taxonomy:
     term:
       id: NCBITaxon:919
       label: Thiobacillus
+    gtdb_classification:
+      gtdb_id: GTDB:g__Thiobacillus
+      gtdb_taxon: Thiobacillus
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Thiobacillaceae;g__Thiobacillus
+      ncbi_source_id: NCBITaxon:919
+      majority_fraction: 0.714
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
     notes: A single Thiobacillus strain proliferated in all reactors at high
       SCN- loadings.
   abundance_level: DOMINANT
@@ -72,6 +80,14 @@ taxonomy:
     term:
       id: NCBITaxon:1033
       label: Afipia
+    gtdb_classification:
+      gtdb_id: GTDB:g__Afipia
+      gtdb_taxon: Afipia
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Afipia
+      ncbi_source_id: NCBITaxon:1033
+      majority_fraction: 0.957
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: A single Afipia variant dominated the molasses-free reactor at
       moderately high SCN- loadings.
   abundance_level: DOMINANT
@@ -90,6 +106,14 @@ taxonomy:
     term:
       id: NCBITaxon:356
       label: Hyphomicrobiales
+    gtdb_classification:
+      gtdb_id: GTDB:o__Rhizobiales
+      gtdb_taxon: Rhizobiales
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales
+      ncbi_source_id: NCBITaxon:356
+      majority_fraction: 0.988
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at o__ rank; 17 GTDB taxa under the NCBI taxon]
     notes: Many Rhizobiales strains were present but did not dominate; Afipia
       (within Rhizobiales) was the molasses-free winner.
   functional_role:

--- a/kb/communities/Tinto_River_Iron_Cycling_Community.yaml
+++ b/kb/communities/Tinto_River_Iron_Cycling_Community.yaml
@@ -39,6 +39,14 @@ taxonomy:
     term:
       id: NCBITaxon:180
       label: Leptospirillum ferrooxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Leptospirillum_ferrooxidans
+      gtdb_taxon: Leptospirillum ferrooxidans
+      gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum;s__Leptospirillum ferrooxidans
+      ncbi_source_id: NCBITaxon:180
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: 'Dominant iron-oxidizing bacterium (approximately 40% of prokaryotic community) in Rio Tinto
       water column. L. ferrooxidans is an obligate chemolithoautotroph that oxidizes ferrous iron (Fe²⁺)
       to ferric iron (Fe³⁺) for energy, fixing CO₂ autotrophically. The organism thrives at pH 1.0-2.5
@@ -66,6 +74,14 @@ taxonomy:
     term:
       id: NCBITaxon:920
       label: Acidithiobacillus ferrooxidans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acidithiobacillus_ferrooxidans
+      gtdb_taxon: Acidithiobacillus ferrooxidans
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
+      ncbi_source_id: NCBITaxon:920
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Second dominant iron-oxidizing bacterium (~25% of prokaryotic community) with metabolic versatility
       for both iron and sulfur oxidation. At. ferrooxidans oxidizes Fe²⁺ to Fe³⁺ and reduced sulfur compounds
       to sulfuric acid, contributing to acidification and metal solubilization. The organism is chemolithoautotrophic,
@@ -88,6 +104,14 @@ taxonomy:
     term:
       id: NCBITaxon:522
       label: Acidiphilium
+    gtdb_classification:
+      gtdb_id: GTDB:g__UBA10281
+      gtdb_taxon: UBA10281
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Christensenellales;f__Borkfalkiaceae;g__UBA10281
+      ncbi_source_id: NCBITaxon:522
+      majority_fraction: 0.633
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Heterotrophic acidophile (~15% of prokaryotic community) forming the critical link between
       carbon and iron cycles in Rio Tinto. Acidiphilium spp. utilize organic carbon from algal exudates,
       cell lysis, and allochthonous inputs, remineralizing nutrients for autotrophs. The genus provides

--- a/kb/communities/Tobacco_Chemotactic_Biocontrol_SynCom.yaml
+++ b/kb/communities/Tobacco_Chemotactic_Biocontrol_SynCom.yaml
@@ -45,6 +45,14 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_classification:
+      gtdb_id: GTDB:g__Bacillus
+      gtdb_taxon: Bacillus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
+      ncbi_source_id: NCBITaxon:1386
+      majority_fraction: 0.508
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Tomato_Oxylipin_SynCom3.yaml
+++ b/kb/communities/Tomato_Oxylipin_SynCom3.yaml
@@ -36,6 +36,14 @@ taxonomy:
     term:
       id: NCBITaxon:76890
       label: Asticcacaulis
+    gtdb_classification:
+      gtdb_id: GTDB:g__Asticcacaulis
+      gtdb_taxon: Asticcacaulis
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Caulobacterales;f__Caulobacteraceae;g__Asticcacaulis
+      ncbi_source_id: NCBITaxon:76890
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -45,6 +53,14 @@ taxonomy:
     term:
       id: NCBITaxon:1769012
       label: Arachidicoccus
+    gtdb_classification:
+      gtdb_id: GTDB:g__Arachidicoccus
+      gtdb_taxon: Arachidicoccus
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Chitinophagales;f__Chitinophagaceae;g__Arachidicoccus
+      ncbi_source_id: NCBITaxon:1769012
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -54,6 +70,14 @@ taxonomy:
     term:
       id: NCBITaxon:20
       label: Phenylobacterium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Phenylobacterium
+      gtdb_taxon: Phenylobacterium
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Caulobacterales;f__Caulobacteraceae;g__Phenylobacterium
+      ncbi_source_id: NCBITaxon:20
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.yaml
+++ b/kb/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.yaml
@@ -39,6 +39,14 @@ taxonomy:
     term:
       id: NCBITaxon:56112
       label: Dehalobacter
+    gtdb_classification:
+      gtdb_id: GTDB:g__Dehalobacter
+      gtdb_taxon: Dehalobacter
+      gtdb_lineage: d__Bacteria;p__Bacillota_B;c__Desulfitobacteriia;o__Desulfitobacteriales;f__Syntrophobotulaceae;g__Dehalobacter
+      ncbi_source_id: NCBITaxon:56112
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.yaml
+++ b/kb/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.yaml
@@ -51,6 +51,14 @@ taxonomy:
     term:
       id: NCBITaxon:82803
       label: Trichococcus flocculiformis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Trichococcus_flocculiformis
+      gtdb_taxon: Trichococcus flocculiformis
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Aerococcaceae;g__Trichococcus;s__Trichococcus flocculiformis
+      ncbi_source_id: NCBITaxon:82803
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: >
       Fermentative strain ES5 was added to the syntrophic coculture; the
       ontology grounding is species-level because the stable NCBI Taxonomy
@@ -101,6 +109,14 @@ taxonomy:
     term:
       id: NCBITaxon:2203
       label: Methanospirillum hungatei
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methanospirillum_hungatei
+      gtdb_taxon: Methanospirillum hungatei
+      gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanospirillum;s__Methanospirillum hungatei
+      ncbi_source_id: NCBITaxon:2203
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Hydrogen/formate-scavenging methanogenic archaeal partner in the three-member coculture.
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.yaml
+++ b/kb/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.yaml
@@ -68,6 +68,14 @@ taxonomy:
     term:
       id: NCBITaxon:562
       label: Escherichia coli
+    gtdb_classification:
+      gtdb_id: GTDB:s__Escherichia_coli
+      gtdb_taxon: Escherichia coli
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
+      ncbi_source_id: NCBITaxon:562
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Bacterial fermentation specialist; source abstract supports species-level identity.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Trichoderma_Lactate_Platform.yaml
+++ b/kb/communities/Trichoderma_Lactate_Platform.yaml
@@ -54,6 +54,14 @@ taxonomy:
     term:
       id: NCBITaxon:1589
       label: Lactiplantibacillus pentosus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Lactiplantibacillus_pentosus
+      gtdb_taxon: Lactiplantibacillus pentosus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactiplantibacillus;s__Lactiplantibacillus pentosus
+      ncbi_source_id: NCBITaxon:1589
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   abundance_level: ABUNDANT
   functional_role:
   - SECONDARY_FERMENTER
@@ -68,6 +76,14 @@ taxonomy:
     term:
       id: NCBITaxon:1519
       label: Clostridium tyrobutyricum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Clostridium_B_tyrobutyricum
+      gtdb_taxon: Clostridium_B tyrobutyricum
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_B;s__Clostridium_B tyrobutyricum
+      ncbi_source_id: NCBITaxon:1519
+      majority_fraction: 0.97
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   abundance_level: ABUNDANT
   functional_role:
   - SECONDARY_FERMENTER

--- a/kb/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.yaml
+++ b/kb/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.yaml
@@ -75,6 +75,14 @@ taxonomy:
     term:
       id: NCBITaxon:100226
       label: Streptomyces coelicolor A3(2)
+    gtdb_classification:
+      gtdb_id: GTDB:s__Streptomyces_anthocyanicus
+      gtdb_taxon: Streptomyces anthocyanicus
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Streptomycetales;f__Streptomycetaceae;g__Streptomyces;s__Streptomyces anthocyanicus
+      ncbi_source_id: NCBITaxon:100226
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Noncellulolytic bacterial member dependent on cellulase-derived hydrolysate sugars.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Trichodesmium_Alteromonas_Marine_Consortium.yaml
+++ b/kb/communities/Trichodesmium_Alteromonas_Marine_Consortium.yaml
@@ -23,6 +23,14 @@ taxonomy:
     term:
       id: NCBITaxon:203124
       label: Trichodesmium erythraeum IMS101
+    gtdb_classification:
+      gtdb_id: GTDB:s__Trichodesmium_erythraeum
+      gtdb_taxon: Trichodesmium erythraeum
+      gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Cyanobacteriales;f__Microcoleaceae;g__Trichodesmium;s__Trichodesmium erythraeum
+      ncbi_source_id: NCBITaxon:203124
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Nitrogen-fixing cyanobacterial colony former and photoautotrophic host of the consortium.
   functional_role:
   - PRIMARY_PRODUCER
@@ -37,6 +45,14 @@ taxonomy:
     term:
       id: NCBITaxon:28108
       label: Alteromonas macleodii
+    gtdb_classification:
+      gtdb_id: GTDB:s__Alteromonas_macleodii
+      gtdb_taxon: Alteromonas macleodii
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Alteromonadaceae;g__Alteromonas;s__Alteromonas macleodii
+      ncbi_source_id: NCBITaxon:28108
+      majority_fraction: 0.9
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Conserved gammaproteobacterial heterotroph associated with Trichodesmium colonies and cultures.
   functional_role:
   - CROSS_FEEDER

--- a/kb/communities/Urine_Nitrification_SynCom.yaml
+++ b/kb/communities/Urine_Nitrification_SynCom.yaml
@@ -36,6 +36,14 @@ taxonomy:
     term:
       id: NCBITaxon:915
       label: Nitrosomonas europaea
+    gtdb_classification:
+      gtdb_id: GTDB:s__Nitrosomonas_europaea
+      gtdb_taxon: Nitrosomonas europaea
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Nitrosomonadaceae;g__Nitrosomonas;s__Nitrosomonas europaea
+      ncbi_source_id: NCBITaxon:915
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -45,6 +53,14 @@ taxonomy:
     term:
       id: NCBITaxon:913
       label: Nitrobacter winogradskyi
+    gtdb_classification:
+      gtdb_id: GTDB:s__Nitrobacter_winogradskyi_A
+      gtdb_taxon: Nitrobacter winogradskyi_A
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Nitrobacter;s__Nitrobacter winogradskyi_A
+      ncbi_source_id: NCBITaxon:913
+      majority_fraction: 0.88
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.yaml
+++ b/kb/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.yaml
@@ -85,6 +85,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: The study identifies a Variovorax species as a thiamine-producing hub
       in the correlation network; species-level identity is not resolved in the
       abstract beyond the genus.

--- a/kb/communities/Wheat_Consortium_C1.yaml
+++ b/kb/communities/Wheat_Consortium_C1.yaml
@@ -38,6 +38,14 @@ taxonomy:
     term:
       id: NCBITaxon:151783
       label: Cupriavidus campinensis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Cupriavidus_campinensis
+      gtdb_taxon: Cupriavidus campinensis
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Cupriavidus;s__Cupriavidus campinensis
+      ncbi_source_id: NCBITaxon:151783
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   abundance_level: DOMINANT
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.yaml
+++ b/kb/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.yaml
@@ -39,6 +39,14 @@ taxonomy:
     term:
       id: NCBITaxon:1423
       label: Bacillus subtilis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Bacillus_subtilis
+      gtdb_taxon: Bacillus subtilis
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
+      ncbi_source_id: NCBITaxon:1423
+      majority_fraction: 0.91
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -48,6 +56,14 @@ taxonomy:
     term:
       id: NCBITaxon:40214
       label: Acinetobacter johnsonii
+    gtdb_classification:
+      gtdb_id: GTDB:s__Acinetobacter_johnsonii
+      gtdb_taxon: Acinetobacter johnsonii
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Moraxellaceae;g__Acinetobacter;s__Acinetobacter johnsonii
+      ncbi_source_id: NCBITaxon:40214
+      majority_fraction: 0.97
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
   functional_role:
   - PRIMARY_DEGRADER
   evidence:

--- a/kb/communities/Yogurt_TwoSpecies_Starter_Culture.yaml
+++ b/kb/communities/Yogurt_TwoSpecies_Starter_Culture.yaml
@@ -48,6 +48,14 @@ taxonomy:
     term:
       id: NCBITaxon:1308
       label: Streptococcus thermophilus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Streptococcus_thermophilus
+      gtdb_taxon: Streptococcus thermophilus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Streptococcus;s__Streptococcus thermophilus
+      ncbi_source_id: NCBITaxon:1308
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Thermophilic dairy starter species represented at species level because the curated community
       summarizes multiple exact two-species publications that use different S. thermophilus strains.
   functional_role:
@@ -70,6 +78,14 @@ taxonomy:
     term:
       id: NCBITaxon:1585
       label: Lactobacillus delbrueckii subsp. bulgaricus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Lactobacillus_delbrueckii
+      gtdb_taxon: Lactobacillus delbrueckii
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactobacillus;s__Lactobacillus delbrueckii
+      ncbi_source_id: NCBITaxon:1585
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Literature often uses Lactobacillus bulgaricus; NCBI taxon captures the accepted subspecies.
       The record is species/subspecies-level because publications use different L. bulgaricus strains.
   functional_role:

--- a/kb/communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.yaml
+++ b/kb/communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.yaml
@@ -51,6 +51,14 @@ taxonomy:
     term:
       id: NCBITaxon:542
       label: Zymomonas mobilis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Zymomonas_mobilis
+      gtdb_taxon: Zymomonas mobilis
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Zymomonas;s__Zymomonas mobilis
+      ncbi_source_id: NCBITaxon:542
+      majority_fraction: 0.89
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Curated at species level because the abstract supports Z. mobilis but does not specify a strain
       in the text used for this record; the interacting population is a ZMO0748 auxotroph.
   functional_role:
@@ -71,6 +79,14 @@ taxonomy:
     term:
       id: NCBITaxon:562
       label: Escherichia coli
+    gtdb_classification:
+      gtdb_id: GTDB:s__Escherichia_coli
+      gtdb_taxon: Escherichia coli
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
+      ncbi_source_id: NCBITaxon:562
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Curated at species level; the paper tested E. coli proA, pheA, and ilvA auxotroph partners.
   functional_role:
   - CROSS_FEEDER

--- a/kb/communities/mCAFEs_Brachypodium_RCC.yaml
+++ b/kb/communities/mCAFEs_Brachypodium_RCC.yaml
@@ -42,6 +42,14 @@ taxonomy:
     term:
       id: NCBITaxon:407
       label: Methylobacterium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Methylobacterium
+      gtdb_taxon: Methylobacterium
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Methylobacterium
+      ncbi_source_id: NCBITaxon:407
+      majority_fraction: 0.992
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Keystone taxon in fast-growing consortia (3-day transfer). Member of Methylobacterium-Methylorubrum
       complex.
   functional_role:
@@ -58,6 +66,14 @@ taxonomy:
     term:
       id: NCBITaxon:40323
       label: Stenotrophomonas
+    gtdb_classification:
+      gtdb_id: GTDB:g__Stenotrophomonas
+      gtdb_taxon: Stenotrophomonas
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Xanthomonadaceae;g__Stenotrophomonas
+      ncbi_source_id: NCBITaxon:40323
+      majority_fraction: 0.987
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
     notes: Keystone taxon in fast-growing consortia (3-day transfer).
   functional_role:
   - PRIMARY_DEGRADER
@@ -73,6 +89,14 @@ taxonomy:
     term:
       id: NCBITaxon:286
       label: Pseudomonas
+    gtdb_classification:
+      gtdb_id: GTDB:g__Pseudomonas
+      gtdb_taxon: Pseudomonas
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
+      ncbi_source_id: NCBITaxon:286
+      majority_fraction: 0.596
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 17 GTDB taxa under the NCBI taxon]
     notes: Keystone taxon in fast-growing consortia (3-day transfer).
   functional_role:
   - PRIMARY_DEGRADER
@@ -88,6 +112,14 @@ taxonomy:
     term:
       id: NCBITaxon:392733
       label: Terriglobus
+    gtdb_classification:
+      gtdb_id: GTDB:g__Terriglobus
+      gtdb_taxon: Terriglobus
+      gtdb_lineage: d__Bacteria;p__Acidobacteriota;c__Terriglobia;o__Terriglobales;f__Acidobacteriaceae;g__Terriglobus
+      ncbi_source_id: NCBITaxon:392733
+      majority_fraction: 0.833
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Keystone taxon in slow-growing consortia (7-day transfer). Enriched in 1/10 R2A medium. Member
       of Acidobacteria.
   functional_role:
@@ -119,6 +151,14 @@ taxonomy:
     term:
       id: NCBITaxon:32008
       label: Burkholderia
+    gtdb_classification:
+      gtdb_id: GTDB:g__Burkholderia
+      gtdb_taxon: Burkholderia
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Burkholderia
+      ncbi_source_id: NCBITaxon:32008
+      majority_fraction: 0.985
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
     notes: Keystone taxon in glycerol stock revivals.
   functional_role:
   - PRIMARY_DEGRADER
@@ -149,6 +189,14 @@ taxonomy:
     term:
       id: NCBITaxon:13687
       label: Sphingomonas
+    gtdb_classification:
+      gtdb_id: GTDB:g__Sphingomonas
+      gtdb_taxon: Sphingomonas
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Sphingomonas
+      ncbi_source_id: NCBITaxon:13687
+      majority_fraction: 0.777
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 24 GTDB taxa under the NCBI taxon]
     notes: Persistent keystone taxon across multiple enrichment conditions.
   functional_role:
   - CROSS_FEEDER
@@ -164,6 +212,14 @@ taxonomy:
     term:
       id: NCBITaxon:423349
       label: Mucilaginibacter
+    gtdb_classification:
+      gtdb_id: GTDB:g__Mucilaginibacter
+      gtdb_taxon: Mucilaginibacter
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Sphingobacteriales;f__Sphingobacteriaceae;g__Mucilaginibacter
+      ncbi_source_id: NCBITaxon:423349
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Persistent keystone taxon across multiple enrichment conditions.
   functional_role:
   - CROSS_FEEDER
@@ -179,6 +235,14 @@ taxonomy:
     term:
       id: NCBITaxon:374
       label: Bradyrhizobium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Bradyrhizobium
+      gtdb_taxon: Bradyrhizobium
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Bradyrhizobium
+      ncbi_source_id: NCBITaxon:374
+      majority_fraction: 0.982
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 8 GTDB taxa under the NCBI taxon]
     notes: Enriched in asparagine enrichment conditions.
   functional_role:
   - CROSS_FEEDER


### PR DESCRIPTION
## Summary
Backfills GTDB grounding across the whole KB using the merged `ground-taxa-gtdb` tooling (`gtdb_ground.py --community <file> --apply`), which #180 only applied to the ~30 new records.

- **+515 `gtdb_classification` blocks across 207 records** → **231/295** records now GTDB-grounded (was 24).
- Rank-aware: species → `GTDB:s__` (NCBI id then species-name fallback); genus/family → `g__`/`f__` by genome-weighted majority; GTDB-ambiguous splits and eukaryotes correctly skipped.
- **Add-only text edits** (0 deletions, no reflow). GTDB CURIEs are pattern-checked strings, not OAK-bound, so no id↔label drift.
- The 64 records still ungrounded have only genus-ambiguous, eukaryotic, or unmapped taxa.

## Verification
`just validate-all` ✓ · `pytest` ✓ · spot-checked `validate-terms` (0 drift). Sourced from the local kg-microbe `data/raw/NCBI2GTDB.tsv.gz`.