### PR TITLE
ENVO-based related_media suggester (issue #30, Use Case 1)

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -145,19 +145,34 @@ both media+ingredients, 34 with neither** — sibling ENVO fields are still spar
 so the near-term value is showing *where* to populate. Offline unit tests in
 `tests/test_cross_repo_environment.py`.
 
-**Item b — ENVO-based suggester — NEXT.** For a community, emit suggested
-`related_media` / `related_ingredients` blocks (with `shared_environment_term`)
-from ENVO matches, for curator review. **Open problem to resolve first: the MIM id
-scheme.** MIM env-context records carry `identifier: kgmicrobe.ingredient:…` /
-`CHEBI:…` / `ENVO:…`, **not** `MediaIngredientMech:NNNNNN` (the schema pattern for
-`mediaingredientmech_id`); 802 `MediaIngredientMech:NNNNNN` ids live in a separate
-MIM crosswalk. CommunityMech's 222 existing `related_ingredients` don't populate
-`mediaingredientmech_id` at all. Decide how (or whether) to reconcile these before
-emitting ingredient ids — this is the "MIM single-source-of-truth direction" the
-scoping note flagged. Exact-ENVO matching is sparse; consider ENVO subsumption
-(e.g. rhizosphere media for a soil community) as a follow-up. Note also
-`ENVO:01001405` "laboratory environment" is over-applied (110 communities) — a
-grounding-quality item, not part of #30.
+**Item b — ENVO-based media suggester — DONE (2026-07-19, PR #211).**
+`scripts/suggest_related_media.py` + `just suggest-related-media`: for each
+community, matches its `environment_term` against CultureMech
+`source_environment` and emits paste-ready `related_media` blocks
+(`relationship_type: ENVIRONMENT_ANALOG`, `shared_environment_term`,
+`culturemech_id`), skipping media already linked via `related_media`/`growth_media`.
+Suggestion-only (edits nothing). Over-generic environments (`ENVO:01001405`
+"laboratory environment", ~110 communities) are excluded by default — `--include-generic`
+to override — and the skipped count is reported (no silent drop). First real run:
+**351 suggestions across 60 communities** (rhizosphere/sediment/compost/freshwater),
+110 lab-only communities skipped. Verified a suggested block LinkML-validates when
+pasted into a real record. Reuses `cross_repo_environment.culturemech_media_by_environment`;
+tests in `tests/test_suggest_related_media.py` + `tests/test_cross_repo_environment.py`.
+
+**Item c — ENVO-based INGREDIENT suggester — DEFERRED (two blockers).**
+(1) *Schema:* `RelatedIngredient` has **no `shared_environment_term` slot** (only
+`chebi_term` for the compound), so an environment→ingredient link isn't even
+expressible — it would need a schema addition. (2) *MIM id scheme:* MIM env-context
+records carry `identifier: kgmicrobe.ingredient:…` / `CHEBI:…` / `ENVO:…`, **not**
+`MediaIngredientMech:NNNNNN` (the `mediaingredientmech_id` pattern); the 802
+`MediaIngredientMech:NNNNNN` ids live only in MIM *analysis/reconciliation reports*,
+and CommunityMech's 222 existing `related_ingredients` don't populate
+`mediaingredientmech_id` at all. Both are the "MIM single-source-of-truth
+direction" the scoping note flagged — resolve on the MIM side (or add the schema
+slot + a crosswalk) before building. **Follow-ups regardless:** exact-ENVO matching
+is sparse — consider ENVO subsumption (rhizosphere media for a soil community); and
+`ENVO:01001405` over-application (110 communities) is a grounding-quality item to
+fix separately.
 
 ## 3. Cross-Mech validator pin guard — DONE (4-repo invariant)
 

--- a/justfile
+++ b/justfile
@@ -103,6 +103,12 @@ validate-cross-repo-ids-all:
 env-coverage *args:
     PYTHONPATH=src uv run python scripts/env_coverage_dashboard.py {{args}}
 
+# Suggest environment-matched CultureMech media as related_media blocks for
+# review (issue #30, Use Case 1). Needs a CultureMech path via
+# COMMUNITYMECH_SIBLING_REPOS or --culturemech. Suggestion-only; edits nothing.
+suggest-related-media *args:
+    PYTHONPATH=src uv run python scripts/suggest_related_media.py {{args}}
+
 # Validate ontology terms in a community file
 validate-terms FILE:
     uv run linkml-term-validator validate-data {{FILE}} -s src/communitymech/schema/communitymech.yaml --labels

--- a/scripts/suggest_related_media.py
+++ b/scripts/suggest_related_media.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Suggest environment-matched CultureMech media for CommunityMech communities (issue #30, Use Case 1).
+
+For each community, match its ``environment_term`` ENVO id against CultureMech
+media that declare the same ``source_environment`` term, and emit ready-to-review
+``related_media`` YAML blocks (with ``shared_environment_term``) for a curator to
+paste. Media already linked from the community (via ``related_media.culturemech_id``
+or ``growth_media.culturemech_id``) are skipped, so re-runs only surface new
+matches.
+
+This is suggestion-only: it prints blocks for review and never edits records —
+mirroring `scripts/suggest_missing_interactions.py`.
+
+Scope: **media only.** Environment-based *ingredient* suggestion is not emitted
+because (a) `RelatedIngredient` has no `shared_environment_term` slot to carry the
+link, and (b) MIM ingredient records don't carry `MediaIngredientMech:NNNNNN` ids
+(the schema pattern) — both tracked in NEXT_TASKS.md §2b.
+
+Sibling repo path comes from ``COMMUNITYMECH_SIBLING_REPOS`` (``Name=path``) or
+``--culturemech``; point it at the CultureMech repo root.
+
+Usage:
+    COMMUNITYMECH_SIBLING_REPOS="CultureMech=../CultureMech" \\
+        PYTHONPATH=src uv run python scripts/suggest_related_media.py
+    PYTHONPATH=src uv run python scripts/suggest_related_media.py \\
+        --culturemech ../CultureMech kb/communities/SPRUCE_Peatland_Methane_Cycling_Community.yaml
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from communitymech.cross_repo_environment import (  # noqa: E402
+    culturemech_media_by_environment,
+    sibling_repos_from_env,
+)
+
+REPO_ROOT = Path(__file__).parent.parent
+COMMUNITY_DIR = REPO_ROOT / "kb" / "communities"
+
+# Over-generic environments where a shared tag does not imply a meaningful
+# environment analog (e.g. every lab-grown community shares "laboratory
+# environment", so matching on it just yields noise). Skipped by default;
+# override with --include-generic. See NEXT_TASKS.md §2b (grounding-quality note).
+GENERIC_ENVIRONMENTS = {
+    "ENVO:01001405",  # laboratory environment (applied to ~110 communities)
+}
+
+
+def _linked_culturemech_ids(data: dict) -> set[str]:
+    """CultureMech ids already referenced by the community (related + growth media)."""
+    linked: set[str] = set()
+    for slot in ("related_media", "growth_media"):
+        for entry in data.get(slot) or []:
+            if isinstance(entry, dict) and entry.get("culturemech_id"):
+                linked.add(entry["culturemech_id"])
+    return linked
+
+
+def _community_env(data: dict) -> tuple[str, str] | None:
+    """(ENVO id, label) from environment_term, or None."""
+    et = data.get("environment_term")
+    term = (et or {}).get("term") if isinstance(et, dict) else None
+    if not isinstance(term, dict):
+        return None
+    envo_id = term.get("id")
+    if isinstance(envo_id, str) and envo_id.startswith("ENVO:"):
+        return envo_id, term.get("label") or ""
+    return None
+
+
+def _suggestion_block(hits, envo_id, env_label):
+    """Render a list of related_media dicts for the given media hits."""
+    blocks = []
+    for hit in sorted(hits, key=lambda h: h.culturemech_id):
+        blocks.append(
+            {
+                "preferred_term": hit.name,
+                "culturemech_id": hit.culturemech_id,
+                "relationship_type": "ENVIRONMENT_ANALOG",
+                "shared_environment_term": {"id": envo_id, "label": env_label or hit.env_label},
+                "relevance_notes": (
+                    f"Shares environment '{env_label or hit.env_label}' ({envo_id}) with this "
+                    "community; surfaced by env-based cross-repo match against CultureMech "
+                    "source_environment."
+                ),
+            }
+        )
+    return blocks
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "yaml_paths",
+        nargs="*",
+        type=Path,
+        help="Community YAMLs to process (default: all in kb/communities/)",
+    )
+    parser.add_argument("--culturemech", type=Path, help="Path to CultureMech repo/records")
+    parser.add_argument(
+        "--include-generic",
+        action="store_true",
+        help="Also match over-generic environments like 'laboratory environment'",
+    )
+    args = parser.parse_args()
+
+    sibling_repos = sibling_repos_from_env()
+    if args.culturemech is not None:
+        sibling_repos["CultureMech"] = args.culturemech
+    cm_path = sibling_repos.get("CultureMech")
+    if cm_path is None or not cm_path.exists():
+        print(
+            "No CultureMech sibling path configured (set COMMUNITYMECH_SIBLING_REPOS "
+            "or --culturemech). Nothing to match against.",
+            file=sys.stderr,
+        )
+        return 2
+
+    media_by_env = culturemech_media_by_environment(cm_path)
+
+    paths = args.yaml_paths or sorted(COMMUNITY_DIR.glob("*.yaml"))
+    total_suggestions = 0
+    communities_with_suggestions = 0
+    skipped_generic = 0
+    for path in paths:
+        try:
+            data = yaml.safe_load(path.read_bytes()) or {}
+        except (OSError, yaml.YAMLError):
+            continue
+        env = _community_env(data)
+        if env is None:
+            continue
+        envo_id, env_label = env
+        if envo_id in GENERIC_ENVIRONMENTS and not args.include_generic:
+            skipped_generic += 1
+            continue
+        candidates = media_by_env.get(envo_id, [])
+        already = _linked_culturemech_ids(data)
+        fresh = [h for h in candidates if h.culturemech_id not in already]
+        if not fresh:
+            continue
+        communities_with_suggestions += 1
+        total_suggestions += len(fresh)
+        blocks = _suggestion_block(fresh, envo_id, env_label)
+        print(f"\n# {path.name}  —  environment {envo_id} ({env_label})")
+        print(f"# {len(fresh)} suggested related_media (paste under `related_media:`)")
+        print(yaml.safe_dump(blocks, sort_keys=False, allow_unicode=True).rstrip())
+
+    note = ""
+    if skipped_generic and not args.include_generic:
+        note = (
+            f" Skipped {skipped_generic} community(ies) whose only environment is "
+            "over-generic (e.g. laboratory environment); use --include-generic to include."
+        )
+    print(
+        f"\n# ---\n# {total_suggestions} media suggestion(s) across "
+        f"{communities_with_suggestions} community(ies).{note}",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/communitymech/cross_repo_environment.py
+++ b/src/communitymech/cross_repo_environment.py
@@ -143,6 +143,43 @@ def mim_environments(root: Path, coverage: EnvCoverage) -> None:
                 coverage.labels.setdefault(envo_id, entry["environment_label"])
 
 
+@dataclass(frozen=True)
+class MediaHit:
+    """A CultureMech medium grounded to a given ENVO environment."""
+
+    culturemech_id: str
+    name: str
+    env_id: str
+    env_label: str
+
+
+def culturemech_media_by_environment(root: Path) -> dict[str, list[MediaHit]]:
+    """Map ENVO id -> CultureMech media grounded to it, for the suggester.
+
+    Unlike :func:`culturemech_environments` (which only counts record ids for the
+    coverage table) this keeps each medium's name and the shared-environment
+    label so a suggestion can be rendered without re-reading the record.
+    """
+    by_env: dict[str, list[MediaHit]] = {}
+    for path, data in _iter_prefiltered(root, _CULTUREMECH_FIELD):
+        cid = data.get("id")
+        if not (isinstance(cid, str) and cid.startswith("CultureMech:")):
+            continue
+        name = data.get("name") or path.stem
+        for entry in data.get("source_environment") or []:
+            term = entry.get("term") if isinstance(entry, dict) else None
+            if not isinstance(term, dict):
+                continue
+            envo_id = _envo(term.get("id"))
+            if envo_id is None:
+                continue
+            hit = MediaHit(cid, str(name), envo_id, term.get("label") or "")
+            bucket = by_env.setdefault(envo_id, [])
+            if hit not in bucket:
+                bucket.append(hit)
+    return by_env
+
+
 def build_coverage(
     community_dir: Path,
     sibling_repos: dict[str, Path] | None = None,

--- a/tests/test_cross_repo_environment.py
+++ b/tests/test_cross_repo_environment.py
@@ -12,6 +12,7 @@ import textwrap
 
 from communitymech.cross_repo_environment import (
     build_coverage,
+    culturemech_media_by_environment,
     sibling_repos_from_env,
 )
 
@@ -144,6 +145,23 @@ def test_prefilter_skips_records_without_the_field(tmp_path):
     cov = build_coverage(comm, {"CultureMech": cm, "MediaIngredientMech": mim})
     media_ids = {rid for ids in cov.media_records.values() for rid in ids}
     assert "CultureMech:009999" not in media_ids
+
+
+def test_culturemech_media_by_environment(tmp_path):
+    cm = tmp_path / "CultureMech"
+    _make_media(cm / "data", "CultureMech:000001", "ENVO:00000044", "peatland")
+    _make_media(cm / "data", "CultureMech:000002", "ENVO:00000044", "peatland")
+    _make_media(cm / "data", "CultureMech:000003", "ENVO:00001998", "soil")
+    # a record with no source_environment must be prefiltered out
+    _write(cm / "data" / "bare.yaml", "id: CultureMech:009999\nname: bare\n")
+
+    by_env = culturemech_media_by_environment(cm)
+    assert set(by_env) == {"ENVO:00000044", "ENVO:00001998"}
+    peat = by_env["ENVO:00000044"]
+    assert {h.culturemech_id for h in peat} == {"CultureMech:000001", "CultureMech:000002"}
+    hit = peat[0]
+    assert hit.name and hit.env_label == "peatland"
+    assert "CultureMech:009999" not in {h.culturemech_id for v in by_env.values() for h in v}
 
 
 def test_sibling_repos_from_env(monkeypatch):

--- a/tests/test_suggest_related_media.py
+++ b/tests/test_suggest_related_media.py
@@ -1,0 +1,53 @@
+"""Tests for the environment-based related_media suggester (issue #30, Use Case 1).
+
+Loads the script module directly (it lives under scripts/, not the package) and
+exercises its pure helpers plus the generic-environment guard. No sibling repos,
+no network.
+"""
+
+import importlib.util
+from pathlib import Path
+
+_spec = importlib.util.spec_from_file_location(
+    "suggest_related_media",
+    Path(__file__).parent.parent / "scripts" / "suggest_related_media.py",
+)
+sug = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sug)
+
+
+def test_community_env_extracts_envo():
+    data = {"environment_term": {"term": {"id": "ENVO:00000044", "label": "peatland"}}}
+    assert sug._community_env(data) == ("ENVO:00000044", "peatland")
+
+
+def test_community_env_ignores_non_envo_and_missing():
+    assert sug._community_env({"environment_term": {"term": {"id": "UBERON:1"}}}) is None
+    assert sug._community_env({}) is None
+
+
+def test_linked_culturemech_ids_spans_related_and_growth_media():
+    data = {
+        "related_media": [{"culturemech_id": "CultureMech:000001"}, {"preferred_term": "x"}],
+        "growth_media": [{"culturemech_id": "CultureMech:000002"}],
+    }
+    assert sug._linked_culturemech_ids(data) == {"CultureMech:000001", "CultureMech:000002"}
+
+
+def test_suggestion_block_shape():
+    from communitymech.cross_repo_environment import MediaHit
+
+    hits = [MediaHit("CultureMech:000009", "peat_medium", "ENVO:00000044", "peatland")]
+    blocks = sug._suggestion_block(hits, "ENVO:00000044", "peatland")
+    assert len(blocks) == 1
+    b = blocks[0]
+    assert b["preferred_term"] == "peat_medium"
+    assert b["culturemech_id"] == "CultureMech:000009"
+    assert b["relationship_type"] == "ENVIRONMENT_ANALOG"
+    assert b["shared_environment_term"] == {"id": "ENVO:00000044", "label": "peatland"}
+    assert "peatland" in b["relevance_notes"]
+
+
+def test_laboratory_environment_is_generic():
+    # the over-generic lab environment is excluded by default (noise guard)
+    assert "ENVO:01001405" in sug.GENERIC_ENVIRONMENTS


### PR DESCRIPTION
## Context

Second slice of **issue #30** (after the coverage dashboard, #210). Emits
environment-matched CultureMech media as `related_media` blocks for curator
review — Use Case 1, for **media** (the cleanly-supported half).

## What

- **`cross_repo_environment.culturemech_media_by_environment`** — ENVO id →
  `MediaHit{culturemech_id, name, env_label}`, reusing the byte-prefiltered scan.
- **`scripts/suggest_related_media.py`** + **`just suggest-related-media`** — for
  each community, match `environment_term` against CultureMech `source_environment`
  and print paste-ready `related_media` entries:
  - `relationship_type: ENVIRONMENT_ANALOG` (the enum value for "medium designed
    to mimic the community's natural environment")
  - `shared_environment_term: {id, label}` (the ENVO join key)
  - `culturemech_id` (valid `CultureMech:NNNNNN`)
  - skips media already linked via `related_media` / `growth_media`
  - **suggestion-only — edits nothing** (mirrors `suggest_missing_interactions.py`)
- **Noise guard:** over-generic environments (`ENVO:01001405` "laboratory
  environment", ~110 communities) are excluded by default; `--include-generic`
  overrides, and the skipped count is always reported (no silent drop).
- **Tests:** `test_suggest_related_media.py` (pure helpers + generic guard) and an
  added `culturemech_media_by_environment` case in `test_cross_repo_environment.py`.

## First real run

**351 suggestions across 60 communities** (rhizosphere / sediment / compost /
freshwater); 110 lab-only communities skipped. A suggested block was injected into
a real record and `linkml-validate` returned **"No issues found"**.

## Deferred: ENVO-based *ingredient* suggestion (two blockers)

1. **Schema** — `RelatedIngredient` has no `shared_environment_term` slot (only
   `chebi_term`), so an environment→ingredient link isn't expressible without a
   schema addition.
2. **MIM id scheme** — MIM env-context records use `identifier:
   kgmicrobe.ingredient:…`, not `MediaIngredientMech:NNNNNN`; those ids live only
   in MIM analysis/reconciliation reports.

Both are the "MIM single-source-of-truth direction" the scoping note flagged —
resolve MIM-side (or add the slot + a crosswalk) first. Tracked in `NEXT_TASKS.md`
§2c, along with two grounding-quality follow-ups (ENVO subsumption matching;
`ENVO:01001405` over-application).

## Verification

- `just test` — **212 passed** (+6)
- `just lint` — black + ruff + mypy clean
- End-to-end: suggested block LinkML-validates inside a real community record

🤖 Generated with [Claude Code](https://claude.com/claude-code)