### PR TITLE
Add causal-edge mode to deep-research-community (Edison, one community)

### DIFF
--- a/.claude/skills/deep-research-community/skill.md
+++ b/.claude/skills/deep-research-community/skill.md
@@ -1,6 +1,6 @@
 ---
 name: deep-research-community
-description: Run Edison Scientific deep research (PaperQA3) for a CommunityMech microbial-community record to gather source-backed composition, ecological interactions/mechanisms, environment, cultivation conditions, and ontology grounding (NCBITaxon/ENVO/CHEBI/GO). Captures a full provenance bundle and produces a curation-focused report for a curator to review and apply.
+description: Run Edison Scientific deep research (PaperQA3) for a CommunityMech microbial-community record to gather source-backed composition, ecological interactions/mechanisms, environment, cultivation conditions, and ontology grounding (NCBITaxon/ENVO/CHEBI/GO). Captures a full provenance bundle and produces a curation-focused report for a curator to review and apply. Includes a causal-edge mode that, for one community, extracts a source-backed causal interaction graph (interaction nodes + directed causal edges → ecological_interactions + downstream).
 category: research
 requires_database: false
 requires_internet: true
@@ -129,6 +129,40 @@ Do **not** mutate `kb/communities/` files in this skill — that is the
 curator's call after reading the report. The per-task markdown + meta
 files are the audit trail and source of truth for citations.
 
+## Causal-edge mode (one community at a time)
+
+The **default** mode (above) produces a broad mechanism report. **Causal-edge
+mode** instead asks Edison to build a source-backed **causal interaction graph**
+for a single community — the nodes are mechanistic interactions, the edges are
+directed causal links ("interaction A enables / drives / suppresses interaction
+B"). It maps directly onto the schema: interaction nodes →
+`ecological_interactions[]` (with `interaction_type`, `scope`,
+`source_taxon`→`target_taxon`, `metabolites`, `biological_processes`, sign), and
+causal edges → `EcologicalInteraction.downstream[]` (`InteractionDownstream`:
+`target` + causal-link `description`).
+
+**When to use it**: when the curation goal is the *wiring* — how the mechanisms
+chain into the community's emergent function — rather than a general
+composition/conditions sweep. Same one-community scope, same Edison plumbing and
+provenance bundle.
+
+Run it (dry-run first to audit the query before spending credits):
+
+```bash
+just research-community-causal <stem-or-id> --dry-run
+just research-community-causal <stem-or-id>
+# deeper (more reads, higher cost):
+just research-community-causal <stem-or-id> --job literature-high
+```
+
+This uses `templates/community_causal_graph_research.md` and a `--label causal`
+suffix, so its outputs are **`<stem>-edison-<job>-causal.*`** and do **not**
+overwrite the default mechanism run's `<stem>-edison-<job>.*`. Everything else —
+Steps 1–2 (resolve + check-existing), the cost/safety rules, and the
+hand-off-to-curator discipline (Step 4: do **not** mutate `kb/communities/`) —
+applies unchanged. The report's node/edge tables + DOT sketch are what a curator
+reviews before writing an `ecological_interactions` block.
+
 ## File outputs at a glance
 
 ```
@@ -182,6 +216,10 @@ research/communities/
 # Single community (dry-run to audit the query first):
 just research-community-edison <stem-or-id> --dry-run
 just research-community-edison <stem-or-id>
+
+# Causal-graph mode for one community (interaction nodes + directed causal edges):
+just research-community-causal <stem-or-id> --dry-run
+just research-community-causal <stem-or-id>
 
 # Deeper job:
 just research-community-edison <stem-or-id> --job literature-high

--- a/justfile
+++ b/justfile
@@ -343,6 +343,19 @@ research-community-edison target *args="":
       --out-dir {{research_dir}}/communities \
       {{args}}
 
+# Edison deep research in CAUSAL-GRAPH mode for ONE community: extracts
+# source-backed interaction nodes + directed causal edges (ecological_interactions
+# + InteractionDownstream). Same Edison plumbing as research-community-edison, with
+# the causal template + a `causal` label so it does NOT overwrite the mechanism run.
+#   just research-community-causal Cellulose_Methane_Quad_Culture_SynCom --dry-run
+research-community-causal target *args="":
+    uv run --extra dev python scripts/research_community_edison.py \
+      --target {{target}} \
+      --template {{templates_dir}}/community_causal_graph_research.md \
+      --label causal \
+      --out-dir {{research_dir}}/communities \
+      {{args}}
+
 # Edison deep research for a batch of communities (JSON list of stems/ids/paths).
 research-community-edison-batch batch *args="":
     uv run --extra dev python scripts/research_community_edison.py \

--- a/scripts/research_community_edison.py
+++ b/scripts/research_community_edison.py
@@ -41,6 +41,7 @@ Usage::
     # have been sent without spending credits.
     python scripts/research_community_edison.py --target <target> --dry-run
 """
+
 from __future__ import annotations
 
 import argparse
@@ -56,8 +57,8 @@ from dotenv import load_dotenv
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
-import research_community as rc  # noqa: E402  -- reuse template_vars + loaders
 import _edison_capture as ec  # noqa: E402  -- response/citation/agent capture
+import research_community as rc  # noqa: E402  -- reuse template_vars + loaders
 
 DEFAULT_TEMPLATE = REPO_ROOT / "templates" / "community_mechanism_research.md"
 DEFAULT_OUT_DIR = REPO_ROOT / "research" / "communities"
@@ -152,6 +153,7 @@ def run_one(
     template_path: Path,
     out_dir: Path,
     dry_run: bool,
+    label: str = "",
 ) -> dict[str, Any]:
     """Submit one task; write results to out_dir; return a stats dict.
 
@@ -166,7 +168,11 @@ def run_one(
     query, variables = render_query(community_path, template_path, doc)
     slug = slug_for(community_path)
     job_short = _short_job(job)
-    stem = f"{slug}-edison-{job_short}"
+    # An optional --label keeps parallel runs of the same (community, job) from
+    # clobbering each other, e.g. `-causal` for the causal-graph template vs the
+    # default mechanism template.
+    label_suffix = f"-{label}" if label else ""
+    stem = f"{slug}-edison-{job_short}{label_suffix}"
     meta_path = out_dir / f"{stem}-meta.yaml"
 
     def _safe_rel(p: Path) -> str:
@@ -181,6 +187,7 @@ def run_one(
         "community_id": str(doc.get("id") or ""),
         "job": job.name,
         "job_id": job.value,
+        "label": label,
         "template_path": _safe_rel(template_path),
         "template_vars": variables,
         "query_chars": len(query),
@@ -194,9 +201,7 @@ def run_one(
         # identical re-runs). No .md is written; only meta.
         meta = ec.capture_dry_run(out_dir=out_dir, stem=stem, query=query, base_meta=base_meta)
         out_dir.mkdir(parents=True, exist_ok=True)
-        meta_path.write_text(
-            yaml.safe_dump(meta, sort_keys=False, allow_unicode=True, width=100)
-        )
+        meta_path.write_text(yaml.safe_dump(meta, sort_keys=False, allow_unicode=True, width=100))
         md_path = out_dir / f"{stem}.md"
         print(f"[DRY RUN] {_display_path(community_path)} -> {_display_path(md_path)}")
         print(f"          job={job.name} query_chars={len(query)} meta={_display_path(meta_path)}")
@@ -259,6 +264,12 @@ def main(argv: list[str] | None = None) -> int:
         help="literature (paperqa3, default) | literature-high | precedent | phoenix",
     )
     ap.add_argument("--template", type=Path, default=DEFAULT_TEMPLATE)
+    ap.add_argument(
+        "--label",
+        default="",
+        help="Optional suffix on output filenames (e.g. 'causal') so a non-default "
+        "template's run doesn't overwrite the default one for the same community+job.",
+    )
     ap.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
     ap.add_argument(
         "--limit", type=int, default=None, help="When using --batch, cap the number researched."
@@ -317,7 +328,15 @@ def main(argv: list[str] | None = None) -> int:
     try:
         for community_path in targets:
             results.append(
-                run_one(client, community_path, job, args.template, args.out_dir, args.dry_run)
+                run_one(
+                    client,
+                    community_path,
+                    job,
+                    args.template,
+                    args.out_dir,
+                    args.dry_run,
+                    args.label,
+                )
             )
     finally:
         if client is not None:

--- a/templates/community_causal_graph_research.md
+++ b/templates/community_causal_graph_research.md
@@ -1,0 +1,95 @@
+# Microbial Community Causal-Graph Research Template
+
+## Target Community
+- **Community name:** {community_name}
+- **Community id:** {community_id}
+- **Community file:** {community_file}
+- **Community category:** {community_category}
+- **Ecological state:** {ecological_state}
+- **Community origin:** {community_origin}
+- **Environment:** {environment_summary}
+- **Description:** {description}
+
+## Existing Record Context
+- **Taxa:** {taxonomy_summary}
+- **Known ecological interactions:** {interaction_summary}
+- **Environmental factors:** {environmental_factor_summary}
+- **Growth media / culture conditions:** {growth_media_summary}
+- **Associated datasets / resources:** {dataset_summary}
+- **Existing evidence:** {evidence_summary}
+
+## Research Objective
+
+Build a source-backed **causal interaction graph** for the microbial community
+**{community_name}**, suitable for the `ecological_interactions` block of
+`kb/communities/{community_file}`. The graph's **nodes are mechanistic
+interactions** and its **directed edges are causal links** ("interaction A
+enables / drives / suppresses interaction B"). Extract only relationships the
+primary literature supports; do not infer edges that are not stated or directly
+implied by an experiment.
+
+## Required Findings
+
+### 1. Interaction nodes (the vertices)
+
+For each mechanistic interaction, report as a table row:
+
+- **name** — a short, unique interaction name (used as the node id and as the
+  `target` of any causal edge that points to it).
+- **interaction_type** — one of: MUTUALISM, COMMENSALISM, CROSS_FEEDING,
+  COMPETITION, PREDATION, SYNTROPHY, NICHE_PARTITIONING, STRAIN_COMPETITION,
+  COLONIZATION_FACILITATION (or state "OTHER: <describe>" if none fit).
+- **scope** — PAIRWISE (organism→organism) or COMMUNITY_LEVEL (emergent /
+  abiotically driven, e.g. electrolysis-supplied H2). PAIRWISE **must** name a
+  source taxon.
+- **source_taxon → target_taxon** — the directed pair (who acts on whom). Give
+  NCBITaxon CURIEs + labels where resolvable.
+- **metabolites / biological_processes** — the exchanged compound(s) (CHEBI) and
+  process(es) (GO) that mediate the interaction.
+- **direction / sign** — does the source **increase (+)** or **decrease (−)** the
+  target's growth/activity? State it explicitly.
+- **evidence** — a short **verbatim** snippet + its reference (PMID/DOI).
+
+### 2. Causal edges (the arcs)
+
+This is the graph structure. For every ordered pair of nodes where the
+literature supports a causal link, report a row:
+
+- **from** — upstream interaction name (a node from §1).
+- **to** — downstream interaction name (a node from §1).
+- **causal link** — one sentence: *how* the upstream interaction causes /
+  enables / is required for / suppresses the downstream one (e.g. "H2 produced
+  by the syntrophic oxidation lowers pH2 enough for the acetogen to grow, which
+  in turn supplies acetate to the methanogen").
+- **evidence** — verbatim snippet + reference for the causal claim specifically
+  (not just for the two endpoints existing).
+
+Prefer chains that a paper demonstrates by perturbation (knockout, substrate
+removal, inhibitor, co-culture vs mono-culture), and say which experiment shows
+each edge. Flag any edge that is hypothesized rather than demonstrated.
+
+### 3. Grounding
+
+- CURIEs where available: NCBITaxon (taxa), CHEBI (metabolites), GO (processes),
+  ENVO (environment), PMID / DOI (evidence).
+- Do not invent taxa, ontology ids, snippets, accession ids, or citations. If a
+  node or edge lacks a citable source, omit it or mark it UNVERIFIED.
+
+## Output Format
+
+Return a curation-focused report with:
+
+1. **Scope summary** — the consortium and the top-level function the causal graph
+   explains (1–3 sentences).
+2. **Node table** — the interaction nodes (§1 columns).
+3. **Edge table** — the directed causal edges (§2 columns: from, to, causal
+   link, evidence).
+4. **Adjacency / DOT sketch** — a compact `from -> to` edge list (or Graphviz DOT
+   snippet) so the graph can be eyeballed; annotate edges with + / − sign.
+5. **Gaps & controversies** — edges the literature disputes, or plausible edges
+   with no direct evidence (candidates for a `Discussion`/knowledge-gap note).
+6. **References** — every PMID/DOI cited, once.
+
+Each biological claim (node and edge) must carry a verbatim snippet and a
+reference. This report is reviewed by a curator before anything is written to
+`kb/communities/`.


### PR DESCRIPTION
## What

Extends the Edison **`deep-research-community`** skill with a **causal-edge mode**:
for a single community, it asks Edison (PaperQA3) to build a **source-backed causal
interaction graph** — interaction **nodes** (type, scope, source→target taxa,
metabolites/processes, +/− sign) and directed causal **edges** ("A enables/drives/
suppresses B").

Maps straight onto the schema:
- nodes → `ecological_interactions[]` (`interaction_type`, `scope`, `source_taxon`→
  `target_taxon`, `metabolites`, `biological_processes`)
- edges → `EcologicalInteraction.downstream[]` (`InteractionDownstream`: `target` +
  causal-link `description`)

## Changes

- **`templates/community_causal_graph_research.md`** — new causal template. Reuses
  the *same* placeholders as the mechanism template, so the existing
  `render_query` / `template_vars` machinery is unchanged. Requires a verbatim
  snippet + CURIEs per node **and per edge**; asks for a node table, an edge table,
  and a DOT/adjacency sketch; flags hypothesized vs demonstrated edges.
- **`scripts/research_community_edison.py`** — add `--label` to suffix output
  filenames, so a causal run (`--label causal`) does **not** overwrite the default
  mechanism run for the same community+job. Label is recorded in the meta yaml.
- **`justfile`** — `just research-community-causal <target>` (causal template +
  `--label causal`), same Edison plumbing/provenance as `research-community-edison`.
- **skill.md** — documents the mode: when to use it, output naming, schema mapping,
  and the unchanged curator hand-off (never mutate `kb/communities/`).

## Verified

- Causal template renders against a real community (10360 chars, all placeholders
  resolve).
- `just research-community-causal <stem> --dry-run` writes
  `<stem>-edison-literature-causal(-meta).*` — **doesn't touch** the mechanism run,
  spends **no credits**.
- Reuses the vendored `_edison_capture` provenance bundle; scoped to **one
  community at a time** (as requested).

Scope note: research/report only — like the base skill, it does not write to
`kb/communities/`; a curator applies the reviewed `ecological_interactions` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)