### PR TITLE
Scout report: outer-space regolith systems & communities

### DIFF
--- a/reports/scout_space_regolith.md
+++ b/reports/scout_space_regolith.md
@@ -1,0 +1,121 @@
+# Scout report — Outer-space regolith systems & communities
+
+**Theme:** microbial communities / consortia / co-cultures relevant to space regolith
+(biomining/bioleaching of lunar & Martian regolith and simulants, BioRock / BioAsteroid
+ISS experiments, cyanobacteria/PGPB consortia for ISRU & regolith agriculture, spaceflight
+microbiomes framed as communities, astrobiology analog consortia).
+
+**Source:** Europe PMC REST (`resultType=core`, `pageSize=50`), 6 angle queries.
+**Run date:** 2026-07-06. Discovery only — no `kb/` records created.
+
+## Summary
+
+| metric | count |
+|---|---|
+| Unique hits across all queries | 173 |
+| Already cited in `kb/communities/` | 1 (PMID:39770610 — *Acidithiobacillus* review, terrestrial) |
+| NEW (not in KB) | 172 |
+| Relevant to theme (space-regolith microbes) | ~60 |
+| **NEW defined/structured-community candidates** | **16** |
+| Relevant single-strain studies (lower priority) | 9 |
+| Relevant reviews / concept papers | 7 |
+| Off-topic noise dropped (coral-reef restoration, regolith materials/geopolymer/battery, plant-only, detection-method papers) | ~85 |
+
+**Dedup note:** The KB's existing biomining/bioleaching records
+(`Copper_Biomining_Heap_Leach`, `Ewaste_Bioleaching_Consortium`,
+`Bayan_Obo_REE_Tailings_Consortium`, `PGM_Spent_Catalyst_Bioleaching`,
+`Cyprus_Copper_Sulphide_Bioleaching_Consortium`, etc.) are all **terrestrial** ore/waste
+systems. **No space, regolith, lunar, Martian, BioRock, or BioAsteroid community exists in
+the KB** — this is an entirely uncovered theme. All candidates below are NEW.
+
+## Ranked candidates — defined / structured communities (curate first)
+
+Score = strength of DEFINED/STRUCTURED community signal (5 = clearly a named multi-member
+consortium/co-culture/syntrophic community; 3 = multi-member but loosely defined or a
+multi-strain screen; lower handled in the single-strain list).
+
+| # | Title | Year | Journal | PMID / DOI | New? | Score | Why relevant (members / structure) |
+|---|---|---|---|---|---|---|---|
+| 1 | Space station biomining experiment demonstrates rare earth element extraction in microgravity and Mars gravity (**BioRock**) | 2020 | Nat Commun | PMID:33173035 / 10.1038/s41467-020-19276-w | NEW | 5 | Seminal ISS experiment. Defined 3-species panel — *Sphingomonas desiccabilis*, *Bacillus subtilis*, *Cupriavidus metallidurans* — bioleaching REEs from basalt in µg / Mars-g biomining reactor. |
+| 2 | From earth to space: how bacterial consortia and green compost improve lettuce growth on lunar and martian simulants | 2025 | Biol Fertil Soils | DOI lookup needed (EPMC AGRICOLA IND609307588) | NEW | 5 | Explicit **selected PGPB consortium**: *Azotobacter chroococcum* 76A, *Priestia megaterium* EL5, *Methylobacterium populi* VP2, *Kosakonia pseudosacchari* TL13 on Martian + Lunar simulants (zero external input). Textbook defined SynCom. |
+| 3 | Phosphorus-solubilizing bacteria improve growth of *Nicotiana benthamiana* on lunar regolith simulant | 2023 | Commun Biol | PMID:37945659 / 10.1038/s42003-023-05391-z | NEW | 5 | Defined 5-species P-solubilizer set; *Bacillus mucilaginosus*, *B. megaterium*, *Pseudomonas fluorescens* tolerate & mobilize P from lunar simulant for plant cultivation. |
+| 4 | Anaerobic digestion of cyanobacterial biomass for plant fertilizer production on Mars | 2025 | Bioresour Technol | PMID:40089033 / 10.1016/j.biortech.2025.132383 | NEW | 5 | Three microbial **communities** digest *Anabaena* biomass in MGS-1; taxonomic analysis reveals a **syntrophic fermentative community + hydrogenotrophic methanogens** — explicit cross-feeding structure. |
+| 5 | Microbial biomining from asteroidal material onboard the ISS (**BioAsteroid**) | 2026 | npj Microgravity | PMID:41617698 / 10.1038/s41526-026-00567-3 | NEW | 5 | ISS bacteria+fungi consortium (incl. *Penicillium simplicissimum*, *Sphingomonas desiccabilis*) leaching 44 elements from L-chondrite in µg. Defined flight experiment. (Preprint dup: bioRxiv 10.1101/2024.01.13.575412.) |
+| 6 | Microbially-enhanced vanadium mining and bioremediation under micro- and Mars gravity on the ISS (**BioRock**) | 2021 | Front Microbiol | PMID:33868198 / 10.3389/fmicb.2021.641387 | NEW | 5 | Same defined 3-species BioRock panel; vanadium bioleaching from basalt across gravity regimes. |
+| 7 | No effect of microgravity and simulated Mars gravity on final bacterial cell concentrations on the ISS (**BioRock**) | 2020 | Front Microbiol | PMID:33154740 / 10.3389/fmicb.2020.579156 | NEW | 4 | BioRock companion; microbe–mineral interactions of the same 3-species community — useful growth/cultivation evidence for the BioRock record. |
+| 8 | Moss-derived microbiome improves crop growth in lunar and Martian soil simulants | 2025 | Ecol Indic | DOI lookup needed (EPMC AGRICOLA IND609292674) | NEW | 4 | Moss–microbe complex: *Hypnum plumaeforme* + isolated *Pseudomonas monteilii* + *Bacillus cereus*; co-treatment on LHS/MGS simulants. Defined plant-associated community. |
+| 9 | Effect of AMF and plant growth-promoting bacteria inoculation on tomato growth in a Martian regolith analog | 2026 | Microorganisms | PMID:41597718 / 10.3390/microorganisms14010200 | NEW | 4 | Multi-kingdom consortium — arbuscular mycorrhizal fungi + PGPB inoculated together on perchlorate-bearing Mars analog. |
+| 10 | Cyanobacteria as candidates to support Mars colonization: growth & biofertilization using Mars regolith | 2022 | Front Microbiol | PMID:35865930 / 10.3389/fmicb.2022.840098 | NEW | 3 | Multi-strain panel: *Anabaena cylindrica*, *Nostoc muscorum*, *Arthrospira platensis* + *Chlorella vulgaris* on MGS-1 extract (screened individually, then as biofertilizer). |
+| 11 | Microbial growth in actual Martian regolith (Mars meteorite EETA79001) | 2023 | Commun Earth Environ | PMID:38665180 / 10.1038/s43247-023-01042-7 | NEW | 3 | Four-organism panel (*E. coli*, *Eucapsis* sp., Chr20 cyanobacterium, *Planococcus halocryophilus*) grown on real Martian material. |
+| 12 | The legume–rhizobia symbiosis can be supported on Mars soil simulants | 2021 | PLoS One | PMID:34879082 / 10.1371/journal.pone.0259957 | NEW | 3 | Defined plant–microbe mutualism (*Medicago truncatula* + *Sinorhizobium*) N-fixing on MMS simulants. |
+| 13 | Effects of microbial fertilizers on the properties of simulated lunar soil and lettuce growth | 2026 | Plants | PMID:41829787 / 10.3390/plants15050756 | NEW | 3 | Three commercial microbial-fertilizer consortia (composition partly undefined) improving nutrient cycling in lunar simulant. |
+| 14 | Bioremediation of lunar regolith simulant through mycorrhizal fungi & plant symbioses enables chickpea to seed | 2026 | Sci Rep | PMID:41786794 / 10.1038/s41598-026-35759-0 | NEW | 3 | AMF + chickpea + vermicompost microbiome on LRS; fungal-plant symbiosis (community loosely defined). |
+| 15 | Survivability and life support in sealed mini-ecosystems with simulated planetary soils | 2024 | Sci Rep | PMID:39487149 / 10.1038/s41598-024-75328-x | NEW | 3 | Biosphere-2-style enclosed ecosystems over lunar + Ryugu-asteroid regolith; quantified proliferating microbial communities. |
+| 16 | Testing microbial biomining from asteroidal material onboard the ISS (preprint of #5) | 2024 | bioRxiv | DOI:10.1101/2024.01.13.575412 | NEW | 5 | Preprint version of the BioAsteroid paper (#5) — cite the published npj Microgravity version of record. |
+
+## Top candidates to curate next (best defined-community papers)
+
+1. **BioRock REE experiment** (PMID:33173035, Nat Commun 2020) — the seminal defined
+   3-species ISS biomining community (*S. desiccabilis*, *B. subtilis*, *C. metallidurans*);
+   anchors an entire "space biomining" community cluster. **Curate first.**
+2. **PGPB consortium on lunar/martian simulants** (Biol Fertil Soils 2025) — cleanest named
+   4-strain SynCom for regolith agriculture; explicit members, defined design, evidence-rich.
+3. **BioAsteroid ISS biomining** (PMID:41617698, npj Microgravity 2026) — companion ISS
+   flight experiment; bacteria+fungi leaching asteroidal L-chondrite; pairs naturally with BioRock.
+4. **P-solubilizing bacteria on lunar regolith simulant** (PMID:37945659, Commun Biol 2023) —
+   defined 5-species set with clear mechanism (insoluble-P mobilization); strong ISRU-agriculture case.
+5. **Anaerobic digestion of cyanobacterial biomass on MGS-1** (PMID:40089033, Bioresour Technol
+   2025) — genuine **syntrophic** community with cross-feeding (fermenters ↔ methanogens); the
+   most mechanistically "community-shaped" paper in the set.
+6. **BioRock vanadium** (PMID:33868198, Front Microbiol 2021) — same 3-species community, second
+   metal target; supports the BioRock record with additional bioleaching evidence.
+7. **Moss–microbe complex on LHS/MGS** (Ecol Indic 2025) — defined moss + 2-isolate community
+   for regolith biofertilization.
+
+Suggested workflow per candidate: `manage-identifiers` (mint id + place file) →
+`deep-research-community` (source-backed taxa/interactions/environment/cultivation) →
+`review-communities` + `evidence-curation`. The BioRock papers (#1, #6, #7) describe **one**
+defined community across multiple papers — curate as a single record citing all three.
+
+## Single-strain studies (relevant theme, but NOT communities — lower priority)
+
+These are space-regolith microbe papers that use a single organism; keep for context /
+cultivation evidence but they are not defined communities.
+
+| Title | Year | Journal | PMID | Organism |
+|---|---|---|---|---|
+| Bioleaching of critical trace metals by *Sphingomonas desiccabilis* (Earth & space analogues) | 2026 | Front Microbiol | 42039836 | *S. desiccabilis* |
+| *Acidithiobacillus ferrooxidans* growth/bioleach on Mars & Lunar simulants under simulated µg | 2021 | Microorganisms | 34946018 | *A. ferrooxidans* |
+| Iron microbially extracted from Lunar/Martian simulants and 3D printed | 2021 | PLoS One | 33909656 | *Shewanella oneidensis* |
+| Biomining of lunar regolith simulant EAC-1A with *Penicillium simplicissimum* | 2025 | Fungal Biol Biotechnol | 40390066 | *P. simplicissimum* |
+| Selection of *Anabaena* sp. PCC 7938 as cyanobacterium model for biological ISRU on Mars | 2022 | Appl Environ Microbiol | 35862672 | *Anabaena* PCC 7938 |
+| Growth dynamics of *Anabaena* sp. PCC 7938 in Martian regolith | 2022 | npj Microgravity | 36289210 | *Anabaena* PCC 7938 |
+| Siderophore phymabactin facilitates *Paraburkholderia phymatum* growth in Al-rich Martian soil | 2025 | Life | 40724547 | *P. phymatum* |
+| Impact of space flight on survival/interaction of *Cupriavidus metallidurans* CH34 with basalt | 2017 | Front Microbiol | 28503167 | *C. metallidurans* CH34 |
+| Microbial preference for chlorate over perchlorate under Mars-like conditions | 2024 | Sci Rep | 38773211 | 3 organisms screened individually |
+
+## Relevant reviews / concept papers (context, not curatable communities)
+
+| Title | Year | Journal | PMID |
+|---|---|---|---|
+| The role of extremophile microbiomes in terraforming Mars | 2025 | Commun Biol | 41249546 |
+| Toward sustainable space exploration: a roadmap for harnessing the power of microorganisms | 2023 | Nat Commun | 36944638 |
+| Plant and microbial science & technology as cornerstones to Bioregenerative Life Support Systems | 2023 | npj Microgravity | 37620398 |
+| Cyanobacteria & algal-based Biological Life Support System / bioreactor concept review | 2023 | Life | 36983971 |
+| The smallest space miners: principles of space biomining | 2022 | Extremophiles | 34993644 |
+| Biologically-based & physicochemical life support and ISRU for solar-system exploration | 2021 | Life | 34440588 |
+| Microbial ecosystems as enablers of sustainable lunar agriculture (Project Moon Hut) | 2025 | Preprints | — (10.20944/preprints202505.1051.v1) |
+
+## Method notes
+
+- Queries (Europe PMC): (a) regolith/lunar-soil/martian-soil/simulant × microbial/bacteria/
+  consortium/community/cyanobacteria/bioleaching; (b) BioRock/BioAsteroid/space-biomining ×
+  microb*; (c) regolith/space-soil × biofertilizer/ISRU × consortium/community/cyanobacteria;
+  (d) named simulants (JSC-1A, LHS-1, MGS-1, JSC-Mars-1, EAC-1) × microbial/consortium;
+  (e) ISS/spaceflight × community/consortium × regolith/biomining/ISRU; (f) cyanobacteria/
+  Anabaena/Nostoc/Arthrospira × regolith/simulant/ISRU. All with `HAS_ABSTRACT:Y`.
+- Dedup: cited PMID/DOI match against all `kb/communities/*.yaml` (362 PMIDs, 193 DOIs indexed).
+- ~85 hits dropped as off-topic (Mediterranean coral-reef restoration — a recurring
+  false-positive cluster from the generic "community" token — plus regolith geopolymer/
+  battery/materials engineering, plant-physiology-only studies, and DNA/biosignature
+  detection-method papers with no microbial community).


### PR DESCRIPTION
Discovery-only scouting sweep for the **outer-space regolith** theme (requested follow-up). Europe PMC, 6 angle queries: biomining/bioleaching of lunar & Martian regolith + simulants, BioRock/BioAsteroid ISS experiments, cyanobacteria/PGPB consortia for ISRU & regolith agriculture, astrobiology analog consortia.

**Findings** (`reports/scout_space_regolith.md`):
- **173 unique hits; 172 not in the KB.**
- **Key gap:** the KB's biomining/bioleaching records are all *terrestrial* — there is **no space/regolith/BioRock/BioAsteroid community** in `kb/communities/` at all. Entirely uncovered theme.
- **16 NEW defined-community candidates** ranked, + 9 single-strain studies and 7 reviews listed separately (~85 off-topic hits dropped).

**Top candidates to curate next:**
1. **BioRock** (PMID:33173035, Nat Commun 2020) — seminal ISS 3-species biomining consortium (*Sphingomonas desiccabilis*, *Bacillus subtilis*, *Cupriavidus metallidurans*); fold in the vanadium (PMID:33868198) and cell-conc (PMID:33154740) follow-ups.
2. **Lunar/Martian PGPB SynCom** (Biol Fertil Soils 2025) — defined 4-strain consortium on simulants.
3. **BioAsteroid** (PMID:41617698, npj Microgravity 2026) — bacteria+fungi leaching L-chondrite in microgravity.
4. **P-solubilizing bacteria on lunar simulant** (PMID:37945659, Commun Biol 2023).
5. **Anaerobic digestion of cyanobacterial biomass on MGS-1** (PMID:40089033) — genuine syntrophic cross-feeding community.

No `kb/` records or stubs created — hand off to `deep-research-community` / `manage-identifiers` when you decide to curate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)