### PR TITLE
Match media suggester on modeled_environment (un-skip lab-env communities)

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -213,15 +213,18 @@ a CHEBI term can be emitted as `RelatedIngredient` (`chebi_term` +
   the *study setting*, often "laboratory environment"), a new **`modeled_environment`**
   slot on `MicrobialCommunity` (multivalued, optional, `EnvironmentDescriptor`,
   ENVO-grounded) captures the natural/applied habitat an engineered community
-  derives from or represents. **PR #216 (this)**: adds the schema slot + test.
-  **Follow-up PR**: populate it for the ~23 triaged records — 18 clear
-  (groundwater/regolith/dairy/marine/gut/anaerobic-digester) + 5 REVIEW
-  enrichments (rumen→digestive tract, Cu-bioleaching→AMD, two thiocyanate/UFMP
-  bioreactors, switchgrass methanogenic→digester); the other ~67 de-novo cocultures
-  keep only `environment_term: laboratory environment`. Triage detail in the report
-  produced 2026-07-19 (buckets REGROUND 18 / REVIEW 25 / LAB-KEEP 67). Then teach
-  the media/ingredient suggester to also match on `modeled_environment`, which
-  un-skips the lab-env communities that have a real modeled habitat.
+  derives from or represents. **DONE:** schema slot + test (PR #216); populated for
+  the 23 triaged records (PR #217) — groundwater×2, anaerobic digester×3,
+  bioreactor×3, regolith×4, dairy×4, intestine×2, marine×3, digestive-tract×1,
+  AMD×1; the other ~67 de-novo cocultures keep only `laboratory environment`.
+  Triage buckets REGROUND 18 / REVIEW 25 / LAB-KEEP 67. **Suggester now matches on
+  `modeled_environment`** (PR #218): the media suggester's env keys are
+  `environment_term` + every `modeled_environment`, so the 23 lab-env communities
+  are no longer skipped (skip count 110 → 87) — they'll match media automatically as
+  CultureMech populates `source_environment` for those habitats (0 today; data-limited,
+  not logic-limited). **Remaining:** regenerate `docs/` pages for the 23 records;
+  optionally apply the same `modeled_environment` matching to the (draft) ingredient
+  suggester.
 
 ## 3. Cross-Mech validator pin guard — DONE (4-repo invariant)
 

--- a/scripts/suggest_related_media.py
+++ b/scripts/suggest_related_media.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 """Suggest environment-matched CultureMech media for CommunityMech communities (issue #30, Use Case 1).
 
-For each community, match its ``environment_term`` ENVO id against CultureMech
-media that declare the same ``source_environment`` term, and emit ready-to-review
+For each community, match its ENVO environment(s) against CultureMech media that
+declare the same ``source_environment`` term, and emit ready-to-review
 ``related_media`` YAML blocks (with ``shared_environment_term``) for a curator to
-paste. Media already linked from the community (via ``related_media.culturemech_id``
-or ``growth_media.culturemech_id``) are skipped, so re-runs only surface new
-matches.
+paste. A community's environment keys are its ``environment_term`` **and** every
+``modeled_environment`` entry — so an engineered community whose ``environment_term``
+is the generic "laboratory environment" still matches media via the real habitat it
+models (e.g. groundwater, regolith, dairy). Media already linked from the community
+(via ``related_media.culturemech_id`` or ``growth_media.culturemech_id``) are
+skipped, so re-runs only surface new matches.
 
 This is suggestion-only: it prints blocks for review and never edits records —
 mirroring `scripts/suggest_missing_interactions.py`.
@@ -64,16 +67,36 @@ def _linked_culturemech_ids(data: dict) -> set[str]:
     return linked
 
 
-def _community_env(data: dict) -> tuple[str, str] | None:
-    """(ENVO id, label) from environment_term, or None."""
-    et = data.get("environment_term")
-    term = (et or {}).get("term") if isinstance(et, dict) else None
+def _env_from_descriptor(desc) -> tuple[str, str] | None:
+    """(ENVO id, label) from an EnvironmentDescriptor mapping, or None."""
+    term = desc.get("term") if isinstance(desc, dict) else None
     if not isinstance(term, dict):
         return None
     envo_id = term.get("id")
     if isinstance(envo_id, str) and envo_id.startswith("ENVO:"):
         return envo_id, term.get("label") or ""
     return None
+
+
+def _community_envs(data: dict) -> list[tuple[str, str]]:
+    """All ENVO (id, label) match keys for a community — `environment_term` plus
+    every `modeled_environment` entry (the habitat an engineered community derives
+    from / represents). De-duplicated, order preserved. This is what lets a
+    community whose `environment_term` is the generic "laboratory environment"
+    still match media via its real modeled habitat.
+    """
+    envs: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    et = _env_from_descriptor(data.get("environment_term"))
+    if et:
+        envs.append(et)
+        seen.add(et[0])
+    for desc in data.get("modeled_environment") or []:
+        me = _env_from_descriptor(desc)
+        if me and me[0] not in seen:
+            envs.append(me)
+            seen.add(me[0])
+    return envs
 
 
 def _suggestion_block(matches, envo_id, env_label):
@@ -186,27 +209,45 @@ def main() -> int:
             data = yaml.safe_load(path.read_bytes()) or {}
         except (OSError, yaml.YAMLError):
             continue
-        env = _community_env(data)
-        if env is None:
-            continue
-        envo_id, env_label = env
-        if envo_id in GENERIC_ENVIRONMENTS and not args.include_generic:
+        envs = _community_envs(data)
+        if not envs:
+            continue  # no ENVO environment to match on
+        active = [
+            (eid, lbl)
+            for eid, lbl in envs
+            if args.include_generic or eid not in GENERIC_ENVIRONMENTS
+        ]
+        if not active:
+            # every env key is over-generic (e.g. only "laboratory environment"
+            # with no modeled_environment) — nothing meaningful to match on
             skipped_generic += 1
             continue
         exclude_subtypes = frozenset() if args.include_generic else GENERIC_ENVIRONMENTS
-        matches = _matches_for(envo_id, media_by_env, envo_adapter, exclude_subtypes)
         already = _linked_culturemech_ids(data)
-        fresh = [(h, rel) for h, rel in matches if h.culturemech_id not in already]
-        if not fresh:
+        seen_media = set(already)
+        env_groups = []  # [(envo_id, label, [(hit, rel), ...])]
+        for eid, lbl in active:
+            matches = _matches_for(eid, media_by_env, envo_adapter, exclude_subtypes)
+            fresh = [(h, rel) for h, rel in matches if h.culturemech_id not in seen_media]
+            for h, _ in fresh:
+                seen_media.add(h.culturemech_id)
+            if fresh:
+                env_groups.append((eid, lbl, fresh))
+        if not env_groups:
             continue
         communities_with_suggestions += 1
-        total_suggestions += len(fresh)
-        n_sub = sum(1 for _, rel in fresh if rel == "subtype")
-        blocks = _suggestion_block(fresh, envo_id, env_label)
-        sub_note = f" ({n_sub} via ENVO subtype)" if n_sub else ""
-        print(f"\n# {path.name}  —  environment {envo_id} ({env_label})")
-        print(f"# {len(fresh)} suggested related_media{sub_note} (paste under `related_media:`)")
-        print(yaml.safe_dump(blocks, sort_keys=False, allow_unicode=True).rstrip())
+        n_fresh = sum(len(g[2]) for g in env_groups)
+        total_suggestions += n_fresh
+        et = _env_from_descriptor(data.get("environment_term"))
+        et_id = et[0] if et else None
+        print(f"\n# {path.name}")
+        for eid, lbl, fresh in env_groups:
+            n_sub = sum(1 for _, rel in fresh if rel == "subtype")
+            sub_note = f" ({n_sub} via ENVO subtype)" if n_sub else ""
+            via = "environment_term" if eid == et_id else "modeled_environment"
+            blocks = _suggestion_block(fresh, eid, lbl)
+            print(f"#   {eid} ({lbl}) via {via} — {len(fresh)} related_media{sub_note}")
+            print(yaml.safe_dump(blocks, sort_keys=False, allow_unicode=True).rstrip())
 
     note = ""
     if skipped_generic and not args.include_generic:

--- a/tests/test_suggest_related_media.py
+++ b/tests/test_suggest_related_media.py
@@ -16,14 +16,37 @@ sug = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(sug)
 
 
-def test_community_env_extracts_envo():
+def test_community_envs_extracts_environment_term():
     data = {"environment_term": {"term": {"id": "ENVO:00000044", "label": "peatland"}}}
-    assert sug._community_env(data) == ("ENVO:00000044", "peatland")
+    assert sug._community_envs(data) == [("ENVO:00000044", "peatland")]
 
 
-def test_community_env_ignores_non_envo_and_missing():
-    assert sug._community_env({"environment_term": {"term": {"id": "UBERON:1"}}}) is None
-    assert sug._community_env({}) is None
+def test_community_envs_includes_modeled_environment():
+    # a lab-grounded community with a real modeled habitat exposes BOTH keys, so it
+    # can be matched via the modeled_environment even though environment_term is generic
+    data = {
+        "environment_term": {"term": {"id": "ENVO:01001405", "label": "laboratory environment"}},
+        "modeled_environment": [
+            {"term": {"id": "ENVO:01001004", "label": "groundwater"}},
+            {"term": {"id": "ENVO:2100002", "label": "intestine environment"}},
+        ],
+    }
+    assert sug._community_envs(data) == [
+        ("ENVO:01001405", "laboratory environment"),
+        ("ENVO:01001004", "groundwater"),
+        ("ENVO:2100002", "intestine environment"),
+    ]
+
+
+def test_community_envs_dedups_and_ignores_non_envo_and_missing():
+    assert sug._community_envs({"environment_term": {"term": {"id": "UBERON:1"}}}) == []
+    assert sug._community_envs({}) == []
+    # a modeled_environment duplicating environment_term is not repeated
+    data = {
+        "environment_term": {"term": {"id": "ENVO:00001998", "label": "soil"}},
+        "modeled_environment": [{"term": {"id": "ENVO:00001998", "label": "soil"}}],
+    }
+    assert sug._community_envs(data) == [("ENVO:00001998", "soil")]
 
 
 def test_linked_culturemech_ids_spans_related_and_growth_media():


### PR DESCRIPTION
## Context

Closes the loop from the **"why are these skipped?"** thread. The media suggester
skipped 110 communities grounded to the generic `environment_term: laboratory
environment`. Now that 23 of them carry a real `modeled_environment` (#217), the
suggester matches on it too.

## What

- `_community_env` → **`_community_envs`**: a community's match keys are its
  `environment_term` **and** every `modeled_environment` entry (ENVO id/label,
  deduped, order preserved).
- The main loop matches media across all non-generic keys for a community, dedups
  by `culturemech_id`, and labels each suggestion group with which key it matched
  (`environment_term` vs `modeled_environment`). Communities with **no** ENVO env
  are silently skipped (as before); only all-generic communities count as skipped.

## Effect

The 23 `modeled_environment` records leave the skipped bucket: **skip count
110 → 87.** They yield **0 media suggestions today** — CultureMech
`source_environment` has no groundwater/regolith/dairy/… entries yet — so this is
**data-limited, not logic-limited**: they'll match automatically as sibling
coverage grows. (Verified: `_community_envs` returns e.g. `[laboratory environment,
groundwater]` for the Rifle aquifer record.)

## Verification

- `just test` — **247 passed** (new `_community_envs` cases: environment_term +
  modeled_environment, dedup, non-ENVO ignored)
- `just lint` — black + ruff + mypy clean
- Real run: skipped 110 → 87; 351 exact suggestions unchanged

## Remaining follow-ups

- Regenerate `docs/` pages for the 23 records.
- Optionally apply the same `modeled_environment` matching to the draft ingredient
  suggester (#215).

🤖 Generated with [Claude Code](https://claude.com/claude-code)