### PR TITLE
Drop vestigial MediaIngredientMech:NNNNNN pattern (MIM#119 §1)

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -194,9 +194,17 @@ record (`MIM:<file-stem>` subject) to it; emits `RelatedIngredient`
 env keys from `environment_term` + `modeled_environment`, supports `--subsumption`.
 Real yield today: 1 suggestion (Sulfur CHEBI:26833 → the hot-spring mat community) —
 data-limited by MIM's 10 context records, correct + scales. Supersedes draft PR #215.
-**Follow-up:** drop the vestigial `^MediaIngredientMech:\d{6}$` pattern from
-`RelatedIngredient.mediaingredientmech_id` (per #119 §1); a rename-stable MIM
-surrogate id would need its own MIM issue if we later want to persist `MIM:<name>`.
+**Vestigial-pattern drop — DONE (2026-07-20, PR #223).** Removed the
+`^MediaIngredientMech:\d{6}$` pattern from **both** schema fields
+(`RelatedIngredient.mediaingredientmech_id`, `GrowthMediaComponent.media_ingredient_mech_id`)
+per #119 §1; descriptions mark the scheme vestigial/deprecated and point to
+`chebi_term` as the join. Datamodel regenerated; a `MIM:<name>` value now validates.
+**Remaining (smaller follow-up):** `src/communitymech/validators/cross_repo_ids.py`
+still enforces `MediaIngredientMech:NNNNNN` on `related_ingredients[].mediaingredientmech_id`
+(a local, non-CI tool with ~6 dedicated tests) — retire or repoint that branch to
+`chebi_term` when convenient; 0 records populate the field so it's inert today. A
+rename-stable MIM surrogate id would need its own MIM issue if we later want to
+persist `MIM:<name>` as a key.
 **Other follow-ups (grounding-quality):**
 - **ENVO subsumption matching — DONE (2026-07-19, PR #213).** `suggest-related-media
   --subsumption` also matches media whose environment is an ENVO `is_a` *subtype*

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-07-19T17:42:00
+# Generation date: 2026-07-19T22:00:47
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech
@@ -3700,7 +3700,6 @@ slots.growthMediaComponent__media_ingredient_mech_id = Slot(
     model_uri=COMMUNITYMECH.growthMediaComponent__media_ingredient_mech_id,
     domain=None,
     range=Optional[str],
-    pattern=re.compile(r"^MediaIngredientMech:\d{6}$"),
 )
 
 slots.growthMediaComponent__media_ingredient_mech_url = Slot(
@@ -4101,7 +4100,6 @@ slots.relatedIngredient__mediaingredientmech_id = Slot(
     model_uri=COMMUNITYMECH.relatedIngredient__mediaingredientmech_id,
     domain=None,
     range=Optional[str],
-    pattern=re.compile(r"^MediaIngredientMech:\d{6}$"),
 )
 
 slots.relatedIngredient__chebi_term = Slot(

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -947,8 +947,11 @@ classes:
         description: Name of the component
         required: true
       media_ingredient_mech_id:
-        description: Identifier in MediaIngredientMech database (e.g., MediaIngredientMech:000001)
-        pattern: "^MediaIngredientMech:\\d{6}$"
+        description: >-
+          MediaIngredientMech identifier. NOTE: the `MediaIngredientMech:NNNNNN`
+          scheme is vestigial — MIM's canonical ingredient CURIE is `MIM:<name>`
+          (confirmed MediaIngredientMech#119), so no pattern is enforced. Prefer
+          `chebi_term` for the compound identity.
       media_ingredient_mech_url:
         description: URL to MediaIngredientMech ingredient entry
       concentration:
@@ -1086,13 +1089,14 @@ classes:
         range: string
       mediaingredientmech_id:
         description: >-
-          MediaIngredientMech identifier. NOTE: MIM's canonical ingredient CURIE
-          is `MIM:<name>` (SSSOM registry), not `MediaIngredientMech:NNNNNN`;
-          reconciliation is tracked in MediaIngredientMech#119 / NEXT_TASKS §2c.
-          Prefer `chebi_term` for the compound identity until that resolves.
+          MediaIngredientMech identifier. NOTE: the `MediaIngredientMech:NNNNNN`
+          scheme is **vestigial** — MIM confirmed (MediaIngredientMech#119) its
+          canonical ingredient CURIE is `MIM:<name>` (SSSOM registry) and the
+          `NNNNNN` form appears in zero canonical records. No schema pattern is
+          enforced. The equivalence-safe join is `chebi_term` (MIM's
+          `skos:exactMatch` CHEBI); prefer it. Deprecated — likely to be removed.
         required: false
         range: string
-        pattern: "^MediaIngredientMech:\\d{6}$"
       chebi_term:
         description: CHEBI ontology term for the ingredient compound
         range: Term


### PR DESCRIPTION
## What

Per **MediaIngredientMech#119 §1** — the `MediaIngredientMech:NNNNNN` scheme is
vestigial (MIM's canonical ingredient CURIE is `MIM:<name>`; the `NNNNNN` form
appears in **zero** canonical records). Remove the `^MediaIngredientMech:\d{6}$`
pattern from both schema fields:

- `RelatedIngredient.mediaingredientmech_id`
- `GrowthMediaComponent.media_ingredient_mech_id`

Descriptions now mark the scheme vestigial/deprecated and point to `chebi_term`
(MIM's `skos:exactMatch` CHEBI) as the equivalence-safe join. Datamodel regenerated.

## Verified

- A `MIM:<name>` value in `mediaingredientmech_id` now LinkML-validates (RC 0)
- `just test` — **256 passed**
- `just lint` — clean; existing records unaffected (dropping a pattern only loosens)

## Follow-up (tracked in NEXT_TASKS)

`src/communitymech/validators/cross_repo_ids.py` still enforces the pattern on
`related_ingredients[].mediaingredientmech_id` — a local, **non-CI** tool with ~6
dedicated tests, **inert today** (0 records populate the field). Retire or repoint
that branch to `chebi_term` when convenient; ripping it out here would be an
invasive refactor beyond dropping the pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)