### PR TITLE
Fix 13 wrong REE/INDIUM CHEBI enum groundings

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -5,7 +5,63 @@ update this file as work is started/finished — move done items out, add new
 deferrals here. Keep the cross-Mech items in sync with the sibling repos'
 `NEXT_TASKS.md` (CultureMech / MIM / TraitMech).
 
-Last reconciled: 2026-06-15.
+Last reconciled: 2026-07-18.
+
+## 0. Element enum CHEBI groundings are wrong + ungated (found 2026-07-18)
+
+**Trigger:** `MetalElementEnum.PALLADIUM` was grounded to `CHEBI:33373`
+(*promethium atom*), not palladium — fixed to `CHEBI:33363` (PR #206). An audit
+of the full `MetalElementEnum` + `RareEarthElementEnum` (`meaning:` id → current
+ChEBI label, via the local `~/.data/oaklib/chebi.db`) then found **13 more wrong
+groundings**, almost all in the rare-earth block:
+
+| enum value | current (wrong) id → label | correct id (candidate) |
+|---|---|---|
+| INDIUM | CHEBI:49464 → *aluminium trifluoride* | CHEBI:49664 indium(3+) |
+| LANTHANUM | CHEBI:32359 → *dodecanoyl group* | CHEBI:49701 lanthanum(3+) |
+| CERIUM | CHEBI:32998 → *(not in build)* | CHEBI:48782 cerium(3+) |
+| PRASEODYMIUM | CHEBI:49648 → *holmium atom* | CHEBI:229784 praseodymium(3+) |
+| SAMARIUM | CHEBI:33376 → *terbium atom* | CHEBI:49890 samarium(3+) |
+| EUROPIUM | CHEBI:30688 → *(not in build)* | CHEBI:49591 europium(3+) |
+| TERBIUM | CHEBI:33374 → *samarium atom* | CHEBI:49902 terbium(3+) |
+| DYSPROSIUM | CHEBI:49782 → *(not in build)* | CHEBI:33377 dysprosium atom |
+| HOLMIUM | CHEBI:49649 → *(not in build)* | CHEBI:49650 holmium(3+) |
+| ERBIUM | CHEBI:49650 → *holmium(3+)* | CHEBI:33379 erbium |
+| THULIUM | CHEBI:33377 → *dysprosium atom* | CHEBI:33380 thulium atom |
+| YTTERBIUM | CHEBI:33378 → *(not in build)* | CHEBI:49980 ytterbium(3+) |
+| YTTRIUM | CHEBI:49976 → *zinc dichloride* | CHEBI:49962 yttrium(3+) |
+
+The pattern is off-by-one shifts within the CHEBI:333xx lanthanide block plus a
+couple of digit transpositions — a copy/paste grounding error, same class as
+PALLADIUM.
+
+**Item 1 — fix the groundings — DONE (2026-07-18, PR #207).** All 13 REE/INDIUM
+`meaning:` ids in `schema/communitymech.yaml` (both element enums) and the mirror
+`REE_CHEBI_MAP`/`METAL_CHEBI_MAP` in `src/communitymech/metal_extraction.py` were
+repointed and the datamodel regenerated. **Curation decision taken: ground REEs as
+the `(3+)` cation** (matches every `description:` "X(3+) cation"); this also
+normalised the previously-atom-grounded NEODYMIUM/GADOLINIUM/LUTETIUM/SCANDIUM to
+their cation ids. Three lanthanides have **no `(3+)` term in ChEBI** — DYSPROSIUM
+(CHEBI:33377 atom), ERBIUM (CHEBI:33379), THULIUM (CHEBI:33380) — so they stay
+atom-grounded with descriptions annotated to say so. Re-audit: 0 mismatches;
+validate-all + 197 tests green.
+
+**Item 2 — STILL DEFERRED — close the systemic gap:** enum `meaning:` groundings
+are **not** covered by
+   any id↔label gate — `validate-products` only checks record-level
+   `term.{id,label}` pairs, so these drifted wrong undetected while the gated
+   record pairs stayed correct (spot-checked: `Ion_Adsorption_REE_Indigenous_`
+   `Community.yaml` uses the *correct* CHEBI:33377/CHEBI:49962). **Follow-up:** add
+   a small test (or extend the label gate) that validates every enum `meaning:` id
+   against its canonical ChEBI/ENVO/etc. label so this class of bug can't recur —
+   without it, item 1 could silently regress on the next hand-edit. See
+   [[ontology-term-cleanup]] / [[chebi-mislabels-backlog]].
+
+**Impact:** shipped community records mostly ground REEs via their own (correct)
+`term.{id,label}` pairs, so the KGX export from those is largely fine; the wrong
+groundings live in the schema enum + `metal_extraction.py` map (any enum-driven
+export/analysis inherits them). Low blast radius today, but a latent correctness
+bug and a clear gate gap.
 
 ## 1. Phase-2 id↔label enforcement rollout (report-only → blocking)
 

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-07-07T13:23:20
+# Generation date: 2026-07-18T19:47:03
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech
@@ -2446,7 +2446,7 @@ class MetalElementEnum(EnumDefinitionImpl):
         text="GALLIUM", description="Gallium(3+) cation", meaning=CHEBI["49631"]
     )
     INDIUM = PermissibleValue(
-        text="INDIUM", description="Indium(3+) cation", meaning=CHEBI["49464"]
+        text="INDIUM", description="Indium(3+) cation", meaning=CHEBI["49664"]
     )
     TITANIUM = PermissibleValue(
         text="TITANIUM", description="Titanium atom", meaning=CHEBI["33341"]
@@ -2467,52 +2467,58 @@ class RareEarthElementEnum(EnumDefinitionImpl):
     """
 
     LANTHANUM = PermissibleValue(
-        text="LANTHANUM", description="Lanthanum(3+) cation", meaning=CHEBI["32359"]
+        text="LANTHANUM", description="Lanthanum(3+) cation", meaning=CHEBI["49701"]
     )
     CERIUM = PermissibleValue(
-        text="CERIUM", description="Cerium(3+) cation", meaning=CHEBI["32998"]
+        text="CERIUM", description="Cerium(3+) cation", meaning=CHEBI["48782"]
     )
     PRASEODYMIUM = PermissibleValue(
-        text="PRASEODYMIUM", description="Praseodymium(3+) cation", meaning=CHEBI["49648"]
+        text="PRASEODYMIUM", description="Praseodymium(3+) cation", meaning=CHEBI["229784"]
     )
     NEODYMIUM = PermissibleValue(
-        text="NEODYMIUM", description="Neodymium(3+) cation", meaning=CHEBI["33372"]
+        text="NEODYMIUM", description="Neodymium(3+) cation", meaning=CHEBI["229785"]
     )
     SAMARIUM = PermissibleValue(
-        text="SAMARIUM", description="Samarium(3+) cation", meaning=CHEBI["33376"]
+        text="SAMARIUM", description="Samarium(3+) cation", meaning=CHEBI["49890"]
     )
     EUROPIUM = PermissibleValue(
-        text="EUROPIUM", description="Europium(3+) cation", meaning=CHEBI["30688"]
+        text="EUROPIUM", description="Europium(3+) cation", meaning=CHEBI["49591"]
     )
     GADOLINIUM = PermissibleValue(
-        text="GADOLINIUM", description="Gadolinium(3+) cation", meaning=CHEBI["33375"]
+        text="GADOLINIUM", description="Gadolinium(3+) cation", meaning=CHEBI["49618"]
     )
     TERBIUM = PermissibleValue(
-        text="TERBIUM", description="Terbium(3+) cation", meaning=CHEBI["33374"]
+        text="TERBIUM", description="Terbium(3+) cation", meaning=CHEBI["49902"]
     )
     DYSPROSIUM = PermissibleValue(
-        text="DYSPROSIUM", description="Dysprosium(3+) cation", meaning=CHEBI["49782"]
+        text="DYSPROSIUM",
+        description="Dysprosium atom (ChEBI has no dysprosium(3+) cation term)",
+        meaning=CHEBI["33377"],
     )
     HOLMIUM = PermissibleValue(
-        text="HOLMIUM", description="Holmium(3+) cation", meaning=CHEBI["49649"]
+        text="HOLMIUM", description="Holmium(3+) cation", meaning=CHEBI["49650"]
     )
     ERBIUM = PermissibleValue(
-        text="ERBIUM", description="Erbium(3+) cation", meaning=CHEBI["49650"]
+        text="ERBIUM",
+        description="Erbium atom (ChEBI has no erbium(3+) cation term)",
+        meaning=CHEBI["33379"],
     )
     THULIUM = PermissibleValue(
-        text="THULIUM", description="Thulium(3+) cation", meaning=CHEBI["33377"]
+        text="THULIUM",
+        description="Thulium atom (ChEBI has no thulium(3+) cation term)",
+        meaning=CHEBI["33380"],
     )
     YTTERBIUM = PermissibleValue(
-        text="YTTERBIUM", description="Ytterbium(3+) cation", meaning=CHEBI["33378"]
+        text="YTTERBIUM", description="Ytterbium(3+) cation", meaning=CHEBI["49980"]
     )
     LUTETIUM = PermissibleValue(
-        text="LUTETIUM", description="Lutetium(3+) cation", meaning=CHEBI["33382"]
+        text="LUTETIUM", description="Lutetium(3+) cation", meaning=CHEBI["49746"]
     )
     YTTRIUM = PermissibleValue(
-        text="YTTRIUM", description="Yttrium(3+) cation", meaning=CHEBI["49976"]
+        text="YTTRIUM", description="Yttrium(3+) cation", meaning=CHEBI["49962"]
     )
     SCANDIUM = PermissibleValue(
-        text="SCANDIUM", description="Scandium(3+) cation", meaning=CHEBI["33330"]
+        text="SCANDIUM", description="Scandium(3+) cation", meaning=CHEBI["231857"]
     )
 
     _defn = EnumDefinition(

--- a/src/communitymech/metal_extraction.py
+++ b/src/communitymech/metal_extraction.py
@@ -28,28 +28,28 @@ METAL_CHEBI_MAP = {
     "CHEBI:30512": "SILVER",
     "CHEBI:33363": "PALLADIUM",
     "CHEBI:49631": "GALLIUM",
-    "CHEBI:49464": "INDIUM",
+    "CHEBI:49664": "INDIUM",
     "CHEBI:33341": "TITANIUM",
 }
 
 # Mapping from CHEBI IDs to RareEarthElementEnum values
 REE_CHEBI_MAP = {
-    "CHEBI:32359": "LANTHANUM",
-    "CHEBI:32998": "CERIUM",
-    "CHEBI:49648": "PRASEODYMIUM",
-    "CHEBI:33372": "NEODYMIUM",
-    "CHEBI:33376": "SAMARIUM",
-    "CHEBI:30688": "EUROPIUM",
-    "CHEBI:33375": "GADOLINIUM",
-    "CHEBI:33374": "TERBIUM",
-    "CHEBI:49782": "DYSPROSIUM",
-    "CHEBI:49649": "HOLMIUM",
-    "CHEBI:49650": "ERBIUM",
-    "CHEBI:33377": "THULIUM",
-    "CHEBI:33378": "YTTERBIUM",
-    "CHEBI:33382": "LUTETIUM",
-    "CHEBI:49976": "YTTRIUM",
-    "CHEBI:33330": "SCANDIUM",
+    "CHEBI:49701": "LANTHANUM",
+    "CHEBI:48782": "CERIUM",
+    "CHEBI:229784": "PRASEODYMIUM",
+    "CHEBI:229785": "NEODYMIUM",
+    "CHEBI:49890": "SAMARIUM",
+    "CHEBI:49591": "EUROPIUM",
+    "CHEBI:49618": "GADOLINIUM",
+    "CHEBI:49902": "TERBIUM",
+    "CHEBI:33377": "DYSPROSIUM",  # atom; ChEBI has no dysprosium(3+) cation
+    "CHEBI:49650": "HOLMIUM",
+    "CHEBI:33379": "ERBIUM",  # atom; ChEBI has no erbium(3+) cation
+    "CHEBI:33380": "THULIUM",  # atom; ChEBI has no thulium(3+) cation
+    "CHEBI:49980": "YTTERBIUM",
+    "CHEBI:49746": "LUTETIUM",
+    "CHEBI:49962": "YTTRIUM",
+    "CHEBI:231857": "SCANDIUM",
 }
 
 # Keywords for metal detection in environmental factors and descriptions

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -363,7 +363,7 @@ enums:
         meaning: CHEBI:49631
         description: Gallium(3+) cation
       INDIUM:
-        meaning: CHEBI:49464
+        meaning: CHEBI:49664
         description: Indium(3+) cation
       TITANIUM:
         meaning: CHEBI:33341
@@ -376,52 +376,52 @@ enums:
     description: Rare earth elements (lanthanides + Y, Sc)
     permissible_values:
       LANTHANUM:
-        meaning: CHEBI:32359
+        meaning: CHEBI:49701
         description: Lanthanum(3+) cation
       CERIUM:
-        meaning: CHEBI:32998
+        meaning: CHEBI:48782
         description: Cerium(3+) cation
       PRASEODYMIUM:
-        meaning: CHEBI:49648
+        meaning: CHEBI:229784
         description: Praseodymium(3+) cation
       NEODYMIUM:
-        meaning: CHEBI:33372
+        meaning: CHEBI:229785
         description: Neodymium(3+) cation
       SAMARIUM:
-        meaning: CHEBI:33376
+        meaning: CHEBI:49890
         description: Samarium(3+) cation
       EUROPIUM:
-        meaning: CHEBI:30688
+        meaning: CHEBI:49591
         description: Europium(3+) cation
       GADOLINIUM:
-        meaning: CHEBI:33375
+        meaning: CHEBI:49618
         description: Gadolinium(3+) cation
       TERBIUM:
-        meaning: CHEBI:33374
+        meaning: CHEBI:49902
         description: Terbium(3+) cation
       DYSPROSIUM:
-        meaning: CHEBI:49782
-        description: Dysprosium(3+) cation
+        meaning: CHEBI:33377
+        description: Dysprosium atom (ChEBI has no dysprosium(3+) cation term)
       HOLMIUM:
-        meaning: CHEBI:49649
+        meaning: CHEBI:49650
         description: Holmium(3+) cation
       ERBIUM:
-        meaning: CHEBI:49650
-        description: Erbium(3+) cation
+        meaning: CHEBI:33379
+        description: Erbium atom (ChEBI has no erbium(3+) cation term)
       THULIUM:
-        meaning: CHEBI:33377
-        description: Thulium(3+) cation
+        meaning: CHEBI:33380
+        description: Thulium atom (ChEBI has no thulium(3+) cation term)
       YTTERBIUM:
-        meaning: CHEBI:33378
+        meaning: CHEBI:49980
         description: Ytterbium(3+) cation
       LUTETIUM:
-        meaning: CHEBI:33382
+        meaning: CHEBI:49746
         description: Lutetium(3+) cation
       YTTRIUM:
-        meaning: CHEBI:49976
+        meaning: CHEBI:49962
         description: Yttrium(3+) cation
       SCANDIUM:
-        meaning: CHEBI:33330
+        meaning: CHEBI:231857
         description: Scandium(3+) cation
 
   MetalRelevanceEnum:


### PR DESCRIPTION
## Problem

Follow-up to #206 (PALLADIUM). Auditing the full `MetalElementEnum` +
`RareEarthElementEnum` (each `meaning:` id vs its current ChEBI label) found the
palladium bug was **not isolated** — **13 more wrong groundings**, almost all in
the rare-earth block. The ids had drifted off-by-one within the `CHEBI:333xx`
lanthanide range, plus a couple of digit transpositions:

| enum | was | resolved to | now |
|---|---|---|---|
| INDIUM | CHEBI:49464 | *aluminium trifluoride* | CHEBI:49664 indium(3+) |
| LANTHANUM | CHEBI:32359 | *dodecanoyl group* | CHEBI:49701 lanthanum(3+) |
| CERIUM | CHEBI:32998 | *(not in build)* | CHEBI:48782 cerium(3+) |
| PRASEODYMIUM | CHEBI:49648 | *holmium atom* | CHEBI:229784 praseodymium(3+) |
| SAMARIUM | CHEBI:33376 | *terbium atom* | CHEBI:49890 samarium(3+) |
| EUROPIUM | CHEBI:30688 | *(not in build)* | CHEBI:49591 europium(3+) |
| TERBIUM | CHEBI:33374 | *samarium atom* | CHEBI:49902 terbium(3+) |
| DYSPROSIUM | CHEBI:49782 | *(not in build)* | CHEBI:33377 dysprosium atom¹ |
| HOLMIUM | CHEBI:49649 | *(not in build)* | CHEBI:49650 holmium(3+) |
| ERBIUM | CHEBI:49650 | *holmium(3+)* | CHEBI:33379 erbium¹ |
| THULIUM | CHEBI:33377 | *dysprosium atom* | CHEBI:33380 thulium atom¹ |
| YTTERBIUM | CHEBI:33378 | *(not in build)* | CHEBI:49980 ytterbium(3+) |
| YTTRIUM | CHEBI:49976 | *zinc dichloride* | CHEBI:49962 yttrium(3+) |

¹ ChEBI has no `(3+)` cation term for Dy/Er/Tm — grounded to the atom, description annotated.

## Decision

Ground REEs as the **`(3+)` cation** to match every enum `description:` "X(3+)
cation". This also normalises the four entries that happened to already resolve
(Nd/Gd/Lu/Sc) from the atom form to their cation ids, making the enum internally
consistent.

## Why it drifted undetected

Enum `meaning:` groundings are **not** covered by `validate-products`, which only
checks record-level `term.{id,label}` pairs. The shipped REE records ground via
their own (correct) term pairs — e.g. `Ion_Adsorption_REE_Indigenous_Community.yaml`
uses `CHEBI:33377`/`CHEBI:49962` — so the **KGX export was unaffected**; the bug
lived purely in the schema enum + the `metal_extraction.py` mirror map. Closing
that gate gap (a test validating enum meanings against canonical labels) is logged
as a deferred follow-up in `NEXT_TASKS.md` §0 item 2.

## Changes

- `schema/communitymech.yaml` — 13 REE + INDIUM `meaning:` ids repointed
- `datamodel/communitymech.py` — regenerated (`just gen-python`)
- `metal_extraction.py` — `REE_CHEBI_MAP` + `METAL_CHEBI_MAP` (INDIUM) mirror
- `NEXT_TASKS.md` — finding logged; this fix marked done, guard-test follow-up deferred

## Verification

- Re-audit of both enums vs ChEBI: **0 mismatches**
- `linkml-validate` on all REE-using records: clean
- `just test` — 197 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)