### PR TITLE
Finalize CHEBI-route ingredient suggester (MediaIngredientMech#119)

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -180,10 +180,23 @@ actioned (2026-07-19, PR #212).**
   ingredient's `CHEBI:` id (already supported by `RelatedIngredient.chebi_term`) is
   an acceptable equivalent link — the likely fast path.
 
-**Remaining before emitting ingredient suggestions:** decide the id per MIM#119.
-The **CHEBI route works today** — env-matched MIM ingredients that `skos:exactMatch`
-a CHEBI term can be emitted as `RelatedIngredient` (`chebi_term` +
-`shared_environment_term`) with no id decision needed; build once MIM confirms (c).
+**Ingredient suggester — DONE (2026-07-20, PR #220; MIM#119 CLOSED as answered).**
+MIM confirmed: (1) `MediaIngredientMech:NNNNNN` is vestigial — drop the pattern;
+(2) the equivalence-safe join is the ingredient's CHEBI term from MIM's SSSOM
+**`skos:exactMatch`** rows (NOT the record `identifier`, NOT close/narrowMatch —
+those would generalise); (3) `environmental_context` coverage is **10 records, not
+~44** (a seawater/soil/sulfur cluster). `scripts/suggest_related_ingredients.py` +
+`just suggest-related-ingredients` implement the CHEBI route accordingly:
+`cross_repo_environment.mim_exactmatch_chebi` parses the SSSOM (exactMatch→CHEBI
+only) and `mim_ingredients_by_environment` joins each `environmental_context`
+record (`MIM:<file-stem>` subject) to it; emits `RelatedIngredient`
+(`chebi_term` with the **canonical** ChEBI label + `shared_environment_term`), reads
+env keys from `environment_term` + `modeled_environment`, supports `--subsumption`.
+Real yield today: 1 suggestion (Sulfur CHEBI:26833 → the hot-spring mat community) —
+data-limited by MIM's 10 context records, correct + scales. Supersedes draft PR #215.
+**Follow-up:** drop the vestigial `^MediaIngredientMech:\d{6}$` pattern from
+`RelatedIngredient.mediaingredientmech_id` (per #119 §1); a rename-stable MIM
+surrogate id would need its own MIM issue if we later want to persist `MIM:<name>`.
 **Other follow-ups (grounding-quality):**
 - **ENVO subsumption matching — DONE (2026-07-19, PR #213).** `suggest-related-media
   --subsumption` also matches media whose environment is an ENVO `is_a` *subtype*

--- a/justfile
+++ b/justfile
@@ -110,6 +110,12 @@ env-coverage *args:
 suggest-related-media *args:
     PYTHONPATH=src uv run python scripts/suggest_related_media.py {{args}}
 
+# Suggest environment-matched MIM ingredients as related_ingredients blocks (CHEBI
+# route via SSSOM skos:exactMatch, per MediaIngredientMech#119). Needs a MIM repo
+# path via COMMUNITYMECH_SIBLING_REPOS or --mediaingredientmech. Suggestion-only.
+suggest-related-ingredients *args:
+    PYTHONPATH=src uv run python scripts/suggest_related_ingredients.py {{args}}
+
 # Environment-grounding quality report: rank community environment_term usage and
 # flag generic (e.g. laboratory environment) / over-applied groundings for review
 # (issue #30 follow-up). Report-only; edits nothing. --list shows affected records.

--- a/scripts/suggest_related_ingredients.py
+++ b/scripts/suggest_related_ingredients.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Suggest environment-matched MIM ingredients for communities (issue #30, Use Case 1).
+
+The ingredient analog of ``suggest_related_media.py``. For each community, match its
+ENVO environment(s) — ``environment_term`` plus every ``modeled_environment`` — against
+MediaIngredientMech (MIM) ingredients that declare the same ``environmental_context``,
+and emit ready-to-review ``related_ingredients`` blocks (``chebi_term`` +
+``shared_environment_term``) for a curator to paste. Suggestion-only — never edits records.
+
+**CHEBI route, per MediaIngredientMech#119.** MIM confirmed:
+* ``MediaIngredientMech:NNNNNN`` is vestigial — this tool never emits it.
+* The equivalence-safe join is the ingredient's CHEBI term taken from MIM's SSSOM
+  ``skos:exactMatch`` rows (NOT the record ``identifier`` field, and NOT
+  close/narrowMatch). ``cross_repo_environment.mim_ingredients_by_environment`` does
+  that join; ingredients with no exactMatch CHEBI (environment materials grounded to
+  ENVO/MICRO, protein digests ChEBI can't represent, …) are skipped.
+
+``chebi_term.label`` is resolved to the **canonical** ChEBI label (from the local
+ChEBI sqlite), not MIM's free-text name, so the id↔label gate stays green; records
+whose CHEBI label can't be resolved locally are skipped (reported).
+
+Sibling repo path comes from ``COMMUNITYMECH_SIBLING_REPOS`` (``Name=path``) or
+``--mediaingredientmech``; point it at the MIM repo root (needs both
+``data/ingredients/`` and ``mappings/``). Add ``--subsumption`` to also match ENVO
+subtype environments.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from communitymech.cross_repo_environment import (  # noqa: E402
+    GENERIC_ENVIRONMENT_TERMS as GENERIC_ENVIRONMENTS,
+    envo_subtypes,
+    get_chebi_adapter,
+    get_envo_adapter,
+    mim_ingredients_by_environment,
+    sibling_repos_from_env,
+)
+
+REPO_ROOT = Path(__file__).parent.parent
+COMMUNITY_DIR = REPO_ROOT / "kb" / "communities"
+
+
+def _env_from_descriptor(desc):
+    term = desc.get("term") if isinstance(desc, dict) else None
+    if not isinstance(term, dict):
+        return None
+    envo_id = term.get("id")
+    if isinstance(envo_id, str) and envo_id.startswith("ENVO:"):
+        return envo_id, term.get("label") or ""
+    return None
+
+
+def _community_envs(data: dict):
+    """All ENVO (id, label) keys: environment_term + every modeled_environment."""
+    envs, seen = [], set()
+    et = _env_from_descriptor(data.get("environment_term"))
+    if et:
+        envs.append(et)
+        seen.add(et[0])
+    for desc in data.get("modeled_environment") or []:
+        me = _env_from_descriptor(desc)
+        if me and me[0] not in seen:
+            envs.append(me)
+            seen.add(me[0])
+    return envs
+
+
+def _linked_chebi_ids(data: dict) -> set[str]:
+    linked = set()
+    for entry in data.get("related_ingredients") or []:
+        if isinstance(entry, dict):
+            ct = entry.get("chebi_term")
+            if isinstance(ct, dict) and ct.get("id"):
+                linked.add(ct["id"])
+    return linked
+
+
+def _matches_for(envo_id, ing_by_env, envo_adapter, exclude_subtype_envs=frozenset()):
+    """[(IngredientHit, relation)] with a CHEBI id, exact + optional subtypes."""
+    seen: dict[str, tuple] = {}
+    for hit in ing_by_env.get(envo_id, []):
+        if hit.chebi_id:
+            seen[hit.chebi_id] = (hit, "exact")
+    if envo_adapter is not None:
+        for sub in envo_subtypes(envo_id, envo_adapter):
+            if sub in exclude_subtype_envs:
+                continue
+            for hit in ing_by_env.get(sub, []):
+                if hit.chebi_id:
+                    seen.setdefault(hit.chebi_id, (hit, "subtype"))
+    return list(seen.values())
+
+
+def _block(hit, relation, envo_id, env_label, canonical):
+    if relation == "exact":
+        note = (
+            f"MIM ingredient shares environment '{env_label}' ({envo_id}) with this "
+            "community; CHEBI route (skos:exactMatch) per MediaIngredientMech#119."
+        )
+    else:
+        note = (
+            f"MIM ingredient environment '{hit.env_label}' ({hit.env_id}) is a subtype of "
+            f"this community's '{env_label}' ({envo_id}); ENVO-subsumption CHEBI route."
+        )
+    return {
+        "preferred_term": hit.name,
+        "chebi_term": {"id": hit.chebi_id, "label": canonical},
+        "shared_environment_term": {"id": envo_id, "label": env_label},
+        "relevance": note,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("yaml_paths", nargs="*", type=Path)
+    parser.add_argument("--mediaingredientmech", type=Path, help="Path to MIM repo root")
+    parser.add_argument("--include-generic", action="store_true")
+    parser.add_argument("--subsumption", action="store_true")
+    args = parser.parse_args()
+
+    sibling_repos = sibling_repos_from_env()
+    if args.mediaingredientmech is not None:
+        sibling_repos["MediaIngredientMech"] = args.mediaingredientmech
+    mim_path = sibling_repos.get("MediaIngredientMech")
+    if mim_path is None or not mim_path.exists():
+        print(
+            "No MediaIngredientMech sibling path configured (COMMUNITYMECH_SIBLING_REPOS "
+            "or --mediaingredientmech).",
+            file=sys.stderr,
+        )
+        return 2
+
+    chebi_adapter = get_chebi_adapter()
+    if chebi_adapter is None:
+        print("ChEBI sqlite not cached; cannot resolve canonical labels — no output.", file=sys.stderr)
+        return 0
+    ing_by_env = mim_ingredients_by_environment(mim_path)
+    envo_adapter = get_envo_adapter() if args.subsumption else None
+    exclude_subtypes = frozenset() if args.include_generic else GENERIC_ENVIRONMENTS
+
+    paths = args.yaml_paths or sorted(COMMUNITY_DIR.glob("*.yaml"))
+    total, n_comm, unresolved = 0, 0, []
+    for path in paths:
+        try:
+            data = yaml.safe_load(path.read_bytes()) or {}
+        except (OSError, yaml.YAMLError):
+            continue
+        envs = _community_envs(data)
+        active = [(e, lbl) for e, lbl in envs if args.include_generic or e not in GENERIC_ENVIRONMENTS]
+        if not active:
+            continue
+        already = _linked_chebi_ids(data)
+        seen_chebi = set(already)
+        groups = []
+        for eid, lbl in active:
+            matches = _matches_for(eid, ing_by_env, envo_adapter, exclude_subtypes)
+            blocks = []
+            for hit, rel in sorted(matches, key=lambda m: m[0].chebi_id):
+                if hit.chebi_id in seen_chebi:
+                    continue
+                canonical = chebi_adapter.label(hit.chebi_id)
+                if not canonical:
+                    unresolved.append(hit.chebi_id)
+                    continue
+                seen_chebi.add(hit.chebi_id)
+                blocks.append(_block(hit, rel, eid, lbl, canonical))
+            if blocks:
+                groups.append((eid, lbl, blocks))
+        if not groups:
+            continue
+        n_comm += 1
+        total += sum(len(g[2]) for g in groups)
+        print(f"\n# {path.name}")
+        for eid, lbl, blocks in groups:
+            print(f"#   {eid} ({lbl}) — {len(blocks)} related_ingredients")
+            print(yaml.safe_dump(blocks, sort_keys=False, allow_unicode=True).rstrip())
+
+    extra = f" {len(set(unresolved))} skipped (unresolved CHEBI label)." if unresolved else ""
+    print(f"\n# ---\n# {total} ingredient suggestion(s) across {n_comm} community(ies).{extra}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/communitymech/cross_repo_environment.py
+++ b/src/communitymech/cross_repo_environment.py
@@ -228,18 +228,103 @@ def envo_subtypes(envo_id: str, adapter: Any) -> set[str]:
     return {d for d in descendants if d != envo_id}
 
 
-def get_envo_adapter() -> Any | None:
-    """Return an OAK adapter for the locally-cached ENVO sqlite, or None.
-
-    Skips (returns None) when the ENVO build isn't cached, so callers can widen
-    matching when the ontology is present without forcing a download in CI.
-    """
-    envo_db = Path.home() / ".data" / "oaklib" / "envo.db"
-    if not envo_db.exists():
+def _cached_oak_adapter(db_name: str) -> Any | None:
+    """OAK adapter for a locally-cached sqlite under ~/.data/oaklib/, or None."""
+    db = Path.home() / ".data" / "oaklib" / db_name
+    if not db.exists():
         return None
     from oaklib import get_adapter  # type: ignore[import-untyped]
 
-    return get_adapter(f"sqlite:{envo_db}")
+    return get_adapter(f"sqlite:{db}")
+
+
+def get_envo_adapter() -> Any | None:
+    """OAK adapter for the locally-cached ENVO sqlite, or None if not cached."""
+    return _cached_oak_adapter("envo.db")
+
+
+def get_chebi_adapter() -> Any | None:
+    """OAK adapter for the locally-cached ChEBI sqlite, or None if not cached."""
+    return _cached_oak_adapter("chebi.db")
+
+
+@dataclass(frozen=True)
+class IngredientHit:
+    """A MediaIngredientMech ingredient grounded to a given ENVO environment.
+
+    ``chebi_id`` is the CHEBI term the MIM subject ``skos:exactMatch``-es (per MIM's
+    SSSOM mappings) — the only equivalence-safe join per MediaIngredientMech#119 —
+    or None when the MIM ingredient has no exactMatch CHEBI (e.g. an environment
+    material grounded to ENVO/MICRO, or a close/narrowMatch). ``mim_subject`` is the
+    provenance CURIE (``MIM:<name>``).
+    """
+
+    name: str
+    chebi_id: str | None
+    env_id: str
+    env_label: str
+    mim_subject: str
+
+
+def mim_exactmatch_chebi(mim_root: Path) -> dict[str, str]:
+    """Map ``MIM:<name>`` subject -> CHEBI id for ``skos:exactMatch`` rows only.
+
+    Reads ``mappings/ingredient_mappings.sssom.tsv`` (skipping its ``#`` preamble).
+    Per MediaIngredientMech#119, only ``skos:exactMatch`` is an equivalence-safe
+    link — ``close``/``narrowMatch`` are excluded (a narrowMatch to CHEBI would
+    silently generalise the ingredient). Returns {} if the SSSOM file is absent.
+    """
+    sssom = mim_root / "mappings" / "ingredient_mappings.sssom.tsv"
+    if not sssom.exists():
+        return {}
+    import csv
+    import io
+
+    body = "".join(
+        ln for ln in sssom.read_text().splitlines(keepends=True) if not ln.startswith("#")
+    )
+    out: dict[str, str] = {}
+    for row in csv.DictReader(io.StringIO(body), delimiter="\t"):
+        if row.get("predicate_id") == "skos:exactMatch" and str(
+            row.get("object_id", "")
+        ).startswith("CHEBI:"):
+            out.setdefault(row["subject_id"], row["object_id"])
+    return out
+
+
+def mim_ingredients_by_environment(mim_root: Path) -> dict[str, list[IngredientHit]]:
+    """Map ENVO id -> MIM ingredients grounded to it, with the exactMatch CHEBI.
+
+    Joins each ``environmental_context`` record (``MIM:<file-stem>`` subject) to the
+    SSSOM ``skos:exactMatch`` CHEBI map, so ``chebi_id`` follows MIM's authoritative
+    mapping rather than the record's ``identifier`` field (which can differ from,
+    or be a broken stand-in for, the real ontology mapping — see #119).
+    """
+    exact = mim_exactmatch_chebi(mim_root)
+    by_env: dict[str, list[IngredientHit]] = {}
+    # scan the per-ingredient record tree, not the whole repo: MIM keeps multi-MB
+    # aggregate/backup dumps under data/curated/ that also mention the field and
+    # would blow up YAML parsing.
+    records_root = mim_root / "data" / "ingredients"
+    if not records_root.exists():
+        records_root = mim_root
+    for path, data in _iter_prefiltered(records_root, _MIM_FIELD):
+        subject = f"MIM:{path.stem}"
+        chebi_id = exact.get(subject)
+        name = data.get("preferred_term") or data.get("name") or path.stem
+        for entry in data.get("environmental_context") or []:
+            if not isinstance(entry, dict):
+                continue
+            envo_id = _envo(entry.get("environment_term"))
+            if envo_id is None:
+                continue
+            hit = IngredientHit(
+                str(name), chebi_id, envo_id, entry.get("environment_label") or "", subject
+            )
+            bucket = by_env.setdefault(envo_id, [])
+            if hit not in bucket:
+                bucket.append(hit)
+    return by_env
 
 
 def sibling_repos_from_env() -> dict[str, Path]:

--- a/tests/test_cross_repo_environment.py
+++ b/tests/test_cross_repo_environment.py
@@ -14,6 +14,8 @@ from communitymech.cross_repo_environment import (
     build_coverage,
     culturemech_media_by_environment,
     envo_subtypes,
+    mim_exactmatch_chebi,
+    mim_ingredients_by_environment,
     sibling_repos_from_env,
 )
 
@@ -174,6 +176,49 @@ def test_culturemech_media_by_environment(tmp_path):
     hit = peat[0]
     assert hit.name and hit.env_label == "peatland"
     assert "CultureMech:009999" not in {h.culturemech_id for v in by_env.values() for h in v}
+
+
+_SSSOM = """\
+# curie_map:
+#   MIM: "https://example/"
+subject_id\tsubject_label\tpredicate_id\tobject_id\tobject_label
+MIM:Sulfur\tSulfur\tskos:exactMatch\tCHEBI:26833\tsulfur atom
+MIM:Nacl\tNaCl\tskos:exactMatch\tCHEBI:26710\tsodium chloride
+MIM:Tryptone\tTryptone\tskos:exactMatch\tMICRO:1\ttryptone
+MIM:Casein\tCasein\tskos:narrowMatch\tCHEBI:99999\tprotein
+"""
+
+
+def _make_mim(tmp_path):
+    mim = tmp_path / "MIM"
+    (mim / "mappings").mkdir(parents=True)
+    (mim / "mappings" / "ingredient_mappings.sssom.tsv").write_text(_SSSOM)
+    _make_ingredient(mim / "data" / "ingredients", "Sulfur", "ENVO:00000051", "hot spring")
+    _make_ingredient(mim / "data" / "ingredients", "Nacl", "ENVO:00002149", "sea water")
+    _make_ingredient(mim / "data" / "ingredients", "Tryptone", "ENVO:00002149", "sea water")
+    _make_ingredient(mim / "data" / "ingredients", "Casein", "ENVO:00002149", "sea water")
+    return mim
+
+
+def test_mim_exactmatch_chebi_filters_predicate_and_prefix(tmp_path):
+    mim = _make_mim(tmp_path)
+    em = mim_exactmatch_chebi(mim)
+    # only skos:exactMatch rows whose object is CHEBI:
+    assert em == {"MIM:Sulfur": "CHEBI:26833", "MIM:Nacl": "CHEBI:26710"}
+    # narrowMatch (Casein->CHEBI) excluded; exactMatch to non-CHEBI (Tryptone->MICRO) excluded
+    assert "MIM:Casein" not in em and "MIM:Tryptone" not in em
+
+
+def test_mim_ingredients_by_environment_joins_via_sssom(tmp_path):
+    mim = _make_mim(tmp_path)
+    by = mim_ingredients_by_environment(mim)
+    # chebi_id comes from the SSSOM exactMatch, keyed by MIM:<file-stem>
+    sulfur = next(h for h in by["ENVO:00000051"] if h.mim_subject == "MIM:Sulfur")
+    assert sulfur.chebi_id == "CHEBI:26833"
+    sea = {h.mim_subject: h.chebi_id for h in by["ENVO:00002149"]}
+    assert sea["MIM:Nacl"] == "CHEBI:26710"
+    # non-exactMatch / non-CHEBI ingredients present but with chebi_id None (filtered by the tool)
+    assert sea["MIM:Tryptone"] is None and sea["MIM:Casein"] is None
 
 
 def test_envo_subtypes_excludes_self_and_handles_errors():

--- a/tests/test_suggest_related_ingredients.py
+++ b/tests/test_suggest_related_ingredients.py
@@ -1,0 +1,80 @@
+"""Tests for the CHEBI-route ingredient suggester (issue #30; MediaIngredientMech#119).
+
+Loads the script module directly and exercises its pure helpers with fake OAK
+adapters. No sibling repos, no network. The CHEBI join is validated at the module
+level (test_cross_repo_environment.py); here we cover the suggester's own logic.
+"""
+
+import importlib.util
+from pathlib import Path
+
+from communitymech.cross_repo_environment import IngredientHit
+
+_spec = importlib.util.spec_from_file_location(
+    "suggest_related_ingredients",
+    Path(__file__).parent.parent / "scripts" / "suggest_related_ingredients.py",
+)
+sug = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sug)
+
+
+class _FakeEnvoAdapter:
+    def descendants(self, envo_id, predicates=None):
+        return {"ENVO:00002007", "ENVO:03000033"} if envo_id == "ENVO:00002007" else {envo_id}
+
+
+class _FakeChebiAdapter:
+    _L = {"CHEBI:26833": "sulfur atom", "CHEBI:26710": "sodium chloride"}
+
+    def label(self, cid):
+        return self._L.get(cid)
+
+
+def _ing(chebi_id, env_id, env_label="e", name="n"):
+    return IngredientHit(name, chebi_id, env_id, env_label, "MIM:x")
+
+
+def test_community_envs_includes_modeled_environment():
+    data = {
+        "environment_term": {"term": {"id": "ENVO:01001405", "label": "laboratory environment"}},
+        "modeled_environment": [{"term": {"id": "ENVO:00000051", "label": "hot spring"}}],
+    }
+    assert sug._community_envs(data) == [
+        ("ENVO:01001405", "laboratory environment"),
+        ("ENVO:00000051", "hot spring"),
+    ]
+
+
+def test_linked_chebi_ids():
+    data = {"related_ingredients": [{"chebi_term": {"id": "CHEBI:1"}}, {"preferred_term": "x"}]}
+    assert sug._linked_chebi_ids(data) == {"CHEBI:1"}
+
+
+def test_matches_for_chebi_only_exact():
+    ing = {
+        "ENVO:00000051": [
+            _ing("CHEBI:26833", "ENVO:00000051"),
+            _ing(None, "ENVO:00000051"),  # no exactMatch CHEBI -> dropped
+        ]
+    }
+    matches = sug._matches_for("ENVO:00000051", ing, envo_adapter=None)
+    assert [(h.chebi_id, rel) for h, rel in matches] == [("CHEBI:26833", "exact")]
+
+
+def test_matches_for_subtype_and_generic_exclusion():
+    ing = {
+        "ENVO:00002007": [_ing("CHEBI:1", "ENVO:00002007")],
+        "ENVO:03000033": [_ing("CHEBI:2", "ENVO:03000033")],
+    }
+    matches = sug._matches_for("ENVO:00002007", ing, _FakeEnvoAdapter())
+    assert {h.chebi_id: rel for h, rel in matches} == {"CHEBI:1": "exact", "CHEBI:2": "subtype"}
+
+
+def test_block_uses_canonical_label():
+    hit = _ing("CHEBI:26833", "ENVO:00000051", "hot spring", "Sulfur")
+    b = sug._block(hit, "exact", "ENVO:00000051", "hot spring", "sulfur atom")
+    assert b["preferred_term"] == "Sulfur"
+    # canonical ChEBI label, NOT MIM's free-text name -> keeps id-label gate green
+    assert b["chebi_term"] == {"id": "CHEBI:26833", "label": "sulfur atom"}
+    assert b["shared_environment_term"] == {"id": "ENVO:00000051", "label": "hot spring"}
+    assert "exactMatch" in b["relevance"]


### PR DESCRIPTION
## Context

**MIM#119 is closed as answered**, which settles the two blockers that held the
draft ingredient suggester (#215). This PR rebuilds it correctly on MIM's guidance
and **supersedes #215**.

## What MIM ruled (#119)

1. `MediaIngredientMech:NNNNNN` is **vestigial** — drop it (follow-up below).
2. The equivalence-safe join is the ingredient's CHEBI term from MIM's SSSOM
   **`skos:exactMatch`** rows — **not** the record `identifier` field (182 records
   have `identifier` ≠ their ontology mapping, some broken), and **not**
   close/narrowMatch (a narrowMatch → CHEBI would silently generalise).
3. `environmental_context` coverage is **10 records, not ~44** (a seawater / soil /
   sulfur cluster).

## What

- **`cross_repo_environment.mim_exactmatch_chebi`** — parses
  `mappings/ingredient_mappings.sssom.tsv` (skips the `#` preamble), keeps only
  `skos:exactMatch` → `CHEBI:` rows.
- **`mim_ingredients_by_environment`** — joins each `environmental_context` record
  (`MIM:<file-stem>` subject) to that map; scans `data/ingredients/` (not the repo
  root — MIM keeps multi-MB aggregate dumps under `data/curated/` that would choke
  YAML parsing).
- **`scripts/suggest_related_ingredients.py`** + **`just suggest-related-ingredients`**
  — emits `RelatedIngredient` with `chebi_term` (**canonical** ChEBI label, not
  MIM's free-text name → id↔label gate stays green) + `shared_environment_term`;
  env keys are `environment_term` + `modeled_environment`; `--subsumption`
  supported; skips already-linked CHEBI ids, generic envs, and unresolved labels.
  **No longer a draft.**
- Tests: SSSOM join (exactMatch vs narrowMatch vs non-CHEBI) + suggester helpers.

## Verified

Real run emits **Sulfur (CHEBI:26833, "sulfur atom") → hot-spring mat community**
(exact `ENVO:00000051` match; Sulfur's `environmental_context` lists hot spring).
The emitted block **LinkML-validates**. Yield is **1 today** — data-limited by
MIM's 10 context records; correct and scales as MIM populates the field.

- `just test` — **254 passed**
- `just lint` — black + ruff + mypy clean

## Follow-up (tracked in NEXT_TASKS)

Drop the vestigial `^MediaIngredientMech:\d{6}$` pattern from
`RelatedIngredient.mediaingredientmech_id` (#119 §1).

Closes #215 (superseded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)