### PR TITLE
Environment-grounding quality report: flag generic/over-applied groundings (issue #30)

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -196,8 +196,19 @@ a CHEBI term can be emitted as `RelatedIngredient` (`chebi_term` +
   future-proofs as coverage grows. NB: some intuitive relations aren't `is_a` in
   ENVO (rhizosphere is *not* a subtype of soil), so those still won't match — an
   ontology limitation, not a bug.
-- **`ENVO:01001405` "laboratory environment" over-applied (110 communities)** —
-  grounding-quality item, addressed next (over-applied-term report).
+- **`ENVO:01001405` over-application report — DONE (2026-07-19, PR #214).**
+  `scripts/env_grounding_quality.py` + `just env-grounding-quality`: ranks
+  community `environment_term` usage and flags **generic** (curated set incl.
+  ENVO:01001405 "laboratory environment") and **over-applied** (>= `--threshold`,
+  default 15) groundings for curator review; `--list` names the affected records,
+  `--strict` exits 1 on any generic grounding. Report-only (edits nothing). Current
+  state: **110 communities** on "laboratory environment" (GENERIC + over-applied)
+  and 42 on "rhizosphere" (over-applied but legitimate). The generic set is shared
+  with the suggester (`cross_repo_environment.GENERIC_ENVIRONMENT_TERMS`). (ENVO
+  `is_a` depth was tried as a genericness signal and rejected — "laboratory
+  environment" is deeper than "soil".) **Still a curation task:** re-ground the 110
+  lab-env records that model a knowable habitat (rumen, gut, groundwater, ISS/space,
+  cheese, …) — needs per-record source review, out of scope for an automated pass.
 
 ## 3. Cross-Mech validator pin guard — DONE (4-repo invariant)
 

--- a/justfile
+++ b/justfile
@@ -106,8 +106,15 @@ env-coverage *args:
 # Suggest environment-matched CultureMech media as related_media blocks for
 # review (issue #30, Use Case 1). Needs a CultureMech path via
 # COMMUNITYMECH_SIBLING_REPOS or --culturemech. Suggestion-only; edits nothing.
+# Add --subsumption to also match ENVO subtype environments.
 suggest-related-media *args:
     PYTHONPATH=src uv run python scripts/suggest_related_media.py {{args}}
+
+# Environment-grounding quality report: rank community environment_term usage and
+# flag generic (e.g. laboratory environment) / over-applied groundings for review
+# (issue #30 follow-up). Report-only; edits nothing. --list shows affected records.
+env-grounding-quality *args:
+    PYTHONPATH=src uv run python scripts/env_grounding_quality.py {{args}}
 
 # Validate ontology terms in a community file
 validate-terms FILE:

--- a/scripts/env_grounding_quality.py
+++ b/scripts/env_grounding_quality.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Environment-grounding quality report for CommunityMech communities (issue #30 follow-up).
+
+Every community grounds a single `environment_term` (an ENVO CURIE). This report
+ranks those terms by how many communities share each, and flags two grounding
+smells for curator review — it never edits records:
+
+* **generic** — the term is a study/lab setting (`GENERIC_ENVIRONMENT_TERMS`, e.g.
+  ENVO:01001405 "laboratory environment") rather than a natural/source habitat. As
+  a *primary* environment it carries little signal; where the community models a
+  knowable habitat (rumen, gut, groundwater, …) it should be re-grounded.
+* **over-applied** — the term grounds an outsized share of communities
+  (>= `--threshold`, default 15), which usually means a catch-all is standing in
+  for more specific habitats.
+
+(ENVO `is_a` depth was evaluated as a genericness signal and rejected: "laboratory
+environment" is *deeper* than "soil", so depth doesn't separate the two. Hence the
+curated set + count heuristic.)
+
+Usage:
+    PYTHONPATH=src uv run python scripts/env_grounding_quality.py
+    PYTHONPATH=src uv run python scripts/env_grounding_quality.py --list --threshold 20
+    PYTHONPATH=src uv run python scripts/env_grounding_quality.py --strict   # exit 1 if any generic groundings
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from communitymech.cross_repo_environment import (  # noqa: E402
+    GENERIC_ENVIRONMENT_TERMS,
+    build_coverage,
+)
+
+REPO_ROOT = Path(__file__).parent.parent
+COMMUNITY_DIR = REPO_ROOT / "kb" / "communities"
+
+
+def flags_for(envo_id: str, count: int, threshold: int) -> list[str]:
+    """Grounding-quality flags for one term: 'GENERIC' and/or 'over-applied'."""
+    flags = []
+    if envo_id in GENERIC_ENVIRONMENT_TERMS:
+        flags.append("GENERIC")
+    if count >= threshold:
+        flags.append("over-applied")
+    return flags
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=15,
+        help="Flag a term as over-applied at or above this many communities (default 15)",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List the community records grounded to each flagged term",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 1 if any community is grounded to a generic environment term",
+    )
+    args = parser.parse_args()
+
+    coverage = build_coverage(COMMUNITY_DIR, sibling_repos={})
+    community_records = coverage.community_records
+
+    rows = sorted(
+        ((envo, coverage.label(envo), len(names)) for envo, names in community_records.items()),
+        key=lambda r: -r[2],
+    )
+    total = sum(r[2] for r in rows)
+
+    print(f"\nEnvironment-grounding quality — {len(rows)} distinct ENVO terms over {total} communities\n")
+    header = f"{'ENVO term':16} {'label':30} {'count':>5}  flags"
+    print(header)
+    print("-" * len(header))
+    generic_hits = 0
+    flagged = []
+    for envo_id, label, count in rows:
+        flags = flags_for(envo_id, count, args.threshold)
+        if "GENERIC" in flags:
+            generic_hits += count
+        if flags:
+            flagged.append((envo_id, label, count))
+        print(f"{envo_id:16} {label[:30]:30} {count:5}  {', '.join(flags)}")
+
+    print(
+        f"\nSummary: {len(flagged)} flagged term(s); "
+        f"{generic_hits} community(ies) grounded to a generic environment.\n"
+    )
+
+    if args.list and flagged:
+        print("Flagged terms — affected community records:")
+        for envo_id, label, _ in flagged:
+            print(f"\n  {envo_id} ({label}):")
+            for name in sorted(community_records[envo_id]):
+                print(f"    - {name}")
+        print()
+
+    if args.strict and generic_hits:
+        print(f"[strict] {generic_hits} community(ies) grounded to a generic environment.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/suggest_related_media.py
+++ b/scripts/suggest_related_media.py
@@ -39,6 +39,7 @@ import yaml
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from communitymech.cross_repo_environment import (  # noqa: E402
+    GENERIC_ENVIRONMENT_TERMS as GENERIC_ENVIRONMENTS,
     culturemech_media_by_environment,
     envo_subtypes,
     get_envo_adapter,
@@ -48,13 +49,9 @@ from communitymech.cross_repo_environment import (  # noqa: E402
 REPO_ROOT = Path(__file__).parent.parent
 COMMUNITY_DIR = REPO_ROOT / "kb" / "communities"
 
-# Over-generic environments where a shared tag does not imply a meaningful
-# environment analog (e.g. every lab-grown community shares "laboratory
-# environment", so matching on it just yields noise). Skipped by default;
-# override with --include-generic. See NEXT_TASKS.md §2b (grounding-quality note).
-GENERIC_ENVIRONMENTS = {
-    "ENVO:01001405",  # laboratory environment (applied to ~110 communities)
-}
+# GENERIC_ENVIRONMENTS (imported above): over-generic environments where a shared
+# tag doesn't imply a meaningful environment analog. Skipped by default; override
+# with --include-generic. Shared with the grounding-quality report.
 
 
 def _linked_culturemech_ids(data: dict) -> set[str]:

--- a/src/communitymech/cross_repo_environment.py
+++ b/src/communitymech/cross_repo_environment.py
@@ -34,6 +34,15 @@ _COMMUNITY_FIELD = b"environment_term"
 _CULTUREMECH_FIELD = b"source_environment"
 _MIM_FIELD = b"environmental_context"
 
+# Over-generic ENVO environments that describe a *study/lab* setting rather than a
+# meaningful natural/source environment. As a community's primary environment they
+# carry little signal (they cannot be re-derived to a specific habitat), and as a
+# cross-repo match key they only add noise. The suggester skips them; the
+# grounding-quality report flags community records grounded to them for review.
+GENERIC_ENVIRONMENT_TERMS = {
+    "ENVO:01001405",  # laboratory environment (applied to ~110 communities)
+}
+
 
 def _iter_prefiltered(root: Path, needle: bytes) -> Iterator[tuple[Path, dict]]:
     """Yield ``(path, parsed_yaml)`` for every ``*.yaml`` under ``root`` whose raw

--- a/tests/test_env_grounding_quality.py
+++ b/tests/test_env_grounding_quality.py
@@ -1,0 +1,44 @@
+"""Tests for the environment-grounding quality report (issue #30 follow-up).
+
+Loads the script module directly and exercises its pure flagging helper plus the
+shared generic-term set. No sibling repos, no network.
+"""
+
+import importlib.util
+from pathlib import Path
+
+from communitymech.cross_repo_environment import GENERIC_ENVIRONMENT_TERMS
+
+_spec = importlib.util.spec_from_file_location(
+    "env_grounding_quality",
+    Path(__file__).parent.parent / "scripts" / "env_grounding_quality.py",
+)
+egq = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(egq)
+
+
+def test_generic_term_flagged_regardless_of_count():
+    # ENVO:01001405 is generic; flagged even below the over-applied threshold
+    assert egq.flags_for("ENVO:01001405", count=1, threshold=15) == ["GENERIC"]
+
+
+def test_generic_and_over_applied_both_flagged():
+    assert egq.flags_for("ENVO:01001405", count=110, threshold=15) == ["GENERIC", "over-applied"]
+
+
+def test_specific_term_over_applied_only_at_threshold():
+    # a legit specific env (rhizosphere) is only flagged when over-applied
+    assert egq.flags_for("ENVO:00005801", count=42, threshold=15) == ["over-applied"]
+    assert egq.flags_for("ENVO:00005801", count=14, threshold=15) == []
+
+
+def test_shared_generic_set_matches_suggester():
+    # both tools must key off the same generic-environment set
+    _sug_spec = importlib.util.spec_from_file_location(
+        "suggest_related_media",
+        Path(__file__).parent.parent / "scripts" / "suggest_related_media.py",
+    )
+    sug = importlib.util.module_from_spec(_sug_spec)
+    _sug_spec.loader.exec_module(sug)
+    assert sug.GENERIC_ENVIRONMENTS is GENERIC_ENVIRONMENT_TERMS
+    assert "ENVO:01001405" in GENERIC_ENVIRONMENT_TERMS


### PR DESCRIPTION
## Context

Second grounding-quality follow-up to #30: make the **`ENVO:01001405` "laboratory
environment" over-application** (110 communities, surfaced by the coverage
dashboard) **visible and actionable** — without risky automated re-grounding.

## What

- **`scripts/env_grounding_quality.py`** + **`just env-grounding-quality`** — ranks
  community `environment_term` usage and flags two smells for review:
  - **GENERIC** — a study/lab term (curated `GENERIC_ENVIRONMENT_TERMS`, incl.
    ENVO:01001405) used as a *primary* environment.
  - **over-applied** — grounds >= `--threshold` communities (default 15).
  - `--list` names the affected records; `--strict` exits 1 on any generic
    grounding (for future gating). **Report-only — edits nothing.**
- Promotes the generic set to `cross_repo_environment.GENERIC_ENVIRONMENT_TERMS`
  (single source of truth); the suggester now imports it (was a local copy).
- Reuses `build_coverage` (community-only; no siblings needed).

## Current output

| ENVO term | label | count | flags |
|---|---|---|---|
| ENVO:01001405 | laboratory environment | **110** | GENERIC, over-applied |
| ENVO:00005801 | rhizosphere | 42 | over-applied *(legit specific — many SynComs)* |

## Design note

ENVO `is_a` **depth was evaluated as a genericness signal and rejected** —
"laboratory environment" (depth 7) is *deeper* than "soil" (depth 6), so depth
doesn't separate generic from specific. Hence the curated set + count heuristic.

## Still a curation task (out of scope here)

Re-grounding the 110 lab-env records that model a knowable habitat (rumen, gut,
groundwater, ISS/space, cheese, …) needs per-record source review — this report
scopes and prioritizes it rather than guessing.

## Verification

- `just test` — **223 passed** (+4)
- `just lint` — black + ruff + mypy clean
- Report run against the real KB (numbers above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)