### PR TITLE
Load d3 locally on per-community pages (drop CDN dependency)

### DIFF
--- a/docs/communities/AMD_Acidophile_Heterotroph_Network.html
+++ b/docs/communities/AMD_Acidophile_Heterotroph_Network.html
@@ -1545,7 +1545,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/AMD_Nitrososphaerota_Archaeal.html
+++ b/docs/communities/AMD_Nitrososphaerota_Archaeal.html
@@ -1381,7 +1381,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/ANME_SRB_Marine_Methane_Seep_Consortium.html
+++ b/docs/communities/ANME_SRB_Marine_Methane_Seep_Consortium.html
@@ -822,7 +822,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Aalborg_East_Full_Scale_EBPR_Community.html
+++ b/docs/communities/Aalborg_East_Full_Scale_EBPR_Community.html
@@ -971,7 +971,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.html
+++ b/docs/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.html
@@ -1154,7 +1154,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.html
+++ b/docs/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.html
@@ -819,7 +819,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Aerobic_Denitrification_Disturbance_SynCom.html
+++ b/docs/communities/Aerobic_Denitrification_Disturbance_SynCom.html
@@ -689,7 +689,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Aerobic_Denitrification_QQ_SynCom.html
+++ b/docs/communities/Aerobic_Denitrification_QQ_SynCom.html
@@ -689,7 +689,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Alaska_Tundra_Permafrost_Iron_Redox_Community.html
+++ b/docs/communities/Alaska_Tundra_Permafrost_Iron_Redox_Community.html
@@ -889,7 +889,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.html
+++ b/docs/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.html
@@ -888,7 +888,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.html
+++ b/docs/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.html
@@ -781,7 +781,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Anammox_Granule_Metabolic_Interaction_Community.html
+++ b/docs/communities/Anammox_Granule_Metabolic_Interaction_Community.html
@@ -1020,7 +1020,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Angelarchaeales_Thermoplasmata_CuMMO_Soil_Sediment_Community.html
+++ b/docs/communities/Angelarchaeales_Thermoplasmata_CuMMO_Soil_Sediment_Community.html
@@ -790,7 +790,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Arabidopsis_Coumarin_Root_SynCom.html
+++ b/docs/communities/Arabidopsis_Coumarin_Root_SynCom.html
@@ -605,7 +605,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Arabidopsis_Phyllosphere_SynCom7.html
+++ b/docs/communities/Arabidopsis_Phyllosphere_SynCom7.html
@@ -605,7 +605,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.html
+++ b/docs/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.html
@@ -910,7 +910,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/At_RSPHERE_SynCom.html
+++ b/docs/communities/At_RSPHERE_SynCom.html
@@ -1397,7 +1397,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Australian_Lead_Zinc_Polymetallic.html
+++ b/docs/communities/Australian_Lead_Zinc_Polymetallic.html
@@ -1727,7 +1727,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.html
+++ b/docs/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.html
@@ -988,7 +988,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.html
+++ b/docs/communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.html
@@ -786,7 +786,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.html
+++ b/docs/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.html
@@ -647,7 +647,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.html
+++ b/docs/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.html
@@ -942,7 +942,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.html
+++ b/docs/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.html
@@ -880,7 +880,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Banana_Fusarium_Biocontrol_SynCom12.html
+++ b/docs/communities/Banana_Fusarium_Biocontrol_SynCom12.html
@@ -689,7 +689,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.html
+++ b/docs/communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.html
@@ -704,7 +704,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Bayan_Obo_REE_Tailings_Consortium.html
+++ b/docs/communities/Bayan_Obo_REE_Tailings_Consortium.html
@@ -1200,7 +1200,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.html
+++ b/docs/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.html
@@ -779,7 +779,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/BioModels_MODEL1806250003_Spittlebug_Sulcia_Sodalis.html
+++ b/docs/communities/BioModels_MODEL1806250003_Spittlebug_Sulcia_Sodalis.html
@@ -773,7 +773,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/BioModels_MODEL1806250004_Sharpshooter_Sulcia_Baumannia.html
+++ b/docs/communities/BioModels_MODEL1806250004_Sharpshooter_Sulcia_Baumannia.html
@@ -773,7 +773,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/BioModels_MODEL1806250005_Cicada_Sulcia_Hodgkinia.html
+++ b/docs/communities/BioModels_MODEL1806250005_Cicada_Sulcia_Hodgkinia.html
@@ -773,7 +773,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/BioModels_MODEL2204300001_Kefir_Community_Model.html
+++ b/docs/communities/BioModels_MODEL2204300001_Kefir_Community_Model.html
@@ -1095,7 +1095,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/BioModels_MODEL2209060002_DPigrum_SAureus_Community.html
+++ b/docs/communities/BioModels_MODEL2209060002_DPigrum_SAureus_Community.html
@@ -705,7 +705,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.html
+++ b/docs/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.html
@@ -1096,7 +1096,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/BioModels_MODEL2407300002_Sponge_Holobiont_Network.html
+++ b/docs/communities/BioModels_MODEL2407300002_Sponge_Holobiont_Network.html
@@ -884,7 +884,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.html
+++ b/docs/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.html
@@ -912,7 +912,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.html
+++ b/docs/communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.html
@@ -853,7 +853,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/CRC_Fusobacterium_Control_SynCom.html
+++ b/docs/communities/CRC_Fusobacterium_Control_SynCom.html
@@ -605,7 +605,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.html
+++ b/docs/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.html
@@ -940,7 +940,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.html
+++ b/docs/communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.html
@@ -1000,7 +1000,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.html
+++ b/docs/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.html
@@ -1149,7 +1149,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/California_Grassland_Precipitation_Legacy_Soil_Community.html
+++ b/docs/communities/California_Grassland_Precipitation_Legacy_Soil_Community.html
@@ -892,7 +892,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Candida_Parapsilosis_Hospitalized_Infant_Microbiome.html
+++ b/docs/communities/Candida_Parapsilosis_Hospitalized_Infant_Microbiome.html
@@ -721,7 +721,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/CeMbio_Caenorhabditis_Elegans_Microbiome.html
+++ b/docs/communities/CeMbio_Caenorhabditis_Elegans_Microbiome.html
@@ -1134,7 +1134,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.html
+++ b/docs/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.html
@@ -1041,7 +1041,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Cellulose_Methane_Quad_Culture_SynCom.html
+++ b/docs/communities/Cellulose_Methane_Quad_Culture_SynCom.html
@@ -731,7 +731,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Cheese_Rind_InSitu_InVitro_Model_Community.html
+++ b/docs/communities/Cheese_Rind_InSitu_InVitro_Model_Community.html
@@ -968,7 +968,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Chlamydomonas_Bacterial_H2_Consortium.html
+++ b/docs/communities/Chlamydomonas_Bacterial_H2_Consortium.html
@@ -1125,7 +1125,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Chlamydomonas_Methylobacterium_Mutualism.html
+++ b/docs/communities/Chlamydomonas_Methylobacterium_Mutualism.html
@@ -1069,7 +1069,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Chlorella_Azospirillum_Synthetic_Mutualism.html
+++ b/docs/communities/Chlorella_Azospirillum_Synthetic_Mutualism.html
@@ -1333,7 +1333,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.html
+++ b/docs/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.html
@@ -1086,7 +1086,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Chlorella_Rhizobium_Bioflocculation.html
+++ b/docs/communities/Chlorella_Rhizobium_Bioflocculation.html
@@ -883,7 +883,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.html
+++ b/docs/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.html
@@ -931,7 +931,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Chromium_Sulfur_Reduction_Enrichment.html
+++ b/docs/communities/Chromium_Sulfur_Reduction_Enrichment.html
@@ -1235,7 +1235,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Cinnamate_Degradation_Consortium.html
+++ b/docs/communities/Cinnamate_Degradation_Consortium.html
@@ -870,7 +870,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.html
+++ b/docs/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.html
@@ -1181,7 +1181,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.html
+++ b/docs/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.html
@@ -1170,7 +1170,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.html
+++ b/docs/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.html
@@ -1155,7 +1155,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.html
+++ b/docs/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.html
@@ -1125,7 +1125,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.html
+++ b/docs/communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.html
@@ -1125,7 +1125,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.html
+++ b/docs/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.html
@@ -1042,7 +1042,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.html
+++ b/docs/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.html
@@ -1218,7 +1218,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.html
+++ b/docs/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.html
@@ -1234,7 +1234,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.html
+++ b/docs/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.html
@@ -1146,7 +1146,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.html
+++ b/docs/communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.html
@@ -1102,7 +1102,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.html
+++ b/docs/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.html
@@ -1095,7 +1095,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.html
+++ b/docs/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.html
@@ -1222,7 +1222,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.html
+++ b/docs/communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.html
@@ -1147,7 +1147,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.html
+++ b/docs/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.html
@@ -1336,7 +1336,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Copper_Biomining_Heap_Leach.html
+++ b/docs/communities/Copper_Biomining_Heap_Leach.html
@@ -1596,7 +1596,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Coscinodiscus_Synthetic_Community.html
+++ b/docs/communities/Coscinodiscus_Synthetic_Community.html
@@ -1436,7 +1436,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community.html
+++ b/docs/communities/Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community.html
@@ -851,7 +851,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.html
+++ b/docs/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.html
@@ -887,7 +887,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/DVM_Triculture.html
+++ b/docs/communities/DVM_Triculture.html
@@ -1074,7 +1074,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Dangl_SynComm_35.html
+++ b/docs/communities/Dangl_SynComm_35.html
@@ -1579,7 +1579,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.html
+++ b/docs/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.html
@@ -1219,7 +1219,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.html
+++ b/docs/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.html
@@ -1278,7 +1278,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.html
+++ b/docs/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.html
@@ -1244,7 +1244,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.html
+++ b/docs/communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.html
@@ -1169,7 +1169,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.html
+++ b/docs/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.html
@@ -1139,7 +1139,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.html
+++ b/docs/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.html
@@ -1191,7 +1191,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Desert_Tomato_Salt_Stress_SynCom5.html
+++ b/docs/communities/Desert_Tomato_Salt_Stress_SynCom5.html
@@ -605,7 +605,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Desulfovibrio_Methanococcus_Syntrophy.html
+++ b/docs/communities/Desulfovibrio_Methanococcus_Syntrophy.html
@@ -1264,7 +1264,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Desulfovibrio_Methanosarcina_Lactate_Syntrophy.html
+++ b/docs/communities/Desulfovibrio_Methanosarcina_Lactate_Syntrophy.html
@@ -922,7 +922,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.html
+++ b/docs/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.html
@@ -1011,7 +1011,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.html
+++ b/docs/communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.html
@@ -847,7 +847,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/ENIGMA_Denitrifying_SynCom.html
+++ b/docs/communities/ENIGMA_Denitrifying_SynCom.html
@@ -882,7 +882,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/East_River_Floodplain_Core_Microbiome.html
+++ b/docs/communities/East_River_Floodplain_Core_Microbiome.html
@@ -939,7 +939,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/East_River_Hillslope_Riparian_Transect_Community.html
+++ b/docs/communities/East_River_Hillslope_Riparian_Transect_Community.html
@@ -1169,7 +1169,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/EcoFAB_Ring_Trial_SynCom17.html
+++ b/docs/communities/EcoFAB_Ring_Trial_SynCom17.html
@@ -2060,7 +2060,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Emiliania_Phaeobacter_Dynamic_Interaction.html
+++ b/docs/communities/Emiliania_Phaeobacter_Dynamic_Interaction.html
@@ -899,7 +899,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.html
+++ b/docs/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.html
@@ -999,7 +999,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Episymbiotic_CPR_DPANN_Groundwater_Community.html
+++ b/docs/communities/Episymbiotic_CPR_DPANN_Groundwater_Community.html
@@ -822,7 +822,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Ewaste_Bioleaching_Consortium.html
+++ b/docs/communities/Ewaste_Bioleaching_Consortium.html
@@ -1319,7 +1319,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Ferroplasma_Leptospirillum_Syntrophy.html
+++ b/docs/communities/Ferroplasma_Leptospirillum_Syntrophy.html
@@ -1447,7 +1447,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/GLBRC_Exometabolite_Transwell_SynCom.html
+++ b/docs/communities/GLBRC_Exometabolite_Transwell_SynCom.html
@@ -605,7 +605,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/GLBRC_Populus_Variovorax_SynCom28.html
+++ b/docs/communities/GLBRC_Populus_Variovorax_SynCom28.html
@@ -2029,7 +2029,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/GLBRC_UFMP_Fermentation_Community.html
+++ b/docs/communities/GLBRC_UFMP_Fermentation_Community.html
@@ -1170,7 +1170,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/GOM_Oil_Degrading_Consortium.html
+++ b/docs/communities/GOM_Oil_Degrading_Consortium.html
@@ -842,7 +842,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Garlic_Pseudomonas_SynCom6.html
+++ b/docs/communities/Garlic_Pseudomonas_SynCom6.html
@@ -605,7 +605,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Geobacter_Clostridium_DIET.html
+++ b/docs/communities/Geobacter_Clostridium_DIET.html
@@ -1164,7 +1164,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Geobacter_Methanosaeta_DIET.html
+++ b/docs/communities/Geobacter_Methanosaeta_DIET.html
@@ -937,7 +937,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Geobacter_Methanosarcina_DIET.html
+++ b/docs/communities/Geobacter_Methanosarcina_DIET.html
@@ -1049,7 +1049,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.html
+++ b/docs/communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.html
@@ -1132,7 +1132,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Grassland_Soil_WetUp_Virus_Host_Community.html
+++ b/docs/communities/Grassland_Soil_WetUp_Virus_Host_Community.html
@@ -821,7 +821,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.html
+++ b/docs/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.html
@@ -860,7 +860,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Hanford_300_Area_Unconfined_Aquifer_Community.html
+++ b/docs/communities/Hanford_300_Area_Unconfined_Aquifer_Community.html
@@ -904,7 +904,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.html
+++ b/docs/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.html
@@ -1324,7 +1324,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Honeybee_Core20_Defined_Microbiota.html
+++ b/docs/communities/Honeybee_Core20_Defined_Microbiota.html
@@ -605,7 +605,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Horonobe_Mizunami_URL_Subsurface_Microbiome.html
+++ b/docs/communities/Horonobe_Mizunami_URL_Subsurface_Microbiome.html
@@ -926,7 +926,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Iberian_Pit_Lake_Stratified_Community.html
+++ b/docs/communities/Iberian_Pit_Lake_Stratified_Community.html
@@ -1554,7 +1554,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Industrial_Bioreactor_Consortium.html
+++ b/docs/communities/Industrial_Bioreactor_Consortium.html
@@ -1842,7 +1842,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.html
+++ b/docs/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.html
@@ -1046,7 +1046,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Infant_Gut_DNA_Phage_Succession_Community.html
+++ b/docs/communities/Infant_Gut_DNA_Phage_Succession_Community.html
@@ -831,7 +831,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Infant_Gut_Strain_Persistence_Maternal_Community.html
+++ b/docs/communities/Infant_Gut_Strain_Persistence_Maternal_Community.html
@@ -913,7 +913,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Ion_Adsorption_REE_Indigenous_Community.html
+++ b/docs/communities/Ion_Adsorption_REE_Indigenous_Community.html
@@ -1431,7 +1431,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Jala_Maize_PGPB_SynCom.html
+++ b/docs/communities/Jala_Maize_PGPB_SynCom.html
@@ -731,7 +731,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/KB1_Chlorinated_Ethene_Dechlorinating_Consortium.html
+++ b/docs/communities/KB1_Chlorinated_Ethene_Dechlorinating_Consortium.html
@@ -923,7 +923,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/KBase_Models_for_Zahmeeth_Original_PLOS.html
+++ b/docs/communities/KBase_Models_for_Zahmeeth_Original_PLOS.html
@@ -822,7 +822,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/KBase_ORT_Workflow_Community_Model.html
+++ b/docs/communities/KBase_ORT_Workflow_Community_Model.html
@@ -896,7 +896,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/KBase_Synthetic_Bacterial_Community_R2A.html
+++ b/docs/communities/KBase_Synthetic_Bacterial_Community_R2A.html
@@ -831,7 +831,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Kombucha_KMC_IMBG1_Fermentation_Community.html
+++ b/docs/communities/Kombucha_KMC_IMBG1_Fermentation_Community.html
@@ -1016,7 +1016,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/LBNL_Brachypodium_Drought_SynCom15.html
+++ b/docs/communities/LBNL_Brachypodium_Drought_SynCom15.html
@@ -605,7 +605,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/LBNL_Human_Gut_Interaction_SynCom.html
+++ b/docs/communities/LBNL_Human_Gut_Interaction_SynCom.html
@@ -605,7 +605,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/LBNL_Switchgrass_Soil_SynCom16.html
+++ b/docs/communities/LBNL_Switchgrass_Soil_SynCom16.html
@@ -605,7 +605,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Lac_Pavin_Stratified_Lake_Community.html
+++ b/docs/communities/Lac_Pavin_Stratified_Lake_Community.html
@@ -832,7 +832,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.html
+++ b/docs/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.html
@@ -1371,7 +1371,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Lotus_LjSC3.html
+++ b/docs/communities/Lotus_LjSC3.html
@@ -1750,7 +1750,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/MAMC_M48_Lignocellulose.html
+++ b/docs/communities/MAMC_M48_Lignocellulose.html
@@ -1198,7 +1198,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/MSC1_Dominant_Core.html
+++ b/docs/communities/MSC1_Dominant_Core.html
@@ -1733,7 +1733,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/MSC2_Model_Soil_Consortium.html
+++ b/docs/communities/MSC2_Model_Soil_Consortium.html
@@ -901,7 +901,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.html
+++ b/docs/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.html
@@ -1292,7 +1292,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Maize_Benzoxazinoid_Metabolizing_SynComs.html
+++ b/docs/communities/Maize_Benzoxazinoid_Metabolizing_SynComs.html
@@ -605,7 +605,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Maize_Drought_Response_SynCom.html
+++ b/docs/communities/Maize_Drought_Response_SynCom.html
@@ -605,7 +605,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Maize_Root_Simplified_Community.html
+++ b/docs/communities/Maize_Root_Simplified_Community.html
@@ -1444,7 +1444,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Medicago_Nodule_Biofertilizer_SynCom.html
+++ b/docs/communities/Medicago_Nodule_Biofertilizer_SynCom.html
@@ -647,7 +647,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Mediterranean_Grassland_qSIP_Rainfall_Community.html
+++ b/docs/communities/Mediterranean_Grassland_qSIP_Rainfall_Community.html
@@ -754,7 +754,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Mercury_SFA_EFPC_Sediment_Community.html
+++ b/docs/communities/Mercury_SFA_EFPC_Sediment_Community.html
@@ -1206,7 +1206,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Methane_Oxidation_CrVI_Reduction_SynCom.html
+++ b/docs/communities/Methane_Oxidation_CrVI_Reduction_SynCom.html
@@ -689,7 +689,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.html
+++ b/docs/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.html
@@ -1104,7 +1104,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.html
+++ b/docs/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.html
@@ -1044,7 +1044,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.html
+++ b/docs/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.html
@@ -1025,7 +1025,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.html
+++ b/docs/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.html
@@ -1028,7 +1028,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.html
+++ b/docs/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.html
@@ -1207,7 +1207,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.html
+++ b/docs/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.html
@@ -1029,7 +1029,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Microcoleus_Massilia_Cyanosphere_Urea_Mutualism.html
+++ b/docs/communities/Microcoleus_Massilia_Cyanosphere_Urea_Mutualism.html
@@ -1084,7 +1084,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.html
+++ b/docs/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.html
@@ -773,7 +773,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Mixed_Gallium_LED_Recovery_Consortium.html
+++ b/docs/communities/Mixed_Gallium_LED_Recovery_Consortium.html
@@ -1116,7 +1116,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.html
+++ b/docs/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.html
@@ -910,7 +910,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.html
+++ b/docs/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.html
@@ -1152,7 +1152,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Multiomics_Corn_Straw_Degradation_SynCom.html
+++ b/docs/communities/Multiomics_Corn_Straw_Degradation_SynCom.html
@@ -605,7 +605,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Mushroom_Spring_Hot_Spring_Phototrophic_Mat_Community.html
+++ b/docs/communities/Mushroom_Spring_Hot_Spring_Phototrophic_Mat_Community.html
@@ -1103,7 +1103,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/NCycle_Bioflocculation_Model_Consortium.html
+++ b/docs/communities/NCycle_Bioflocculation_Model_Consortium.html
@@ -605,7 +605,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Naica_Deep_Subsurface_Thermophilic.html
+++ b/docs/communities/Naica_Deep_Subsurface_Thermophilic.html
@@ -1301,7 +1301,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Neocallimastix_Methanobrevibacter_Xylan_Coculture.html
+++ b/docs/communities/Neocallimastix_Methanobrevibacter_Xylan_Coculture.html
@@ -964,7 +964,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Ngawha_Geothermal_Mercury_Cycling_Community.html
+++ b/docs/communities/Ngawha_Geothermal_Mercury_Cycling_Community.html
@@ -843,7 +843,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/OMM12_Gnotobiotic_Mouse_Gut_Community.html
+++ b/docs/communities/OMM12_Gnotobiotic_Mouse_Gut_Community.html
@@ -747,7 +747,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.html
+++ b/docs/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.html
@@ -1239,7 +1239,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/ORNL_PMI_Populus_PD10_SynCom.html
+++ b/docs/communities/ORNL_PMI_Populus_PD10_SynCom.html
@@ -1576,7 +1576,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.html
+++ b/docs/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.html
@@ -928,7 +928,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Okeke_Lu_Cellulolytic_Consortium.html
+++ b/docs/communities/Okeke_Lu_Cellulolytic_Consortium.html
@@ -1222,7 +1222,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.html
+++ b/docs/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.html
@@ -939,7 +939,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/PET_Artificial_FourSpecies_Degradation_Consortium.html
+++ b/docs/communities/PET_Artificial_FourSpecies_Degradation_Consortium.html
@@ -1268,7 +1268,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/PGM_Spent_Catalyst_Bioleaching.html
+++ b/docs/communities/PGM_Spent_Catalyst_Bioleaching.html
@@ -1519,7 +1519,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/PMI_Variovorax_Thermotolerance_Collection.html
+++ b/docs/communities/PMI_Variovorax_Thermotolerance_Collection.html
@@ -910,7 +910,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.html
+++ b/docs/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.html
@@ -932,7 +932,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Panzhihua_Vanadium_Titanium_Tailings.html
+++ b/docs/communities/Panzhihua_Vanadium_Titanium_Tailings.html
@@ -1613,7 +1613,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Peanut_Seed_Bacterial_CS_SynCom.html
+++ b/docs/communities/Peanut_Seed_Bacterial_CS_SynCom.html
@@ -605,7 +605,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.html
+++ b/docs/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.html
@@ -1224,7 +1224,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Pelotomaculum_Methanothermobacter_Syntrophy.html
+++ b/docs/communities/Pelotomaculum_Methanothermobacter_Syntrophy.html
@@ -1301,7 +1301,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Pepper_Growth_Rhizosphere_SynCom.html
+++ b/docs/communities/Pepper_Growth_Rhizosphere_SynCom.html
@@ -605,7 +605,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Pepper_Phytophthora_SynCom5.html
+++ b/docs/communities/Pepper_Phytophthora_SynCom5.html
@@ -731,7 +731,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Phenol_Carboxylation_Consortium.html
+++ b/docs/communities/Phenol_Carboxylation_Consortium.html
@@ -909,7 +909,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Phormidium_Alkaline_Consortium.html
+++ b/docs/communities/Phormidium_Alkaline_Consortium.html
@@ -1378,7 +1378,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Phylogenetically_Diverse_Denitrifying_SynCom.html
+++ b/docs/communities/Phylogenetically_Diverse_Denitrifying_SynCom.html
@@ -647,7 +647,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Polaromonas_Vanadium_Reduction_Community.html
+++ b/docs/communities/Polaromonas_Vanadium_Reduction_Community.html
@@ -1325,7 +1325,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Populus_Salt_Tolerant_SynComs.html
+++ b/docs/communities/Populus_Salt_Tolerant_SynComs.html
@@ -605,7 +605,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.html
+++ b/docs/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.html
@@ -1248,7 +1248,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.html
+++ b/docs/communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.html
@@ -760,7 +760,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Prochlorococcus_Alteromonas_Helper_Coculture.html
+++ b/docs/communities/Prochlorococcus_Alteromonas_Helper_Coculture.html
@@ -839,7 +839,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.html
+++ b/docs/communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.html
@@ -1285,7 +1285,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Pseudomonas_Pedobacter_Social_Spreading_Coculture.html
+++ b/docs/communities/Pseudomonas_Pedobacter_Social_Spreading_Coculture.html
@@ -966,7 +966,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Pseudomonas_Rhodococcus_Chloronitrobenzene_Coculture.html
+++ b/docs/communities/Pseudomonas_Rhodococcus_Chloronitrobenzene_Coculture.html
@@ -1124,7 +1124,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Pseudonitzschia_Sulfitobacter_Association.html
+++ b/docs/communities/Pseudonitzschia_Sulfitobacter_Association.html
@@ -1045,7 +1045,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Rammelsberg_Cobalt_Nickel_Tailings.html
+++ b/docs/communities/Rammelsberg_Cobalt_Nickel_Tailings.html
@@ -1123,7 +1123,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.html
+++ b/docs/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.html
@@ -647,7 +647,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.html
+++ b/docs/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.html
@@ -1169,7 +1169,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Rice_Acid_Soil_Bioinoculant_SynCom.html
+++ b/docs/communities/Rice_Acid_Soil_Bioinoculant_SynCom.html
@@ -605,7 +605,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Rice_Duckweed_Bacillus_SynCom.html
+++ b/docs/communities/Rice_Duckweed_Bacillus_SynCom.html
@@ -791,7 +791,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Rice_P_Uptake_Intercropping_SynCom4.html
+++ b/docs/communities/Rice_P_Uptake_Intercropping_SynCom4.html
@@ -731,7 +731,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Richmond_Mine_AMD_Biofilm.html
+++ b/docs/communities/Richmond_Mine_AMD_Biofilm.html
@@ -1975,7 +1975,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Rifle_Aquifer_Bioanode_EET_Community.html
+++ b/docs/communities/Rifle_Aquifer_Bioanode_EET_Community.html
@@ -1022,7 +1022,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Rifle_Uranium_Reducing_Community.html
+++ b/docs/communities/Rifle_Uranium_Reducing_Community.html
@@ -1413,7 +1413,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/SF356_Cellulose_Degrader.html
+++ b/docs/communities/SF356_Cellulose_Degrader.html
@@ -1198,7 +1198,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/SIHUMIx_Human_Intestinal_Model_Community.html
+++ b/docs/communities/SIHUMIx_Human_Intestinal_Model_Community.html
@@ -1165,7 +1165,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/SMutans_CAlbicans_ECC_Biofilm.html
+++ b/docs/communities/SMutans_CAlbicans_ECC_Biofilm.html
@@ -692,7 +692,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/SMutans_SSputigena_ECC_Pathobiont.html
+++ b/docs/communities/SMutans_SSputigena_ECC_Pathobiont.html
@@ -638,7 +638,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/SMutans_VParvula_ASC_Biofilm.html
+++ b/docs/communities/SMutans_VParvula_ASC_Biofilm.html
@@ -638,7 +638,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/SPRUCE_Peatland_Methane_Cycling_Community.html
+++ b/docs/communities/SPRUCE_Peatland_Methane_Cycling_Community.html
@@ -887,7 +887,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.html
+++ b/docs/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.html
@@ -974,7 +974,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.html
+++ b/docs/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.html
@@ -740,7 +740,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Saccharomyces_Chlamydomonas_Fungal_Algal_Mutualism.html
+++ b/docs/communities/Saccharomyces_Chlamydomonas_Fungal_Algal_Mutualism.html
@@ -1016,7 +1016,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Salar_Atacama_Lithium_Brine_Community.html
+++ b/docs/communities/Salar_Atacama_Lithium_Brine_Community.html
@@ -1283,7 +1283,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Shewanella_Denitrifying_Richness_SynComs.html
+++ b/docs/communities/Shewanella_Denitrifying_Richness_SynComs.html
@@ -605,7 +605,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.html
+++ b/docs/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.html
@@ -999,7 +999,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.html
+++ b/docs/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.html
@@ -1100,7 +1100,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/SkinCom_Synthetic_Skin_Community.html
+++ b/docs/communities/SkinCom_Synthetic_Skin_Community.html
@@ -605,7 +605,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.html
+++ b/docs/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.html
@@ -862,7 +862,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.html
+++ b/docs/communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.html
@@ -752,7 +752,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Soil_Corrinoid_B12_Reservoir_Community.html
+++ b/docs/communities/Soil_Corrinoid_B12_Reservoir_Community.html
@@ -839,7 +839,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Sorghum_SRC1_Subset.html
+++ b/docs/communities/Sorghum_SRC1_Subset.html
@@ -1167,7 +1167,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.html
+++ b/docs/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.html
@@ -1130,7 +1130,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.html
+++ b/docs/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.html
@@ -647,7 +647,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Soybean_N_Fixation_sfSynCom.html
+++ b/docs/communities/Soybean_N_Fixation_sfSynCom.html
@@ -1385,7 +1385,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Sphingobium_Rhodococcus_Lignin_Dimer_Valorization_Coculture.html
+++ b/docs/communities/Sphingobium_Rhodococcus_Lignin_Dimer_Valorization_Coculture.html
@@ -1030,7 +1030,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.html
+++ b/docs/communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.html
@@ -1143,7 +1143,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Subsurface_Carboxydocella_CO_Aquifer_Community.html
+++ b/docs/communities/Subsurface_Carboxydocella_CO_Aquifer_Community.html
@@ -747,7 +747,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.html
+++ b/docs/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.html
@@ -838,7 +838,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/SynComBac10_Chicken_Intestinal_SynCom.html
+++ b/docs/communities/SynComBac10_Chicken_Intestinal_SynCom.html
@@ -605,7 +605,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.html
+++ b/docs/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.html
@@ -1142,7 +1142,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Synechococcus_Bacillus_SPC.html
+++ b/docs/communities/Synechococcus_Bacillus_SPC.html
@@ -700,7 +700,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Synechococcus_Ecoli_SPC.html
+++ b/docs/communities/Synechococcus_Ecoli_SPC.html
@@ -794,7 +794,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.html
+++ b/docs/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.html
@@ -980,7 +980,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.html
+++ b/docs/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.html
@@ -1339,7 +1339,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.html
+++ b/docs/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.html
@@ -1122,7 +1122,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Synechococcus_Yarrowia_SPC.html
+++ b/docs/communities/Synechococcus_Yarrowia_SPC.html
@@ -710,7 +710,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.html
+++ b/docs/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.html
@@ -941,7 +941,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Synthetic_Periphyton_Freshwater_Biofilm.html
+++ b/docs/communities/Synthetic_Periphyton_Freshwater_Biofilm.html
@@ -689,7 +689,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Syntrophobacter_Methanobacterium_Syntrophy.html
+++ b/docs/communities/Syntrophobacter_Methanobacterium_Syntrophy.html
@@ -842,7 +842,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Syntrophobacter_Methanospirillum_Syntrophy.html
+++ b/docs/communities/Syntrophobacter_Methanospirillum_Syntrophy.html
@@ -1251,7 +1251,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.html
+++ b/docs/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.html
@@ -1136,7 +1136,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Syntrophomonas_Methanospirillum_Syntrophy.html
+++ b/docs/communities/Syntrophomonas_Methanospirillum_Syntrophy.html
@@ -1243,7 +1243,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Syntrophus_Benzoate_Degrader.html
+++ b/docs/communities/Syntrophus_Benzoate_Degrader.html
@@ -868,7 +868,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.html
+++ b/docs/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.html
@@ -1212,7 +1212,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/THOR_Rhizosphere_Model_Community.html
+++ b/docs/communities/THOR_Rhizosphere_Model_Community.html
@@ -902,7 +902,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/TYQ1_Nematode_Biocontrol_SynCom.html
+++ b/docs/communities/TYQ1_Nematode_Biocontrol_SynCom.html
@@ -1040,7 +1040,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Teosinte_Maize_Biofertilizer_SynCom7.html
+++ b/docs/communities/Teosinte_Maize_Biofertilizer_SynCom7.html
@@ -731,7 +731,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.html
+++ b/docs/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.html
@@ -1077,7 +1077,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.html
+++ b/docs/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.html
@@ -1022,7 +1022,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.html
+++ b/docs/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.html
@@ -1345,7 +1345,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Thermophilic_Pyrite_QS_Consortium.html
+++ b/docs/communities/Thermophilic_Pyrite_QS_Consortium.html
@@ -1583,7 +1583,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.html
+++ b/docs/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.html
@@ -1134,7 +1134,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.html
+++ b/docs/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.html
@@ -892,7 +892,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Tinto_River_Iron_Cycling_Community.html
+++ b/docs/communities/Tinto_River_Iron_Cycling_Community.html
@@ -1194,7 +1194,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Tobacco_Chemotactic_Biocontrol_SynCom.html
+++ b/docs/communities/Tobacco_Chemotactic_Biocontrol_SynCom.html
@@ -647,7 +647,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Tomato_Oxylipin_SynCom3.html
+++ b/docs/communities/Tomato_Oxylipin_SynCom3.html
@@ -689,7 +689,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.html
+++ b/docs/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.html
@@ -689,7 +689,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.html
+++ b/docs/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.html
@@ -1236,7 +1236,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.html
+++ b/docs/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.html
@@ -1107,7 +1107,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Trichoderma_Lactate_Platform.html
+++ b/docs/communities/Trichoderma_Lactate_Platform.html
@@ -889,7 +889,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.html
+++ b/docs/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.html
@@ -1071,7 +1071,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Trichodesmium_Alteromonas_Marine_Consortium.html
+++ b/docs/communities/Trichodesmium_Alteromonas_Marine_Consortium.html
@@ -914,7 +914,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Urine_Nitrification_SynCom.html
+++ b/docs/communities/Urine_Nitrification_SynCom.html
@@ -773,7 +773,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.html
+++ b/docs/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.html
@@ -966,7 +966,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Watermelon_Rhizosphere_Fusarium_SynCom8.html
+++ b/docs/communities/Watermelon_Rhizosphere_Fusarium_SynCom8.html
@@ -647,7 +647,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.html
+++ b/docs/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.html
@@ -1136,7 +1136,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Wheat_Consortium_C1.html
+++ b/docs/communities/Wheat_Consortium_C1.html
@@ -764,7 +764,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Wheat_Consortium_C6.html
+++ b/docs/communities/Wheat_Consortium_C6.html
@@ -772,7 +772,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.html
+++ b/docs/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.html
@@ -731,7 +731,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Yogurt_TwoSpecies_Starter_Culture.html
+++ b/docs/communities/Yogurt_TwoSpecies_Starter_Culture.html
@@ -1223,7 +1223,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.html
+++ b/docs/communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.html
@@ -1066,7 +1066,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/hCom2_Complex_Gut_Microbiome.html
+++ b/docs/communities/hCom2_Complex_Gut_Microbiome.html
@@ -605,7 +605,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/docs/communities/mCAFEs_Brachypodium_RCC.html
+++ b/docs/communities/mCAFEs_Brachypodium_RCC.html
@@ -1086,7 +1086,7 @@
     </footer>
 
     
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {

--- a/src/communitymech/templates/community.html
+++ b/src/communitymech/templates/community.html
@@ -915,7 +915,7 @@
     </footer>
 
     {% if community.ecological_interactions %}
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../d3.v7.min.js"></script>
     <script>
     (function() {
         var interactionColors = {


### PR DESCRIPTION
## Problem
`src/communitymech/templates/community.html` loaded d3 from `https://d3js.org/d3.v7.min.js` with no fallback, while every sibling page (landing, browser, UMAP) already bundles the local `docs/d3.v7.min.js`. Offline or under a strict CSP, the per-community **network diagram silently rendered blank**.

Surfaced by a front-end design review against the `dataviz`/`artifact-design` skills.

## Fix
Point the template's d3 `<script>` at `../d3.v7.min.js` (per-community pages render to `docs/communities/`, one level below the bundle) and regenerate the 262 affected community pages. Every changed line is only the `<script src>` swap.

## Verification
`../d3.v7.min.js` from `docs/communities/*.html` resolves to the existing `docs/d3.v7.min.js`; no other CDN d3 references remain in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)