### PR TITLE
Add modeled_environment slot for lab-env re-grounding (issue #30)

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -206,9 +206,22 @@ a CHEBI term can be emitted as `RelatedIngredient` (`chebi_term` +
   and 42 on "rhizosphere" (over-applied but legitimate). The generic set is shared
   with the suggester (`cross_repo_environment.GENERIC_ENVIRONMENT_TERMS`). (ENVO
   `is_a` depth was tried as a genericness signal and rejected — "laboratory
-  environment" is deeper than "soil".) **Still a curation task:** re-ground the 110
-  lab-env records that model a knowable habitat (rumen, gut, groundwater, ISS/space,
-  cheese, …) — needs per-record source review, out of scope for an automated pass.
+  environment" is deeper than "soil".)
+
+- **Lab-env re-grounding via a new `modeled_environment` slot — IN PROGRESS
+  (2026-07-19).** Rather than overwrite `environment_term` (which honestly records
+  the *study setting*, often "laboratory environment"), a new **`modeled_environment`**
+  slot on `MicrobialCommunity` (multivalued, optional, `EnvironmentDescriptor`,
+  ENVO-grounded) captures the natural/applied habitat an engineered community
+  derives from or represents. **PR #216 (this)**: adds the schema slot + test.
+  **Follow-up PR**: populate it for the ~23 triaged records — 18 clear
+  (groundwater/regolith/dairy/marine/gut/anaerobic-digester) + 5 REVIEW
+  enrichments (rumen→digestive tract, Cu-bioleaching→AMD, two thiocyanate/UFMP
+  bioreactors, switchgrass methanogenic→digester); the other ~67 de-novo cocultures
+  keep only `environment_term: laboratory environment`. Triage detail in the report
+  produced 2026-07-19 (buckets REGROUND 18 / REVIEW 25 / LAB-KEEP 67). Then teach
+  the media/ingredient suggester to also match on `modeled_environment`, which
+  un-skips the lab-env communities that have a real modeled habitat.
 
 ## 3. Cross-Mech validator pin guard — DONE (4-repo invariant)
 

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-07-19T15:13:06
+# Generation date: 2026-07-19T17:42:00
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech
@@ -1343,6 +1343,9 @@ class MicrobialCommunity(YAMLRoot):
     community_category: Optional[Union[str, "CommunityCategoryEnum"]] = None
     engineering_design: Optional[Union[dict, CommunityEngineeringDesign]] = None
     environment_term: Optional[Union[dict, EnvironmentDescriptor]] = None
+    modeled_environment: Optional[
+        Union[Union[dict, EnvironmentDescriptor], list[Union[dict, EnvironmentDescriptor]]]
+    ] = empty_list()
     taxonomy: Optional[
         Union[Union[dict, TaxonomicComposition], list[Union[dict, TaxonomicComposition]]]
     ] = empty_list()
@@ -1420,6 +1423,15 @@ class MicrobialCommunity(YAMLRoot):
             self.environment_term, EnvironmentDescriptor
         ):
             self.environment_term = EnvironmentDescriptor(**as_dict(self.environment_term))
+
+        if not isinstance(self.modeled_environment, list):
+            self.modeled_environment = (
+                [self.modeled_environment] if self.modeled_environment is not None else []
+            )
+        self.modeled_environment = [
+            v if isinstance(v, EnvironmentDescriptor) else EnvironmentDescriptor(**as_dict(v))
+            for v in self.modeled_environment
+        ]
 
         self._normalize_inlined_as_dict(
             slot_name="taxonomy", slot_type=TaxonomicComposition, key_name="taxon_term", keyed=False
@@ -4541,6 +4553,17 @@ slots.microbialCommunity__environment_term = Slot(
     model_uri=COMMUNITYMECH.microbialCommunity__environment_term,
     domain=None,
     range=Optional[Union[dict, EnvironmentDescriptor]],
+)
+
+slots.microbialCommunity__modeled_environment = Slot(
+    uri=COMMUNITYMECH.modeled_environment,
+    name="microbialCommunity__modeled_environment",
+    curie=COMMUNITYMECH.curie("modeled_environment"),
+    model_uri=COMMUNITYMECH.microbialCommunity__modeled_environment,
+    domain=None,
+    range=Optional[
+        Union[Union[dict, EnvironmentDescriptor], list[Union[dict, EnvironmentDescriptor]]]
+    ],
 )
 
 slots.microbialCommunity__taxonomy = Slot(

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -1271,6 +1271,21 @@ classes:
       environment_term:
         description: Environment where community exists
         range: EnvironmentDescriptor
+      modeled_environment:
+        description: >-
+          The natural or applied environment(s) this community derives from,
+          models, or represents — as distinct from `environment_term` (where it
+          physically exists / was studied). For an engineered or synthetic
+          community, `environment_term` is often "laboratory environment" while
+          this captures the real habitat it stands in for (e.g. a groundwater
+          enrichment → groundwater; a synthetic infant-gut consortium → intestine
+          environment; a space-agriculture SynCom → regolith). Leave empty for
+          de-novo assemblies with no specific habitat. ENVO-grounded, so it also
+          serves as an environment-based cross-repo join key (issue #30).
+        range: EnvironmentDescriptor
+        multivalued: true
+        required: false
+        inlined_as_list: true
       taxonomy:
         description: Organisms present in the community
         range: TaxonomicComposition

--- a/tests/test_modeled_environment.py
+++ b/tests/test_modeled_environment.py
@@ -1,0 +1,53 @@
+"""Tests for the `modeled_environment` slot (issue #30 / lab-env re-grounding).
+
+`modeled_environment` records the natural/applied habitat an (often engineered)
+community derives from or represents, distinct from `environment_term` (where it
+was studied). It's multivalued, optional, ENVO-grounded, and reuses
+`EnvironmentDescriptor`.
+"""
+
+from pathlib import Path
+
+import yaml
+
+from communitymech.datamodel.communitymech import (
+    EnvironmentDescriptor,
+    MicrobialCommunity,
+    Term,
+)
+
+SCHEMA = Path(__file__).parent.parent / "src" / "communitymech" / "schema" / "communitymech.yaml"
+
+
+def test_modeled_environment_is_optional_multivalued():
+    # a community with no modeled_environment is valid (backward compatible)
+    mc = MicrobialCommunity(id="CommunityMech:000999", name="Bare")
+    assert mc.modeled_environment == []
+
+
+def test_modeled_environment_accepts_multiple_env_descriptors():
+    mc = MicrobialCommunity(
+        id="CommunityMech:000999",
+        name="Groundwater enrichment",
+        environment_term=EnvironmentDescriptor(
+            preferred_term="laboratory environment",
+            term=Term(id="ENVO:01001405", label="laboratory environment"),
+        ),
+        modeled_environment=[
+            EnvironmentDescriptor(
+                preferred_term="groundwater", term=Term(id="ENVO:01001004", label="groundwater")
+            ),
+        ],
+    )
+    assert len(mc.modeled_environment) == 1
+    assert mc.modeled_environment[0].term.id == "ENVO:01001004"
+    # environment_term stays independent (honest study setting)
+    assert mc.environment_term.term.id == "ENVO:01001405"
+
+
+def test_schema_defines_modeled_environment_on_community():
+    schema = yaml.safe_load(SCHEMA.read_text())
+    slot = schema["classes"]["MicrobialCommunity"]["attributes"]["modeled_environment"]
+    assert slot["range"] == "EnvironmentDescriptor"
+    assert slot["multivalued"] is True
+    assert slot.get("required") is False


### PR DESCRIPTION
## Context

Following the "why are these skipped?" discussion: 110 communities are grounded to
`environment_term: ENVO:01001405 "laboratory environment"`. That's honest about
*where they were studied*, but hides the real habitat many of them derive from or
model. Chosen resolution (per review): **don't overwrite `environment_term` — add a
separate slot.**

## What

- **schema**: `modeled_environment` on `MicrobialCommunity` — multivalued,
  optional, range `EnvironmentDescriptor` (reused), ENVO id-binding required. It
  records the natural/applied environment the community **derives from or
  represents**, distinct from where it physically exists:
  - groundwater enrichment → groundwater
  - synthetic infant-gut consortium → intestine environment
  - space-agriculture SynCom → regolith
  - left **empty** for de-novo assemblies with no specific habitat.
  Being ENVO-grounded, it also serves as an environment-based cross-repo join key.
- datamodel regenerated; `tests/test_modeled_environment.py` (optional/multivalued,
  independence from `environment_term`, schema shape).

## Follow-ups (separate PRs)

1. **Populate** `modeled_environment` for the ~23 triaged records — 18 clear
   (groundwater / regolith / dairy / marine / gut / anaerobic-digester) + 5 REVIEW
   enrichments (rumen→digestive tract, Cu-bioleaching→AMD, thiocyanate/UFMP
   bioreactors, switchgrass-methanogenic→digester). The other ~67 de-novo cocultures
   keep only `laboratory environment`.
2. **Suggester** matches on `modeled_environment` too → un-skips the lab-env
   communities that have a real modeled habitat (closes the original concern).

Triage detail: buckets REGROUND 18 / REVIEW 25 / LAB-KEEP 67 (evidence-backed by
each record's description). Notably, ENVO has **no** clean term for "rumen"
(ENVO:00002051 is "stony-iron meteorite") or "urine" — caught during triage.

## Verification

- `just test` — **226 passed** (+3)
- `just lint` — black + ruff + mypy clean
- A `related`-record with `modeled_environment` LinkML-validates; existing records
  unaffected (optional slot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)