### PR TITLE
DRAFT: CHEBI-route related_ingredients suggester (issue #30, pending MIM#119)

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -180,10 +180,20 @@ actioned (2026-07-19, PR #212).**
   ingredient's `CHEBI:` id (already supported by `RelatedIngredient.chebi_term`) is
   an acceptable equivalent link — the likely fast path.
 
-**Remaining before emitting ingredient suggestions:** decide the id per MIM#119.
-The **CHEBI route works today** — env-matched MIM ingredients that `skos:exactMatch`
-a CHEBI term can be emitted as `RelatedIngredient` (`chebi_term` +
-`shared_environment_term`) with no id decision needed; build once MIM confirms (c).
+**Ingredient suggester — DRAFTED, awaiting MIM#119 (PR #215, draft).**
+`scripts/suggest_related_ingredients.py` + `just suggest-related-ingredients`: the
+CHEBI-route analog of the media suggester. For each community it matches
+`environment_term` against MIM `environmental_context` and emits `RelatedIngredient`
+blocks (`chebi_term` + `shared_environment_term`, no `mediaingredientmech_id`) for
+MIM records whose `identifier` is a CHEBI CURIE. `chebi_term.label` is resolved to
+the **canonical** ChEBI label (not MIM's free-text name) so the id↔label gate stays
+green; records without a resolvable label are skipped and reported. Supports
+`--subsumption`. Verified an emitted block LinkML-validates in a real record (Sulfur
+CHEBI:26833 for a hot-spring mat community). **Held as a draft PR — do not merge
+until MIM confirms the CHEBI route (#119 ask c).** Current real yield is tiny (~3
+CHEBI-identified MIM env-context ingredients today); it scales as MIM populates
+`environmental_context`. Reuses `cross_repo_environment.mim_ingredients_by_environment`;
+tests in `tests/test_suggest_related_ingredients.py`.
 **Other follow-ups (grounding-quality):**
 - **ENVO subsumption matching — DONE (2026-07-19, PR #213).** `suggest-related-media
   --subsumption` also matches media whose environment is an ENVO `is_a` *subtype*

--- a/justfile
+++ b/justfile
@@ -116,6 +116,12 @@ suggest-related-media *args:
 env-grounding-quality *args:
     PYTHONPATH=src uv run python scripts/env_grounding_quality.py {{args}}
 
+# DRAFT (pending MediaIngredientMech#119): suggest env-matched MIM ingredients as
+# related_ingredients blocks via the CHEBI route. Needs a MIM path via
+# COMMUNITYMECH_SIBLING_REPOS or --mediaingredientmech. Suggestion-only.
+suggest-related-ingredients *args:
+    PYTHONPATH=src uv run python scripts/suggest_related_ingredients.py {{args}}
+
 # Validate ontology terms in a community file
 validate-terms FILE:
     uv run linkml-term-validator validate-data {{FILE}} -s src/communitymech/schema/communitymech.yaml --labels

--- a/scripts/suggest_related_ingredients.py
+++ b/scripts/suggest_related_ingredients.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""DRAFT: suggest environment-matched MIM ingredients for communities (issue #30, Use Case 1).
+
+The ingredient analog of ``suggest_related_media.py``. For each community, match its
+``environment_term`` ENVO id against MediaIngredientMech (MIM) ingredients that
+declare the same ``environmental_context``, and emit ready-to-review
+``related_ingredients`` blocks (``chebi_term`` + ``shared_environment_term``) for a
+curator to paste. Suggestion-only — never edits records.
+
+**Status: DRAFT, pending MediaIngredientMech#119.** It links via the ingredient's
+**CHEBI** term (`RelatedIngredient.chebi_term`) — the "CHEBI route" — which needs
+no `MediaIngredientMech:NNNNNN` id and works today for MIM records whose
+`identifier` is a CHEBI CURIE. It does **not** emit `mediaingredientmech_id`,
+because MIM's canonical id is `MIM:<name>` (not the schema's pattern); that
+reconciliation is the open question in MIM#119. Do not merge for production use
+until MIM confirms the CHEBI route is an acceptable link (#119 ask c).
+
+`chebi_term.label` is set to the **canonical** ChEBI label (from the local ChEBI
+sqlite), not MIM's free-text ingredient name, so the id↔label gate stays green.
+Records whose CHEBI label can't be resolved locally are skipped (reported).
+
+Sibling repo path comes from ``COMMUNITYMECH_SIBLING_REPOS`` (``Name=path``) or
+``--mediaingredientmech``; point it at the MIM repo root. Add ``--subsumption`` to
+also match ENVO subtype environments.
+
+Usage:
+    COMMUNITYMECH_SIBLING_REPOS="MediaIngredientMech=../MediaIngredientMech" \\
+        PYTHONPATH=src uv run python scripts/suggest_related_ingredients.py
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from communitymech.cross_repo_environment import (  # noqa: E402
+    GENERIC_ENVIRONMENT_TERMS as GENERIC_ENVIRONMENTS,
+    envo_subtypes,
+    get_chebi_adapter,
+    get_envo_adapter,
+    mim_ingredients_by_environment,
+    sibling_repos_from_env,
+)
+
+REPO_ROOT = Path(__file__).parent.parent
+COMMUNITY_DIR = REPO_ROOT / "kb" / "communities"
+
+
+def _community_env(data: dict):
+    et = data.get("environment_term")
+    term = (et or {}).get("term") if isinstance(et, dict) else None
+    if not isinstance(term, dict):
+        return None
+    envo_id = term.get("id")
+    if isinstance(envo_id, str) and envo_id.startswith("ENVO:"):
+        return envo_id, term.get("label") or ""
+    return None
+
+
+def _linked_chebi_ids(data: dict) -> set[str]:
+    """CHEBI ids already referenced by the community's related_ingredients."""
+    linked: set[str] = set()
+    for entry in data.get("related_ingredients") or []:
+        if isinstance(entry, dict):
+            ct = entry.get("chebi_term")
+            if isinstance(ct, dict) and ct.get("id"):
+                linked.add(ct["id"])
+    return linked
+
+
+def _ingredient_matches(envo_id, ing_by_env, envo_adapter, exclude_subtype_envs=frozenset()):
+    """[(IngredientHit, relation)] for a community ENVO term, exact + optional subtypes."""
+    seen: dict[str, tuple] = {}
+    for hit in ing_by_env.get(envo_id, []):
+        if hit.chebi_id:
+            seen[hit.chebi_id] = (hit, "exact")
+    if envo_adapter is not None:
+        for sub in envo_subtypes(envo_id, envo_adapter):
+            if sub in exclude_subtype_envs:
+                continue
+            for hit in ing_by_env.get(sub, []):
+                if hit.chebi_id:
+                    seen.setdefault(hit.chebi_id, (hit, "subtype"))
+    return list(seen.values())
+
+
+def _blocks(matches, envo_id, env_label, chebi_adapter):
+    """Render related_ingredients dicts; skip any whose canonical CHEBI label is unresolved."""
+    blocks, unresolved = [], []
+    for hit, relation in sorted(matches, key=lambda m: m[0].chebi_id):
+        canonical = chebi_adapter.label(hit.chebi_id) if chebi_adapter is not None else None
+        if not canonical:
+            unresolved.append(hit.chebi_id)
+            continue
+        if relation == "exact":
+            note = (
+                f"MIM ingredient shares environment '{env_label}' ({envo_id}) with this "
+                "community; surfaced by env-based cross-repo match (CHEBI route)."
+            )
+        else:
+            note = (
+                f"MIM ingredient environment '{hit.env_label}' ({hit.env_id}) is a subtype of "
+                f"this community's '{env_label}' ({envo_id}); ENVO-subsumption match (CHEBI route)."
+            )
+        blocks.append(
+            {
+                "preferred_term": hit.name,
+                "chebi_term": {"id": hit.chebi_id, "label": canonical},
+                "shared_environment_term": {"id": envo_id, "label": env_label},
+                "relevance": note,
+            }
+        )
+    return blocks, unresolved
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="DRAFT ingredient suggester (issue #30)")
+    parser.add_argument("yaml_paths", nargs="*", type=Path)
+    parser.add_argument("--mediaingredientmech", type=Path, help="Path to MIM repo/records")
+    parser.add_argument("--include-generic", action="store_true")
+    parser.add_argument("--subsumption", action="store_true")
+    args = parser.parse_args()
+
+    sibling_repos = sibling_repos_from_env()
+    if args.mediaingredientmech is not None:
+        sibling_repos["MediaIngredientMech"] = args.mediaingredientmech
+    mim_path = sibling_repos.get("MediaIngredientMech")
+    if mim_path is None or not mim_path.exists():
+        print(
+            "No MediaIngredientMech sibling path configured (COMMUNITYMECH_SIBLING_REPOS "
+            "or --mediaingredientmech).",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(
+        "# DRAFT — pending MediaIngredientMech#119 (CHEBI-route ingredient linking). "
+        "Review before applying.",
+    )
+    ing_by_env = mim_ingredients_by_environment(mim_path)
+    chebi_adapter = get_chebi_adapter()
+    if chebi_adapter is None:
+        print("# WARNING: ChEBI sqlite not cached; cannot resolve canonical labels — no output.")
+        return 0
+    envo_adapter = get_envo_adapter() if args.subsumption else None
+    exclude_subtypes = frozenset() if args.include_generic else GENERIC_ENVIRONMENTS
+
+    paths = args.yaml_paths or sorted(COMMUNITY_DIR.glob("*.yaml"))
+    total, n_comm, all_unresolved = 0, 0, []
+    for path in paths:
+        try:
+            data = yaml.safe_load(path.read_bytes()) or {}
+        except (OSError, yaml.YAMLError):
+            continue
+        env = _community_env(data)
+        if env is None:
+            continue
+        envo_id, env_label = env
+        if envo_id in GENERIC_ENVIRONMENTS and not args.include_generic:
+            continue
+        matches = _ingredient_matches(envo_id, ing_by_env, envo_adapter, exclude_subtypes)
+        already = _linked_chebi_ids(data)
+        fresh = [(h, rel) for h, rel in matches if h.chebi_id not in already]
+        if not fresh:
+            continue
+        blocks, unresolved = _blocks(fresh, envo_id, env_label, chebi_adapter)
+        all_unresolved += unresolved
+        if not blocks:
+            continue
+        n_comm += 1
+        total += len(blocks)
+        print(f"\n# {path.name}  —  environment {envo_id} ({env_label})")
+        print(f"# {len(blocks)} suggested related_ingredients (paste under `related_ingredients:`)")
+        print(yaml.safe_dump(blocks, sort_keys=False, allow_unicode=True).rstrip())
+
+    extra = f" {len(set(all_unresolved))} skipped (unresolved CHEBI label)." if all_unresolved else ""
+    print(f"\n# ---\n# {total} ingredient suggestion(s) across {n_comm} community(ies).{extra}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/communitymech/cross_repo_environment.py
+++ b/src/communitymech/cross_repo_environment.py
@@ -228,18 +228,70 @@ def envo_subtypes(envo_id: str, adapter: Any) -> set[str]:
     return {d for d in descendants if d != envo_id}
 
 
+def _cached_oak_adapter(db_name: str) -> Any | None:
+    """OAK adapter for a locally-cached sqlite under ~/.data/oaklib/, or None."""
+    db = Path.home() / ".data" / "oaklib" / db_name
+    if not db.exists():
+        return None
+    from oaklib import get_adapter  # type: ignore[import-untyped]
+
+    return get_adapter(f"sqlite:{db}")
+
+
 def get_envo_adapter() -> Any | None:
     """Return an OAK adapter for the locally-cached ENVO sqlite, or None.
 
     Skips (returns None) when the ENVO build isn't cached, so callers can widen
     matching when the ontology is present without forcing a download in CI.
     """
-    envo_db = Path.home() / ".data" / "oaklib" / "envo.db"
-    if not envo_db.exists():
-        return None
-    from oaklib import get_adapter  # type: ignore[import-untyped]
+    return _cached_oak_adapter("envo.db")
 
-    return get_adapter(f"sqlite:{envo_db}")
+
+def get_chebi_adapter() -> Any | None:
+    """Return an OAK adapter for the locally-cached ChEBI sqlite, or None."""
+    return _cached_oak_adapter("chebi.db")
+
+
+@dataclass(frozen=True)
+class IngredientHit:
+    """A MediaIngredientMech ingredient grounded to a given ENVO environment.
+
+    ``chebi_id`` is set only when the MIM record's ``identifier`` is a CHEBI CURIE
+    (the "CHEBI route"); other MIM id schemes (kgmicrobe.ingredient:, ENVO:,
+    MICRO:) leave it None. ``source_identifier`` preserves the raw MIM identifier.
+    """
+
+    name: str
+    chebi_id: str | None
+    env_id: str
+    env_label: str
+    source_identifier: str
+
+
+def mim_ingredients_by_environment(root: Path) -> dict[str, list[IngredientHit]]:
+    """Map ENVO id -> MIM ingredients grounded to it (for the ingredient suggester).
+
+    Reads ``environmental_context[].environment_term`` and the record ``identifier``
+    (setting ``chebi_id`` when that identifier is a CHEBI CURIE), byte-prefiltered.
+    """
+    by_env: dict[str, list[IngredientHit]] = {}
+    for path, data in _iter_prefiltered(root, _MIM_FIELD):
+        ident = str(data.get("identifier") or "")
+        name = data.get("preferred_term") or data.get("name") or path.stem
+        chebi_id = ident if ident.startswith("CHEBI:") else None
+        for entry in data.get("environmental_context") or []:
+            if not isinstance(entry, dict):
+                continue
+            envo_id = _envo(entry.get("environment_term"))
+            if envo_id is None:
+                continue
+            hit = IngredientHit(
+                str(name), chebi_id, envo_id, entry.get("environment_label") or "", ident
+            )
+            bucket = by_env.setdefault(envo_id, [])
+            if hit not in bucket:
+                bucket.append(hit)
+    return by_env
 
 
 def sibling_repos_from_env() -> dict[str, Path]:

--- a/tests/test_cross_repo_environment.py
+++ b/tests/test_cross_repo_environment.py
@@ -14,6 +14,7 @@ from communitymech.cross_repo_environment import (
     build_coverage,
     culturemech_media_by_environment,
     envo_subtypes,
+    mim_ingredients_by_environment,
     sibling_repos_from_env,
 )
 
@@ -174,6 +175,37 @@ def test_culturemech_media_by_environment(tmp_path):
     hit = peat[0]
     assert hit.name and hit.env_label == "peatland"
     assert "CultureMech:009999" not in {h.culturemech_id for v in by_env.values() for h in v}
+
+
+def test_mim_ingredients_by_environment_sets_chebi_only_for_chebi_ids(tmp_path):
+    mim = tmp_path / "MIM"
+    _write(
+        mim / "data" / "sulfur.yaml",
+        """
+        identifier: CHEBI:26833
+        preferred_term: Sulfur
+        environmental_context:
+        - environment_term: ENVO:00000051
+          environment_label: hot spring
+        """,
+    )
+    _write(
+        mim / "data" / "seawater.yaml",
+        """
+        identifier: kgmicrobe.ingredient:natural_sea_water
+        preferred_term: Natural sea water
+        environmental_context:
+        - environment_term: ENVO:00002149
+          environment_label: sea water
+        """,
+    )
+    by_env = mim_ingredients_by_environment(mim)
+    assert set(by_env) == {"ENVO:00000051", "ENVO:00002149"}
+    sulfur = by_env["ENVO:00000051"][0]
+    assert sulfur.chebi_id == "CHEBI:26833" and sulfur.name == "Sulfur"
+    seawater = by_env["ENVO:00002149"][0]
+    assert seawater.chebi_id is None  # non-CHEBI identifier -> CHEBI route can't use it
+    assert seawater.source_identifier == "kgmicrobe.ingredient:natural_sea_water"
 
 
 def test_envo_subtypes_excludes_self_and_handles_errors():

--- a/tests/test_suggest_related_ingredients.py
+++ b/tests/test_suggest_related_ingredients.py
@@ -1,0 +1,83 @@
+"""Tests for the DRAFT CHEBI-route ingredient suggester (issue #30, pending MIM#119).
+
+Loads the script module directly and exercises its pure helpers with fake OAK
+adapters. No sibling repos, no network.
+"""
+
+import importlib.util
+from pathlib import Path
+
+from communitymech.cross_repo_environment import IngredientHit
+
+_spec = importlib.util.spec_from_file_location(
+    "suggest_related_ingredients",
+    Path(__file__).parent.parent / "scripts" / "suggest_related_ingredients.py",
+)
+sug = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sug)
+
+
+class _FakeEnvoAdapter:
+    def descendants(self, envo_id, predicates=None):
+        return {"ENVO:00002007", "ENVO:03000033"} if envo_id == "ENVO:00002007" else {envo_id}
+
+
+class _FakeChebiAdapter:
+    _L = {"CHEBI:26833": "sulfur atom", "CHEBI:16136": "hydrogen sulfide"}
+
+    def label(self, cid):
+        return self._L.get(cid)
+
+
+def _ing(chebi_id, env_id, env_label="e", name="n"):
+    return IngredientHit(name, chebi_id, env_id, env_label, chebi_id or "kgmicrobe.ingredient:x")
+
+
+def test_linked_chebi_ids():
+    data = {"related_ingredients": [{"chebi_term": {"id": "CHEBI:1"}}, {"preferred_term": "x"}]}
+    assert sug._linked_chebi_ids(data) == {"CHEBI:1"}
+
+
+def test_community_env():
+    assert sug._community_env(
+        {"environment_term": {"term": {"id": "ENVO:00000051", "label": "hot spring"}}}
+    ) == ("ENVO:00000051", "hot spring")
+    assert sug._community_env({}) is None
+
+
+def test_ingredient_matches_chebi_only_exact():
+    ing = {
+        "ENVO:00000051": [
+            _ing("CHEBI:26833", "ENVO:00000051"),
+            _ing(None, "ENVO:00000051"),  # non-CHEBI ingredient must be dropped
+        ]
+    }
+    matches = sug._ingredient_matches("ENVO:00000051", ing, envo_adapter=None)
+    assert [(h.chebi_id, rel) for h, rel in matches] == [("CHEBI:26833", "exact")]
+
+
+def test_ingredient_matches_subtype_and_generic_exclusion():
+    ing = {
+        "ENVO:00002007": [_ing("CHEBI:1", "ENVO:00002007")],
+        "ENVO:03000033": [_ing("CHEBI:2", "ENVO:03000033")],
+    }
+    matches = sug._ingredient_matches("ENVO:00002007", ing, _FakeEnvoAdapter())
+    assert {h.chebi_id: rel for h, rel in matches} == {"CHEBI:1": "exact", "CHEBI:2": "subtype"}
+
+
+def test_blocks_uses_canonical_label_and_skips_unresolved():
+    matches = [
+        (_ing("CHEBI:26833", "ENVO:00000051", "hot spring", "Sulfur"), "exact"),
+        (
+            _ing("CHEBI:99999", "ENVO:00000051", "hot spring", "Mystery"),
+            "exact",
+        ),  # no canonical label
+    ]
+    blocks, unresolved = sug._blocks(matches, "ENVO:00000051", "hot spring", _FakeChebiAdapter())
+    assert unresolved == ["CHEBI:99999"]
+    assert len(blocks) == 1
+    b = blocks[0]
+    assert b["preferred_term"] == "Sulfur"
+    # canonical ChEBI label, NOT the MIM free-text name -> keeps id-label gate green
+    assert b["chebi_term"] == {"id": "CHEBI:26833", "label": "sulfur atom"}
+    assert b["shared_environment_term"] == {"id": "ENVO:00000051", "label": "hot spring"}


### PR DESCRIPTION
> **⚠️ DRAFT — do not merge until MediaIngredientMech#119 confirms the CHEBI route (ask c).**
> Everything is implemented, tested, and green; this is parked ready to finalize.

## Context

The ingredient analog of the media suggester (#211), built now so it lands the
moment MIM confirms. It links via the ingredient's **CHEBI** term
(`RelatedIngredient.chebi_term`) — the "CHEBI route" — which needs **no**
`MediaIngredientMech:NNNNNN` id (the schema pattern MIM doesn't use; see MIM#119).

## What

- **`cross_repo_environment.py`**: `IngredientHit` + `mim_ingredients_by_environment()`
  (byte-prefiltered; `chebi_id` set only when the MIM `identifier` is a CHEBI CURIE),
  plus `get_chebi_adapter()` and a shared `_cached_oak_adapter()` helper.
- **`scripts/suggest_related_ingredients.py`** + **`just suggest-related-ingredients`**:
  for each community, matches `environment_term` against MIM `environmental_context`
  and emits `related_ingredients` blocks:
  - `chebi_term` with the **canonical ChEBI label** (resolved from the local ChEBI
    sqlite — *not* MIM's free-text name) so the id↔label gate stays green;
  - `shared_environment_term` (the ENVO join key);
  - skips already-linked CHEBI ids, generic environments, and records whose
    canonical label can't be resolved (reported, not silently dropped);
  - `--subsumption` supported; **suggestion-only**, prints a DRAFT banner.
- Tests: `test_suggest_related_ingredients.py` + a `mim_ingredients_by_environment`
  case (fake OAK adapters, offline).

## Verified

An emitted block LinkML-validates in a real record — **Sulfur (CHEBI:26833, label
"sulfur atom") for a hot-spring phototrophic mat community**, keyed on shared
ENVO:00000051.

## Honest yield

~3 CHEBI-identified MIM env-context ingredients today, so immediate output is tiny.
The tool scales as MIM populates `environmental_context` (the field it committed to
in MIM#1). This PR is about having the capability ready, not bulk output.

## Before finalizing

- MIM#119 ask (c): confirm citing the ingredient's `CHEBI:` id is an acceptable
  cross-repo link. If yes → mark ready, merge. If MIM prefers `MIM:<name>` → add a
  `mim_id` field and emit that instead (small change).

## Verification

- `just test` — **229 passed** (+6)
- `just lint` — black + ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)