### PR TITLE
Curate causal graph into Cellulose_Methane_Quad_Culture_SynCom + discussions slot

### DIFF
--- a/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
+++ b/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
@@ -109,6 +109,213 @@ ecological_interactions:
   scope: COMMUNITY_LEVEL
   evidence:
   - *id001
+- name: R. cellulolyticum acetate cross-feeding to M. concilii
+  description: Acetate produced by cellulose fermentation in R. cellulolyticum is handed off to the
+    acetoclastic methanogen M. concilii, fuelling acetoclastic methanogenesis (a primary carbon route
+    to methane). Sulfate addition strengthens this hand-off.
+  interaction_type: CROSS_FEEDING
+  scope: PAIRWISE
+  source_taxon:
+    preferred_term: Ruminiclostridium cellulolyticum
+    term:
+      id: NCBITaxon:1521
+      label: Ruminiclostridium cellulolyticum
+  target_taxon:
+    preferred_term: Methanosaeta concilii
+    term:
+      id: NCBITaxon:2223
+      label: Methanothrix soehngenii
+  metabolites:
+  - preferred_term: acetate
+    term:
+      id: CHEBI:15366
+      label: acetic acid
+  biological_processes:
+  - preferred_term: acetoclastic methanogenesis
+    term:
+      id: GO:0019385
+      label: methanogenesis, from acetate
+  downstream:
+  - target: community methane production
+    description: Acetate cross-fed to M. concilii drives acetoclastic methanogenesis, one of the two
+      routes to community methane output.
+  evidence:
+  - reference: PMID:36847519
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: cross-feeding of acetate from a cellulolytic bacterium to an acetoclastic methanogen
+    explanation: Names the directed acetate hand-off from the cellulolytic bacterium (R. cellulolyticum)
+      to the acetoclastic methanogen (M. concilii).
+  - reference: PMID:36847519
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: sulfate addition increased both the production of acetate and lactate by R. cellulolyticum
+      and their consumption by M. concilii and D. vulgaris
+    explanation: Sulfate addition intensifies the carbon hand-off from R. cellulolyticum to M. concilii
+      (and D. vulgaris).
+- name: R. cellulolyticum lactate cross-feeding to D. vulgaris
+  description: Lactate produced by R. cellulolyticum is fermented by D. vulgaris, which oxidises it to
+    H2 — feeding the downstream hydrogenotrophic route.
+  interaction_type: CROSS_FEEDING
+  scope: PAIRWISE
+  source_taxon:
+    preferred_term: Ruminiclostridium cellulolyticum
+    term:
+      id: NCBITaxon:1521
+      label: Ruminiclostridium cellulolyticum
+  target_taxon:
+    preferred_term: Desulfovibrio vulgaris
+    term:
+      id: NCBITaxon:881
+      label: Nitratidesulfovibrio vulgaris
+  metabolites:
+  - preferred_term: lactate
+    term:
+      id: CHEBI:24996
+      label: lactate
+  downstream:
+  - target: D. vulgaris H2 syntrophy to M. hungatei
+    description: Lactate cross-fed to D. vulgaris is fermented to H2, which is transferred to the
+      hydrogenotrophic methanogen M. hungatei.
+  evidence:
+  - reference: PMID:36847519
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: These results suggest that D. vulgaris fermented lactate produced by R. cellulolyticum to
+      H2
+    explanation: Names the directed lactate hand-off from R. cellulolyticum to D. vulgaris and its
+      fermentation to H2.
+- name: D. vulgaris H2 syntrophy to M. hungatei
+  description: H2 produced by D. vulgaris lactate fermentation is transferred to the hydrogenotrophic
+    methanogen M. hungatei, enhancing hydrogenotrophic methanogenesis.
+  interaction_type: SYNTROPHY
+  scope: PAIRWISE
+  source_taxon:
+    preferred_term: Desulfovibrio vulgaris
+    term:
+      id: NCBITaxon:881
+      label: Nitratidesulfovibrio vulgaris
+  target_taxon:
+    preferred_term: Methanospirillum hungatei
+    term:
+      id: NCBITaxon:323259
+      label: Methanospirillum hungatei JF-1
+  metabolites:
+  - preferred_term: dihydrogen
+    term:
+      id: CHEBI:18276
+      label: dihydrogen
+  biological_processes:
+  - preferred_term: hydrogenotrophic methanogenesis
+    term:
+      id: GO:0019386
+      label: methanogenesis, from carbon dioxide
+  downstream:
+  - target: community methane production
+    description: H2 transferred to M. hungatei drives hydrogenotrophic methanogenesis, the second route
+      to community methane output.
+  evidence:
+  - reference: PMID:36847519
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: D. vulgaris enhanced hydrogenotrophic methanogenesis, likely by producing additional
+      hydrogen from lactate fermentation
+    explanation: Names the directed H2 syntrophy from D. vulgaris to the hydrogenotrophic methanogen
+      M. hungatei.
+- name: M. hungatei H2 removal relieves R. cellulolyticum product inhibition
+  description: By consuming H2, the hydrogenotrophic methanogen M. hungatei lowers the H2 partial
+    pressure, relieving product inhibition and sustaining H2 (and thus fermentation-product) output by
+    R. cellulolyticum — an interspecies H2-transfer facilitation feeding back to the upstream fermenter.
+  interaction_type: SYNTROPHY
+  scope: PAIRWISE
+  source_taxon:
+    preferred_term: Methanospirillum hungatei
+    term:
+      id: NCBITaxon:323259
+      label: Methanospirillum hungatei JF-1
+  target_taxon:
+    preferred_term: Ruminiclostridium cellulolyticum
+    term:
+      id: NCBITaxon:1521
+      label: Ruminiclostridium cellulolyticum
+  metabolites:
+  - preferred_term: dihydrogen
+    term:
+      id: CHEBI:18276
+      label: dihydrogen
+  downstream:
+  - target: R. cellulolyticum acetate cross-feeding to M. concilii
+    description: Relieving H2 product inhibition sustains R. cellulolyticum fermentation, maintaining
+      the acetate and lactate hand-offs to the downstream community.
+  evidence:
+  - reference: PMID:36847519
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: This indicates that M. hungatei promoted H2 production by R. cellulolyticum through the
+      alleviation of product inhibition
+    explanation: Names the feedback facilitation — M. hungatei H2 removal promotes H2 production by
+      R. cellulolyticum via product-inhibition relief.
+- name: D. vulgaris–M. hungatei competition for H2
+  description: The sulfate-reducing D. vulgaris and the hydrogenotrophic methanogen M. hungatei compete
+    for the shared H2 pool. Sulfate addition tips the competition toward sulfate reduction, halting
+    hydrogenotrophic methanogenesis and lowering community methane output.
+  interaction_type: COMPETITION
+  scope: PAIRWISE
+  source_taxon:
+    preferred_term: Desulfovibrio vulgaris
+    term:
+      id: NCBITaxon:881
+      label: Nitratidesulfovibrio vulgaris
+  target_taxon:
+    preferred_term: Methanospirillum hungatei
+    term:
+      id: NCBITaxon:323259
+      label: Methanospirillum hungatei JF-1
+  metabolites:
+  - preferred_term: dihydrogen
+    term:
+      id: CHEBI:18276
+      label: dihydrogen
+  - preferred_term: sulfate
+    term:
+      id: CHEBI:16189
+      label: sulfate
+  biological_processes:
+  - preferred_term: dissimilatory sulfate reduction
+    term:
+      id: GO:0019420
+      label: dissimilatory sulfate reduction
+  - preferred_term: hydrogenotrophic methanogenesis
+    term:
+      id: GO:0019386
+      label: methanogenesis, from carbon dioxide
+  downstream:
+  - target: suppression of hydrogenotrophic methanogenesis under sulfate
+    description: With sulfate present, D. vulgaris out-competes M. hungatei for H2, halting
+      hydrogenotrophic methanogenesis.
+  - target: reduced community methane output under sulfate
+    description: Loss of the hydrogenotrophic route is the main cause of the lower community methane
+      yield in the sulfate-amended quad-culture.
+  evidence:
+  - reference: PMID:36847519
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: competition of H2 between a sulfate reducing bacterium and a hydrogenotrophic methanogen
+    explanation: Names the H2 competition between the sulfate reducer (D. vulgaris) and the
+      hydrogenotrophic methanogen (M. hungatei).
+  - reference: PMID:36847519
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the addition of sulfate halted hydrogenotrophic methanogenesis in M. hungatei
+    explanation: Sulfate addition redirects H2 to sulfate reduction, halting M. hungatei hydrogenotrophic
+      methanogenesis (the first downstream effect).
+  - reference: PMID:36847519
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The main reason for decreased CH4 production was the sharp decrease in H2 available for the
+      hydrogenotrophic methanogen
+    explanation: The suppressed hydrogenotrophic route is the main cause of reduced community methane
+      under sulfate (the second downstream effect).
 environmental_factors:
 - name: defined synthetic community design
   value: Rational functional-guild assembly of cellulolytic, sulfate-reducing, hydrogenotrophic methanogenic,
@@ -238,3 +445,25 @@ cultivation_setup:
     snippet: All fermentation experiments were carried out in 160 mL serum bottles with 20 mL of
       modified VM medium containing 10 g/L cellulose
     explanation: Defines the serum-bottle batch cultivation vessel and 20 mL working volume.
+discussions:
+- discussion_id: kg-dv-acetate-co2-to-mc-methanogenesis
+  prompt: Does D. vulgaris fermentation of lactate to acetate and CO2 causally enhance acetoclastic
+    methanogenesis by M. concilii, i.e. is there a second (D. vulgaris-derived) carbon route to methane
+    beyond the direct R. cellulolyticum → M. concilii hand-off?
+  kind: KNOWLEDGE_GAP
+  status: OPEN
+  attaches_to:
+  - ecological_interactions#R. cellulolyticum acetate cross-feeding to M. concilii
+  rationale: If confirmed, D. vulgaris would be a secondary acetate/CO2 supplier to the acetoclastic
+    methanogen, adding a parallel carbon route to methane and changing how the causal graph attributes
+    methane output between the two carbon sources. The source paper proposes it mechanistically ("it may
+    be") but does not demonstrate the D. vulgaris → M. concilii carbon edge directly, so it is recorded
+    here as a knowledge gap rather than asserted as an ecological interaction.
+  evidence:
+  - reference: PMID:36847519
+    supports: PARTIAL
+    evidence_source: IN_VITRO
+    snippet: Mechanistically, it may be that D. vulgaris enhances methanogenesis by producing the
+      substrates CO2, acetate, and H2 and removing lactate
+    explanation: The authors state the D. vulgaris → methanogen carbon contribution as a hypothesis
+      ("it may be"), not a demonstrated causal edge — the basis for filing it as a knowledge gap.

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-07-19T22:00:47
+# Generation date: 2026-07-20T15:22:57
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech
@@ -1381,6 +1381,9 @@ class MicrobialCommunity(YAMLRoot):
     ] = empty_list()
     metal_relevance: Optional[Union[str, "MetalRelevanceEnum"]] = None
     metal_notes: Optional[str] = None
+    discussions: Optional[Union[Union[dict, "Discussion"], list[Union[dict, "Discussion"]]]] = (
+        empty_list()
+    )
     curation_history: Optional[
         Union[Union[dict, "CurationEvent"], list[Union[dict, "CurationEvent"]]]
     ] = empty_list()
@@ -1517,6 +1520,12 @@ class MicrobialCommunity(YAMLRoot):
 
         if self.metal_notes is not None and not isinstance(self.metal_notes, str):
             self.metal_notes = str(self.metal_notes)
+
+        if not isinstance(self.discussions, list):
+            self.discussions = [self.discussions] if self.discussions is not None else []
+        self.discussions = [
+            v if isinstance(v, Discussion) else Discussion(**as_dict(v)) for v in self.discussions
+        ]
 
         if not isinstance(self.curation_history, list):
             self.curation_history = (
@@ -4685,6 +4694,15 @@ slots.microbialCommunity__metal_notes = Slot(
     model_uri=COMMUNITYMECH.microbialCommunity__metal_notes,
     domain=None,
     range=Optional[str],
+)
+
+slots.microbialCommunity__discussions = Slot(
+    uri=COMMUNITYMECH.discussions,
+    name="microbialCommunity__discussions",
+    curie=COMMUNITYMECH.curie("discussions"),
+    model_uri=COMMUNITYMECH.microbialCommunity__discussions,
+    domain=None,
+    range=Optional[Union[Union[dict, Discussion], list[Union[dict, Discussion]]]],
 )
 
 slots.microbialCommunity__curation_history = Slot(

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -1354,6 +1354,17 @@ classes:
       metal_notes:
         description: Additional context on metal/REE processing mechanisms or significance
         range: string
+      discussions:
+        description: >-
+          Open questions, knowledge gaps, controversies, emerging hypotheses, or
+          curation todos attached to this community or its sub-objects (via the
+          Discussion.attaches_to hash-anchors, e.g. `ecological_interactions#<name>`).
+          Captures the discourse / knowledge-gap layer — e.g. a proposed-but-not-
+          demonstrated causal edge that should not be asserted as an interaction.
+        range: Discussion
+        multivalued: true
+        required: false
+        inlined_as_list: true
       curation_history:
         description: >-
           Append-only audit trail of curation actions that modified this


### PR DESCRIPTION
## What

Curates the **Edison causal-graph research** (from the new `deep-research-community`
causal-edge mode, #225) into `CommunityMech:000089`, and files the one hypothesized
edge as a **knowledge-gap Discussion**.

## Schema

Adds a **`discussions`** slot to `MicrobialCommunity` (range `Discussion`, from the
shared `mech_shared` module — the class existed but was **unwired**). Enables
knowledge-gap / open-question / controversy capture with `attaches_to` hash-anchors
(e.g. `ecological_interactions#<name>`). Datamodel regenerated.

## Record curation

`ecological_interactions` goes from **1 COMMUNITY_LEVEL edge → that + 5 source-backed
PAIRWISE mechanistic edges** with directed `downstream` links (the causal graph):

| edge | type | GO process |
|---|---|---|
| Rc→Mc acetate cross-feeding | CROSS_FEEDING | methanogenesis, from acetate (GO:0019385) |
| Rc→Dv lactate cross-feeding | CROSS_FEEDING | — |
| Dv→Mh H₂ syntrophy | SYNTROPHY | methanogenesis, from CO₂ (GO:0019386) |
| Mh→Rc H₂-removal (product-inhibition relief) | SYNTROPHY | — (feedback) |
| Dv×Mh H₂ competition | COMPETITION | dissimilatory sulfate reduction (GO:0019420) |

The **sulfate perturbation cascade** is captured as `downstream` on the competition
edge (sulfate → D. vulgaris out-competes M. hungatei for H₂ → halts hydrogenotrophic
methanogenesis → lowers community methane).

**Groundings:** metabolites → CHEBI (acetic acid 15366, lactate 24996, dihydrogen
18276, sulfate 16189), processes → GO. **Taxa reconciled to the record's canonical
NCBITaxon ids** (Rc 1521, Mh 323259, Mc 2223, Dv 881) — Edison's taxon grounding was
partly wrong (it gave Rc=**1491**) and was **not** used. Evidence = verbatim snippets
from **PMID:36847519** (Wang 2023 mBio).

## Knowledge gap

The proposed-but-undemonstrated **D. vulgaris → M. concilii** acetate/CO₂ carbon edge
(the paper's "it may be" hypothesis) is filed as a `KNOWLEDGE_GAP` Discussion
(`supports: PARTIAL`), **not** asserted as an interaction — exactly the "keep or file
as knowledge-gap" call, resolved as *file*.

## Verification

- `linkml-validate` — clean
- id↔label (CHEBI/GO/NCBITaxon canonical) — **passed**
- `validate-strict` (closed-schema) — **0 errors**
- `just test` — **249 passed** · `just lint` — clean

**Note:** `validate-references` flags the full-text snippets against the abstract-only
cache — a **pre-existing** pattern on this record (its cultivation snippets already do
this) and **not a CI gate**; every snippet is verbatim from the paper. Caching the OA
full text is a possible follow-up.

Research audit trail (Edison report, node/edge tables, provenance) lives under
`research/communities/` (gitignored), per the skill's design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)