### PR TITLE
Widen media suggester with ENVO is_a subsumption matching (issue #30 follow-up)

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -184,10 +184,20 @@ actioned (2026-07-19, PR #212).**
 The **CHEBI route works today** — env-matched MIM ingredients that `skos:exactMatch`
 a CHEBI term can be emitted as `RelatedIngredient` (`chebi_term` +
 `shared_environment_term`) with no id decision needed; build once MIM confirms (c).
-**Other follow-ups (grounding-quality, addressed separately):** exact-ENVO
-matching is sparse — consider ENVO subsumption (rhizosphere media for a soil
-community); and `ENVO:01001405` "laboratory environment" is over-applied (110
-communities).
+**Other follow-ups (grounding-quality):**
+- **ENVO subsumption matching — DONE (2026-07-19, PR #213).** `suggest-related-media
+  --subsumption` also matches media whose environment is an ENVO `is_a` *subtype*
+  of the community's (e.g. "marine sediment" medium for a "sediment" community),
+  via a locally-cached ENVO adapter (skips gracefully in CI). Ancestors are
+  intentionally excluded (they'd match super-generic parents), and generic media
+  envs (`ENVO:01001405`) are filtered from subtype expansion too. Current
+  real-data yield is ~0 extra non-generic matches (CultureMech `source_environment`
+  is too sparse to have `is_a`-subtype overlap yet) — the capability is correct and
+  future-proofs as coverage grows. NB: some intuitive relations aren't `is_a` in
+  ENVO (rhizosphere is *not* a subtype of soil), so those still won't match — an
+  ontology limitation, not a bug.
+- **`ENVO:01001405` "laboratory environment" over-applied (110 communities)** —
+  grounding-quality item, addressed next (over-applied-term report).
 
 ## 3. Cross-Mech validator pin guard — DONE (4-repo invariant)
 

--- a/scripts/suggest_related_media.py
+++ b/scripts/suggest_related_media.py
@@ -19,10 +19,14 @@ link, and (b) MIM ingredient records don't carry `MediaIngredientMech:NNNNNN` id
 Sibling repo path comes from ``COMMUNITYMECH_SIBLING_REPOS`` (``Name=path``) or
 ``--culturemech``; point it at the CultureMech repo root.
 
+Matching is exact-ENVO by default. `--subsumption` also matches media whose
+environment is an ENVO *subtype* of the community's (e.g. a "marine sediment"
+medium for a "sediment" community), when the ENVO sqlite is cached locally.
+
 Usage:
     COMMUNITYMECH_SIBLING_REPOS="CultureMech=../CultureMech" \\
         PYTHONPATH=src uv run python scripts/suggest_related_media.py
-    PYTHONPATH=src uv run python scripts/suggest_related_media.py \\
+    PYTHONPATH=src uv run python scripts/suggest_related_media.py --subsumption \\
         --culturemech ../CultureMech kb/communities/SPRUCE_Peatland_Methane_Cycling_Community.yaml
 """
 
@@ -36,6 +40,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from communitymech.cross_repo_environment import (  # noqa: E402
     culturemech_media_by_environment,
+    envo_subtypes,
+    get_envo_adapter,
     sibling_repos_from_env,
 )
 
@@ -73,24 +79,59 @@ def _community_env(data: dict) -> tuple[str, str] | None:
     return None
 
 
-def _suggestion_block(hits, envo_id, env_label):
-    """Render a list of related_media dicts for the given media hits."""
+def _suggestion_block(matches, envo_id, env_label):
+    """Render related_media dicts for (MediaHit, relation) matches.
+
+    ``relation`` is "exact" or "subtype" (the medium's environment is a subtype of
+    the community's). For subtype matches the shared_environment_term is the
+    community's own (broader) ENVO term — the valid join key — and the medium's
+    more-specific environment is recorded in the notes.
+    """
     blocks = []
-    for hit in sorted(hits, key=lambda h: h.culturemech_id):
+    for hit, relation in sorted(matches, key=lambda m: m[0].culturemech_id):
+        if relation == "exact":
+            note = (
+                f"Shares environment '{env_label or hit.env_label}' ({envo_id}) with this "
+                "community; surfaced by env-based cross-repo match against CultureMech "
+                "source_environment."
+            )
+        else:
+            note = (
+                f"CultureMech source_environment '{hit.env_label}' ({hit.env_id}) is a subtype "
+                f"of this community's environment '{env_label}' ({envo_id}); surfaced by "
+                "ENVO-subsumption cross-repo match."
+            )
         blocks.append(
             {
                 "preferred_term": hit.name,
                 "culturemech_id": hit.culturemech_id,
                 "relationship_type": "ENVIRONMENT_ANALOG",
                 "shared_environment_term": {"id": envo_id, "label": env_label or hit.env_label},
-                "relevance_notes": (
-                    f"Shares environment '{env_label or hit.env_label}' ({envo_id}) with this "
-                    "community; surfaced by env-based cross-repo match against CultureMech "
-                    "source_environment."
-                ),
+                "relevance_notes": note,
             }
         )
     return blocks
+
+
+def _matches_for(envo_id, media_by_env, envo_adapter, exclude_subtype_envs=frozenset()):
+    """Return [(MediaHit, relation)] for a community ENVO term.
+
+    Always includes exact matches; when ``envo_adapter`` is provided, also includes
+    media whose environment is an ENVO subtype of ``envo_id`` — except subtypes in
+    ``exclude_subtype_envs`` (e.g. the over-generic "laboratory environment", which
+    subsumption would otherwise pull in as a media env). Each medium appears once,
+    preferring an exact match over a subtype match.
+    """
+    seen: dict[str, tuple] = {}
+    for hit in media_by_env.get(envo_id, []):
+        seen[hit.culturemech_id] = (hit, "exact")
+    if envo_adapter is not None:
+        for sub in envo_subtypes(envo_id, envo_adapter):
+            if sub in exclude_subtype_envs:
+                continue
+            for hit in media_by_env.get(sub, []):
+                seen.setdefault(hit.culturemech_id, (hit, "subtype"))
+    return list(seen.values())
 
 
 def main() -> int:
@@ -106,6 +147,12 @@ def main() -> int:
         "--include-generic",
         action="store_true",
         help="Also match over-generic environments like 'laboratory environment'",
+    )
+    parser.add_argument(
+        "--subsumption",
+        action="store_true",
+        help="Also match media whose environment is an ENVO subtype of the community's "
+        "(needs the ENVO sqlite cached locally)",
     )
     args = parser.parse_args()
 
@@ -123,6 +170,16 @@ def main() -> int:
 
     media_by_env = culturemech_media_by_environment(cm_path)
 
+    envo_adapter = None
+    if args.subsumption:
+        envo_adapter = get_envo_adapter()
+        if envo_adapter is None:
+            print(
+                "--subsumption requested but ENVO sqlite not cached locally; "
+                "falling back to exact matches only.",
+                file=sys.stderr,
+            )
+
     paths = args.yaml_paths or sorted(COMMUNITY_DIR.glob("*.yaml"))
     total_suggestions = 0
     communities_with_suggestions = 0
@@ -139,16 +196,19 @@ def main() -> int:
         if envo_id in GENERIC_ENVIRONMENTS and not args.include_generic:
             skipped_generic += 1
             continue
-        candidates = media_by_env.get(envo_id, [])
+        exclude_subtypes = frozenset() if args.include_generic else GENERIC_ENVIRONMENTS
+        matches = _matches_for(envo_id, media_by_env, envo_adapter, exclude_subtypes)
         already = _linked_culturemech_ids(data)
-        fresh = [h for h in candidates if h.culturemech_id not in already]
+        fresh = [(h, rel) for h, rel in matches if h.culturemech_id not in already]
         if not fresh:
             continue
         communities_with_suggestions += 1
         total_suggestions += len(fresh)
+        n_sub = sum(1 for _, rel in fresh if rel == "subtype")
         blocks = _suggestion_block(fresh, envo_id, env_label)
+        sub_note = f" ({n_sub} via ENVO subtype)" if n_sub else ""
         print(f"\n# {path.name}  —  environment {envo_id} ({env_label})")
-        print(f"# {len(fresh)} suggested related_media (paste under `related_media:`)")
+        print(f"# {len(fresh)} suggested related_media{sub_note} (paste under `related_media:`)")
         print(yaml.safe_dump(blocks, sort_keys=False, allow_unicode=True).rstrip())
 
     note = ""

--- a/src/communitymech/cross_repo_environment.py
+++ b/src/communitymech/cross_repo_environment.py
@@ -25,6 +25,7 @@ import os
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -200,6 +201,36 @@ def build_coverage(
     if mim is not None:
         mim_environments(mim, coverage)
     return coverage
+
+
+def envo_subtypes(envo_id: str, adapter: Any) -> set[str]:
+    """ENVO ids that are ``is_a`` (rdfs:subClassOf) descendants of ``envo_id``.
+
+    Used to widen environment matching: a medium grounded to a *subtype* of the
+    community's environment (e.g. medium "marine sediment" for a "sediment"
+    community) is a specific analog. Ancestors are intentionally NOT returned —
+    broadening to super-generic parents ("environmental system", …) would
+    over-match. ``adapter`` is an OAK adapter for ENVO.
+    """
+    try:
+        descendants = adapter.descendants(envo_id, predicates=["rdfs:subClassOf"])
+    except Exception:
+        return set()
+    return {d for d in descendants if d != envo_id}
+
+
+def get_envo_adapter() -> Any | None:
+    """Return an OAK adapter for the locally-cached ENVO sqlite, or None.
+
+    Skips (returns None) when the ENVO build isn't cached, so callers can widen
+    matching when the ontology is present without forcing a download in CI.
+    """
+    envo_db = Path.home() / ".data" / "oaklib" / "envo.db"
+    if not envo_db.exists():
+        return None
+    from oaklib import get_adapter  # type: ignore[import-untyped]
+
+    return get_adapter(f"sqlite:{envo_db}")
 
 
 def sibling_repos_from_env() -> dict[str, Path]:

--- a/tests/test_cross_repo_environment.py
+++ b/tests/test_cross_repo_environment.py
@@ -13,8 +13,20 @@ import textwrap
 from communitymech.cross_repo_environment import (
     build_coverage,
     culturemech_media_by_environment,
+    envo_subtypes,
     sibling_repos_from_env,
 )
+
+
+class _FakeEnvoAdapter:
+    """Minimal ENVO adapter: ``_SUB[id]`` are the is_a descendants of ``id``."""
+
+    _SUB = {
+        "ENVO:00002007": {"ENVO:03000033", "ENVO:00002007"},  # sediment -> marine sediment
+    }
+
+    def descendants(self, envo_id, predicates=None):
+        return self._SUB.get(envo_id, {envo_id})
 
 
 def _write(path, text):
@@ -162,6 +174,20 @@ def test_culturemech_media_by_environment(tmp_path):
     hit = peat[0]
     assert hit.name and hit.env_label == "peatland"
     assert "CultureMech:009999" not in {h.culturemech_id for v in by_env.values() for h in v}
+
+
+def test_envo_subtypes_excludes_self_and_handles_errors():
+    adapter = _FakeEnvoAdapter()
+    # sediment -> {marine sediment} (self stripped)
+    assert envo_subtypes("ENVO:00002007", adapter) == {"ENVO:03000033"}
+    # unknown term -> only self in fake -> stripped -> empty
+    assert envo_subtypes("ENVO:99999999", adapter) == set()
+
+    class _Broken:
+        def descendants(self, *a, **k):
+            raise RuntimeError("no hierarchy")
+
+    assert envo_subtypes("ENVO:00002007", _Broken()) == set()
 
 
 def test_sibling_repos_from_env(monkeypatch):

--- a/tests/test_suggest_related_media.py
+++ b/tests/test_suggest_related_media.py
@@ -37,8 +37,8 @@ def test_linked_culturemech_ids_spans_related_and_growth_media():
 def test_suggestion_block_shape():
     from communitymech.cross_repo_environment import MediaHit
 
-    hits = [MediaHit("CultureMech:000009", "peat_medium", "ENVO:00000044", "peatland")]
-    blocks = sug._suggestion_block(hits, "ENVO:00000044", "peatland")
+    hit = MediaHit("CultureMech:000009", "peat_medium", "ENVO:00000044", "peatland")
+    blocks = sug._suggestion_block([(hit, "exact")], "ENVO:00000044", "peatland")
     assert len(blocks) == 1
     b = blocks[0]
     assert b["preferred_term"] == "peat_medium"
@@ -48,6 +48,73 @@ def test_suggestion_block_shape():
     assert "peatland" in b["relevance_notes"]
 
 
+def test_suggestion_block_subtype_note_mentions_subtype():
+    from communitymech.cross_repo_environment import MediaHit
+
+    hit = MediaHit("CultureMech:000002", "marine_sed_medium", "ENVO:03000033", "marine sediment")
+    blocks = sug._suggestion_block([(hit, "subtype")], "ENVO:00002007", "sediment")
+    note = blocks[0]["relevance_notes"]
+    assert "subtype" in note and "marine sediment" in note
+    # join key is the community's (broader) term
+    assert blocks[0]["shared_environment_term"] == {"id": "ENVO:00002007", "label": "sediment"}
+
+
 def test_laboratory_environment_is_generic():
     # the over-generic lab environment is excluded by default (noise guard)
     assert "ENVO:01001405" in sug.GENERIC_ENVIRONMENTS
+
+
+class _FakeEnvoAdapter:
+    """sediment (ENVO:00002007) has one subtype: marine sediment (ENVO:03000033)."""
+
+    def descendants(self, envo_id, predicates=None):
+        return {"ENVO:00002007", "ENVO:03000033"} if envo_id == "ENVO:00002007" else {envo_id}
+
+
+def _hit(cid, env_id, env_label):
+    from communitymech.cross_repo_environment import MediaHit
+
+    return MediaHit(cid, f"{cid}_medium", env_id, env_label)
+
+
+def test_matches_for_exact_only_without_adapter():
+    media = {"ENVO:00002007": [_hit("CultureMech:000001", "ENVO:00002007", "sediment")]}
+    matches = sug._matches_for("ENVO:00002007", media, envo_adapter=None)
+    assert matches == [(media["ENVO:00002007"][0], "exact")]
+
+
+def test_matches_for_includes_subtype_media_with_adapter():
+    media = {
+        "ENVO:00002007": [_hit("CultureMech:000001", "ENVO:00002007", "sediment")],
+        "ENVO:03000033": [_hit("CultureMech:000002", "ENVO:03000033", "marine sediment")],
+    }
+    matches = sug._matches_for("ENVO:00002007", media, _FakeEnvoAdapter())
+    by_id = {h.culturemech_id: rel for h, rel in matches}
+    assert by_id == {"CultureMech:000001": "exact", "CultureMech:000002": "subtype"}
+
+
+def test_matches_for_excludes_generic_subtype_env():
+    # a generic subtype env (e.g. laboratory environment) must not leak in via subsumption
+    class _AdapterWithGenericSub:
+        def descendants(self, envo_id, predicates=None):
+            return {envo_id, "ENVO:01001405"}
+
+    media = {
+        "ENVO:01000313": [_hit("CultureMech:000001", "ENVO:01000313", "anthropogenic")],
+        "ENVO:01001405": [_hit("CultureMech:000009", "ENVO:01001405", "laboratory environment")],
+    }
+    matches = sug._matches_for(
+        "ENVO:01000313",
+        media,
+        _AdapterWithGenericSub(),
+        exclude_subtype_envs=sug.GENERIC_ENVIRONMENTS,
+    )
+    assert {h.culturemech_id for h, _ in matches} == {"CultureMech:000001"}
+
+
+def test_matches_for_prefers_exact_over_subtype_on_dupe():
+    hit = _hit("CultureMech:000001", "ENVO:00002007", "sediment")
+    # same medium reachable both exactly and as a subtype -> exact wins
+    media = {"ENVO:00002007": [hit], "ENVO:03000033": [hit]}
+    matches = sug._matches_for("ENVO:00002007", media, _FakeEnvoAdapter())
+    assert matches == [(hit, "exact")]


### PR DESCRIPTION
## Context

Grounding-quality follow-up to the #30 media suggester (#211): widen matching
beyond exact ENVO equality, as flagged in `NEXT_TASKS.md` §2c.

## What

`suggest-related-media --subsumption` also matches media whose environment is an
ENVO **`is_a` subtype** of the community's — e.g. a *marine sediment* medium for a
*sediment* community. Uses a locally-cached ENVO OAK adapter; **skips gracefully**
when absent, so CI never pulls the ENVO build.

- `cross_repo_environment.py`: `envo_subtypes()` (`is_a` descendants, self
  excluded) + `get_envo_adapter()` (cached-only).
- `suggest_related_media.py`: `_matches_for()` unifies exact + subtype matches,
  dedups preferring exact, and labels each. Subtype `relevance_notes` record the
  medium's more-specific environment while `shared_environment_term` stays the
  community's (broader) ENVO term — the valid join key.

## Design choices

- **Descendants only, not ancestors.** Broadening to ancestors would match
  super-generic parents ("environmental system", …). Subtypes are unambiguously
  relevant.
- **Generic media envs still filtered.** Subsumption initially pulled
  "laboratory environment" media into an "anthropogenic environment" community (lab
  `is_a` anthropogenic); the `ENVO:01001405` guard now applies to subtype expansion
  too.

## Honest yield

**~0 extra non-generic matches on current data** — CultureMech `source_environment`
is too sparse to have `is_a`-subtype overlap yet. This is a correct, future-proofing
capability, not an immediate bulk gain. (Also: rhizosphere is **not** an `is_a`
subtype of soil in ENVO, so that intuitive pair still won't match — an ontology
limitation, not a bug.)

## Verification

- `just test` — **219 passed** (+6, offline fake-adapter tests for
  exact/subtype/dedup/generic-exclusion)
- `just lint` — black + ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)