### PR TITLE
Follow-ups #181 + #184: taxa term-gate in qc/CI; scout DOI backfill

### DIFF
--- a/.github/workflows/label-correspondence.yaml
+++ b/.github/workflows/label-correspondence.yaml
@@ -86,3 +86,10 @@ jobs:
       # MISSING_COLUMN). Curator-accepted residuals pass as OK_EXCEPTION.
       - name: Enforce id↔label correspondence
         run: just validate-products
+
+      # Engine A (LinkML-native) for the CommonTaxon gene records: enforce that
+      # GeneAnnotation.go_terms[].label is the canonical GO label (the
+      # go_terms id↔label binding). kb/taxa/ roots are CommonTaxon, not the
+      # schema tree_root, so this uses --target-class CommonTaxon.
+      - name: Enforce id↔label correspondence (kb/taxa go_terms)
+        run: just validate-terms-taxa

--- a/justfile
+++ b/justfile
@@ -250,7 +250,7 @@ lint:
     uv run mypy src/
 
 # Full QC (validate + strict validate + lint + test)
-qc: validate-all validate-strict validate-terms-all validate-references-all lint test
+qc: validate-all validate-taxa validate-strict validate-terms-all validate-terms-taxa validate-references-all lint test
     @echo "✅ All QC checks passed!"
 
 # Check which community strains are represented in UniProt reference proteomes

--- a/scripts/scout_communities.py
+++ b/scripts/scout_communities.py
@@ -83,20 +83,41 @@ PRESETS = {
 }
 
 STOPWORDS = {
-    "the", "a", "an", "of", "and", "in", "on", "for", "with", "to", "from",
-    "community", "communities", "consortium", "consortia", "coculture",
-    "co", "culture", "microbial", "synthetic", "syncom", "defined", "system",
-    "model", "based", "using", "study", "novel", "new",
+    "the",
+    "a",
+    "an",
+    "of",
+    "and",
+    "in",
+    "on",
+    "for",
+    "with",
+    "to",
+    "from",
+    "community",
+    "communities",
+    "consortium",
+    "consortia",
+    "coculture",
+    "co",
+    "culture",
+    "microbial",
+    "synthetic",
+    "syncom",
+    "defined",
+    "system",
+    "model",
+    "based",
+    "using",
+    "study",
+    "novel",
+    "new",
 }
 
 
 def _tokens(text: str) -> set[str]:
     """Lowercase alphanumeric tokens minus stopwords, length >= 4."""
-    return {
-        t
-        for t in re.findall(r"[a-z0-9]+", text.lower())
-        if len(t) >= 4 and t not in STOPWORDS
-    }
+    return {t for t in re.findall(r"[a-z0-9]+", text.lower()) if len(t) >= 4 and t not in STOPWORDS}
 
 
 def build_dedup_index(communities_dir: Path) -> dict:
@@ -190,7 +211,9 @@ def query_epmc(query: str, since: int, limit: int) -> list[dict]:
                 {
                     "pmid": r.get("pmid", ""),
                     "doi": r.get("doi", ""),
-                    "title": re.sub(r"<[^>]+>", "", html.unescape(r.get("title") or "")).rstrip("."),
+                    "title": re.sub(r"<[^>]+>", "", html.unescape(r.get("title") or "")).rstrip(
+                        "."
+                    ),
                     "abstract": re.sub(r"<[^>]+>", "", html.unescape(r.get("abstractText") or "")),
                     "year": r.get("pubYear", ""),
                     "journal": (r.get("journalInfo", {}) or {}).get("journal", {}).get("title", ""),
@@ -205,6 +228,49 @@ def query_epmc(query: str, since: int, limit: int) -> list[dict]:
     return hits[:limit]
 
 
+def crossref_doi_for_title(title: str, session: requests.Session) -> str:
+    """Best-effort DOI for a title via CrossRef, so ref-less hits can dedup by DOI.
+
+    Europe PMC AGR-source records often carry no PMID/DOI; without one a hit for an
+    already-curated paper re-surfaces as NEW. Resolving the DOI lets dedup_status
+    catch it against cited_dois. Requires a high title-token overlap to avoid
+    grabbing an unrelated DOI.
+    """
+    if not title:
+        return ""
+    try:
+        resp = session.get(
+            "https://api.crossref.org/works",
+            params={"query.bibliographic": title, "rows": "1"},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        items = resp.json().get("message", {}).get("items", [])
+    except (requests.exceptions.RequestException, ValueError):
+        return ""
+    if not items:
+        return ""
+    it = items[0]
+    cand_title = (it.get("title") or [""])[0]
+    # Require the CrossRef hit's title to substantially match the query title.
+    q, c = _tokens(title), _tokens(cand_title)
+    if q and len(q & c) / len(q) >= 0.7:
+        return (it.get("DOI") or "").strip()
+    return ""
+
+
+def backfill_missing_dois(hits: list[dict], session: requests.Session) -> int:
+    """Fill hit['doi'] from CrossRef for hits lacking both PMID and DOI. Returns count filled."""
+    filled = 0
+    for h in hits:
+        if not (h.get("pmid") or "").strip() and not (h.get("doi") or "").strip():
+            doi = crossref_doi_for_title(h.get("title", ""), session)
+            if doi:
+                h["doi"] = doi
+                filled += 1
+    return filled
+
+
 def slugify(text: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")[:40] or "scout"
 
@@ -213,7 +279,11 @@ def emit_stub(hit: dict, out_dir: Path) -> Path:
     """Write a minimal review-only draft record (placeholder id, NOT minted)."""
     stub_dir = out_dir / "stubs"
     stub_dir.mkdir(parents=True, exist_ok=True)
-    ref = f"PMID:{hit['pmid']}" if hit.get("pmid") else (f"doi:{hit['doi']}" if hit.get("doi") else "")
+    ref = (
+        f"PMID:{hit['pmid']}"
+        if hit.get("pmid")
+        else (f"doi:{hit['doi']}" if hit.get("doi") else "")
+    )
     name = hit["title"][:120]
     stub = {
         "id": "CommunityMech:XXXXXX",  # placeholder — mint via manage-identifiers
@@ -235,14 +305,24 @@ def emit_stub(hit: dict, out_dir: Path) -> Path:
 
 
 def main(argv: list[str] | None = None) -> int:
-    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     grp = p.add_mutually_exclusive_group(required=True)
     grp.add_argument("--query", help="Free-text Europe PMC query.")
     grp.add_argument("--preset", choices=sorted(PRESETS), help="Ready-made query angle.")
-    p.add_argument("--since", type=int, default=2024, help="Earliest first-publication year (default 2024).")
-    p.add_argument("--limit", type=int, default=40, help="Max Europe PMC hits to fetch (default 40).")
-    p.add_argument("--min-score", type=int, default=1, help="Drop hits below this community-signal score.")
-    p.add_argument("--include-cited", action="store_true", help="Keep hits already cited by a record.")
+    p.add_argument(
+        "--since", type=int, default=2024, help="Earliest first-publication year (default 2024)."
+    )
+    p.add_argument(
+        "--limit", type=int, default=40, help="Max Europe PMC hits to fetch (default 40)."
+    )
+    p.add_argument(
+        "--min-score", type=int, default=1, help="Drop hits below this community-signal score."
+    )
+    p.add_argument(
+        "--include-cited", action="store_true", help="Keep hits already cited by a record."
+    )
     p.add_argument("--emit-stubs", action="store_true", help="Write review-only draft stub YAMLs.")
     p.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
     args = p.parse_args(argv)
@@ -259,6 +339,12 @@ def main(argv: list[str] | None = None) -> int:
         print(f"[scout] Europe PMC request failed: {e}", file=sys.stderr)
         return 1
     print(f"[scout] fetched {len(hits)} hits", file=sys.stderr)
+
+    # Ref-less hits (e.g. Europe PMC AGR source) can't dedup by PMID/DOI; try to
+    # resolve a DOI via CrossRef so already-curated papers don't re-surface as NEW.
+    n_filled = backfill_missing_dois(hits, requests.Session())
+    if n_filled:
+        print(f"[scout] backfilled DOIs for {n_filled} ref-less hits (CrossRef)", file=sys.stderr)
 
     index = build_dedup_index(COMMUNITIES_DIR)
     print(
@@ -306,14 +392,20 @@ def main(argv: list[str] | None = None) -> int:
             (f"_{h['dedup_detail']}_  " if h["dedup_detail"] else ""),
             f"Signals: {', '.join(h['signals']) or '—'}  ",
             "",
-            (h["abstract"][:600] + ("…" if len(h["abstract"]) > 600 else "")) if h["abstract"] else "_(no abstract)_",
+            (
+                (h["abstract"][:600] + ("…" if len(h["abstract"]) > 600 else ""))
+                if h["abstract"]
+                else "_(no abstract)_"
+            ),
             "",
         ]
     report_path.write_text("\n".join(lines))
 
     queue = [
         {
-            "reference": f"PMID:{h['pmid']}" if h["pmid"] else (f"doi:{h['doi']}" if h["doi"] else ""),
+            "reference": (
+                f"PMID:{h['pmid']}" if h["pmid"] else (f"doi:{h['doi']}" if h["doi"] else "")
+            ),
             "title": h["title"],
             "year": h["year"],
             "journal": h["journal"],
@@ -334,8 +426,7 @@ def main(argv: list[str] | None = None) -> int:
 
     n_new = sum(1 for h in candidates if h["dedup"] == "NEW")
     print(
-        f"[scout] {len(candidates)} candidates ({n_new} NEW). "
-        f"Report: {report_path}{stub_note}",
+        f"[scout] {len(candidates)} candidates ({n_new} NEW). " f"Report: {report_path}{stub_note}",
         file=sys.stderr,
     )
     return 0

--- a/scripts/scout_loop.py
+++ b/scripts/scout_loop.py
@@ -35,17 +35,50 @@ ANGLES: list[tuple[str, str]] = [
     ("preset:engineered", sc.PRESETS["engineered"]),
     ("gut", '(gut OR intestinal) AND (consortium OR "defined community" OR "cross-feeding")'),
     ("rhizosphere", '(rhizosphere OR root OR phyllosphere) AND (SynCom OR "synthetic community")'),
-    ("marine", '(marine OR ocean OR seep OR sediment) AND (consortium OR syntrophic OR co-culture)'),
-    ("methane", '(methanogen OR methanotroph OR "anaerobic oxidation of methane") AND (consortium OR syntrophic)'),
-    ("anaerobic_digestion", '"anaerobic digestion" AND (syntrophic OR "interspecies electron transfer" OR consortium)'),
-    ("wastewater", '(wastewater OR "activated sludge" OR EBPR OR anammox) AND (community OR consortium)'),
-    ("nitrogen", '(nitrification OR denitrification OR "nitrogen fixation" OR anammox) AND (consortium OR co-culture)'),
-    ("photosynthetic", '(cyanobacteria OR microalgae OR phototroph) AND (consortium OR co-culture OR "synthetic community")'),
-    ("bioelectrochemical", '(electroactive OR "microbial fuel cell" OR electrofermentation) AND (consortium OR co-culture)'),
-    ("acid_mine", '("acid mine drainage" OR acidophile OR bioleaching) AND (community OR consortium)'),
-    ("fermented_food", '(kefir OR kombucha OR cheese OR sourdough OR fermented) AND (community OR consortium OR co-culture)'),
-    ("degradation", '(degradation OR dechlorination OR bioremediation OR "plastic") AND (consortium OR "defined community")'),
-    ("division_of_labor", '"division of labor" AND (microbial OR consortium OR "synthetic community")'),
+    (
+        "marine",
+        "(marine OR ocean OR seep OR sediment) AND (consortium OR syntrophic OR co-culture)",
+    ),
+    (
+        "methane",
+        '(methanogen OR methanotroph OR "anaerobic oxidation of methane") AND (consortium OR syntrophic)',
+    ),
+    (
+        "anaerobic_digestion",
+        '"anaerobic digestion" AND (syntrophic OR "interspecies electron transfer" OR consortium)',
+    ),
+    (
+        "wastewater",
+        '(wastewater OR "activated sludge" OR EBPR OR anammox) AND (community OR consortium)',
+    ),
+    (
+        "nitrogen",
+        '(nitrification OR denitrification OR "nitrogen fixation" OR anammox) AND (consortium OR co-culture)',
+    ),
+    (
+        "photosynthetic",
+        '(cyanobacteria OR microalgae OR phototroph) AND (consortium OR co-culture OR "synthetic community")',
+    ),
+    (
+        "bioelectrochemical",
+        '(electroactive OR "microbial fuel cell" OR electrofermentation) AND (consortium OR co-culture)',
+    ),
+    (
+        "acid_mine",
+        '("acid mine drainage" OR acidophile OR bioleaching) AND (community OR consortium)',
+    ),
+    (
+        "fermented_food",
+        "(kefir OR kombucha OR cheese OR sourdough OR fermented) AND (community OR consortium OR co-culture)",
+    ),
+    (
+        "degradation",
+        '(degradation OR dechlorination OR bioremediation OR "plastic") AND (consortium OR "defined community")',
+    ),
+    (
+        "division_of_labor",
+        '"division of labor" AND (microbial OR consortium OR "synthetic community")',
+    ),
 ]
 
 
@@ -54,13 +87,25 @@ def norm_title(title: str) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
-    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    p.add_argument("--since", type=int, default=2023, help="Earliest first-publication year (default 2023).")
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument(
+        "--since", type=int, default=2023, help="Earliest first-publication year (default 2023)."
+    )
     p.add_argument("--limit", type=int, default=50, help="Max hits fetched per angle (default 50).")
-    p.add_argument("--min-score", type=int, default=1, help="Drop hits below this community-signal score.")
-    p.add_argument("--dry-streak", type=int, default=3,
-                   help="Stop after this many consecutive angles with zero new communities (default 3).")
-    p.add_argument("--emit-stubs", action="store_true", help="Write review-only draft stub YAMLs for NEW hits.")
+    p.add_argument(
+        "--min-score", type=int, default=1, help="Drop hits below this community-signal score."
+    )
+    p.add_argument(
+        "--dry-streak",
+        type=int,
+        default=3,
+        help="Stop after this many consecutive angles with zero new communities (default 3).",
+    )
+    p.add_argument(
+        "--emit-stubs", action="store_true", help="Write review-only draft stub YAMLs for NEW hits."
+    )
     p.add_argument("--out-dir", type=Path, default=sc.DEFAULT_OUT_DIR)
     args = p.parse_args(argv)
 
@@ -81,9 +126,13 @@ def main(argv: list[str] | None = None) -> int:
     per_angle: list[tuple[str, int]] = []
     dry_streak = 0
 
+    import requests
+
+    session = requests.Session()
     for label, query in ANGLES:
         try:
             hits = sc.query_epmc(query, args.since, args.limit)
+            sc.backfill_missing_dois(hits, session)  # resolve ref-less hits so they dedup by DOI
         except Exception as e:  # network / API — log and treat angle as empty
             print(f"[loop] {label}: query failed ({e})", file=sys.stderr)
             hits = []
@@ -96,7 +145,11 @@ def main(argv: list[str] | None = None) -> int:
             status, detail = sc.dedup_status(hit, index)
             if status == "ALREADY_CITED":
                 continue
-            ref = f"PMID:{hit['pmid']}" if hit["pmid"] else (f"doi:{hit['doi']}" if hit["doi"] else "")
+            ref = (
+                f"PMID:{hit['pmid']}"
+                if hit["pmid"]
+                else (f"doi:{hit['doi']}" if hit["doi"] else "")
+            )
             nt = norm_title(hit["title"])
             if (ref and ref in seen_refs) or (nt and nt in seen_titles):
                 continue  # cross-angle / preprint-vs-published dedup
@@ -104,11 +157,15 @@ def main(argv: list[str] | None = None) -> int:
                 seen_refs.add(ref)
             if nt:
                 seen_titles.add(nt)
-            hit.update({
-                "score": score, "signals": signals,
-                "dedup": status, "dedup_detail": detail,
-                "angle": label,
-            })
+            hit.update(
+                {
+                    "score": score,
+                    "signals": signals,
+                    "dedup": status,
+                    "dedup_detail": detail,
+                    "angle": label,
+                }
+            )
             new_candidates.append(hit)
             round_new += 1
 
@@ -119,8 +176,7 @@ def main(argv: list[str] | None = None) -> int:
         dry_streak = dry_streak + 1 if round_new == 0 else 0
         if dry_streak >= args.dry_streak:
             print(
-                f"[loop] {dry_streak} consecutive dry angles — stopping "
-                f"(loop-until-dry).",
+                f"[loop] {dry_streak} consecutive dry angles — stopping " f"(loop-until-dry).",
                 file=sys.stderr,
             )
             break
@@ -140,8 +196,11 @@ def main(argv: list[str] | None = None) -> int:
         "# Community scouting — loop-until-dry sweep",
         "",
         f"- Angles run: {angles_run}/{len(ANGLES)} · since {args.since} · {args.limit}/angle",
-        f"- Stopped after {args.dry_streak} consecutive dry angles"
-        if dry_streak >= args.dry_streak else "- Battery exhausted (no early stop)",
+        (
+            f"- Stopped after {args.dry_streak} consecutive dry angles"
+            if dry_streak >= args.dry_streak
+            else "- Battery exhausted (no early stop)"
+        ),
         f"- Distinct candidates: **{len(new_candidates)}** "
         f"({n_new} NEW, {n_overlap} possible-existing) after dedup vs "
         f"{len(index['name_token_sets'])} records + cross-angle",
@@ -162,16 +221,26 @@ def main(argv: list[str] | None = None) -> int:
             (f"_{h['dedup_detail']}_  " if h["dedup_detail"] else ""),
             f"Signals: {', '.join(h['signals']) or '—'}  ",
             "",
-            (h["abstract"][:500] + ("…" if len(h["abstract"]) > 500 else "")) if h["abstract"] else "_(no abstract)_",
+            (
+                (h["abstract"][:500] + ("…" if len(h["abstract"]) > 500 else ""))
+                if h["abstract"]
+                else "_(no abstract)_"
+            ),
             "",
         ]
     report_path.write_text("\n".join(lines))
 
     queue = [
         {
-            "reference": f"PMID:{h['pmid']}" if h["pmid"] else (f"doi:{h['doi']}" if h["doi"] else ""),
-            "title": h["title"], "year": h["year"], "journal": h["journal"],
-            "score": h["score"], "dedup": h["dedup"], "angle": h["angle"],
+            "reference": (
+                f"PMID:{h['pmid']}" if h["pmid"] else (f"doi:{h['doi']}" if h["doi"] else "")
+            ),
+            "title": h["title"],
+            "year": h["year"],
+            "journal": h["journal"],
+            "score": h["score"],
+            "dedup": h["dedup"],
+            "angle": h["angle"],
         }
         for h in new_candidates
     ]


### PR DESCRIPTION
Two self-contained follow-ups from the #180 session.

**#181 — enforce the taxa go_terms id↔label gate.** #180 added the `GeneAnnotation.go_terms` binding + a `just validate-terms-taxa` recipe but never wired it in. This adds `validate-taxa` + `validate-terms-taxa` to the `qc` target and a `validate-terms-taxa` step to the `label-correspondence` CI workflow (both `kb/taxa/` records pass).

**#184 — scout DOI backfill for ref-less hits.** `scout_communities.py`/`scout_loop.py` now resolve a DOI via CrossRef for hits lacking both PMID and DOI (e.g. Europe PMC AGR-source records) before dedup, requiring ≥70% title-token overlap. This stops already-curated papers from re-surfacing as `NEW` — verified with the cigar-tobacco lead (already `CommunityMech:000278`), which now dedups.

Closes #181, closes #184.