### PR TITLE
Dark mode: restore brand pastel pair on landing hero + cards

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -52,11 +52,19 @@
   :root:not([data-theme="light"]) .stat{background:rgba(255,255,255,.05)}
   :root:not([data-theme="light"]) footer{background:rgba(255,255,255,.05)}
   :root:not([data-theme="light"]) .btn{color:#101420}
+  /* brand pastel PAIR: darkened fill + vivid pastel top edge */
+  :root:not([data-theme="light"]) .hero{background:linear-gradient(135deg,#574d5a,#485060);border-bottom:0;border-top:3px solid;border-image:linear-gradient(90deg,#FBD3E3,#CBDDF6) 1}
+  :root:not([data-theme="light"]) .card{position:relative}
+  :root:not([data-theme="light"]) .card::before{content:"";position:absolute;top:0;left:0;right:0;height:2px;border-radius:16px 16px 0 0;background:linear-gradient(90deg,#FBD3E3,#CBDDF6)}
 }
 :root[data-theme="dark"]{--pastel-a:#1d2740; --pastel-b:#101420; --accent:#6ea6f0; --ink:#e8ecf4; --muted:#99a2b5; --card:#1a1f2e; --line:#2a3142;}
 :root[data-theme="dark"] .stat{background:rgba(255,255,255,.05)}
 :root[data-theme="dark"] footer{background:rgba(255,255,255,.05)}
 :root[data-theme="dark"] .btn{color:#101420}
+/* brand pastel PAIR: darkened fill + vivid pastel top edge */
+:root[data-theme="dark"] .hero{background:linear-gradient(135deg,#574d5a,#485060);border-bottom:0;border-top:3px solid;border-image:linear-gradient(90deg,#FBD3E3,#CBDDF6) 1}
+:root[data-theme="dark"] .card{position:relative}
+:root[data-theme="dark"] .card::before{content:"";position:absolute;top:0;left:0;right:0;height:2px;border-radius:16px 16px 0 0;background:linear-gradient(90deg,#FBD3E3,#CBDDF6)}
 @media (prefers-reduced-motion: reduce){
   *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
 }

--- a/src/communitymech/templates/landing.html
+++ b/src/communitymech/templates/landing.html
@@ -52,11 +52,19 @@
   :root:not([data-theme="light"]) .stat{background:rgba(255,255,255,.05)}
   :root:not([data-theme="light"]) footer{background:rgba(255,255,255,.05)}
   :root:not([data-theme="light"]) .btn{color:#101420}
+  /* brand pastel PAIR: darkened fill + vivid pastel top edge */
+  :root:not([data-theme="light"]) .hero{background:linear-gradient(135deg,#574d5a,#485060);border-bottom:0;border-top:3px solid;border-image:linear-gradient(90deg,#FBD3E3,#CBDDF6) 1}
+  :root:not([data-theme="light"]) .card{position:relative}
+  :root:not([data-theme="light"]) .card::before{content:"";position:absolute;top:0;left:0;right:0;height:2px;border-radius:16px 16px 0 0;background:linear-gradient(90deg,#FBD3E3,#CBDDF6)}
 }
 :root[data-theme="dark"]{--pastel-a:#1d2740; --pastel-b:#101420; --accent:#6ea6f0; --ink:#e8ecf4; --muted:#99a2b5; --card:#1a1f2e; --line:#2a3142;}
 :root[data-theme="dark"] .stat{background:rgba(255,255,255,.05)}
 :root[data-theme="dark"] footer{background:rgba(255,255,255,.05)}
 :root[data-theme="dark"] .btn{color:#101420}
+/* brand pastel PAIR: darkened fill + vivid pastel top edge */
+:root[data-theme="dark"] .hero{background:linear-gradient(135deg,#574d5a,#485060);border-bottom:0;border-top:3px solid;border-image:linear-gradient(90deg,#FBD3E3,#CBDDF6) 1}
+:root[data-theme="dark"] .card{position:relative}
+:root[data-theme="dark"] .card::before{content:"";position:absolute;top:0;left:0;right:0;height:2px;border-radius:16px 16px 0 0;background:linear-gradient(90deg,#FBD3E3,#CBDDF6)}
 @media (prefers-reduced-motion: reduce){
   *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
 }


### PR DESCRIPTION
Small dark-mode refinement for the generated CommunityMech landing page: bring the brand pastel **pair** back into the dark theme.

## What changed
In dark mode the hero previously rendered with the neutral dark tokens. This restores the brand pastel pair, dark-only and additively:

- **`.hero`** — darkened pastel-pair fill (`#574d5a → #485060`) plus a thin **full-strength** pastel-pair top edge (`#FBD3E3 → #CBDDF6`) via `border-image` (the signature).
- **`.card`** — subtle 2px pastel-pair top edge via a `::before` bar, leaving the existing all-sides 1px border undisturbed.

Rules are mirrored under **both** dark selectors:
- `@media (prefers-color-scheme: dark){ :root:not([data-theme="light"]) … }` (OS default)
- `:root[data-theme="dark"] …` (toggle)

## Files changed
- `src/communitymech/templates/landing.html`
- `docs/index.html`

Edited both identically (the added CSS is outside any Jinja logic, so the template and generated output stay in sync without a full `gen-html` run that would touch all community pages).

## Verification
- 16 insertions, 0 removals — purely additive.
- All new rules live inside dark selectors, so the **light theme is byte-identical**.
- `--pastel-b` / page background untouched — dark page stays dark.

Do not merge — leader merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)