### PR TITLE
Landing: relabel embedding button UMAP → PaCMAP

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -68,7 +68,7 @@
       </div>
       <div class="card">
         <div class="ic">&#128506;&#65039;</div>
-        <div class="actions"><a class="btn" href="community_umap.html">Explore UMAP &rarr;</a><a class="btn" href="community_graph.html">Graph layout &rarr;</a></div>
+        <div class="actions"><a class="btn" href="community_umap.html">Explore embedding (PaCMAP) &rarr;</a><a class="btn" href="community_graph.html">Graph layout &rarr;</a></div>
         <h2>Embedding browser</h2>
         <p>Interactive UMAP of community embedding space from taxonomic composition.</p>
       </div>

--- a/src/communitymech/templates/landing.html
+++ b/src/communitymech/templates/landing.html
@@ -68,7 +68,7 @@
       </div>
       <div class="card">
         <div class="ic">&#128506;&#65039;</div>
-        <div class="actions"><a class="btn" href="community_umap.html">Explore UMAP &rarr;</a><a class="btn" href="community_graph.html">Graph layout &rarr;</a></div>
+        <div class="actions"><a class="btn" href="community_umap.html">Explore embedding (PaCMAP) &rarr;</a><a class="btn" href="community_graph.html">Graph layout &rarr;</a></div>
         <h2>Embedding browser</h2>
         <p>Interactive UMAP of community embedding space from taxonomic composition.</p>
       </div>


### PR DESCRIPTION
The default projection is PaCMAP; the landing button still read "Explore UMAP". Now "Explore embedding (PaCMAP)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)