### PR TITLE
Toggleable dark theme + reduced-motion guard (CommunityMech site)

### DIFF
--- a/docs/browser.html
+++ b/docs/browser.html
@@ -413,7 +413,83 @@
             color: #64748b;
             font-size: 0.875rem;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--card:#1a1f2e; --ink:#e8ecf4; --line:#2a3142; --accent:#6ea6f0;}
+  :root:not([data-theme="light"]) body{background:#101420;color:#e8ecf4}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) header .home-link{color:#6ea6f0}
+  :root:not([data-theme="light"]) h1{color:#e8ecf4}
+  :root:not([data-theme="light"]) .subtitle{color:#99a2b5}
+  :root:not([data-theme="light"]) .filter-panel{background:#1a1f2e;border-color:#2a3142}
+  :root:not([data-theme="light"]) .filter-panel h3{color:#e8ecf4}
+  :root:not([data-theme="light"]) .search-container input{background:#101420;border-color:#2a3142;color:#e8ecf4}
+  :root:not([data-theme="light"]) .clear-btn{color:#99a2b5}
+  :root:not([data-theme="light"]) .clear-btn:hover{color:#e8ecf4}
+  :root:not([data-theme="light"]) .search-results-count{color:#99a2b5;border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) .facet-section{border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) .facet-toggle{color:#99a2b5}
+  :root:not([data-theme="light"]) .facet-actions button{background:#101420;border-color:#2a3142;color:#e8ecf4}
+  :root:not([data-theme="light"]) .facet-actions button:hover{background:#232a3d}
+  :root:not([data-theme="light"]) .facet-checkbox:hover{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .facet-count{color:#99a2b5}
+  :root:not([data-theme="light"]) .active-filters{background:rgba(251,191,36,.12);border-color:#fbbf24}
+  :root:not([data-theme="light"]) .btn-reset{background:#101420;border-color:#fbbf24;color:#e8ecf4}
+  :root:not([data-theme="light"]) .btn-reset:hover{background:rgba(251,191,36,.15)}
+  :root:not([data-theme="light"]) .filter-tag{background:#101420;border-color:#2a3142;color:#e8ecf4}
+  :root:not([data-theme="light"]) .filter-tag-remove{color:#99a2b5}
+  :root:not([data-theme="light"]) .filter-tag-remove:hover{color:#f87171}
+  :root:not([data-theme="light"]) .umap-link{background:#1a1f2e;border-color:#6ea6f0}
+  :root:not([data-theme="light"]) .umap-link h2{color:#6ea6f0}
+  :root:not([data-theme="light"]) .umap-link p{color:#99a2b5}
+  :root:not([data-theme="light"]) .umap-link a{background:#6ea6f0;color:#101420}
+  :root:not([data-theme="light"]) .umap-link a:hover{background:#8fbcf5}
+  :root:not([data-theme="light"]) .community-card{background:#1a1f2e;border-color:#2a3142}
+  :root:not([data-theme="light"]) .community-card h2{color:#6ea6f0}
+  :root:not([data-theme="light"]) .community-card .description{color:#99a2b5}
+  :root:not([data-theme="light"]) .badge-category{background:#232a3d;color:#cbd5e1}
+  :root:not([data-theme="light"]) .badge-member-count{background:#232a3d;color:#cbd5e1}
+  :root:not([data-theme="light"]) footer{border-top-color:#2a3142;color:#99a2b5}
+}
+:root[data-theme="dark"]{--card:#1a1f2e; --ink:#e8ecf4; --line:#2a3142; --accent:#6ea6f0;}
+:root[data-theme="dark"] body{background:#101420;color:#e8ecf4}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] header .home-link{color:#6ea6f0}
+:root[data-theme="dark"] h1{color:#e8ecf4}
+:root[data-theme="dark"] .subtitle{color:#99a2b5}
+:root[data-theme="dark"] .filter-panel{background:#1a1f2e;border-color:#2a3142}
+:root[data-theme="dark"] .filter-panel h3{color:#e8ecf4}
+:root[data-theme="dark"] .search-container input{background:#101420;border-color:#2a3142;color:#e8ecf4}
+:root[data-theme="dark"] .clear-btn{color:#99a2b5}
+:root[data-theme="dark"] .clear-btn:hover{color:#e8ecf4}
+:root[data-theme="dark"] .search-results-count{color:#99a2b5;border-bottom-color:#2a3142}
+:root[data-theme="dark"] .facet-section{border-bottom-color:#2a3142}
+:root[data-theme="dark"] .facet-toggle{color:#99a2b5}
+:root[data-theme="dark"] .facet-actions button{background:#101420;border-color:#2a3142;color:#e8ecf4}
+:root[data-theme="dark"] .facet-actions button:hover{background:#232a3d}
+:root[data-theme="dark"] .facet-checkbox:hover{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .facet-count{color:#99a2b5}
+:root[data-theme="dark"] .active-filters{background:rgba(251,191,36,.12);border-color:#fbbf24}
+:root[data-theme="dark"] .btn-reset{background:#101420;border-color:#fbbf24;color:#e8ecf4}
+:root[data-theme="dark"] .btn-reset:hover{background:rgba(251,191,36,.15)}
+:root[data-theme="dark"] .filter-tag{background:#101420;border-color:#2a3142;color:#e8ecf4}
+:root[data-theme="dark"] .filter-tag-remove{color:#99a2b5}
+:root[data-theme="dark"] .filter-tag-remove:hover{color:#f87171}
+:root[data-theme="dark"] .umap-link{background:#1a1f2e;border-color:#6ea6f0}
+:root[data-theme="dark"] .umap-link h2{color:#6ea6f0}
+:root[data-theme="dark"] .umap-link p{color:#99a2b5}
+:root[data-theme="dark"] .umap-link a{background:#6ea6f0;color:#101420}
+:root[data-theme="dark"] .umap-link a:hover{background:#8fbcf5}
+:root[data-theme="dark"] .community-card{background:#1a1f2e;border-color:#2a3142}
+:root[data-theme="dark"] .community-card h2{color:#6ea6f0}
+:root[data-theme="dark"] .community-card .description{color:#99a2b5}
+:root[data-theme="dark"] .badge-category{background:#232a3d;color:#cbd5e1}
+:root[data-theme="dark"] .badge-member-count{background:#232a3d;color:#cbd5e1}
+:root[data-theme="dark"] footer{border-top-color:#2a3142;color:#99a2b5}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -9155,5 +9231,6 @@
         // Initialize facets when page loads
         initializeFacets();
     </script>
+    <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/AMD_Acidophile_Heterotroph_Network.html
+++ b/docs/communities/AMD_Acidophile_Heterotroph_Network.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -2014,7 +2036,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -2022,7 +2044,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -2140,5 +2162,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/AMD_Nitrososphaerota_Archaeal.html
+++ b/docs/communities/AMD_Nitrososphaerota_Archaeal.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1768,7 +1790,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1776,7 +1798,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1894,5 +1916,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/ANME_SRB_Marine_Methane_Seep_Consortium.html
+++ b/docs/communities/ANME_SRB_Marine_Methane_Seep_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1045,7 +1067,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1053,7 +1075,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1171,5 +1193,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Aalborg_East_Full_Scale_EBPR_Community.html
+++ b/docs/communities/Aalborg_East_Full_Scale_EBPR_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1240,7 +1262,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1248,7 +1270,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1366,5 +1388,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.html
+++ b/docs/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1417,7 +1439,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1425,7 +1447,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1543,5 +1565,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.html
+++ b/docs/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1036,7 +1058,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1044,7 +1066,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1162,5 +1184,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Aerobic_Denitrification_Disturbance_SynCom.html
+++ b/docs/communities/Aerobic_Denitrification_Disturbance_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -863,7 +885,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -871,7 +893,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -989,5 +1011,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Aerobic_Denitrification_QQ_SynCom.html
+++ b/docs/communities/Aerobic_Denitrification_QQ_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -863,7 +885,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -871,7 +893,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -989,5 +1011,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Alaska_Tundra_Permafrost_Iron_Redox_Community.html
+++ b/docs/communities/Alaska_Tundra_Permafrost_Iron_Redox_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1174,7 +1196,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1182,7 +1204,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1300,5 +1322,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.html
+++ b/docs/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1117,7 +1139,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1125,7 +1147,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1243,5 +1265,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.html
+++ b/docs/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -992,7 +1014,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1000,7 +1022,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1118,5 +1140,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Anammox_Granule_Metabolic_Interaction_Community.html
+++ b/docs/communities/Anammox_Granule_Metabolic_Interaction_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1317,7 +1339,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1325,7 +1347,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1443,5 +1465,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Angelarchaeales_Thermoplasmata_CuMMO_Soil_Sediment_Community.html
+++ b/docs/communities/Angelarchaeales_Thermoplasmata_CuMMO_Soil_Sediment_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1010,7 +1032,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1018,7 +1040,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1136,5 +1158,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Arabidopsis_Coumarin_Root_SynCom.html
+++ b/docs/communities/Arabidopsis_Coumarin_Root_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -765,7 +787,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -773,7 +795,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -891,5 +913,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Arabidopsis_Phyllosphere_SynCom7.html
+++ b/docs/communities/Arabidopsis_Phyllosphere_SynCom7.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -765,7 +787,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -773,7 +795,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -891,5 +913,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.html
+++ b/docs/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1174,7 +1196,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1182,7 +1204,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1300,5 +1322,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/At_RSPHERE_SynCom.html
+++ b/docs/communities/At_RSPHERE_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1772,7 +1794,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1780,7 +1802,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1898,5 +1920,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Australian_Lead_Zinc_Polymetallic.html
+++ b/docs/communities/Australian_Lead_Zinc_Polymetallic.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -2189,7 +2211,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -2197,7 +2219,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -2315,5 +2337,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.html
+++ b/docs/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1272,7 +1294,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1280,7 +1302,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1398,5 +1420,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.html
+++ b/docs/communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -998,7 +1020,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1006,7 +1028,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1124,5 +1146,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.html
+++ b/docs/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -814,7 +836,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -822,7 +844,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -940,5 +962,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.html
+++ b/docs/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1205,7 +1227,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1213,7 +1235,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1331,5 +1353,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.html
+++ b/docs/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1146,7 +1168,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1154,7 +1176,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1272,5 +1294,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Banana_Fusarium_Biocontrol_SynCom12.html
+++ b/docs/communities/Banana_Fusarium_Biocontrol_SynCom12.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -863,7 +885,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -871,7 +893,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -989,5 +1011,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.html
+++ b/docs/communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -888,7 +910,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -896,7 +918,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1014,5 +1036,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Bayan_Obo_REE_Tailings_Consortium.html
+++ b/docs/communities/Bayan_Obo_REE_Tailings_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1574,7 +1596,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1582,7 +1604,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1700,5 +1722,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.html
+++ b/docs/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -990,7 +1012,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -998,7 +1020,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1116,5 +1138,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/BioModels_MODEL1806250003_Spittlebug_Sulcia_Sodalis.html
+++ b/docs/communities/BioModels_MODEL1806250003_Spittlebug_Sulcia_Sodalis.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1003,7 +1025,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1011,7 +1033,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1129,5 +1151,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/BioModels_MODEL1806250004_Sharpshooter_Sulcia_Baumannia.html
+++ b/docs/communities/BioModels_MODEL1806250004_Sharpshooter_Sulcia_Baumannia.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1003,7 +1025,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1011,7 +1033,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1129,5 +1151,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/BioModels_MODEL1806250005_Cicada_Sulcia_Hodgkinia.html
+++ b/docs/communities/BioModels_MODEL1806250005_Cicada_Sulcia_Hodgkinia.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1003,7 +1025,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1011,7 +1033,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1129,5 +1151,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/BioModels_MODEL2204300001_Kefir_Community_Model.html
+++ b/docs/communities/BioModels_MODEL2204300001_Kefir_Community_Model.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1410,7 +1432,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1418,7 +1440,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1536,5 +1558,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/BioModels_MODEL2209060002_DPigrum_SAureus_Community.html
+++ b/docs/communities/BioModels_MODEL2209060002_DPigrum_SAureus_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -886,7 +908,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -894,7 +916,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1012,5 +1034,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/BioModels_MODEL2310020001_Mouse_Metaorganism_Model.html
+++ b/docs/communities/BioModels_MODEL2310020001_Mouse_Metaorganism_Model.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -528,5 +550,6 @@
     </footer>
 
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.html
+++ b/docs/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1419,7 +1441,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1427,7 +1449,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1545,5 +1567,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/BioModels_MODEL2407300002_Sponge_Holobiont_Network.html
+++ b/docs/communities/BioModels_MODEL2407300002_Sponge_Holobiont_Network.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1118,7 +1140,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1126,7 +1148,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1244,5 +1266,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.html
+++ b/docs/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1141,7 +1163,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1149,7 +1171,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1267,5 +1289,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.html
+++ b/docs/communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1110,7 +1132,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1118,7 +1140,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1236,5 +1258,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/CRC_Fusobacterium_Control_SynCom.html
+++ b/docs/communities/CRC_Fusobacterium_Control_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -765,7 +787,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -773,7 +795,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -891,5 +913,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.html
+++ b/docs/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1218,7 +1240,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1226,7 +1248,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1344,5 +1366,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.html
+++ b/docs/communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1272,7 +1294,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1280,7 +1302,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1398,5 +1420,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.html
+++ b/docs/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1422,7 +1444,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1430,7 +1452,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1548,5 +1570,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/California_Grassland_Precipitation_Legacy_Soil_Community.html
+++ b/docs/communities/California_Grassland_Precipitation_Legacy_Soil_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1120,7 +1142,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1128,7 +1150,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1246,5 +1268,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Candida_Parapsilosis_Hospitalized_Infant_Microbiome.html
+++ b/docs/communities/Candida_Parapsilosis_Hospitalized_Infant_Microbiome.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -905,7 +927,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -913,7 +935,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1031,5 +1053,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/CeMbio_Caenorhabditis_Elegans_Microbiome.html
+++ b/docs/communities/CeMbio_Caenorhabditis_Elegans_Microbiome.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1432,7 +1454,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1440,7 +1462,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1558,5 +1580,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.html
+++ b/docs/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1294,7 +1316,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1302,7 +1324,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1420,5 +1442,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Cellulose_Methane_Quad_Culture_SynCom.html
+++ b/docs/communities/Cellulose_Methane_Quad_Culture_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -912,7 +934,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -920,7 +942,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1038,5 +1060,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Cheese_Rind_InSitu_InVitro_Model_Community.html
+++ b/docs/communities/Cheese_Rind_InSitu_InVitro_Model_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1209,7 +1231,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1217,7 +1239,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1335,5 +1357,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Chlamydomonas_Bacterial_H2_Consortium.html
+++ b/docs/communities/Chlamydomonas_Bacterial_H2_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1409,7 +1431,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1417,7 +1439,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1535,5 +1557,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Chlamydomonas_Methylobacterium_Mutualism.html
+++ b/docs/communities/Chlamydomonas_Methylobacterium_Mutualism.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1333,7 +1355,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1341,7 +1363,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1459,5 +1481,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Chlorella_Azospirillum_Synthetic_Mutualism.html
+++ b/docs/communities/Chlorella_Azospirillum_Synthetic_Mutualism.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1652,7 +1674,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1660,7 +1682,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1778,5 +1800,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.html
+++ b/docs/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1357,7 +1379,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1365,7 +1387,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1483,5 +1505,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Chlorella_Rhizobium_Bioflocculation.html
+++ b/docs/communities/Chlorella_Rhizobium_Bioflocculation.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1135,7 +1157,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1143,7 +1165,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1261,5 +1283,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.html
+++ b/docs/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1194,7 +1216,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1202,7 +1224,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1320,5 +1342,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Chromium_Sulfur_Reduction_Enrichment.html
+++ b/docs/communities/Chromium_Sulfur_Reduction_Enrichment.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1571,7 +1593,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1579,7 +1601,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1697,5 +1719,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Cinnamate_Degradation_Consortium.html
+++ b/docs/communities/Cinnamate_Degradation_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1145,7 +1167,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1153,7 +1175,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1271,5 +1293,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.html
+++ b/docs/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1455,7 +1477,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1463,7 +1485,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1581,5 +1603,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.html
+++ b/docs/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1405,7 +1427,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1413,7 +1435,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1531,5 +1553,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.html
+++ b/docs/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1428,7 +1450,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1436,7 +1458,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1554,5 +1576,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.html
+++ b/docs/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1400,7 +1422,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1408,7 +1430,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1526,5 +1548,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.html
+++ b/docs/communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1409,7 +1431,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1417,7 +1439,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1535,5 +1557,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.html
+++ b/docs/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1297,7 +1319,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1305,7 +1327,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1423,5 +1445,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.html
+++ b/docs/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1549,7 +1571,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1557,7 +1579,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1675,5 +1697,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.html
+++ b/docs/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1507,7 +1529,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1515,7 +1537,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1633,5 +1655,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.html
+++ b/docs/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1417,7 +1439,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1425,7 +1447,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1543,5 +1565,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.html
+++ b/docs/communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1375,7 +1397,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1383,7 +1405,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1501,5 +1523,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.html
+++ b/docs/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1364,7 +1386,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1372,7 +1394,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1490,5 +1512,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.html
+++ b/docs/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1497,7 +1519,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1505,7 +1527,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1623,5 +1645,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.html
+++ b/docs/communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1445,7 +1467,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1453,7 +1475,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1571,5 +1593,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.html
+++ b/docs/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1613,7 +1635,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1621,7 +1643,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1739,5 +1761,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Copper_Biomining_Heap_Leach.html
+++ b/docs/communities/Copper_Biomining_Heap_Leach.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1979,7 +2001,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1987,7 +2009,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -2105,5 +2127,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Coscinodiscus_Synthetic_Community.html
+++ b/docs/communities/Coscinodiscus_Synthetic_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1807,7 +1829,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1815,7 +1837,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1933,5 +1955,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community.html
+++ b/docs/communities/Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1084,7 +1106,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1092,7 +1114,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1210,5 +1232,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.html
+++ b/docs/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1116,7 +1138,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1124,7 +1146,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1242,5 +1264,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/DVM_Triculture.html
+++ b/docs/communities/DVM_Triculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1392,7 +1414,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1400,7 +1422,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1518,5 +1540,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Dangl_SynComm_35.html
+++ b/docs/communities/Dangl_SynComm_35.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -2037,7 +2059,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -2045,7 +2067,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -2163,5 +2185,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.html
+++ b/docs/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1489,7 +1511,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1497,7 +1519,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1615,5 +1637,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Defined_Multispecies_Enamel_Caries_Model.html
+++ b/docs/communities/Defined_Multispecies_Enamel_Caries_Model.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -683,5 +705,6 @@
     </footer>
 
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.html
+++ b/docs/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1565,7 +1587,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1573,7 +1595,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1691,5 +1713,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.html
+++ b/docs/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1534,7 +1556,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1542,7 +1564,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1660,5 +1682,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.html
+++ b/docs/communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1446,7 +1468,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1454,7 +1476,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1572,5 +1594,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.html
+++ b/docs/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1407,7 +1429,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1415,7 +1437,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1533,5 +1555,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.html
+++ b/docs/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1474,7 +1496,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1482,7 +1504,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1600,5 +1622,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Desert_Tomato_Salt_Stress_SynCom5.html
+++ b/docs/communities/Desert_Tomato_Salt_Stress_SynCom5.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -765,7 +787,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -773,7 +795,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -891,5 +913,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Desulfovibrio_Methanococcus_Syntrophy.html
+++ b/docs/communities/Desulfovibrio_Methanococcus_Syntrophy.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1493,7 +1515,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1501,7 +1523,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1619,5 +1641,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Desulfovibrio_Methanosarcina_Lactate_Syntrophy.html
+++ b/docs/communities/Desulfovibrio_Methanosarcina_Lactate_Syntrophy.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1194,7 +1216,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1202,7 +1224,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1320,5 +1342,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.html
+++ b/docs/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1281,7 +1303,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1289,7 +1311,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1407,5 +1429,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.html
+++ b/docs/communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1069,7 +1091,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1077,7 +1099,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1195,5 +1217,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/ENIGMA_Denitrifying_SynCom.html
+++ b/docs/communities/ENIGMA_Denitrifying_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1103,7 +1125,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1111,7 +1133,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1229,5 +1251,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Early_Dental_Biofilm_FiveSpecies.html
+++ b/docs/communities/Early_Dental_Biofilm_FiveSpecies.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -693,5 +715,6 @@
     </footer>
 
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/East_River_Floodplain_Core_Microbiome.html
+++ b/docs/communities/East_River_Floodplain_Core_Microbiome.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1180,7 +1202,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1188,7 +1210,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1306,5 +1328,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/East_River_Hillslope_Riparian_Transect_Community.html
+++ b/docs/communities/East_River_Hillslope_Riparian_Transect_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1445,7 +1467,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1453,7 +1475,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1571,5 +1593,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/EcoFAB_Ring_Trial_SynCom17.html
+++ b/docs/communities/EcoFAB_Ring_Trial_SynCom17.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -2876,7 +2898,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -2884,7 +2906,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -3002,5 +3024,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Emiliania_Phaeobacter_Dynamic_Interaction.html
+++ b/docs/communities/Emiliania_Phaeobacter_Dynamic_Interaction.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1162,7 +1184,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1170,7 +1192,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1288,5 +1310,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.html
+++ b/docs/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1246,7 +1268,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1254,7 +1276,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1372,5 +1394,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Episymbiotic_CPR_DPANN_Groundwater_Community.html
+++ b/docs/communities/Episymbiotic_CPR_DPANN_Groundwater_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1030,7 +1052,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1038,7 +1060,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1156,5 +1178,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Ewaste_Bioleaching_Consortium.html
+++ b/docs/communities/Ewaste_Bioleaching_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1709,7 +1731,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1717,7 +1739,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1835,5 +1857,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Ferroplasma_Leptospirillum_Syntrophy.html
+++ b/docs/communities/Ferroplasma_Leptospirillum_Syntrophy.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1812,7 +1834,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1820,7 +1842,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1938,5 +1960,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/GLBRC_Exometabolite_Transwell_SynCom.html
+++ b/docs/communities/GLBRC_Exometabolite_Transwell_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -765,7 +787,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -773,7 +795,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -891,5 +913,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/GLBRC_Populus_Variovorax_SynCom28.html
+++ b/docs/communities/GLBRC_Populus_Variovorax_SynCom28.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -2434,7 +2456,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -2442,7 +2464,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -2560,5 +2582,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/GLBRC_UFMP_Fermentation_Community.html
+++ b/docs/communities/GLBRC_UFMP_Fermentation_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1477,7 +1499,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1485,7 +1507,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1603,5 +1625,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/GOM_Oil_Degrading_Consortium.html
+++ b/docs/communities/GOM_Oil_Degrading_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1091,7 +1113,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1099,7 +1121,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1217,5 +1239,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Garlic_Pseudomonas_SynCom6.html
+++ b/docs/communities/Garlic_Pseudomonas_SynCom6.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -765,7 +787,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -773,7 +795,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -891,5 +913,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Geobacter_Clostridium_DIET.html
+++ b/docs/communities/Geobacter_Clostridium_DIET.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1395,7 +1417,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1403,7 +1425,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1521,5 +1543,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Geobacter_Methanosaeta_DIET.html
+++ b/docs/communities/Geobacter_Methanosaeta_DIET.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1162,7 +1184,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1170,7 +1192,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1288,5 +1310,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Geobacter_Methanosarcina_DIET.html
+++ b/docs/communities/Geobacter_Methanosarcina_DIET.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1274,7 +1296,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1282,7 +1304,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1400,5 +1422,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.html
+++ b/docs/communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1447,7 +1469,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1455,7 +1477,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1573,5 +1595,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Grassland_Soil_WetUp_Virus_Host_Community.html
+++ b/docs/communities/Grassland_Soil_WetUp_Virus_Host_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1030,7 +1052,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1038,7 +1060,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1156,5 +1178,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.html
+++ b/docs/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1099,7 +1121,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1107,7 +1129,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1225,5 +1247,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Hanford_300_Area_Unconfined_Aquifer_Community.html
+++ b/docs/communities/Hanford_300_Area_Unconfined_Aquifer_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1149,7 +1171,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1157,7 +1179,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1275,5 +1297,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.html
+++ b/docs/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1614,7 +1636,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1622,7 +1644,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1740,5 +1762,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Honeybee_Core20_Defined_Microbiota.html
+++ b/docs/communities/Honeybee_Core20_Defined_Microbiota.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -765,7 +787,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -773,7 +795,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -891,5 +913,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Horonobe_Mizunami_URL_Subsurface_Microbiome.html
+++ b/docs/communities/Horonobe_Mizunami_URL_Subsurface_Microbiome.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1179,7 +1201,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1187,7 +1209,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1305,5 +1327,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Iberian_Pit_Lake_Stratified_Community.html
+++ b/docs/communities/Iberian_Pit_Lake_Stratified_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1955,7 +1977,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1963,7 +1985,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -2081,5 +2103,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Industrial_Bioreactor_Consortium.html
+++ b/docs/communities/Industrial_Bioreactor_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -2413,7 +2435,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -2421,7 +2443,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -2539,5 +2561,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.html
+++ b/docs/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1294,7 +1316,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1302,7 +1324,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1420,5 +1442,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Infant_Gut_DNA_Phage_Succession_Community.html
+++ b/docs/communities/Infant_Gut_DNA_Phage_Succession_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1060,7 +1082,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1068,7 +1090,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1186,5 +1208,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Infant_Gut_Strain_Persistence_Maternal_Community.html
+++ b/docs/communities/Infant_Gut_Strain_Persistence_Maternal_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1165,7 +1187,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1173,7 +1195,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1291,5 +1313,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Ion_Adsorption_REE_Indigenous_Community.html
+++ b/docs/communities/Ion_Adsorption_REE_Indigenous_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1832,7 +1854,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1840,7 +1862,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1958,5 +1980,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Jala_Maize_PGPB_SynCom.html
+++ b/docs/communities/Jala_Maize_PGPB_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -912,7 +934,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -920,7 +942,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1038,5 +1060,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/KB1_Chlorinated_Ethene_Dechlorinating_Consortium.html
+++ b/docs/communities/KB1_Chlorinated_Ethene_Dechlorinating_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1152,7 +1174,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1160,7 +1182,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1278,5 +1300,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/KBase_Models_for_Zahmeeth_Original_PLOS.html
+++ b/docs/communities/KBase_Models_for_Zahmeeth_Original_PLOS.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1041,7 +1063,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1049,7 +1071,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1167,5 +1189,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/KBase_ORT_Workflow_Community_Model.html
+++ b/docs/communities/KBase_ORT_Workflow_Community_Model.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1129,7 +1151,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1137,7 +1159,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1255,5 +1277,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/KBase_Synthetic_Bacterial_Community_R2A.html
+++ b/docs/communities/KBase_Synthetic_Bacterial_Community_R2A.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1083,7 +1105,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1091,7 +1113,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1209,5 +1231,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Kombucha_KMC_IMBG1_Fermentation_Community.html
+++ b/docs/communities/Kombucha_KMC_IMBG1_Fermentation_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1264,7 +1286,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1272,7 +1294,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1390,5 +1412,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/LBNL_Brachypodium_Drought_SynCom15.html
+++ b/docs/communities/LBNL_Brachypodium_Drought_SynCom15.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -765,7 +787,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -773,7 +795,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -891,5 +913,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/LBNL_Human_Gut_Interaction_SynCom.html
+++ b/docs/communities/LBNL_Human_Gut_Interaction_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -765,7 +787,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -773,7 +795,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -891,5 +913,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/LBNL_Switchgrass_Soil_SynCom16.html
+++ b/docs/communities/LBNL_Switchgrass_Soil_SynCom16.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -765,7 +787,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -773,7 +795,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -891,5 +913,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Lac_Pavin_Stratified_Lake_Community.html
+++ b/docs/communities/Lac_Pavin_Stratified_Lake_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1046,7 +1068,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1054,7 +1076,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1172,5 +1194,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.html
+++ b/docs/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1674,7 +1696,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1682,7 +1704,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1800,5 +1822,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Lotus_LjSC3.html
+++ b/docs/communities/Lotus_LjSC3.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -2321,7 +2343,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -2329,7 +2351,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -2447,5 +2469,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/MAMC_M48_Lignocellulose.html
+++ b/docs/communities/MAMC_M48_Lignocellulose.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1490,7 +1512,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1498,7 +1520,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1616,5 +1638,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/MSC1_Dominant_Core.html
+++ b/docs/communities/MSC1_Dominant_Core.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -2395,7 +2417,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -2403,7 +2425,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -2521,5 +2543,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/MSC2_Model_Soil_Consortium.html
+++ b/docs/communities/MSC2_Model_Soil_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1143,7 +1165,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1151,7 +1173,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1269,5 +1291,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.html
+++ b/docs/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1601,7 +1623,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1609,7 +1631,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1727,5 +1749,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Maize_Benzoxazinoid_Metabolizing_SynComs.html
+++ b/docs/communities/Maize_Benzoxazinoid_Metabolizing_SynComs.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -765,7 +787,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -773,7 +795,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -891,5 +913,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Maize_Drought_Response_SynCom.html
+++ b/docs/communities/Maize_Drought_Response_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -765,7 +787,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -773,7 +795,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -891,5 +913,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Maize_Root_Simplified_Community.html
+++ b/docs/communities/Maize_Root_Simplified_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -2044,7 +2066,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -2052,7 +2074,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -2170,5 +2192,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Medicago_Nodule_Biofertilizer_SynCom.html
+++ b/docs/communities/Medicago_Nodule_Biofertilizer_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -814,7 +836,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -822,7 +844,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -940,5 +962,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Mediterranean_Grassland_qSIP_Rainfall_Community.html
+++ b/docs/communities/Mediterranean_Grassland_qSIP_Rainfall_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -921,7 +943,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -929,7 +951,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1047,5 +1069,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Mercury_SFA_EFPC_Sediment_Community.html
+++ b/docs/communities/Mercury_SFA_EFPC_Sediment_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1492,7 +1514,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1500,7 +1522,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1618,5 +1640,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Methane_Oxidation_CrVI_Reduction_SynCom.html
+++ b/docs/communities/Methane_Oxidation_CrVI_Reduction_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -863,7 +885,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -871,7 +893,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -989,5 +1011,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.html
+++ b/docs/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1383,7 +1405,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1391,7 +1413,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1509,5 +1531,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.html
+++ b/docs/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1277,7 +1299,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1285,7 +1307,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1403,5 +1425,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.html
+++ b/docs/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1260,7 +1282,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1268,7 +1290,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1386,5 +1408,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.html
+++ b/docs/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1219,7 +1241,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1227,7 +1249,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1345,5 +1367,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.html
+++ b/docs/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1484,7 +1506,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1492,7 +1514,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1610,5 +1632,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.html
+++ b/docs/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1262,7 +1284,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1270,7 +1292,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1388,5 +1410,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Microcoleus_Massilia_Cyanosphere_Urea_Mutualism.html
+++ b/docs/communities/Microcoleus_Massilia_Cyanosphere_Urea_Mutualism.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1361,7 +1383,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1369,7 +1391,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1487,5 +1509,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.html
+++ b/docs/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -961,7 +983,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -969,7 +991,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1087,5 +1109,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Mixed_Gallium_LED_Recovery_Consortium.html
+++ b/docs/communities/Mixed_Gallium_LED_Recovery_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1448,7 +1470,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1456,7 +1478,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1574,5 +1596,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.html
+++ b/docs/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1147,7 +1169,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1155,7 +1177,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1273,5 +1295,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.html
+++ b/docs/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1469,7 +1491,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1477,7 +1499,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1595,5 +1617,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Multiomics_Corn_Straw_Degradation_SynCom.html
+++ b/docs/communities/Multiomics_Corn_Straw_Degradation_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -765,7 +787,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -773,7 +795,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -891,5 +913,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Mushroom_Spring_Hot_Spring_Phototrophic_Mat_Community.html
+++ b/docs/communities/Mushroom_Spring_Hot_Spring_Phototrophic_Mat_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1386,7 +1408,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1394,7 +1416,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1512,5 +1534,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/NCycle_Bioflocculation_Model_Consortium.html
+++ b/docs/communities/NCycle_Bioflocculation_Model_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -765,7 +787,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -773,7 +795,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -891,5 +913,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Naica_Deep_Subsurface_Thermophilic.html
+++ b/docs/communities/Naica_Deep_Subsurface_Thermophilic.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1686,7 +1708,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1694,7 +1716,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1812,5 +1834,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Neocallimastix_Methanobrevibacter_Xylan_Coculture.html
+++ b/docs/communities/Neocallimastix_Methanobrevibacter_Xylan_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1241,7 +1263,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1249,7 +1271,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1367,5 +1389,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Ngawha_Geothermal_Mercury_Cycling_Community.html
+++ b/docs/communities/Ngawha_Geothermal_Mercury_Cycling_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1051,7 +1073,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1059,7 +1081,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1177,5 +1199,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/OMM12_Gnotobiotic_Mouse_Gut_Community.html
+++ b/docs/communities/OMM12_Gnotobiotic_Mouse_Gut_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -939,7 +961,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -947,7 +969,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1065,5 +1087,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.html
+++ b/docs/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1553,7 +1575,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1561,7 +1583,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1679,5 +1701,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/ORNL_PMI_Populus_PD10_SynCom.html
+++ b/docs/communities/ORNL_PMI_Populus_PD10_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -2133,7 +2155,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -2141,7 +2163,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -2259,5 +2281,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.html
+++ b/docs/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1167,7 +1189,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1175,7 +1197,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1293,5 +1315,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Okeke_Lu_Cellulolytic_Consortium.html
+++ b/docs/communities/Okeke_Lu_Cellulolytic_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1518,7 +1540,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1526,7 +1548,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1644,5 +1666,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.html
+++ b/docs/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1212,7 +1234,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1220,7 +1242,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1338,5 +1360,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/PET_Artificial_FourSpecies_Degradation_Consortium.html
+++ b/docs/communities/PET_Artificial_FourSpecies_Degradation_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1593,7 +1615,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1601,7 +1623,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1719,5 +1741,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/PGM_Spent_Catalyst_Bioleaching.html
+++ b/docs/communities/PGM_Spent_Catalyst_Bioleaching.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1959,7 +1981,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1967,7 +1989,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -2085,5 +2107,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/PMI_Variovorax_Thermotolerance_Collection.html
+++ b/docs/communities/PMI_Variovorax_Thermotolerance_Collection.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1119,7 +1141,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1127,7 +1149,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1245,5 +1267,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.html
+++ b/docs/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1188,7 +1210,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1196,7 +1218,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1314,5 +1336,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Panzhihua_Vanadium_Titanium_Tailings.html
+++ b/docs/communities/Panzhihua_Vanadium_Titanium_Tailings.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -2065,7 +2087,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -2073,7 +2095,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -2191,5 +2213,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Peanut_Seed_Bacterial_CS_SynCom.html
+++ b/docs/communities/Peanut_Seed_Bacterial_CS_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -765,7 +787,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -773,7 +795,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -891,5 +913,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.html
+++ b/docs/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1537,7 +1559,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1545,7 +1567,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1663,5 +1685,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Pelotomaculum_Methanothermobacter_Syntrophy.html
+++ b/docs/communities/Pelotomaculum_Methanothermobacter_Syntrophy.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1530,7 +1552,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1538,7 +1560,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1656,5 +1678,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Pepper_Growth_Rhizosphere_SynCom.html
+++ b/docs/communities/Pepper_Growth_Rhizosphere_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -765,7 +787,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -773,7 +795,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -891,5 +913,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Pepper_Phytophthora_SynCom5.html
+++ b/docs/communities/Pepper_Phytophthora_SynCom5.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -912,7 +934,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -920,7 +942,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1038,5 +1060,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Phenol_Carboxylation_Consortium.html
+++ b/docs/communities/Phenol_Carboxylation_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1201,7 +1223,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1209,7 +1231,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1327,5 +1349,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Phormidium_Alkaline_Consortium.html
+++ b/docs/communities/Phormidium_Alkaline_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1846,7 +1868,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1854,7 +1876,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1972,5 +1994,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Phylogenetically_Diverse_Denitrifying_SynCom.html
+++ b/docs/communities/Phylogenetically_Diverse_Denitrifying_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -814,7 +836,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -822,7 +844,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -940,5 +962,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Polaromonas_Vanadium_Reduction_Community.html
+++ b/docs/communities/Polaromonas_Vanadium_Reduction_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1668,7 +1690,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1676,7 +1698,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1794,5 +1816,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Populus_Salt_Tolerant_SynComs.html
+++ b/docs/communities/Populus_Salt_Tolerant_SynComs.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -765,7 +787,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -773,7 +795,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -891,5 +913,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.html
+++ b/docs/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1568,7 +1590,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1576,7 +1598,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1694,5 +1716,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.html
+++ b/docs/communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -968,7 +990,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -976,7 +998,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1094,5 +1116,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Prochlorococcus_Alteromonas_Helper_Coculture.html
+++ b/docs/communities/Prochlorococcus_Alteromonas_Helper_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1068,7 +1090,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1076,7 +1098,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1194,5 +1216,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.html
+++ b/docs/communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1620,7 +1642,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1628,7 +1650,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1746,5 +1768,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Pseudomonas_Pedobacter_Social_Spreading_Coculture.html
+++ b/docs/communities/Pseudomonas_Pedobacter_Social_Spreading_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1229,7 +1251,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1237,7 +1259,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1355,5 +1377,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Pseudomonas_Rhodococcus_Chloronitrobenzene_Coculture.html
+++ b/docs/communities/Pseudomonas_Rhodococcus_Chloronitrobenzene_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1392,7 +1414,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1400,7 +1422,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1518,5 +1540,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Pseudonitzschia_Sulfitobacter_Association.html
+++ b/docs/communities/Pseudonitzschia_Sulfitobacter_Association.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1274,7 +1296,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1282,7 +1304,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1400,5 +1422,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Rammelsberg_Cobalt_Nickel_Tailings.html
+++ b/docs/communities/Rammelsberg_Cobalt_Nickel_Tailings.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1446,7 +1468,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1454,7 +1476,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1572,5 +1594,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.html
+++ b/docs/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -814,7 +836,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -822,7 +844,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -940,5 +962,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.html
+++ b/docs/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1476,7 +1498,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1484,7 +1506,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1602,5 +1624,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Rice_Acid_Soil_Bioinoculant_SynCom.html
+++ b/docs/communities/Rice_Acid_Soil_Bioinoculant_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -765,7 +787,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -773,7 +795,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -891,5 +913,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Rice_Duckweed_Bacillus_SynCom.html
+++ b/docs/communities/Rice_Duckweed_Bacillus_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1018,7 +1040,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1026,7 +1048,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1144,5 +1166,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Rice_P_Uptake_Intercropping_SynCom4.html
+++ b/docs/communities/Rice_P_Uptake_Intercropping_SynCom4.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -912,7 +934,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -920,7 +942,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1038,5 +1060,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Richmond_Mine_AMD_Biofilm.html
+++ b/docs/communities/Richmond_Mine_AMD_Biofilm.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -2409,7 +2431,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -2417,7 +2439,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -2535,5 +2557,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Rifle_Aquifer_Bioanode_EET_Community.html
+++ b/docs/communities/Rifle_Aquifer_Bioanode_EET_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1256,7 +1278,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1264,7 +1286,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1382,5 +1404,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Rifle_Uranium_Reducing_Community.html
+++ b/docs/communities/Rifle_Uranium_Reducing_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1851,7 +1873,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1859,7 +1881,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1977,5 +1999,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/SF356_Cellulose_Degrader.html
+++ b/docs/communities/SF356_Cellulose_Degrader.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1545,7 +1567,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1553,7 +1575,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1671,5 +1693,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/SIHUMIx_Human_Intestinal_Model_Community.html
+++ b/docs/communities/SIHUMIx_Human_Intestinal_Model_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1416,7 +1438,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1424,7 +1446,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1542,5 +1564,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/SMutans_CAlbicans_ECC_Biofilm.html
+++ b/docs/communities/SMutans_CAlbicans_ECC_Biofilm.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -937,7 +959,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -945,7 +967,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1063,5 +1085,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/SMutans_SSputigena_ECC_Pathobiont.html
+++ b/docs/communities/SMutans_SSputigena_ECC_Pathobiont.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -849,7 +871,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -857,7 +879,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -975,5 +997,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/SMutans_VParvula_ASC_Biofilm.html
+++ b/docs/communities/SMutans_VParvula_ASC_Biofilm.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -849,7 +871,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -857,7 +879,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -975,5 +997,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/SPRUCE_Peatland_Methane_Cycling_Community.html
+++ b/docs/communities/SPRUCE_Peatland_Methane_Cycling_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1107,7 +1129,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1115,7 +1137,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1233,5 +1255,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.html
+++ b/docs/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1265,7 +1287,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1273,7 +1295,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1391,5 +1413,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.html
+++ b/docs/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -965,7 +987,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -973,7 +995,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1091,5 +1113,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Saccharomyces_Chlamydomonas_Fungal_Algal_Mutualism.html
+++ b/docs/communities/Saccharomyces_Chlamydomonas_Fungal_Algal_Mutualism.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1291,7 +1313,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1299,7 +1321,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1417,5 +1439,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Salar_Atacama_Lithium_Brine_Community.html
+++ b/docs/communities/Salar_Atacama_Lithium_Brine_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1666,7 +1688,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1674,7 +1696,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1792,5 +1814,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Shewanella_Denitrifying_Richness_SynComs.html
+++ b/docs/communities/Shewanella_Denitrifying_Richness_SynComs.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -765,7 +787,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -773,7 +795,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -891,5 +913,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.html
+++ b/docs/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1263,7 +1285,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1271,7 +1293,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1389,5 +1411,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.html
+++ b/docs/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1375,7 +1397,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1383,7 +1405,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1501,5 +1523,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/SkinCom_Synthetic_Skin_Community.html
+++ b/docs/communities/SkinCom_Synthetic_Skin_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -765,7 +787,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -773,7 +795,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -891,5 +913,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.html
+++ b/docs/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1067,7 +1089,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1075,7 +1097,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1193,5 +1215,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.html
+++ b/docs/communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -943,7 +965,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -951,7 +973,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1069,5 +1091,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Soil_Corrinoid_B12_Reservoir_Community.html
+++ b/docs/communities/Soil_Corrinoid_B12_Reservoir_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1045,7 +1067,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1053,7 +1075,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1171,5 +1193,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Sorghum_SRC1_Subset.html
+++ b/docs/communities/Sorghum_SRC1_Subset.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1579,7 +1601,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1587,7 +1609,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1705,5 +1727,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.html
+++ b/docs/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1408,7 +1430,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1416,7 +1438,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1534,5 +1556,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.html
+++ b/docs/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -814,7 +836,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -822,7 +844,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -940,5 +962,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Soybean_N_Fixation_sfSynCom.html
+++ b/docs/communities/Soybean_N_Fixation_sfSynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1678,7 +1700,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1686,7 +1708,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1804,5 +1826,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Sphingobium_Rhodococcus_Lignin_Dimer_Valorization_Coculture.html
+++ b/docs/communities/Sphingobium_Rhodococcus_Lignin_Dimer_Valorization_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1279,7 +1301,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1287,7 +1309,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1405,5 +1427,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.html
+++ b/docs/communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1421,7 +1443,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1429,7 +1451,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1547,5 +1569,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Subsurface_Carboxydocella_CO_Aquifer_Community.html
+++ b/docs/communities/Subsurface_Carboxydocella_CO_Aquifer_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -935,7 +957,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -943,7 +965,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1061,5 +1083,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.html
+++ b/docs/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1065,7 +1087,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1073,7 +1095,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1191,5 +1213,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/SynComBac10_Chicken_Intestinal_SynCom.html
+++ b/docs/communities/SynComBac10_Chicken_Intestinal_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -765,7 +787,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -773,7 +795,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -891,5 +913,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.html
+++ b/docs/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1415,7 +1437,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1423,7 +1445,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1541,5 +1563,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Synechococcus_Bacillus_SPC.html
+++ b/docs/communities/Synechococcus_Bacillus_SPC.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -919,7 +941,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -927,7 +949,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1045,5 +1067,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Synechococcus_Ecoli_SPC.html
+++ b/docs/communities/Synechococcus_Ecoli_SPC.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1013,7 +1035,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1021,7 +1043,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1139,5 +1161,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.html
+++ b/docs/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1211,7 +1233,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1219,7 +1241,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1337,5 +1359,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.html
+++ b/docs/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1644,7 +1666,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1652,7 +1674,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1770,5 +1792,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.html
+++ b/docs/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1391,7 +1413,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1399,7 +1421,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1517,5 +1539,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Synechococcus_Yarrowia_SPC.html
+++ b/docs/communities/Synechococcus_Yarrowia_SPC.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -933,7 +955,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -941,7 +963,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1059,5 +1081,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.html
+++ b/docs/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1211,7 +1233,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1219,7 +1241,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1337,5 +1359,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Synthetic_Periphyton_Freshwater_Biofilm.html
+++ b/docs/communities/Synthetic_Periphyton_Freshwater_Biofilm.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -863,7 +885,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -871,7 +893,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -989,5 +1011,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Syntrophobacter_Methanobacterium_Syntrophy.html
+++ b/docs/communities/Syntrophobacter_Methanobacterium_Syntrophy.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1071,7 +1093,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1079,7 +1101,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1197,5 +1219,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Syntrophobacter_Methanospirillum_Syntrophy.html
+++ b/docs/communities/Syntrophobacter_Methanospirillum_Syntrophy.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1480,7 +1502,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1488,7 +1510,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1606,5 +1628,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.html
+++ b/docs/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1401,7 +1423,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1409,7 +1431,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1527,5 +1549,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Syntrophomonas_Methanospirillum_Syntrophy.html
+++ b/docs/communities/Syntrophomonas_Methanospirillum_Syntrophy.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1468,7 +1490,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1476,7 +1498,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1594,5 +1616,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Syntrophus_Benzoate_Degrader.html
+++ b/docs/communities/Syntrophus_Benzoate_Degrader.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1097,7 +1119,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1105,7 +1127,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1223,5 +1245,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.html
+++ b/docs/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1491,7 +1513,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1499,7 +1521,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1617,5 +1639,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/THOR_Rhizosphere_Model_Community.html
+++ b/docs/communities/THOR_Rhizosphere_Model_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1164,7 +1186,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1172,7 +1194,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1290,5 +1312,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/TYQ1_Nematode_Biocontrol_SynCom.html
+++ b/docs/communities/TYQ1_Nematode_Biocontrol_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1336,7 +1358,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1344,7 +1366,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1462,5 +1484,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Teosinte_Maize_Biofertilizer_SynCom7.html
+++ b/docs/communities/Teosinte_Maize_Biofertilizer_SynCom7.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -912,7 +934,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -920,7 +942,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1038,5 +1060,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.html
+++ b/docs/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1374,7 +1396,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1382,7 +1404,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1500,5 +1522,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.html
+++ b/docs/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1289,7 +1311,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1297,7 +1319,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1415,5 +1437,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.html
+++ b/docs/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1626,7 +1648,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1634,7 +1656,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1752,5 +1774,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Thermophilic_Pyrite_QS_Consortium.html
+++ b/docs/communities/Thermophilic_Pyrite_QS_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -2026,7 +2048,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -2034,7 +2056,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -2152,5 +2174,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.html
+++ b/docs/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1405,7 +1427,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1413,7 +1435,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1531,5 +1553,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.html
+++ b/docs/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1128,7 +1150,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1136,7 +1158,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1254,5 +1276,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Tinto_River_Iron_Cycling_Community.html
+++ b/docs/communities/Tinto_River_Iron_Cycling_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1567,7 +1589,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1575,7 +1597,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1693,5 +1715,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Tobacco_Chemotactic_Biocontrol_SynCom.html
+++ b/docs/communities/Tobacco_Chemotactic_Biocontrol_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -814,7 +836,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -822,7 +844,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -940,5 +962,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Tomato_Oxylipin_SynCom3.html
+++ b/docs/communities/Tomato_Oxylipin_SynCom3.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -863,7 +885,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -871,7 +893,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -989,5 +1011,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.html
+++ b/docs/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -863,7 +885,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -871,7 +893,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -989,5 +1011,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.html
+++ b/docs/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1508,7 +1530,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1516,7 +1538,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1634,5 +1656,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.html
+++ b/docs/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1378,7 +1400,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1386,7 +1408,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1504,5 +1526,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Trichoderma_Lactate_Platform.html
+++ b/docs/communities/Trichoderma_Lactate_Platform.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1168,7 +1190,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1176,7 +1198,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1294,5 +1316,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.html
+++ b/docs/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1328,7 +1350,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1336,7 +1358,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1454,5 +1476,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Trichodesmium_Alteromonas_Marine_Consortium.html
+++ b/docs/communities/Trichodesmium_Alteromonas_Marine_Consortium.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1186,7 +1208,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1194,7 +1216,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1312,5 +1334,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Urine_Nitrification_SynCom.html
+++ b/docs/communities/Urine_Nitrification_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -961,7 +983,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -969,7 +991,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1087,5 +1109,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.html
+++ b/docs/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1236,7 +1258,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1244,7 +1266,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1362,5 +1384,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Watermelon_Rhizosphere_Fusarium_SynCom8.html
+++ b/docs/communities/Watermelon_Rhizosphere_Fusarium_SynCom8.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -814,7 +836,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -822,7 +844,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -940,5 +962,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.html
+++ b/docs/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1415,7 +1437,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1423,7 +1445,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1541,5 +1563,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Wheat_Consortium_C1.html
+++ b/docs/communities/Wheat_Consortium_C1.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -994,7 +1016,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1002,7 +1024,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1120,5 +1142,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Wheat_Consortium_C6.html
+++ b/docs/communities/Wheat_Consortium_C6.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1006,7 +1028,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1014,7 +1036,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1132,5 +1154,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.html
+++ b/docs/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -912,7 +934,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -920,7 +942,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1038,5 +1060,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Yogurt_TwoSpecies_Starter_Culture.html
+++ b/docs/communities/Yogurt_TwoSpecies_Starter_Culture.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1534,7 +1556,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1542,7 +1564,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1660,5 +1682,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.html
+++ b/docs/communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1331,7 +1353,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1339,7 +1361,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1457,5 +1479,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/hCom2_Complex_Gut_Microbiome.html
+++ b/docs/communities/hCom2_Complex_Gut_Microbiome.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -765,7 +787,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -773,7 +795,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -891,5 +913,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/communities/mCAFEs_Brachypodium_RCC.html
+++ b/docs/communities/mCAFEs_Brachypodium_RCC.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1333,7 +1355,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1341,7 +1363,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1459,5 +1481,6 @@
     })();
     </script>
     
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/community_graph.html
+++ b/docs/community_graph.html
@@ -442,7 +442,29 @@
                 flex: 0 0 100%;
             }
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --primary-dark:#8fbcf5; --secondary:#99a2b5; --background:#101420; --surface:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-light:#99a2b5; --success:#34d399; --warning:#fbbf24; --error:#f87171; --point-stroke:#1a1f2e;}
+  :root:not([data-theme="light"]) #umap-plot{background:var(--surface)}
+  :root:not([data-theme="light"]) .point{stroke:var(--surface)}
+  :root:not([data-theme="light"]) .facet-actions button{background:var(--background);color:var(--text)}
+  :root:not([data-theme="light"]) .btn-reset{background:var(--background);color:var(--text)}
+  :root:not([data-theme="light"]) .filter-tag{background:var(--background);border-color:var(--border);color:var(--text)}
+  :root:not([data-theme="light"]) .active-filters{background:rgba(251,191,36,.12)}
+  :root:not([data-theme="light"]) .facet-checkbox:hover{background:rgba(255,255,255,.04)}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --primary-dark:#8fbcf5; --secondary:#99a2b5; --background:#101420; --surface:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-light:#99a2b5; --success:#34d399; --warning:#fbbf24; --error:#f87171; --point-stroke:#1a1f2e;}
+:root[data-theme="dark"] #umap-plot{background:var(--surface)}
+:root[data-theme="dark"] .point{stroke:var(--surface)}
+:root[data-theme="dark"] .facet-actions button{background:var(--background);color:var(--text)}
+:root[data-theme="dark"] .btn-reset{background:var(--background);color:var(--text)}
+:root[data-theme="dark"] .filter-tag{background:var(--background);border-color:var(--border);color:var(--text)}
+:root[data-theme="dark"] .active-filters{background:rgba(251,191,36,.12)}
+:root[data-theme="dark"] .facet-checkbox:hover{background:rgba(255,255,255,.04)}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
     <script src="d3.v7.min.js"></script>
 </head>
 <body>
@@ -4894,7 +4916,7 @@
                     })
                     .attr('transform', 'translate(10,10)')
                     .attr('fill', d => colorScale(d))
-                    .attr('stroke', '#fff')
+                    .style('stroke', 'var(--point-stroke, #fff)')
                     .attr('stroke-width', 1);
             } else {
                 items.append('div')
@@ -5296,5 +5318,6 @@
             .attr('text-anchor', 'middle')
             .text('UMAP Dimension 2');
     </script>
+    <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/community_umap.html
+++ b/docs/community_umap.html
@@ -442,7 +442,29 @@
                 flex: 0 0 100%;
             }
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --primary-dark:#8fbcf5; --secondary:#99a2b5; --background:#101420; --surface:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-light:#99a2b5; --success:#34d399; --warning:#fbbf24; --error:#f87171; --point-stroke:#1a1f2e;}
+  :root:not([data-theme="light"]) #umap-plot{background:var(--surface)}
+  :root:not([data-theme="light"]) .point{stroke:var(--surface)}
+  :root:not([data-theme="light"]) .facet-actions button{background:var(--background);color:var(--text)}
+  :root:not([data-theme="light"]) .btn-reset{background:var(--background);color:var(--text)}
+  :root:not([data-theme="light"]) .filter-tag{background:var(--background);border-color:var(--border);color:var(--text)}
+  :root:not([data-theme="light"]) .active-filters{background:rgba(251,191,36,.12)}
+  :root:not([data-theme="light"]) .facet-checkbox:hover{background:rgba(255,255,255,.04)}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --primary-dark:#8fbcf5; --secondary:#99a2b5; --background:#101420; --surface:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-light:#99a2b5; --success:#34d399; --warning:#fbbf24; --error:#f87171; --point-stroke:#1a1f2e;}
+:root[data-theme="dark"] #umap-plot{background:var(--surface)}
+:root[data-theme="dark"] .point{stroke:var(--surface)}
+:root[data-theme="dark"] .facet-actions button{background:var(--background);color:var(--text)}
+:root[data-theme="dark"] .btn-reset{background:var(--background);color:var(--text)}
+:root[data-theme="dark"] .filter-tag{background:var(--background);border-color:var(--border);color:var(--text)}
+:root[data-theme="dark"] .active-filters{background:rgba(251,191,36,.12)}
+:root[data-theme="dark"] .facet-checkbox:hover{background:rgba(255,255,255,.04)}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
     <script src="d3.v7.min.js"></script>
 </head>
 <body>
@@ -4894,7 +4916,7 @@
                     })
                     .attr('transform', 'translate(10,10)')
                     .attr('fill', d => colorScale(d))
-                    .attr('stroke', '#fff')
+                    .style('stroke', 'var(--point-stroke, #fff)')
                     .attr('stroke-width', 1);
             } else {
                 items.append('div')
@@ -5296,5 +5318,6 @@
             .attr('text-anchor', 'middle')
             .text('UMAP Dimension 2');
     </script>
+    <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -46,6 +46,20 @@
   footer .fam{margin:.2em 0}
   footer .fam a{margin:0 .45em;white-space:nowrap}
   footer strong{color:var(--ink)}
+/* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--pastel-a:#1d2740; --pastel-b:#101420; --accent:#6ea6f0; --ink:#e8ecf4; --muted:#99a2b5; --card:#1a1f2e; --line:#2a3142;}
+  :root:not([data-theme="light"]) .stat{background:rgba(255,255,255,.05)}
+  :root:not([data-theme="light"]) footer{background:rgba(255,255,255,.05)}
+  :root:not([data-theme="light"]) .btn{color:#101420}
+}
+:root[data-theme="dark"]{--pastel-a:#1d2740; --pastel-b:#101420; --accent:#6ea6f0; --ink:#e8ecf4; --muted:#99a2b5; --card:#1a1f2e; --line:#2a3142;}
+:root[data-theme="dark"] .stat{background:rgba(255,255,255,.05)}
+:root[data-theme="dark"] footer{background:rgba(255,255,255,.05)}
+:root[data-theme="dark"] .btn{color:#101420}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
 </style>
 </head>
 <body>
@@ -88,5 +102,6 @@
       <a href="https://github.com/Knowledge-Graph-Hub/kg-microbe">kg-microbe</a>&middot;<a href="https://bioportal.bioontology.org/ontologies/METPO">METPO</a>
     </div>
   </footer>
+    <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/theme-toggle.js
+++ b/docs/theme-toggle.js
@@ -1,0 +1,74 @@
+/* Mech theme toggle — vendored byte-identical across all Mech sites.
+ * Applies the saved theme to <html data-theme> (falling back to the OS
+ * preference) before paint, and injects a self-contained fixed toggle button.
+ * No dependencies; no per-page markup or CSS required beyond loading this file.
+ * The page's own dark palette is supplied via :root[data-theme="dark"] and the
+ * prefers-color-scheme media query in that page's stylesheet. */
+(function () {
+  var KEY = 'mech-theme';
+  var root = document.documentElement;
+
+  function osDark() {
+    return !!(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  }
+  function current() {
+    return root.getAttribute('data-theme') || (osDark() ? 'dark' : 'light');
+  }
+
+  // Apply the saved preference as early as possible to avoid a flash.
+  try {
+    var saved = localStorage.getItem(KEY);
+    if (saved === 'dark' || saved === 'light') root.setAttribute('data-theme', saved);
+  } catch (e) {}
+
+  function setIcon(btn) {
+    var dark = current() === 'dark';
+    btn.querySelector('.theme-toggle-icon').textContent = dark ? '☀' : '☾'; // sun / moon
+    btn.setAttribute('aria-pressed', dark ? 'true' : 'false');
+  }
+  function toggle(btn) {
+    var next = current() === 'dark' ? 'light' : 'dark';
+    root.setAttribute('data-theme', next);
+    try { localStorage.setItem(KEY, next); } catch (e) {}
+    setIcon(btn);
+  }
+  function mount() {
+    if (document.querySelector('.theme-toggle')) return;
+
+    var css =
+      '.theme-toggle{position:fixed;bottom:18px;right:18px;z-index:2000;width:40px;height:40px;' +
+      'border-radius:50%;border:1px solid var(--line,var(--border,rgba(128,128,128,.4)));' +
+      'background:var(--card,var(--surface,var(--card-bg,#fff)));' +
+      'color:var(--ink,var(--text,var(--fg,#1a1a1a)));font-size:18px;line-height:1;cursor:pointer;' +
+      'display:flex;align-items:center;justify-content:center;box-shadow:0 2px 8px rgba(0,0,0,.25);' +
+      'transition:border-color .15s,transform .15s;}' +
+      '.theme-toggle:hover{border-color:var(--accent,var(--primary,var(--brand-1,#888)));transform:translateY(-1px);}' +
+      '.theme-toggle:focus-visible{outline:2px solid var(--accent,var(--primary,#888));outline-offset:2px;}' +
+      '@media (prefers-reduced-motion: reduce){.theme-toggle{transition:none;}}';
+    var st = document.createElement('style');
+    st.textContent = css;
+    document.head.appendChild(st);
+
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'theme-toggle';
+    btn.setAttribute('aria-label', 'Toggle dark mode');
+    btn.title = 'Toggle light / dark';
+    btn.innerHTML = '<span class="theme-toggle-icon" aria-hidden="true"></span>';
+    btn.addEventListener('click', function () { toggle(btn); });
+    document.body.appendChild(btn);
+    setIcon(btn);
+
+    // If the visitor has no explicit choice, follow live OS-theme changes.
+    if (window.matchMedia) {
+      try {
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function () {
+          if (!root.getAttribute('data-theme')) setIcon(btn);
+        });
+      } catch (e) {}
+    }
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', mount);
+  else mount();
+})();

--- a/src/communitymech/templates/community.html
+++ b/src/communitymech/templates/community.html
@@ -342,7 +342,29 @@
         .network-tooltip strong {
             color: #93c5fd;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1093,7 +1115,7 @@
             .attr("text-anchor", "middle")
             .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
             .attr("font-size", "10px")
-            .attr("fill", "#475569");
+            .style("fill", "var(--net-label, #475569)");
 
         // Labels for interactions (multi-line, centered in rectangle)
         node.filter(function(d) { return d.type === "interaction"; })
@@ -1101,7 +1123,7 @@
                 var textElem = d3.select(this).append("text")
                     .attr("text-anchor", "middle")
                     .attr("font-size", "9px")
-                    .attr("fill", "#475569")
+                    .style("fill", "var(--net-label, #475569)")
                     .style("pointer-events", "none");
 
                 // Word-wrap text to fit in rectangle (max ~24 chars per line)
@@ -1219,5 +1241,6 @@
     })();
     </script>
     {% endif %}
+    <script src="../theme-toggle.js"></script>
 </body>
 </html>

--- a/src/communitymech/templates/community_umap.html
+++ b/src/communitymech/templates/community_umap.html
@@ -442,7 +442,29 @@
                 flex: 0 0 100%;
             }
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --primary-dark:#8fbcf5; --secondary:#99a2b5; --background:#101420; --surface:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-light:#99a2b5; --success:#34d399; --warning:#fbbf24; --error:#f87171; --point-stroke:#1a1f2e;}
+  :root:not([data-theme="light"]) #umap-plot{background:var(--surface)}
+  :root:not([data-theme="light"]) .point{stroke:var(--surface)}
+  :root:not([data-theme="light"]) .facet-actions button{background:var(--background);color:var(--text)}
+  :root:not([data-theme="light"]) .btn-reset{background:var(--background);color:var(--text)}
+  :root:not([data-theme="light"]) .filter-tag{background:var(--background);border-color:var(--border);color:var(--text)}
+  :root:not([data-theme="light"]) .active-filters{background:rgba(251,191,36,.12)}
+  :root:not([data-theme="light"]) .facet-checkbox:hover{background:rgba(255,255,255,.04)}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --primary-dark:#8fbcf5; --secondary:#99a2b5; --background:#101420; --surface:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-light:#99a2b5; --success:#34d399; --warning:#fbbf24; --error:#f87171; --point-stroke:#1a1f2e;}
+:root[data-theme="dark"] #umap-plot{background:var(--surface)}
+:root[data-theme="dark"] .point{stroke:var(--surface)}
+:root[data-theme="dark"] .facet-actions button{background:var(--background);color:var(--text)}
+:root[data-theme="dark"] .btn-reset{background:var(--background);color:var(--text)}
+:root[data-theme="dark"] .filter-tag{background:var(--background);border-color:var(--border);color:var(--text)}
+:root[data-theme="dark"] .active-filters{background:rgba(251,191,36,.12)}
+:root[data-theme="dark"] .facet-checkbox:hover{background:rgba(255,255,255,.04)}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
     <script src="d3.v7.min.js"></script>
 </head>
 <body>
@@ -805,7 +827,7 @@
                     })
                     .attr('transform', 'translate(10,10)')
                     .attr('fill', d => colorScale(d))
-                    .attr('stroke', '#fff')
+                    .style('stroke', 'var(--point-stroke, #fff)')
                     .attr('stroke-width', 1);
             } else {
                 items.append('div')
@@ -1207,5 +1229,6 @@
             .attr('text-anchor', 'middle')
             .text('UMAP Dimension 2');
     </script>
+    <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/src/communitymech/templates/index.html
+++ b/src/communitymech/templates/index.html
@@ -413,7 +413,83 @@
             color: #64748b;
             font-size: 0.875rem;
         }
-    </style>
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--card:#1a1f2e; --ink:#e8ecf4; --line:#2a3142; --accent:#6ea6f0;}
+  :root:not([data-theme="light"]) body{background:#101420;color:#e8ecf4}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) header .home-link{color:#6ea6f0}
+  :root:not([data-theme="light"]) h1{color:#e8ecf4}
+  :root:not([data-theme="light"]) .subtitle{color:#99a2b5}
+  :root:not([data-theme="light"]) .filter-panel{background:#1a1f2e;border-color:#2a3142}
+  :root:not([data-theme="light"]) .filter-panel h3{color:#e8ecf4}
+  :root:not([data-theme="light"]) .search-container input{background:#101420;border-color:#2a3142;color:#e8ecf4}
+  :root:not([data-theme="light"]) .clear-btn{color:#99a2b5}
+  :root:not([data-theme="light"]) .clear-btn:hover{color:#e8ecf4}
+  :root:not([data-theme="light"]) .search-results-count{color:#99a2b5;border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) .facet-section{border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) .facet-toggle{color:#99a2b5}
+  :root:not([data-theme="light"]) .facet-actions button{background:#101420;border-color:#2a3142;color:#e8ecf4}
+  :root:not([data-theme="light"]) .facet-actions button:hover{background:#232a3d}
+  :root:not([data-theme="light"]) .facet-checkbox:hover{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .facet-count{color:#99a2b5}
+  :root:not([data-theme="light"]) .active-filters{background:rgba(251,191,36,.12);border-color:#fbbf24}
+  :root:not([data-theme="light"]) .btn-reset{background:#101420;border-color:#fbbf24;color:#e8ecf4}
+  :root:not([data-theme="light"]) .btn-reset:hover{background:rgba(251,191,36,.15)}
+  :root:not([data-theme="light"]) .filter-tag{background:#101420;border-color:#2a3142;color:#e8ecf4}
+  :root:not([data-theme="light"]) .filter-tag-remove{color:#99a2b5}
+  :root:not([data-theme="light"]) .filter-tag-remove:hover{color:#f87171}
+  :root:not([data-theme="light"]) .umap-link{background:#1a1f2e;border-color:#6ea6f0}
+  :root:not([data-theme="light"]) .umap-link h2{color:#6ea6f0}
+  :root:not([data-theme="light"]) .umap-link p{color:#99a2b5}
+  :root:not([data-theme="light"]) .umap-link a{background:#6ea6f0;color:#101420}
+  :root:not([data-theme="light"]) .umap-link a:hover{background:#8fbcf5}
+  :root:not([data-theme="light"]) .community-card{background:#1a1f2e;border-color:#2a3142}
+  :root:not([data-theme="light"]) .community-card h2{color:#6ea6f0}
+  :root:not([data-theme="light"]) .community-card .description{color:#99a2b5}
+  :root:not([data-theme="light"]) .badge-category{background:#232a3d;color:#cbd5e1}
+  :root:not([data-theme="light"]) .badge-member-count{background:#232a3d;color:#cbd5e1}
+  :root:not([data-theme="light"]) footer{border-top-color:#2a3142;color:#99a2b5}
+}
+:root[data-theme="dark"]{--card:#1a1f2e; --ink:#e8ecf4; --line:#2a3142; --accent:#6ea6f0;}
+:root[data-theme="dark"] body{background:#101420;color:#e8ecf4}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] header .home-link{color:#6ea6f0}
+:root[data-theme="dark"] h1{color:#e8ecf4}
+:root[data-theme="dark"] .subtitle{color:#99a2b5}
+:root[data-theme="dark"] .filter-panel{background:#1a1f2e;border-color:#2a3142}
+:root[data-theme="dark"] .filter-panel h3{color:#e8ecf4}
+:root[data-theme="dark"] .search-container input{background:#101420;border-color:#2a3142;color:#e8ecf4}
+:root[data-theme="dark"] .clear-btn{color:#99a2b5}
+:root[data-theme="dark"] .clear-btn:hover{color:#e8ecf4}
+:root[data-theme="dark"] .search-results-count{color:#99a2b5;border-bottom-color:#2a3142}
+:root[data-theme="dark"] .facet-section{border-bottom-color:#2a3142}
+:root[data-theme="dark"] .facet-toggle{color:#99a2b5}
+:root[data-theme="dark"] .facet-actions button{background:#101420;border-color:#2a3142;color:#e8ecf4}
+:root[data-theme="dark"] .facet-actions button:hover{background:#232a3d}
+:root[data-theme="dark"] .facet-checkbox:hover{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .facet-count{color:#99a2b5}
+:root[data-theme="dark"] .active-filters{background:rgba(251,191,36,.12);border-color:#fbbf24}
+:root[data-theme="dark"] .btn-reset{background:#101420;border-color:#fbbf24;color:#e8ecf4}
+:root[data-theme="dark"] .btn-reset:hover{background:rgba(251,191,36,.15)}
+:root[data-theme="dark"] .filter-tag{background:#101420;border-color:#2a3142;color:#e8ecf4}
+:root[data-theme="dark"] .filter-tag-remove{color:#99a2b5}
+:root[data-theme="dark"] .filter-tag-remove:hover{color:#f87171}
+:root[data-theme="dark"] .umap-link{background:#1a1f2e;border-color:#6ea6f0}
+:root[data-theme="dark"] .umap-link h2{color:#6ea6f0}
+:root[data-theme="dark"] .umap-link p{color:#99a2b5}
+:root[data-theme="dark"] .umap-link a{background:#6ea6f0;color:#101420}
+:root[data-theme="dark"] .umap-link a:hover{background:#8fbcf5}
+:root[data-theme="dark"] .community-card{background:#1a1f2e;border-color:#2a3142}
+:root[data-theme="dark"] .community-card h2{color:#6ea6f0}
+:root[data-theme="dark"] .community-card .description{color:#99a2b5}
+:root[data-theme="dark"] .badge-category{background:#232a3d;color:#cbd5e1}
+:root[data-theme="dark"] .badge-member-count{background:#232a3d;color:#cbd5e1}
+:root[data-theme="dark"] footer{border-top-color:#2a3142;color:#99a2b5}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
 </head>
 <body>
     <header>
@@ -1129,5 +1205,6 @@
         // Initialize facets when page loads
         initializeFacets();
     </script>
+    <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/src/communitymech/templates/landing.html
+++ b/src/communitymech/templates/landing.html
@@ -46,6 +46,20 @@
   footer .fam{margin:.2em 0}
   footer .fam a{margin:0 .45em;white-space:nowrap}
   footer strong{color:var(--ink)}
+/* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--pastel-a:#1d2740; --pastel-b:#101420; --accent:#6ea6f0; --ink:#e8ecf4; --muted:#99a2b5; --card:#1a1f2e; --line:#2a3142;}
+  :root:not([data-theme="light"]) .stat{background:rgba(255,255,255,.05)}
+  :root:not([data-theme="light"]) footer{background:rgba(255,255,255,.05)}
+  :root:not([data-theme="light"]) .btn{color:#101420}
+}
+:root[data-theme="dark"]{--pastel-a:#1d2740; --pastel-b:#101420; --accent:#6ea6f0; --ink:#e8ecf4; --muted:#99a2b5; --card:#1a1f2e; --line:#2a3142;}
+:root[data-theme="dark"] .stat{background:rgba(255,255,255,.05)}
+:root[data-theme="dark"] footer{background:rgba(255,255,255,.05)}
+:root[data-theme="dark"] .btn{color:#101420}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
 </style>
 </head>
 <body>
@@ -88,5 +102,6 @@
       <a href="https://github.com/Knowledge-Graph-Hub/kg-microbe">kg-microbe</a>&middot;<a href="https://bioportal.bioontology.org/ontologies/METPO">METPO</a>
     </div>
   </footer>
+    <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/src/communitymech/templates/style.css
+++ b/src/communitymech/templates/style.css
@@ -86,3 +86,22 @@ a { color: var(--accent); }
 .interaction h3 { margin: 0 0 0.4em 0; font-size: 1.05em; }
 details.evidence-list summary { cursor: pointer; padding: 0.3em 0; }
 .description { color: #444; max-width: 70ch; }
+
+/* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--fg:#e8ecf4; --muted:#99a2b5; --line:#2a3142; --bg-soft:#1a1f2e; --accent:#6ea6f0; --pass:#34d399; --warn:#fbbf24; --fail:#f87171;}
+  :root:not([data-theme="light"]) .badge{color:#cbd5e1}
+  :root:not([data-theme="light"]) .evidence blockquote.snippet{color:#cbd5e1}
+  :root:not([data-theme="light"]) .evidence p.explanation{color:#cbd5e1}
+  :root:not([data-theme="light"]) .description{color:#cbd5e1}
+  :root:not([data-theme="light"]) .interaction{background:#1a1f2e}
+}
+:root[data-theme="dark"]{--fg:#e8ecf4; --muted:#99a2b5; --line:#2a3142; --bg-soft:#1a1f2e; --accent:#6ea6f0; --pass:#34d399; --warn:#fbbf24; --fail:#f87171;}
+:root[data-theme="dark"] .badge{color:#cbd5e1}
+:root[data-theme="dark"] .evidence blockquote.snippet{color:#cbd5e1}
+:root[data-theme="dark"] .evidence p.explanation{color:#cbd5e1}
+:root[data-theme="dark"] .description{color:#cbd5e1}
+:root[data-theme="dark"] .interaction{background:#1a1f2e}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}


### PR DESCRIPTION
Adds a **user-toggleable dark theme** (OS `prefers-color-scheme` default + a persisted `data-theme` toggle) and a **reduced-motion guard** to every reviewed page of the CommunityMech site, without changing the light appearance.

**Stacked PR:** base is `fix/community-d3-local` (touches the same community pages) to avoid conflicts. Do not merge before the base.

### What changed
- Vendored self-contained `docs/theme-toggle.js` (byte-identical shared script). Injects a fixed ☾/☀ button that themes itself from page tokens; sets `data-theme` before paint from `localStorage`.
- Per-page dark blocks redefine each page's own tokens by role using the CommunityMech slate palette (bg `#101420`, surface `#1a1f2e`, ink `#e8ecf4`, muted `#99a2b5`, line `#2a3142`, accent `#6ea6f0`, hero `#1d2740`; brightened status colors). Both `@media (prefers-color-scheme: dark)` and `:root[data-theme="dark"]`; the OS default yields to an explicit light choice.
- Landing: `--pastel-b`→bg, `--pastel-a`→hero; dark translucent stat/footer surfaces; accent buttons get dark text.
- Browser (token-less): targeted dark overrides for the specific selectors; dark-only button tokens so the toggle themes correctly.
- UMAP/graph: plot bg → `--surface`, scatter `.point` stroke → `--surface`, legend symbol stroke driven from a `--point-stroke` var.
- Community network diagram: label fills driven from a `--net-label` var; plot bg follows `--card`; dark chip/box tints.
- Reduced-motion guard on every page and `style.css`.

### Approach
Edited templates **and** every generated output identically (no re-render), so template and `docs/` stay in sync. Additive only — base `:root` light tokens untouched.

### Verification (269 reviewed pages: index, browser, umap, graph, 265 communities)
- `@media (prefers-color-scheme: dark)`: 269/269
- `:root[data-theme="dark"]`: 269/269
- `prefers-reduced-motion`: 269/269
- includes `theme-toggle.js`: 269/269
- pages missing a dark block: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)