### PR TITLE
Fix lint on main (graph_layout.py + dimensionality.py)

### DIFF
--- a/src/communitymech/embedding/dimensionality.py
+++ b/src/communitymech/embedding/dimensionality.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pandas as pd
 import umap  # type: ignore[import-untyped]
-from sklearn.preprocessing import normalize
+from sklearn.preprocessing import normalize  # type: ignore[import-untyped]
 
 
 class UMAPReducer:
@@ -70,11 +70,11 @@ class UMAPReducer:
             import pacmap  # type: ignore[import-untyped]
 
             # L2-normalize rows to mirror cosine geometry, then PCA-init + fixed seed.
-            X = normalize(vectors_matrix.astype("float32"))
+            normalized_vectors = normalize(vectors_matrix.astype("float32"))
             coords = pacmap.PaCMAP(
                 n_components=self.n_components,
                 random_state=self.random_state,
-            ).fit_transform(X, init="pca")
+            ).fit_transform(normalized_vectors, init="pca")
         elif self.method == "sfdp":
             # Force-directed (Graphviz sfdp) layout of the mutual-kNN graph over
             # the KG embeddings — a global-structure-first graph view.

--- a/src/communitymech/embedding/graph_layout.py
+++ b/src/communitymech/embedding/graph_layout.py
@@ -4,10 +4,12 @@ Self-contained: scikit-learn (kNN) + the `sfdp` binary (Graphviz). No pygraphviz
 pydot needed. Deterministic-ish via -Gstart=<seed>. Rows are L2-normalized so the
 Euclidean kNN mirrors the cosine metric used elsewhere. Output row order == input.
 """
+
 import subprocess
+
 import numpy as np
-from sklearn.preprocessing import normalize
-from sklearn.neighbors import kneighbors_graph
+from sklearn.neighbors import kneighbors_graph  # type: ignore[import-untyped]
+from sklearn.preprocessing import normalize  # type: ignore[import-untyped]
 
 
 def sfdp_layout(matrix, k=15, seed=42, sfdp_bin="sfdp"):
@@ -17,15 +19,23 @@ def sfdp_layout(matrix, k=15, seed=42, sfdp_bin="sfdp"):
     if n == 0:
         return np.zeros((0, 2), dtype="float32")
     k = min(k, max(1, n - 1))
-    A = kneighbors_graph(matrix, n_neighbors=k, mode="connectivity")
-    A = A.maximum(A.T)  # symmetric union-kNN graph
-    coo = A.tocoo()
-    edges = {(min(i, j), max(i, j)) for i, j in zip(coo.row.tolist(), coo.col.tolist()) if i != j}
-    dot = "\n".join(["graph G {"] + [f"{i};" for i in range(n)]
-                    + [f"{i}--{j};" for i, j in edges] + ["}"])
+    adj = kneighbors_graph(matrix, n_neighbors=k, mode="connectivity")
+    adj = adj.maximum(adj.T)  # symmetric union-kNN graph
+    coo = adj.tocoo()
+    edges = {
+        (min(i, j), max(i, j))
+        for i, j in zip(coo.row.tolist(), coo.col.tolist(), strict=True)
+        if i != j
+    }
+    dot = "\n".join(
+        ["graph G {"] + [f"{i};" for i in range(n)] + [f"{i}--{j};" for i, j in edges] + ["}"]
+    )
     out = subprocess.run(
         [sfdp_bin, "-Tplain", f"-Gstart={seed}", "-Goverlap=prism", "-Gsmoothing=triangle"],
-        input=dot, capture_output=True, text=True, timeout=900,
+        input=dot,
+        capture_output=True,
+        text=True,
+        timeout=900,
     )
     if out.returncode != 0:
         raise RuntimeError(f"sfdp failed (is graphviz installed?): {out.stderr[:300]}")
@@ -33,5 +43,7 @@ def sfdp_layout(matrix, k=15, seed=42, sfdp_bin="sfdp"):
     for ln in out.stdout.splitlines():
         if ln.startswith("node "):
             p = ln.split()
-            idx = int(p[1]); xy[idx, 0] = float(p[2]); xy[idx, 1] = float(p[3])
+            idx = int(p[1])
+            xy[idx, 0] = float(p[2])
+            xy[idx, 1] = float(p[3])
     return xy


### PR DESCRIPTION
## Why
The `lint` CI job (black + ruff + mypy) has been **red on `main`**. `#190`/`#194` merged `embedding/graph_layout.py` and PaCMAP code that fail black/ruff/mypy; the failure was masked on downstream PRs because black exits before ruff/mypy run. This is why open PRs #187 and #189 show a red `lint` check — they inherit main's breakage.

## What
- **graph_layout.py**: black reformat; sort imports (I001); rename adjacency matrix `A` → `adj` (N806); `zip(..., strict=True)` (B905); `# type: ignore[import-untyped]` on the sklearn imports (matches the existing `umap`/`pacmap` pattern).
- **dimensionality.py**: rename `X` → `normalized_vectors` (N806); type-ignore the `sklearn.preprocessing` import.

Behavior-neutral. `black --check` + `ruff check` + `mypy` all pass locally; `sfdp_layout` smoke-tested on a real 6×4 matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)