### PR TITLE
Render modeled_environment on community pages (regen 23 records)

### DIFF
--- a/docs/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.html
+++ b/docs/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        groundwater
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01001004"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:01001004
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/docs/communities/Anabaena_MGS1_Anaerobic_Digestion_Methanogen_Consortium.html
+++ b/docs/communities/Anabaena_MGS1_Anaerobic_Digestion_Methanogen_Consortium.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        anaerobic digester sludge
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_00003965"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:00003965
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/docs/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.html
+++ b/docs/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        bioreactor
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_00002123"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:00002123
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/docs/communities/BioAsteroid_ISS_Chondrite_Biomining_Consortium.html
+++ b/docs/communities/BioAsteroid_ISS_Chondrite_Biomining_Consortium.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        regolith
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01000747"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:01000747
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/docs/communities/BioModels_MODEL2204300001_Kefir_Community_Model.html
+++ b/docs/communities/BioModels_MODEL2204300001_Kefir_Community_Model.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        dairy
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_00003862"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:00003862
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/docs/communities/BioModels_MODEL2310020001_Mouse_Metaorganism_Model.html
+++ b/docs/communities/BioModels_MODEL2310020001_Mouse_Metaorganism_Model.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        intestine environment
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_2100002"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:2100002
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/docs/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.html
+++ b/docs/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        intestine environment
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_2100002"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:2100002
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/docs/communities/BioRock_ISS_Basalt_Biomining_Consortium.html
+++ b/docs/communities/BioRock_ISS_Basalt_Biomining_Consortium.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        regolith
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01000747"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:01000747
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/docs/communities/Butyrivibrio_Selenomonas_Ruminococcus_Lignocellulolytic_Rumen_Consortium.html
+++ b/docs/communities/Butyrivibrio_Selenomonas_Ruminococcus_Lignocellulolytic_Rumen_Consortium.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        digestive tract environment
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01001033"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:01001033
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/docs/communities/Cheese_Rind_InSitu_InVitro_Model_Community.html
+++ b/docs/communities/Cheese_Rind_InSitu_InVitro_Model_Community.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        dairy
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_00003862"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:00003862
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/docs/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.html
+++ b/docs/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        acid mine drainage
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_00001997"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:00001997
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/docs/communities/GLBRC_UFMP_Fermentation_Community.html
+++ b/docs/communities/GLBRC_UFMP_Fermentation_Community.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        bioreactor
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_00002123"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:00002123
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/docs/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.html
+++ b/docs/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        anaerobic digester sludge
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_00003965"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:00003965
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/docs/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.html
+++ b/docs/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        dairy
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_00003862"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:00003862
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/docs/communities/Lunar_Martian_Simulant_PGPB_Lettuce_SynCom.html
+++ b/docs/communities/Lunar_Martian_Simulant_PGPB_Lettuce_SynCom.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        regolith
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01000747"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:01000747
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/docs/communities/Lunar_Simulant_Phosphate_Solubilizing_Bacteria_Nicotiana.html
+++ b/docs/communities/Lunar_Simulant_Phosphate_Solubilizing_Bacteria_Nicotiana.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        regolith
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01000747"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:01000747
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/docs/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.html
+++ b/docs/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        marine environment
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01000320"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:01000320
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/docs/communities/Rifle_Aquifer_Bioanode_EET_Community.html
+++ b/docs/communities/Rifle_Aquifer_Bioanode_EET_Community.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        groundwater
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01001004"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:01001004
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/docs/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.html
+++ b/docs/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        marine environment
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01000320"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:01000320
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/docs/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.html
+++ b/docs/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        marine environment
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01000320"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:01000320
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/docs/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.html
+++ b/docs/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        bioreactor
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_00002123"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:00002123
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/docs/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.html
+++ b/docs/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        anaerobic digester sludge
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_00003965"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:00003965
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/docs/communities/Yogurt_TwoSpecies_Starter_Culture.html
+++ b/docs/communities/Yogurt_TwoSpecies_Starter_Culture.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        dairy
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_00003862"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:00003862
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
             </div>
         </section>
 

--- a/src/communitymech/templates/community.html
+++ b/src/communitymech/templates/community.html
@@ -409,6 +409,22 @@
                     </span>
                 </div>
                 {% endif %}
+                {% if community.modeled_environment %}
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        {% for me in community.modeled_environment %}
+                        {{ me.preferred_term or me.term.label }}
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/{{ me.term.id.replace(':', '_') }}"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            {{ me.term.id }}
+                        </a>
+                        {% if not loop.last %}<br>{% endif %}
+                        {% endfor %}
+                    </span>
+                </div>
+                {% endif %}
             </div>
         </section>
 


### PR DESCRIPTION
## What

Adds a **"Modeled Environment"** block to the `community.html` template (parallel to
Environment / `environment_term`, with ENVO OLS links, multivalued) and regenerates
the **23** community pages that carry `modeled_environment` (populated in #217).

Renders e.g. Rifle Aquifer → *groundwater*, BioRock ISS → *regolith*, Yogurt
Starter → *dairy*.

## Scope

Docs-only. **Only the 23 modeled pages change** — I staged just the real content
changes and reverted the 1-line whitespace churn the template's conditional leaves
on non-modeled pages, so the other 277 pages and `browser.html`/`index.html` are
untouched. Keeps the diff to the 23 pages + the template.

Completes the remaining follow-up from the `modeled_environment` work
(#216 schema → #217 population → #218 suggester → this: pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)