### PR TITLE
Chlorobium chlorochromatii CaD3: g__ genus fallback instead of null gtdb_id

### DIFF
--- a/kb/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml
+++ b/kb/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml
@@ -22,13 +22,14 @@ taxonomy:
       id: NCBITaxon:340177
       label: Chlorobium chlorochromatii CaD3
     gtdb_classification:
-      gtdb_id: null
-      gtdb_taxon: null
+      gtdb_id: GTDB:g__Chlorobium
+      gtdb_taxon: Chlorobium
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Chlorobiia;o__Chlorobiales;f__Chlorobiaceae;g__Chlorobium
       ncbi_source_id: NCBITaxon:340177
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded
+        at g__ rank; no species-level GTDB representative for strain CaD3]
     notes: Photolithoautotrophic green sulfur bacterial epibiont that surrounds the central bacterium.
   strain_designation:
     strain_name: CaD3


### PR DESCRIPTION
Follow-up tidy-up flagged during the #185 review. `Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml` held the KB's **only** `gtdb_classification` block with `gtdb_id: null` / `gtdb_taxon: null`, even though its `gtdb_lineage` already resolved to `g__Chlorobium` (majority_fraction 1.0).

This grounds the strain-level NCBI taxon (`NCBITaxon:340177`, *Chlorobium chlorochromatii* CaD3) at **genus rank** — `GTDB:g__Chlorobium` / `Chlorobium` — matching the skill's genus-fallback convention used elsewhere (e.g. `AMD_Nitrososphaerota` → `GTDB:g__Nitrososphaera`). Species-level GTDB has no representative for strain CaD3; that's noted in `mapping_source`. Uses only data already present in the block (no new grounding invented).

`linkml-validate` passes; 0 null-`gtdb_id` blocks remain KB-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)