### PR TITLE
ENVO cross-repo coverage dashboard (issue #30, Use Case 2)

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -125,9 +125,39 @@ export (the id ≠ the labelled compound) — a data-quality item worth tracking
 
 ## 2. Cross-repository environmental linking (issue #30)
 
-Open issue: enhance environment/isolation-source links between CommunityMech,
-CultureMech, and MIM (shared ENVO grounding, cross-references). Scope and
-sequence against the MIM single-source-of-truth direction before building.
+**Scoping finding (2026-07-19):** most of #30's *schema* is already built — the
+`RelatedMedia` / `RelatedIngredient` classes, `related_media` /
+`related_ingredients` slots, `GrowthMedia.culturemech_id`, and
+`GrowthMediaComponent.mediaingredientmech_id` all exist, and cross-repo **ID**
+existence checks ship in `scripts/validate_cross_repo_ids.py`. The name-based
+`scripts/link_growth_media.py` links growth_media → CultureMech recipes. What was
+missing is the **ENVO-based** cross-repo layer (issue Use Cases 1–2): match a
+community's `environment_term` against CultureMech `source_environment[].term.id`
+and MIM `environmental_context[].environment_term`. Both sibling env fields now
+exist (CultureMech 18 real records, MIM ~44); read siblings from local paths via
+`COMMUNITYMECH_SIBLING_REPOS`.
+
+**Item a — ENVO coverage dashboard — DONE (2026-07-19, PR #210).**
+`src/communitymech/cross_repo_environment.py` (byte-prefiltered ENVO index across
+the three repos, no network) + `scripts/env_coverage_dashboard.py` +
+`just env-coverage`. First real run: **41 community ENVO terms, only 1 (soil) with
+both media+ingredients, 34 with neither** — sibling ENVO fields are still sparse,
+so the near-term value is showing *where* to populate. Offline unit tests in
+`tests/test_cross_repo_environment.py`.
+
+**Item b — ENVO-based suggester — NEXT.** For a community, emit suggested
+`related_media` / `related_ingredients` blocks (with `shared_environment_term`)
+from ENVO matches, for curator review. **Open problem to resolve first: the MIM id
+scheme.** MIM env-context records carry `identifier: kgmicrobe.ingredient:…` /
+`CHEBI:…` / `ENVO:…`, **not** `MediaIngredientMech:NNNNNN` (the schema pattern for
+`mediaingredientmech_id`); 802 `MediaIngredientMech:NNNNNN` ids live in a separate
+MIM crosswalk. CommunityMech's 222 existing `related_ingredients` don't populate
+`mediaingredientmech_id` at all. Decide how (or whether) to reconcile these before
+emitting ingredient ids — this is the "MIM single-source-of-truth direction" the
+scoping note flagged. Exact-ENVO matching is sparse; consider ENVO subsumption
+(e.g. rhizosphere media for a soil community) as a follow-up. Note also
+`ENVO:01001405` "laboratory environment" is over-applied (110 communities) — a
+grounding-quality item, not part of #30.
 
 ## 3. Cross-Mech validator pin guard — DONE (4-repo invariant)
 

--- a/justfile
+++ b/justfile
@@ -96,6 +96,13 @@ validate-cross-repo-ids FILE:
 validate-cross-repo-ids-all:
     PYTHONPATH=src uv run python scripts/validate_cross_repo_ids.py kb/communities/*.yaml
 
+# Environmental coverage dashboard: per-ENVO counts of communities vs CultureMech
+# media vs MediaIngredientMech ingredients (issue #30). Reads sibling repos from
+# COMMUNITYMECH_SIBLING_REPOS env (Name=path,Name=path); pass --tsv to also write
+# a report. Without siblings configured it lists community ENVO terms only.
+env-coverage *args:
+    PYTHONPATH=src uv run python scripts/env_coverage_dashboard.py {{args}}
+
 # Validate ontology terms in a community file
 validate-terms FILE:
     uv run linkml-term-validator validate-data {{FILE}} -s src/communitymech/schema/communitymech.yaml --labels

--- a/scripts/env_coverage_dashboard.py
+++ b/scripts/env_coverage_dashboard.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Environmental coverage dashboard across CommunityMech + CultureMech + MIM (issue #30).
+
+For every ENVO environment term used by a CommunityMech community, report how many
+communities, CultureMech media (``source_environment``), and MediaIngredientMech
+ingredients (``environmental_context``) share it — surfacing where a community's
+environment has good media/ingredient support and where it is a gap.
+
+Sibling repos are read from local paths (no network), configured via the
+``COMMUNITYMECH_SIBLING_REPOS`` env var (``Name=path,Name=path``) or the
+``--culturemech`` / ``--mediaingredientmech`` flags. Point them at each sibling
+repo root (or any subtree holding its records).
+
+Usage:
+    PYTHONPATH=src uv run python scripts/env_coverage_dashboard.py
+    COMMUNITYMECH_SIBLING_REPOS="CultureMech=../CultureMech,MediaIngredientMech=../MediaIngredientMech" \\
+        PYTHONPATH=src uv run python scripts/env_coverage_dashboard.py --tsv reports/env_coverage.tsv
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from communitymech.cross_repo_environment import build_coverage, sibling_repos_from_env
+
+REPO_ROOT = Path(__file__).parent.parent
+COMMUNITY_DIR = REPO_ROOT / "kb" / "communities"
+
+
+def _rows(coverage):
+    """Sorted rows: (envo_id, label, n_comm, n_media, n_ingred), community terms only."""
+    rows = []
+    for envo_id in sorted(coverage.community_records):
+        rows.append(
+            (
+                envo_id,
+                coverage.label(envo_id),
+                len(coverage.community_records[envo_id]),
+                len(coverage.media_records.get(envo_id, [])),
+                len(coverage.ingredient_records.get(envo_id, [])),
+            )
+        )
+    # Gaps first: least sibling support, then most communities affected.
+    rows.sort(key=lambda r: (r[3] + r[4], -r[2]))
+    return rows
+
+
+def _print_table(rows, have_siblings) -> None:
+    print(f"\nEnvironmental coverage — {len(rows)} community ENVO terms\n")
+    header = f"{'ENVO term':16} {'label':28} {'comm':>5} {'media':>6} {'ingred':>7}  status"
+    print(header)
+    print("-" * len(header))
+    for envo_id, label, n_comm, n_media, n_ingred in rows:
+        if not have_siblings:
+            status = "siblings not configured"
+        elif n_media == 0 and n_ingred == 0:
+            status = "GAP: no media or ingredients"
+        elif n_media == 0:
+            status = "gap: no media"
+        elif n_ingred == 0:
+            status = "gap: no ingredients"
+        else:
+            status = "covered"
+        print(f"{envo_id:16} {label[:28]:28} {n_comm:5} {n_media:6} {n_ingred:7}  {status}")
+
+
+def _summary(rows, have_siblings) -> None:
+    total = len(rows)
+    if not have_siblings:
+        print(f"\n{total} community ENVO terms. Configure sibling repos for coverage.\n")
+        return
+    both = sum(1 for r in rows if r[3] and r[4])
+    no_media = sum(1 for r in rows if r[3] == 0)
+    no_ingred = sum(1 for r in rows if r[4] == 0)
+    full_gap = sum(1 for r in rows if r[3] == 0 and r[4] == 0)
+    print(
+        f"\nSummary: {total} community ENVO terms | "
+        f"{both} with both media+ingredients | {no_media} lack media | "
+        f"{no_ingred} lack ingredients | {full_gap} have neither\n"
+    )
+
+
+def _write_tsv(path: Path, rows) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = ["envo_id\tlabel\tcommunities\tmedia\tingredients"]
+    lines += ["\t".join(map(str, r)) for r in rows]
+    path.write_text("\n".join(lines) + "\n")
+    print(f"Wrote {path} ({len(rows)} rows)")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--culturemech", type=Path, help="Path to CultureMech repo/records")
+    parser.add_argument("--mediaingredientmech", type=Path, help="Path to MIM repo/records")
+    parser.add_argument("--tsv", type=Path, help="Also write the table to this TSV path")
+    args = parser.parse_args()
+
+    sibling_repos = sibling_repos_from_env()
+    if args.culturemech is not None:
+        sibling_repos["CultureMech"] = args.culturemech
+    if args.mediaingredientmech is not None:
+        sibling_repos["MediaIngredientMech"] = args.mediaingredientmech
+
+    coverage = build_coverage(COMMUNITY_DIR, sibling_repos=sibling_repos)
+    rows = _rows(coverage)
+    have_siblings = bool(sibling_repos)
+
+    _print_table(rows, have_siblings)
+    _summary(rows, have_siblings)
+    if args.tsv is not None:
+        _write_tsv(args.tsv, rows)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/communitymech/cross_repo_environment.py
+++ b/src/communitymech/cross_repo_environment.py
@@ -1,0 +1,181 @@
+"""Index ENVO environment terms across CommunityMech and its sibling repos.
+
+Issue #30 asks for environment-based links between CommunityMech communities,
+CultureMech media, and MediaIngredientMech (MIM) ingredients, all keyed on shared
+ENVO grounding. This module is the shared substrate for that: it reads the ENVO
+environment terms out of each repo's records and builds a per-ENVO coverage map
+used by the coverage dashboard (Use Case 2) and the ENVO-based suggester (Use
+Case 1).
+
+Where each repo records its environment (all as ENVO CURIEs):
+
+* CommunityMech community: ``environment_term.term.id``
+* CultureMech media:       ``source_environment[].term.id``
+* MIM ingredient:          ``environmental_context[].environment_term`` (bare CURIE)
+
+Sibling repos are read from **local paths** (no network). Their record trees are
+large (CultureMech's is ~16k YAMLs) but only a handful carry an environment
+field, so files are **byte-prefiltered** on the field name before YAML parsing —
+scanning a full sibling tree stays well under a second.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+# Field-name bytes used to prefilter candidate files before YAML parsing.
+_COMMUNITY_FIELD = b"environment_term"
+_CULTUREMECH_FIELD = b"source_environment"
+_MIM_FIELD = b"environmental_context"
+
+
+def _iter_prefiltered(root: Path, needle: bytes) -> Iterator[tuple[Path, dict]]:
+    """Yield ``(path, parsed_yaml)`` for every ``*.yaml`` under ``root`` whose raw
+    bytes contain ``needle``. Files under a ``tests`` directory are skipped, as
+    are unreadable / non-mapping / unparseable files.
+    """
+    if not root.exists():
+        return
+    for path in root.rglob("*.yaml"):
+        if "tests" in path.parts:
+            continue
+        try:
+            raw = path.read_bytes()
+        except OSError:
+            continue
+        if needle not in raw:
+            continue
+        try:
+            data = yaml.safe_load(raw)
+        except yaml.YAMLError:
+            continue
+        if isinstance(data, dict):
+            yield path, data
+
+
+def _envo(curie: object) -> str | None:
+    """Return ``curie`` if it is an ENVO CURIE string, else None."""
+    return curie if isinstance(curie, str) and curie.startswith("ENVO:") else None
+
+
+@dataclass
+class EnvCoverage:
+    """Per-ENVO coverage across the three repos.
+
+    Each ``*_records`` maps an ENVO id to the sorted list of record identifiers
+    (community name / CultureMech id / MIM identifier) grounded to that term.
+    ``labels`` holds a human label for each ENVO id (harvested from whichever
+    record first supplied one), so the dashboard needs no ontology lookup.
+    """
+
+    community_records: dict[str, list[str]] = field(default_factory=dict)
+    media_records: dict[str, list[str]] = field(default_factory=dict)
+    ingredient_records: dict[str, list[str]] = field(default_factory=dict)
+    labels: dict[str, str] = field(default_factory=dict)
+
+    def all_terms(self) -> set[str]:
+        return set(self.community_records) | set(self.media_records) | set(self.ingredient_records)
+
+    def label(self, envo_id: str) -> str:
+        return self.labels.get(envo_id, "")
+
+
+def _add(index: dict[str, list[str]], envo_id: str, record_id: str) -> None:
+    index.setdefault(envo_id, [])
+    if record_id not in index[envo_id]:
+        index[envo_id].append(record_id)
+
+
+def community_environments(community_dir: Path, coverage: EnvCoverage) -> None:
+    """Populate ``coverage.community_records`` from CommunityMech community YAMLs."""
+    for path in sorted(community_dir.glob("*.yaml")):
+        try:
+            data = yaml.safe_load(path.read_bytes())
+        except (OSError, yaml.YAMLError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        et = data.get("environment_term")
+        term = (et or {}).get("term") if isinstance(et, dict) else None
+        if not isinstance(term, dict):
+            continue
+        envo_id = _envo(term.get("id"))
+        if envo_id is None:
+            continue
+        _add(coverage.community_records, envo_id, data.get("name") or path.stem)
+        if term.get("label"):
+            coverage.labels.setdefault(envo_id, term["label"])
+
+
+def culturemech_environments(root: Path, coverage: EnvCoverage) -> None:
+    """Populate ``coverage.media_records`` from CultureMech media YAMLs."""
+    for path, data in _iter_prefiltered(root, _CULTUREMECH_FIELD):
+        record_id = data.get("id") or data.get("name") or path.stem
+        for entry in data.get("source_environment") or []:
+            term = entry.get("term") if isinstance(entry, dict) else None
+            if not isinstance(term, dict):
+                continue
+            envo_id = _envo(term.get("id"))
+            if envo_id is None:
+                continue
+            _add(coverage.media_records, envo_id, str(record_id))
+            if term.get("label"):
+                coverage.labels.setdefault(envo_id, term["label"])
+
+
+def mim_environments(root: Path, coverage: EnvCoverage) -> None:
+    """Populate ``coverage.ingredient_records`` from MIM ingredient YAMLs."""
+    for path, data in _iter_prefiltered(root, _MIM_FIELD):
+        record_id = data.get("identifier") or data.get("name") or path.stem
+        for entry in data.get("environmental_context") or []:
+            if not isinstance(entry, dict):
+                continue
+            envo_id = _envo(entry.get("environment_term"))
+            if envo_id is None:
+                continue
+            _add(coverage.ingredient_records, envo_id, str(record_id))
+            if entry.get("environment_label"):
+                coverage.labels.setdefault(envo_id, entry["environment_label"])
+
+
+def build_coverage(
+    community_dir: Path,
+    sibling_repos: dict[str, Path] | None = None,
+) -> EnvCoverage:
+    """Build an :class:`EnvCoverage` from CommunityMech + configured sibling repos.
+
+    ``sibling_repos`` maps repo name to a local path (repo root or any subtree
+    holding its records). Recognized keys: ``CultureMech``,
+    ``MediaIngredientMech``. Missing keys are simply not scanned.
+    """
+    sibling_repos = sibling_repos or {}
+    coverage = EnvCoverage()
+    community_environments(community_dir, coverage)
+    cm = sibling_repos.get("CultureMech")
+    if cm is not None:
+        culturemech_environments(cm, coverage)
+    mim = sibling_repos.get("MediaIngredientMech")
+    if mim is not None:
+        mim_environments(mim, coverage)
+    return coverage
+
+
+def sibling_repos_from_env() -> dict[str, Path]:
+    """Parse ``COMMUNITYMECH_SIBLING_REPOS`` (``Name=path,Name=path``) into paths.
+
+    Mirrors ``scripts/validate_cross_repo_ids.py`` so both cross-repo tools share
+    one configuration convention.
+    """
+    raw = os.environ.get("COMMUNITYMECH_SIBLING_REPOS", "").strip()
+    out: dict[str, Path] = {}
+    for pair in raw.split(","):
+        if "=" not in pair:
+            continue
+        name, path = pair.split("=", 1)
+        out[name.strip()] = Path(path.strip())
+    return out

--- a/tests/test_cross_repo_environment.py
+++ b/tests/test_cross_repo_environment.py
@@ -1,0 +1,159 @@
+"""Tests for the cross-repo ENVO coverage index (issue #30).
+
+Uses tiny on-disk fixtures under ``tmp_path`` — no real sibling repos, no
+network — mirroring the three repos' environment-field shapes:
+
+* CommunityMech community: ``environment_term.term.id``
+* CultureMech media:       ``source_environment[].term.id``
+* MIM ingredient:          ``environmental_context[].environment_term`` (bare CURIE)
+"""
+
+import textwrap
+
+from communitymech.cross_repo_environment import (
+    build_coverage,
+    sibling_repos_from_env,
+)
+
+
+def _write(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(text))
+
+
+def _make_community(dir_, name, envo_id, label):
+    _write(
+        dir_ / f"{name}.yaml",
+        f"""
+        name: {name}
+        environment_term:
+          preferred_term: {label}
+          term:
+            id: {envo_id}
+            label: {label}
+        """,
+    )
+
+
+def _make_media(dir_, cid, envo_id, label):
+    _write(
+        dir_ / f"{cid.replace(':', '_')}.yaml",
+        f"""
+        id: {cid}
+        name: {cid}
+        source_environment:
+        - preferred_term: {label}
+          term:
+            id: {envo_id}
+            label: {label}
+        """,
+    )
+
+
+def _make_ingredient(dir_, ident, envo_id, label):
+    _write(
+        dir_ / f"{ident.replace(':', '_')}.yaml",
+        f"""
+        identifier: {ident}
+        environmental_context:
+        - environment_term: {envo_id}
+          environment_label: {label}
+        """,
+    )
+
+
+def _fixture(tmp_path):
+    comm = tmp_path / "communities"
+    cm = tmp_path / "CultureMech"
+    mim = tmp_path / "MIM"
+    # peatland: community + media, no ingredient
+    _make_community(comm, "PeatCommunity", "ENVO:00000044", "peatland")
+    _make_media(cm / "data", "CultureMech:000001", "ENVO:00000044", "peatland")
+    # soil: community + ingredient, no media
+    _make_community(comm, "SoilCommunity", "ENVO:00001998", "soil")
+    _make_ingredient(mim / "data", "kgmicrobe.ingredient:humic_acid", "ENVO:00001998", "soil")
+    # vent: community only (full gap)
+    _make_community(comm, "VentCommunity", "ENVO:01000030", "hydrothermal vent")
+    return comm, cm, mim
+
+
+def test_build_coverage_maps_all_three_repos(tmp_path):
+    comm, cm, mim = _fixture(tmp_path)
+    cov = build_coverage(comm, {"CultureMech": cm, "MediaIngredientMech": mim})
+
+    assert cov.all_terms() == {"ENVO:00000044", "ENVO:00001998", "ENVO:01000030"}
+    assert cov.community_records["ENVO:00000044"] == ["PeatCommunity"]
+    assert cov.media_records["ENVO:00000044"] == ["CultureMech:000001"]
+    assert cov.ingredient_records["ENVO:00001998"] == ["kgmicrobe.ingredient:humic_acid"]
+    # labels harvested from records, no ontology lookup
+    assert cov.label("ENVO:00000044") == "peatland"
+
+
+def test_gap_terms_have_no_sibling_records(tmp_path):
+    comm, cm, mim = _fixture(tmp_path)
+    cov = build_coverage(comm, {"CultureMech": cm, "MediaIngredientMech": mim})
+
+    # vent community has neither media nor ingredients
+    assert "ENVO:01000030" in cov.community_records
+    assert "ENVO:01000030" not in cov.media_records
+    assert "ENVO:01000030" not in cov.ingredient_records
+    # peatland lacks ingredients; soil lacks media
+    assert "ENVO:00000044" not in cov.ingredient_records
+    assert "ENVO:00001998" not in cov.media_records
+
+
+def test_no_siblings_still_indexes_communities(tmp_path):
+    comm, _, _ = _fixture(tmp_path)
+    cov = build_coverage(comm, sibling_repos={})
+    assert set(cov.community_records) == {"ENVO:00000044", "ENVO:00001998", "ENVO:01000030"}
+    assert cov.media_records == {}
+    assert cov.ingredient_records == {}
+
+
+def test_non_envo_and_missing_terms_ignored(tmp_path):
+    comm = tmp_path / "communities"
+    _make_community(comm, "GoodCommunity", "ENVO:00000044", "peatland")
+    # a community grounded to a non-ENVO term is ignored
+    _write(
+        comm / "OtherCommunity.yaml",
+        """
+        name: OtherCommunity
+        environment_term:
+          term:
+            id: UBERON:0000955
+            label: brain
+        """,
+    )
+    # a community with no environment_term at all is ignored
+    _write(comm / "BareCommunity.yaml", "name: BareCommunity\n")
+    cov = build_coverage(comm, sibling_repos={})
+    assert set(cov.community_records) == {"ENVO:00000044"}
+
+
+def test_prefilter_skips_records_without_the_field(tmp_path):
+    comm, cm, mim = _fixture(tmp_path)
+    # add a CultureMech record with NO source_environment — must be skipped
+    _write(
+        cm / "data" / "no_env.yaml",
+        """
+        id: CultureMech:009999
+        name: no_env
+        ingredients: []
+        """,
+    )
+    cov = build_coverage(comm, {"CultureMech": cm, "MediaIngredientMech": mim})
+    media_ids = {rid for ids in cov.media_records.values() for rid in ids}
+    assert "CultureMech:009999" not in media_ids
+
+
+def test_sibling_repos_from_env(monkeypatch):
+    monkeypatch.setenv(
+        "COMMUNITYMECH_SIBLING_REPOS",
+        "CultureMech=/x/CultureMech, MediaIngredientMech=/y/MIM",
+    )
+    repos = sibling_repos_from_env()
+    assert set(repos) == {"CultureMech", "MediaIngredientMech"}
+    assert str(repos["CultureMech"]) == "/x/CultureMech"
+
+    monkeypatch.delenv("COMMUNITYMECH_SIBLING_REPOS")
+    assert sibling_repos_from_env() == {}


### PR DESCRIPTION
## Context

Scoping **issue #30** (cross-repo environmental linking) found that most of its
proposed *schema* already exists — `RelatedMedia` / `RelatedIngredient`,
`related_media` / `related_ingredients`, `GrowthMedia.culturemech_id`,
`GrowthMediaComponent.mediaingredientmech_id` — plus cross-repo **ID** existence
checks (`validate_cross_repo_ids.py`) and a name-based media linker
(`link_growth_media.py`). The genuinely missing piece is the **ENVO-based**
cross-repo layer (issue Use Cases 1–2).

This PR is the first of two slices: a **read-only coverage dashboard**. The
ENVO-based **suggester** (Use Case 1) is the next slice.

## What

- **`src/communitymech/cross_repo_environment.py`** — shared ENVO index across the
  three repos, no network:
  - community `environment_term.term.id`
  - CultureMech `source_environment[].term.id`
  - MIM `environmental_context[].environment_term` (bare CURIE)

  Sibling record trees are large (CultureMech ~16k YAMLs) but few carry an
  environment field, so files are **byte-prefiltered** on the field name before
  YAML parsing — a full scan stays under ~0.5s. Labels are harvested from the
  records themselves, so no ontology lookup is needed.
- **`scripts/env_coverage_dashboard.py`** + **`just env-coverage`** — per-ENVO
  table of community vs media vs ingredient counts, gaps first, optional `--tsv`.
  Siblings come from local paths via `COMMUNITYMECH_SIBLING_REPOS` (the same
  convention the cross-repo-id validator already uses) or `--culturemech` /
  `--mediaingredientmech`.
- **`tests/test_cross_repo_environment.py`** — offline unit tests with `tmp_path`
  fixtures (community / media / ingredient shapes, gap terms, prefilter skip,
  env-var parsing).

## First real run

41 community ENVO terms — **only 1 (soil) has both media + ingredients; 34 have
neither.** Sibling ENVO fields are still sparse, so the near-term value is showing
*where* populating media/ingredient environments pays off. (Also surfaced:
`ENVO:01001405` "laboratory environment" is applied to 110 communities — a
grounding-quality item, tracked separately.)

## Next slice (not this PR)

The ENVO suggester must first resolve the **MIM id-scheme mismatch**: MIM
env-context records use `identifier: kgmicrobe.ingredient:…`, not
`MediaIngredientMech:NNNNNN` (the schema pattern); 802 `MediaIngredientMech:NNNNNN`
ids live in a separate crosswalk. Details in `NEXT_TASKS.md` §2b.

## Verification

- `just test` — **206 passed** (+6)
- `just lint` — black + ruff + mypy clean
- Dashboard exercised against the real local CultureMech + MIM checkouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)