### PR TITLE
Retire vestigial MediaIngredientMech id validation (MIM#119)

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -199,12 +199,14 @@ data-limited by MIM's 10 context records, correct + scales. Supersedes draft PR 
 (`RelatedIngredient.mediaingredientmech_id`, `GrowthMediaComponent.media_ingredient_mech_id`)
 per #119 §1; descriptions mark the scheme vestigial/deprecated and point to
 `chebi_term` as the join. Datamodel regenerated; a `MIM:<name>` value now validates.
-**Remaining (smaller follow-up):** `src/communitymech/validators/cross_repo_ids.py`
-still enforces `MediaIngredientMech:NNNNNN` on `related_ingredients[].mediaingredientmech_id`
-(a local, non-CI tool with ~6 dedicated tests) — retire or repoint that branch to
-`chebi_term` when convenient; 0 records populate the field so it's inert today. A
-rename-stable MIM surrogate id would need its own MIM issue if we later want to
-persist `MIM:<name>` as a key.
+**Validator retirement — DONE (2026-07-20, PR #224).** Removed the
+`related_ingredients` / `mediaingredientmech_id` branch from
+`src/communitymech/validators/cross_repo_ids.py` (+ the `MEDIAINGREDIENTMECH_ID_RE`
+constant, the `--mediaingredientmech` script flag, and the vestigial pattern tests
+in `test_cross_repo_ids.py` / `test_cross_repo_linking.py`). The validator now only
+checks `related_media` CultureMech ids; ingredient linking joins on `chebi_term`
+(covered by the id-label validator). A rename-stable MIM surrogate id would need its
+own MIM issue if we later want to persist `MIM:<name>` as a key.
 **Other follow-ups (grounding-quality):**
 - **ENVO subsumption matching — DONE (2026-07-19, PR #213).** `suggest-related-media
   --subsumption` also matches media whose environment is an ENVO `is_a` *subtype*

--- a/scripts/validate_cross_repo_ids.py
+++ b/scripts/validate_cross_repo_ids.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
-"""CLI: validate cross-repo IDs (CultureMech, MediaIngredientMech) in one or more community YAMLs.
+"""CLI: validate cross-repo CultureMech IDs (related_media) in one or more community YAMLs.
 
-Pattern checks always run. Existence checks run only when sibling-repo
-paths are supplied via flags or via the COMMUNITYMECH_SIBLING_REPOS
-environment variable (comma-separated `Name=path` pairs).
+Pattern checks always run. Existence checks run only when a CultureMech sibling-repo
+path is supplied via flag or via the COMMUNITYMECH_SIBLING_REPOS environment
+variable (comma-separated `Name=path` pairs). `related_ingredients` is no longer
+checked — the MediaIngredientMech:NNNNNN scheme is vestigial (MediaIngredientMech#119).
 
 Usage:
     PYTHONPATH=src uv run python scripts/validate_cross_repo_ids.py kb/communities/X.yaml
     PYTHONPATH=src uv run python scripts/validate_cross_repo_ids.py kb/communities/X.yaml \\
-        --culturemech ../CultureMech/kb/media \\
-        --mediaingredientmech ../MediaIngredientMech/kb/ingredients
+        --culturemech ../CultureMech/kb/media
     PYTHONPATH=src uv run python scripts/validate_cross_repo_ids.py kb/communities/*.yaml
 """
 
@@ -40,16 +40,11 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("yaml_paths", nargs="+", type=Path)
     parser.add_argument("--culturemech", type=Path, help="Path to CultureMech kb/ dir")
-    parser.add_argument(
-        "--mediaingredientmech", type=Path, help="Path to MediaIngredientMech kb/ dir"
-    )
     args = parser.parse_args()
 
     sibling_repos = _sibling_repos_from_env()
     if args.culturemech is not None:
         sibling_repos["CultureMech"] = args.culturemech
-    if args.mediaingredientmech is not None:
-        sibling_repos["MediaIngredientMech"] = args.mediaingredientmech
 
     total_errors = 0
     for yaml_path in args.yaml_paths:

--- a/src/communitymech/validators/cross_repo_ids.py
+++ b/src/communitymech/validators/cross_repo_ids.py
@@ -1,17 +1,22 @@
-"""Cross-repository ID validation for related_media and related_ingredients.
+"""Cross-repository ID validation for related_media.
 
-When a community YAML references a `culturemech_id` or `mediaingredientmech_id`
-under `related_media` / `related_ingredients`, two things should hold:
+When a community YAML references a `culturemech_id` under `related_media`, two
+things should hold:
 
-1. The ID matches its CURIE pattern (`CultureMech:NNNNNN` /
-   `MediaIngredientMech:NNNNNN`). LinkML's schema-level pattern check
-   covers this, but mirroring it here surfaces issues without booting
-   the full validator and lets callers act on individual offenders.
+1. The ID matches its CURIE pattern (`CultureMech:NNNNNN`). LinkML's schema-level
+   pattern check covers this, but mirroring it here surfaces issues without
+   booting the full validator and lets callers act on individual offenders.
 
 2. The ID actually exists in the sibling repository. This requires a
    path to the sibling repo and is therefore opt-in — if no sibling-repo
    path is supplied, existence checks are skipped (and the validator
    says so explicitly rather than silently passing).
+
+`related_ingredients` is intentionally NOT validated here: the
+`MediaIngredientMech:NNNNNN` scheme is vestigial (MediaIngredientMech#119 — MIM's
+canonical CURIE is `MIM:<name>`, absent from canonical records), so there is no
+cross-repo id to verify. Ingredient linking now joins on `chebi_term`, whose
+id↔label correctness is covered by the id-label validator, not this one.
 
 Usage:
 
@@ -20,10 +25,7 @@ Usage:
 
     issues = validate_cross_repo_ids(
         Path("kb/communities/SPRUCE_Peatland_Methane_Cycling_Community.yaml"),
-        sibling_repos={
-            "CultureMech": Path("../CultureMech/kb/media"),
-            "MediaIngredientMech": Path("../MediaIngredientMech/kb/ingredients"),
-        },
+        sibling_repos={"CultureMech": Path("../CultureMech/kb/media")},
     )
     for i in issues:
         print(i.severity, i.message)
@@ -39,7 +41,6 @@ from pathlib import Path
 import yaml
 
 CULTUREMECH_ID_RE = re.compile(r"^CultureMech:\d{6}$")
-MEDIAINGREDIENTMECH_ID_RE = re.compile(r"^MediaIngredientMech:\d{6}$")
 
 
 @dataclass
@@ -106,10 +107,10 @@ def validate_cross_repo_ids(
     Args:
         yaml_path: Path to the community YAML.
         sibling_repos: Optional dict mapping repo name to the directory
-            holding the sibling repo's record YAMLs. Recognized keys:
-            ``CultureMech``, ``MediaIngredientMech``. If a key is missing
-            or its path doesn't exist, the existence check for that repo
-            is skipped (with an info-level note in the issue list).
+            holding the sibling repo's record YAMLs. Recognized key:
+            ``CultureMech``. If it is missing or its path doesn't exist, the
+            existence check is skipped (with an info-level note in the issue
+            list).
 
     Returns:
         List of CrossRepoIssue. Empty if everything checks out (or if
@@ -118,7 +119,6 @@ def validate_cross_repo_ids(
     """
     sibling_repos = sibling_repos or {}
     culturemech = SiblingRepoIndex(path=sibling_repos.get("CultureMech"))
-    mim = SiblingRepoIndex(path=sibling_repos.get("MediaIngredientMech"))
 
     data = yaml.safe_load(yaml_path.read_text()) or {}
     issues: list[CrossRepoIssue] = []
@@ -154,41 +154,6 @@ def validate_cross_repo_ids(
                     message=(
                         f"existence check for '{cid}' skipped: no CultureMech "
                         "sibling-repo path configured"
-                    ),
-                )
-            )
-
-    for idx, entry in _iter_entries(data, "related_ingredients"):
-        mid = entry.get("mediaingredientmech_id")
-        if mid is None:
-            continue
-        field_path = f"related_ingredients[{idx}].mediaingredientmech_id"
-        if not MEDIAINGREDIENTMECH_ID_RE.match(mid):
-            issues.append(
-                CrossRepoIssue(
-                    severity="error",
-                    field_path=field_path,
-                    message=f"'{mid}' does not match pattern MediaIngredientMech:NNNNNN",
-                )
-            )
-            continue
-        if mim.available:
-            if mid not in mim:
-                issues.append(
-                    CrossRepoIssue(
-                        severity="error",
-                        field_path=field_path,
-                        message=f"'{mid}' not found in MediaIngredientMech repo at {mim.path}",
-                    )
-                )
-        else:
-            issues.append(
-                CrossRepoIssue(
-                    severity="info",
-                    field_path=field_path,
-                    message=(
-                        f"existence check for '{mid}' skipped: no "
-                        "MediaIngredientMech sibling-repo path configured"
                     ),
                 )
             )

--- a/tests/test_cross_repo_ids.py
+++ b/tests/test_cross_repo_ids.py
@@ -1,4 +1,9 @@
-"""Tests for the cross-repo ID validator."""
+"""Tests for the cross-repo ID validator (related_media / CultureMech).
+
+`related_ingredients` is no longer validated here — the `MediaIngredientMech:NNNNNN`
+scheme is vestigial (MediaIngredientMech#119); ingredient linking joins on
+`chebi_term`, covered by the id-label validator.
+"""
 
 from pathlib import Path
 
@@ -12,7 +17,7 @@ from communitymech.validators.cross_repo_ids import (
 
 @pytest.fixture
 def community_with_ids(tmp_path: Path) -> Path:
-    """A community YAML that references both kinds of sibling-repo IDs."""
+    """A community YAML that references CultureMech media IDs."""
     path = tmp_path / "community.yaml"
     path.write_text("""
 id: CommunityMech:000999
@@ -22,11 +27,6 @@ related_media:
   culturemech_id: CultureMech:010001
 - preferred_term: Iron Selective Medium
   culturemech_id: CultureMech:010002
-related_ingredients:
-- preferred_term: Humic acid
-  mediaingredientmech_id: MediaIngredientMech:000523
-- preferred_term: Ferrous sulfate
-  mediaingredientmech_id: MediaIngredientMech:000089
 """.strip())
     return path
 
@@ -37,15 +37,6 @@ def culturemech_repo(tmp_path: Path) -> Path:
     repo = tmp_path / "culturemech_kb"
     repo.mkdir()
     (repo / "medium_a.yaml").write_text("id: CultureMech:010001\nname: Acidic Peatland Medium\n")
-    return repo
-
-
-@pytest.fixture
-def mediaingredientmech_repo(tmp_path: Path) -> Path:
-    """A sibling MIM kb/ dir with one of the two IDs above."""
-    repo = tmp_path / "mim_kb"
-    repo.mkdir()
-    (repo / "humic.yaml").write_text("id: MediaIngredientMech:000523\nname: Humic acid\n")
     return repo
 
 
@@ -67,26 +58,13 @@ class TestPatternCheck:
         assert len(errors) == 1
         assert "does not match pattern" in errors[0].message
 
-    def test_malformed_mim_id_reports_error(self, tmp_path: Path) -> None:
-        path = tmp_path / "bad.yaml"
-        path.write_text(
-            "id: CommunityMech:000001\n"
-            "related_ingredients:\n"
-            "- preferred_term: X\n"
-            "  mediaingredientmech_id: bogus\n"
-        )
-        issues = validate_cross_repo_ids(path)
-        errors = [i for i in issues if i.severity == "error"]
-        assert len(errors) == 1
-        assert "MediaIngredientMech:NNNNNN" in errors[0].message
-
 
 class TestExistenceCheck:
     def test_no_sibling_repo_emits_info_per_id(self, community_with_ids: Path) -> None:
         issues = validate_cross_repo_ids(community_with_ids, sibling_repos={})
         infos = [i for i in issues if i.severity == "info"]
-        # 2 culturemech + 2 mim IDs = 4 info notices
-        assert len(infos) == 4
+        # 2 culturemech IDs = 2 info notices
+        assert len(infos) == 2
 
     def test_sibling_repo_finds_missing_culturemech_id(
         self, community_with_ids: Path, culturemech_repo: Path
@@ -100,34 +78,28 @@ class TestExistenceCheck:
         assert "CultureMech:010002" in errors[0].message
         assert "not found" in errors[0].message
 
-    def test_sibling_repo_finds_missing_mim_id(
-        self, community_with_ids: Path, mediaingredientmech_repo: Path
+    def test_configured_repo_leaves_only_real_errors(
+        self, community_with_ids: Path, culturemech_repo: Path
     ) -> None:
         issues = validate_cross_repo_ids(
             community_with_ids,
-            sibling_repos={"MediaIngredientMech": mediaingredientmech_repo},
-        )
-        errors = [i for i in issues if i.severity == "error"]
-        assert len(errors) == 1
-        assert "MediaIngredientMech:000089" in errors[0].message
-
-    def test_both_repos_configured_only_real_errors_remain(
-        self,
-        community_with_ids: Path,
-        culturemech_repo: Path,
-        mediaingredientmech_repo: Path,
-    ) -> None:
-        issues = validate_cross_repo_ids(
-            community_with_ids,
-            sibling_repos={
-                "CultureMech": culturemech_repo,
-                "MediaIngredientMech": mediaingredientmech_repo,
-            },
+            sibling_repos={"CultureMech": culturemech_repo},
         )
         infos = [i for i in issues if i.severity == "info"]
         errors = [i for i in issues if i.severity == "error"]
-        assert not infos  # both repos configured, no skip notices
-        assert len(errors) == 2  # 010002 + 000089 missing
+        assert not infos  # repo configured, no skip notices
+        assert len(errors) == 1  # 010002 missing
+
+    def test_related_ingredients_are_not_validated(self, tmp_path: Path) -> None:
+        # a bogus mediaingredientmech_id (vestigial scheme) must NOT be flagged
+        path = tmp_path / "ingredients.yaml"
+        path.write_text(
+            "id: CommunityMech:000001\n"
+            "related_ingredients:\n"
+            "- preferred_term: X\n"
+            "  mediaingredientmech_id: bogus\n"
+        )
+        assert validate_cross_repo_ids(path) == []
 
 
 class TestEdgeCases:

--- a/tests/test_cross_repo_linking.py
+++ b/tests/test_cross_repo_linking.py
@@ -31,7 +31,8 @@ from communitymech.datamodel.communitymech import (
 TEST_DATA_DIR = Path(__file__).parent / "data" / "test_cross_repo_linking"
 
 CULTUREMECH_ID_PATTERN = re.compile(r"^CultureMech:\d{6}$")
-MEDIAINGREDIENTMECH_ID_PATTERN = re.compile(r"^MediaIngredientMech:\d{6}$")
+# The MediaIngredientMech:NNNNNN scheme is retired (vestigial per
+# MediaIngredientMech#119); ingredient linking joins on chebi_term.
 
 
 # ---------------------------------------------------------------------------
@@ -96,14 +97,6 @@ class TestSPRUCEWithLinks:
     def test_related_ingredients_present(self):
         assert "related_ingredients" in self.data
         assert len(self.data["related_ingredients"]) == 2
-
-    def test_related_ingredients_mim_ids(self):
-        for ri in self.data["related_ingredients"]:
-            mid = ri.get("mediaingredientmech_id")
-            if mid is not None:
-                assert MEDIAINGREDIENTMECH_ID_PATTERN.match(
-                    mid
-                ), f"Invalid MediaIngredientMech ID: {mid}"
 
     def test_related_ingredients_chebi_term(self):
         humic = self.data["related_ingredients"][0]
@@ -198,10 +191,6 @@ class TestAllRelationshipTypes:
         for rm in self.data["related_media"]:
             assert CULTUREMECH_ID_PATTERN.match(rm["culturemech_id"])
 
-    def test_all_mim_ids_valid(self):
-        for ri in self.data["related_ingredients"]:
-            assert MEDIAINGREDIENTMECH_ID_PATTERN.match(ri["mediaingredientmech_id"])
-
 
 # ---------------------------------------------------------------------------
 # Cross-repo ID pattern validation
@@ -226,28 +215,6 @@ class TestIDPatternValidation:
         ]
         for cid in invalid:
             assert not CULTUREMECH_ID_PATTERN.match(cid), f"Should be invalid: {cid}"
-
-    def test_valid_mim_ids(self):
-        valid = [
-            "MediaIngredientMech:000001",
-            "MediaIngredientMech:000523",
-            "MediaIngredientMech:999999",
-        ]
-        for mid in valid:
-            assert MEDIAINGREDIENTMECH_ID_PATTERN.match(mid), f"Should be valid: {mid}"
-
-    def test_invalid_mim_ids(self):
-        invalid = [
-            "MediaIngredientMech:12345",
-            "MediaIngredientMech:1234567",
-            "mediaingredientmech:000001",
-            "CultureMech:000001",
-            "MediaIngredientMech:abcdef",
-            "MIM:000001",
-            "",
-        ]
-        for mid in invalid:
-            assert not MEDIAINGREDIENTMECH_ID_PATTERN.match(mid), f"Should be invalid: {mid}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Follow-up to #223. The `MediaIngredientMech:NNNNNN` scheme is vestigial per
**MediaIngredientMech#119**; #223 dropped its schema pattern. This removes the last
inert enforcement:

- **`validators/cross_repo_ids.py`** — drop the `related_ingredients` /
  `mediaingredientmech_id` branch and `MEDIAINGREDIENTMECH_ID_RE`. The validator now
  checks only `related_media` CultureMech ids. Ingredient linking joins on
  `chebi_term` (id↔label covered by the id-label validator), so there is no
  cross-repo id to verify here.
- **`scripts/validate_cross_repo_ids.py`** — drop the unused `--mediaingredientmech`
  flag; update docstring.
- **tests** — remove the vestigial MIM-pattern tests (`test_cross_repo_ids.py`,
  `test_cross_repo_linking.py`); add a test asserting a bogus `mediaingredientmech_id`
  is **not** flagged (documents the retirement).

## Verified

- `just test` — **251 passed**
- `just lint` — clean
- **0 records** populate `mediaingredientmech_id`, so no behavior change on real data.

Closes the last `NEXT_TASKS` item from the MIM#119 thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)