### PR TITLE
RelatedIngredient.shared_environment_term + flag MIM id mismatch (issue #30)

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -159,20 +159,35 @@ to override — and the skipped count is reported (no silent drop). First real r
 pasted into a real record. Reuses `cross_repo_environment.culturemech_media_by_environment`;
 tests in `tests/test_suggest_related_media.py` + `tests/test_cross_repo_environment.py`.
 
-**Item c — ENVO-based INGREDIENT suggester — DEFERRED (two blockers).**
-(1) *Schema:* `RelatedIngredient` has **no `shared_environment_term` slot** (only
-`chebi_term` for the compound), so an environment→ingredient link isn't even
-expressible — it would need a schema addition. (2) *MIM id scheme:* MIM env-context
-records carry `identifier: kgmicrobe.ingredient:…` / `CHEBI:…` / `ENVO:…`, **not**
-`MediaIngredientMech:NNNNNN` (the `mediaingredientmech_id` pattern); the 802
-`MediaIngredientMech:NNNNNN` ids live only in MIM *analysis/reconciliation reports*,
-and CommunityMech's 222 existing `related_ingredients` don't populate
-`mediaingredientmech_id` at all. Both are the "MIM single-source-of-truth
-direction" the scoping note flagged — resolve on the MIM side (or add the schema
-slot + a crosswalk) before building. **Follow-ups regardless:** exact-ENVO matching
-is sparse — consider ENVO subsumption (rhizosphere media for a soil community); and
-`ENVO:01001405` over-application (110 communities) is a grounding-quality item to
-fix separately.
+**Item c — ENVO-based INGREDIENT suggester — was DEFERRED (two blockers); both now
+actioned (2026-07-19, PR #212).**
+
+- **Blocker 1 (schema, ours) — RESOLVED.** Added `shared_environment_term` (Term,
+  id-binding REQUIRED) to `RelatedIngredient`, mirroring `RelatedMedia`, so an
+  environment→ingredient link is now expressible. Datamodel regenerated; verified a
+  `related_ingredient` with `shared_environment_term` + `chebi_term`
+  LinkML-validates; regression test in `tests/test_cross_repo_linking.py`.
+- **Blocker 2 (MIM id scheme) — RAISED with MIM (MediaIngredientMech#119).**
+  Investigation resolved the *facts*: MIM's canonical ingredient CURIE is
+  **`MIM:<name>`** (2200 SSSOM subjects; `MIM:` expands to
+  `.../data/ingredients/mapped/`), mapped to CHEBI/FOODON via SSSOM —
+  **not** `MediaIngredientMech:NNNNNN` (that style exists only in two MIM
+  `analysis/` reports and in zero canonical records / the unified mapping TSV). So
+  CommunityMech's `RelatedIngredient.mediaingredientmech_id` pattern references a
+  scheme MIM never adopted; its docstring now says so and points at #119. MIM#119
+  asks MIM to confirm (a) `MIM:<name>` as the stable cross-repo id, (b)
+  `environmental_context` durability/coverage, and (c) whether citing the
+  ingredient's `CHEBI:` id (already supported by `RelatedIngredient.chebi_term`) is
+  an acceptable equivalent link — the likely fast path.
+
+**Remaining before emitting ingredient suggestions:** decide the id per MIM#119.
+The **CHEBI route works today** — env-matched MIM ingredients that `skos:exactMatch`
+a CHEBI term can be emitted as `RelatedIngredient` (`chebi_term` +
+`shared_environment_term`) with no id decision needed; build once MIM confirms (c).
+**Other follow-ups (grounding-quality, addressed separately):** exact-ENVO
+matching is sparse — consider ENVO subsumption (rhizosphere media for a soil
+community); and `ENVO:01001405` "laboratory environment" is over-applied (110
+communities).
 
 ## 3. Cross-Mech validator pin guard — DONE (4-repo invariant)
 

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-07-18T19:47:03
+# Generation date: 2026-07-19T15:13:06
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech
@@ -1041,6 +1041,7 @@ class RelatedIngredient(YAMLRoot):
     preferred_term: str = None
     mediaingredientmech_id: Optional[str] = None
     chebi_term: Optional[Union[dict, Term]] = None
+    shared_environment_term: Optional[Union[dict, Term]] = None
     relevance: Optional[str] = None
     evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
         empty_list()
@@ -1059,6 +1060,11 @@ class RelatedIngredient(YAMLRoot):
 
         if self.chebi_term is not None and not isinstance(self.chebi_term, Term):
             self.chebi_term = Term(**as_dict(self.chebi_term))
+
+        if self.shared_environment_term is not None and not isinstance(
+            self.shared_environment_term, Term
+        ):
+            self.shared_environment_term = Term(**as_dict(self.shared_environment_term))
 
         if self.relevance is not None and not isinstance(self.relevance, str):
             self.relevance = str(self.relevance)
@@ -4091,6 +4097,15 @@ slots.relatedIngredient__chebi_term = Slot(
     name="relatedIngredient__chebi_term",
     curie=COMMUNITYMECH.curie("chebi_term"),
     model_uri=COMMUNITYMECH.relatedIngredient__chebi_term,
+    domain=None,
+    range=Optional[Union[dict, Term]],
+)
+
+slots.relatedIngredient__shared_environment_term = Slot(
+    uri=COMMUNITYMECH.shared_environment_term,
+    name="relatedIngredient__shared_environment_term",
+    curie=COMMUNITYMECH.curie("shared_environment_term"),
+    model_uri=COMMUNITYMECH.relatedIngredient__shared_environment_term,
     domain=None,
     range=Optional[Union[dict, Term]],
 )

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -1085,12 +1085,27 @@ classes:
         required: true
         range: string
       mediaingredientmech_id:
-        description: MediaIngredientMech identifier
+        description: >-
+          MediaIngredientMech identifier. NOTE: MIM's canonical ingredient CURIE
+          is `MIM:<name>` (SSSOM registry), not `MediaIngredientMech:NNNNNN`;
+          reconciliation is tracked in MediaIngredientMech#119 / NEXT_TASKS §2c.
+          Prefer `chebi_term` for the compound identity until that resolves.
         required: false
         range: string
         pattern: "^MediaIngredientMech:\\d{6}$"
       chebi_term:
         description: CHEBI ontology term for the ingredient compound
+        range: Term
+        required: false
+        bindings:
+          - binds_value_of: id
+            obligation_level: REQUIRED
+      shared_environment_term:
+        description: >-
+          ENVO term for the shared environment linking this ingredient to the
+          community. Enables environment-based joins between CommunityMech
+          environment_term and MediaIngredientMech environmental_context, mirroring
+          RelatedMedia.shared_environment_term.
         range: Term
         required: false
         bindings:

--- a/tests/test_cross_repo_linking.py
+++ b/tests/test_cross_repo_linking.py
@@ -287,6 +287,16 @@ class TestDataclassEdgeCases:
         )
         assert ri.chebi_term.id == "CHEBI:34818"
 
+    def test_related_ingredient_with_shared_environment_term(self):
+        """RelatedIngredient carries an ENVO shared_environment_term (issue #30,
+        constraint A) — the env join key, mirroring RelatedMedia."""
+        ri = RelatedIngredient(
+            preferred_term="Humic acid",
+            chebi_term=Term(id="CHEBI:34818", label="humic acid"),
+            shared_environment_term=Term(id="ENVO:00000044", label="peatland"),
+        )
+        assert ri.shared_environment_term.id == "ENVO:00000044"
+
     def test_community_with_both_growth_and_related(self):
         """MicrobialCommunity can have both growth_media and related_media."""
         mc = MicrobialCommunity(


### PR DESCRIPTION
## Context

Actions the two ingredient-linking blockers recorded in `NEXT_TASKS.md` §2c
(deferred from the #30 media suggester, #211). Taking the blocker "to the MIM
side" surfaced a clean answer for one and a schema fix for the other.

## Blocker 1 (schema, ours) — RESOLVED

`RelatedIngredient` had no slot to carry the environment that justifies an
ingredient link. Added **`shared_environment_term`** (Term, id-binding REQUIRED),
mirroring `RelatedMedia.shared_environment_term`, so environment→ingredient links
are now expressible.

- Datamodel regenerated (`just gen-python`).
- Verified a `related_ingredient` with `shared_environment_term` + `chebi_term`
  returns **"No issues found"** from `linkml-validate`.
- Regression test in `tests/test_cross_repo_linking.py`.

## Blocker 2 (MIM id scheme) — RAISED with MIM

Investigation of the MIM repo resolved the facts: MIM's **canonical** ingredient
CURIE is **`MIM:<name>`** — 2200 subjects in `mappings/ingredient_mappings.sssom.tsv`,
the `MIM:` prefix expanding to `.../data/ingredients/mapped/`, mapped to
CHEBI/FOODON via SSSOM (per `MAPPING_SEMANTICS.md`). The `MediaIngredientMech:NNNNNN`
style exists only in two MIM `analysis/` reports and in **zero** canonical records
or the unified mapping TSV.

So CommunityMech's `RelatedIngredient.mediaingredientmech_id` (pattern
`^MediaIngredientMech:\d{6}$`) references a scheme MIM never adopted. This PR
**documents that in the slot description** and points at the coordination issue —
it does **not** change the pattern yet (that awaits MIM's answer, the disciplined
sequencing the backlog asked for).

Filed **MediaIngredientMech#119** asking MIM to confirm: (a) `MIM:<name>` as the
stable cross-repo id, (b) `environmental_context` durability/coverage, (c) whether
citing the ingredient's `CHEBI:` id (already supported by
`RelatedIngredient.chebi_term`) is an acceptable equivalent link — the likely fast
path that needs no id decision.

## Not in this PR

Emitting ingredient suggestions — gated on MIM#119's id answer. The CHEBI route is
ready to build the moment MIM confirms (c). Grounding-quality follow-ups
(ENVO:01001405 over-application; ENVO-subsumption matching) are handled separately.

## Verification

- `just test` — **213 passed** (+1)
- `just lint` — black + ruff + mypy clean
- End-to-end LinkML validation of the new slot in a real record

🤖 Generated with [Claude Code](https://claude.com/claude-code)