### PR TITLE
Populate modeled_environment for 23 lab-env community records (issue #30)

### DIFF
--- a/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
+++ b/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
@@ -42,6 +42,11 @@ environment_term:
     label: laboratory environment
   notes: Stable laboratory enrichment from TCE/PCE-contaminated groundwater fed
     with C2H2 as sole electron donor and carbon source.
+modeled_environment:
+- preferred_term: groundwater
+  term:
+    id: ENVO:01001004
+    label: groundwater
 taxonomy:
 - taxon_term:
     preferred_term: novel anaerobic acetylenotroph (Actinobacteria)

--- a/kb/communities/Anabaena_MGS1_Anaerobic_Digestion_Methanogen_Consortium.yaml
+++ b/kb/communities/Anabaena_MGS1_Anaerobic_Digestion_Methanogen_Consortium.yaml
@@ -61,6 +61,11 @@ environment_term:
     which cyanobacterial biomass is digested in a 200 g/L MGS-1 Mars regolith-simulant
     matrix; the Mars/simulant context is captured in the description and environmental
     factors rather than as an ENVO term.
+modeled_environment:
+- preferred_term: anaerobic digester sludge
+  term:
+    id: ENVO:00003965
+    label: anaerobic digester sludge
 taxonomy:
 - taxon_term:
     preferred_term: Anabaena sp. (cyanobacterial digestion feedstock)

--- a/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
+++ b/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
@@ -42,6 +42,11 @@ environment_term:
     label: laboratory environment
   notes: Laboratory-scale anammox bioreactor treating reactive nitrogen,
     followed by metagenomics through destabilization and recovery.
+modeled_environment:
+- preferred_term: bioreactor
+  term:
+    id: ENVO:00002123
+    label: bioreactor
 taxonomy:
 - taxon_term:
     preferred_term: anammox bacterium

--- a/kb/communities/BioAsteroid_ISS_Chondrite_Biomining_Consortium.yaml
+++ b/kb/communities/BioAsteroid_ISS_Chondrite_Biomining_Consortium.yaml
@@ -74,6 +74,11 @@ environment_term:
     was crushed Northwest Africa (NWA) 869 L-chondrite meteorite. The generic
     laboratory-environment ENVO term is used because no ontology term captures
     the spaceflight/microgravity biomining hardware context.
+modeled_environment:
+- preferred_term: regolith
+  term:
+    id: ENVO:01000747
+    label: regolith
 taxonomy:
 - taxon_term:
     preferred_term: Sphingomonas desiccabilis CP1D

--- a/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
+++ b/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
@@ -26,6 +26,11 @@ environment_term:
     id: ENVO:01001405
     label: laboratory environment
   notes: Model context is kefir fermentation community analysis.
+modeled_environment:
+- preferred_term: dairy
+  term:
+    id: ENVO:00003862
+    label: dairy
 taxonomy:
 - taxon_term:
     preferred_term: Lactobacillus kefiranofaciens

--- a/kb/communities/BioModels_MODEL2310020001_Mouse_Metaorganism_Model.yaml
+++ b/kb/communities/BioModels_MODEL2310020001_Mouse_Metaorganism_Model.yaml
@@ -27,6 +27,11 @@ environment_term:
     id: ENVO:01001405
     label: laboratory environment
   notes: Computational host-microbiota modeling framework.
+modeled_environment:
+- preferred_term: intestine environment
+  term:
+    id: ENVO:2100002
+    label: intestine environment
 associated_datasets:
 - title: BioModels model file
   dataset_type: OTHER

--- a/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
+++ b/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
@@ -26,6 +26,11 @@ environment_term:
     id: ENVO:01001405
     label: laboratory environment
   notes: Model set represents a synthetic infant gut community under defined in silico conditions.
+modeled_environment:
+- preferred_term: intestine environment
+  term:
+    id: ENVO:2100002
+    label: intestine environment
 taxonomy:
 - taxon_term:
     preferred_term: Bifidobacterium longum subsp. infantis

--- a/kb/communities/BioRock_ISS_Basalt_Biomining_Consortium.yaml
+++ b/kb/communities/BioRock_ISS_Basalt_Biomining_Consortium.yaml
@@ -66,6 +66,11 @@ environment_term:
     miniature biomining reactor in the KUBIK incubator in the Columbus module of the
     International Space Station, under microgravity, simulated Mars gravity, and
     simulated Earth gravity, with ground 1 x g controls.
+modeled_environment:
+- preferred_term: regolith
+  term:
+    id: ENVO:01000747
+    label: regolith
 taxonomy:
 - taxon_term:
     preferred_term: Sphingomonas desiccabilis CP1D

--- a/kb/communities/Butyrivibrio_Selenomonas_Ruminococcus_Lignocellulolytic_Rumen_Consortium.yaml
+++ b/kb/communities/Butyrivibrio_Selenomonas_Ruminococcus_Lignocellulolytic_Rumen_Consortium.yaml
@@ -20,6 +20,11 @@ environment_term:
     label: laboratory environment
   notes: Members are bovine-rumen-associated bacteria, but this record curates the constructed in vitro
     coculture / in silico community-model study. ENVO has no dedicated rumen environment term.
+modeled_environment:
+- preferred_term: digestive tract environment
+  term:
+    id: ENVO:01001033
+    label: digestive tract environment
 taxonomy:
 - taxon_term:
     preferred_term: Butyrivibrio fibrisolvens

--- a/kb/communities/Cheese_Rind_InSitu_InVitro_Model_Community.yaml
+++ b/kb/communities/Cheese_Rind_InSitu_InVitro_Model_Community.yaml
@@ -35,6 +35,11 @@ environment_term:
     label: laboratory environment
   notes: The source communities are naturally aged cheese rind biofilms; this curated record emphasizes
     the controlled in vitro reconstruction on cheese curd agar.
+modeled_environment:
+- preferred_term: dairy
+  term:
+    id: ENVO:00003862
+    label: dairy
 taxonomy:
 - taxon_term:
     preferred_term: Staphylococcus

--- a/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
+++ b/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
@@ -52,6 +52,11 @@ environment_term:
   notes: Acidophilic enrichments on chalcopyrite or chalcocite ores under
     bioleaching conditions, characterized by genome-resolved metagenomics at 4
     and 8 weeks.
+modeled_environment:
+- preferred_term: acid mine drainage
+  term:
+    id: ENVO:00001997
+    label: acid mine drainage
 taxonomy:
 - taxon_term:
     preferred_term: Acidithiobacillus species

--- a/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
+++ b/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
@@ -51,6 +51,11 @@ environment_term:
     period was 282 days.
 
     '
+modeled_environment:
+- preferred_term: bioreactor
+  term:
+    id: ENVO:00002123
+    label: bioreactor
 taxonomy:
 - taxon_term:
     preferred_term: Olsenella_B sp. (MAG ATO3)

--- a/kb/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.yaml
+++ b/kb/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.yaml
@@ -46,6 +46,11 @@ environment_term:
     label: laboratory environment
   notes: Semi-continuously fed thermophilic enrichment reactor operated on switchgrass solids under
     anaerobic methanogenic conditions.
+modeled_environment:
+- preferred_term: anaerobic digester sludge
+  term:
+    id: ENVO:00003965
+    label: anaerobic digester sludge
 taxonomy:
 - taxon_term:
     preferred_term: Clostridia

--- a/kb/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.yaml
+++ b/kb/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.yaml
@@ -35,6 +35,11 @@ environment_term:
     label: laboratory environment
   notes: The isolates originated from an industrial milk pasteurization-line biofilm, but the curated
     system is the controlled laboratory model biofilm.
+modeled_environment:
+- preferred_term: dairy
+  term:
+    id: ENVO:00003862
+    label: dairy
 taxonomy:
 - taxon_term:
     preferred_term: Rhodocyclus sp.

--- a/kb/communities/Lunar_Martian_Simulant_PGPB_Lettuce_SynCom.yaml
+++ b/kb/communities/Lunar_Martian_Simulant_PGPB_Lettuce_SynCom.yaml
@@ -70,6 +70,11 @@ environment_term:
     agriculture. The ENVO grounding reflects the controlled experimental
     (laboratory/greenhouse) setting; the extraterrestrial simulant context is
     captured in the description and environmental_factors.
+modeled_environment:
+- preferred_term: regolith
+  term:
+    id: ENVO:01000747
+    label: regolith
 taxonomy:
 - taxon_term:
     preferred_term: Azotobacter chroococcum 76A

--- a/kb/communities/Lunar_Simulant_Phosphate_Solubilizing_Bacteria_Nicotiana.yaml
+++ b/kb/communities/Lunar_Simulant_Phosphate_Solubilizing_Bacteria_Nicotiana.yaml
@@ -65,6 +65,11 @@ environment_term:
     copy of lunar regolith), not a sampled natural community. The simulant provides
     insoluble inorganic phosphorus (Ca3(PO4)2, FePO4, AlPO4) that the PSBs mobilize;
     the space / lunar-base ISRU context is captured in the description.
+modeled_environment:
+- preferred_term: regolith
+  term:
+    id: ENVO:01000747
+    label: regolith
 taxonomy:
 - taxon_term:
     preferred_term: Bacillus mucilaginosus (AS1.232)

--- a/kb/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.yaml
+++ b/kb/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.yaml
@@ -34,6 +34,11 @@ environment_term:
     label: laboratory environment
   notes: The strains are marine-derived, but the curated community is the controlled laboratory coculture
     used to test B-vitamin exchange.
+modeled_environment:
+- preferred_term: marine environment
+  term:
+    id: ENVO:01000320
+    label: marine environment
 taxonomy:
 - taxon_term:
     preferred_term: Ostreococcus tauri

--- a/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
+++ b/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
@@ -44,6 +44,11 @@ environment_term:
     label: laboratory environment
   notes: Acetate-fed microbial electrochemical cells inoculated with Rifle, CO
     aquifer material; anodes poised at iron-oxide-like redox potentials.
+modeled_environment:
+- preferred_term: groundwater
+  term:
+    id: ENVO:01001004
+    label: groundwater
 taxonomy:
 - taxon_term:
     preferred_term: novel multiheme-cytochrome Geobacter sp.

--- a/kb/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.yaml
+++ b/kb/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.yaml
@@ -46,6 +46,11 @@ environment_term:
     Controlled laboratory coculture modeling a marine phycosphere and marine
     snow formation process; the environmental context is marine particulate
     organic matter and sinking diatom aggregates.
+modeled_environment:
+- preferred_term: marine environment
+  term:
+    id: ENVO:01000320
+    label: marine environment
 taxonomy:
 - taxon_term:
     preferred_term: Thalassiosira weissflogii

--- a/kb/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.yaml
+++ b/kb/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.yaml
@@ -39,6 +39,11 @@ environment_term:
     label: laboratory environment
   notes: The curated community is a controlled laboratory pairwise coculture of marine-derived organisms in
     L1 +Si medium; the biological context is a marine phycosphere phototroph-heterotroph interaction.
+modeled_environment:
+- preferred_term: marine environment
+  term:
+    id: ENVO:01000320
+    label: marine environment
 taxonomy:
 - taxon_term:
     preferred_term: Thalassiosira pseudonana CCMP1335

--- a/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
+++ b/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
@@ -48,6 +48,11 @@ environment_term:
     label: laboratory environment
   notes: Laboratory bioreactor cultivations of SCN- degrading consortia over
     790 days with molasses-amended and molasses-free reactors.
+modeled_environment:
+- preferred_term: bioreactor
+  term:
+    id: ENVO:00002123
+    label: bioreactor
 taxonomy:
 - taxon_term:
     preferred_term: Thiobacillus thiocyanate-degrader strain

--- a/kb/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.yaml
+++ b/kb/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.yaml
@@ -33,6 +33,11 @@ environment_term:
     label: laboratory environment
   notes: Synthetic microbial community for enzyme production and wheat straw pretreatment before anaerobic
     digestion.
+modeled_environment:
+- preferred_term: anaerobic digester sludge
+  term:
+    id: ENVO:00003965
+    label: anaerobic digester sludge
 taxonomy:
 - taxon_term:
     preferred_term: Bacillus subtilis

--- a/kb/communities/Yogurt_TwoSpecies_Starter_Culture.yaml
+++ b/kb/communities/Yogurt_TwoSpecies_Starter_Culture.yaml
@@ -42,6 +42,11 @@ environment_term:
     label: laboratory environment
   notes: The curated system is the controlled milk/yogurt fermentation community used in laboratory and
     starter-culture studies.
+modeled_environment:
+- preferred_term: dairy
+  term:
+    id: ENVO:00003862
+    label: dairy
 taxonomy:
 - taxon_term:
     preferred_term: Streptococcus thermophilus


### PR DESCRIPTION
## Context

Applies the lab-env re-grounding triage (from the "why are these skipped?"
discussion) using the `modeled_environment` slot added in #216. 23 of the 110
communities grounded to `environment_term: laboratory environment` derive from or
model a real habitat; this records that habitat while leaving `environment_term`
(the honest study setting) unchanged. The other ~67 de-novo cocultures keep only
`laboratory environment`.

## Mapping (all evidence-backed by each record's description)

| habitat (ENVO) | n | records |
|---|---|---|
| groundwater (ENVO:01001004) | 2 | Acetylene-TCE-Groundwater, Rifle-Aquifer-Bioanode |
| anaerobic digester sludge (ENVO:00003965) | 3 | Anabaena-AD, Wheat-Straw-Biogas, High-Solids-Switchgrass |
| bioreactor (ENVO:00002123) | 3 | Anammox-Bioreactor, GLBRC-UFMP, Thiocyanate-Bioreactor |
| regolith (ENVO:01000747) | 4 | BioAsteroid-ISS, BioRock-ISS, Lunar-Martian-Simulant, Lunar-Simulant-PSB |
| dairy (ENVO:00003862) | 4 | Kefir, Cheese-Rind, Industrial-Milk-Biofilm, Yogurt-Starter |
| intestine environment (ENVO:2100002) | 2 | Mouse-Metaorganism, Infant-Gut-HMO |
| marine environment (ENVO:01000320) | 3 | Ostreococcus-Dinoroseobacter, Thalassiosira-Marine-Snow, Thalassiosira-Phycosphere |
| digestive tract environment (ENVO:01001033) | 1 | Butyrivibrio-Rumen (ENVO has no clean "rumen") |
| acid mine drainage (ENVO:00001997) | 1 | Cyprus-Cu-Bioleaching |

## How

Targeted **text insertion** after each `environment_term` block — a clean **+5
lines per file**, curated content preserved byte-for-byte (a ruamel round-trip
that reflowed wrapped scalars was rejected in favor of this).

## Verification

- All 23 `linkml-validate` clean
- id↔label label check on all 23: **✅ passed** (canonical ENVO labels)
- `just test` — **246 passed**

## Follow-ups (separate PRs)

1. Regenerate `docs/` pages for these records (pages aren't CI-gated).
2. Teach the env media/ingredient suggester to also match on
   `modeled_environment` → un-skips these lab-env communities (closes the
   original concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)