### PR TITLE
Re-ground acetate to CHEBI:30089 (KB convention) — quad-culture review fix

### DIFF
--- a/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
+++ b/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
@@ -128,8 +128,8 @@ ecological_interactions:
   metabolites:
   - preferred_term: acetate
     term:
-      id: CHEBI:15366
-      label: acetic acid
+      id: CHEBI:30089
+      label: acetate
   biological_processes:
   - preferred_term: acetoclastic methanogenesis
     term:
@@ -341,8 +341,8 @@ related_ingredients:
     explanation: Names cellulose as the substrate the quad-culture anaerobically degrades.
 - preferred_term: acetate
   chebi_term:
-    id: CHEBI:15366
-    label: acetic acid
+    id: CHEBI:30089
+    label: acetate
   relevance: Cross-fed intermediate — acetate produced by the cellulolytic R. cellulolyticum is the
     handoff substrate consumed by the acetoclastic methanogen M. concilii, the central cross-feeding
     flux in the quad-culture's cellulose-to-methane cascade.


### PR DESCRIPTION
## Context

You asked me to research each of the 6 curation decisions from #226 and pick the
better option. **5 of 6 stand; only the acetate grounding changes.** Verdicts, each
grounded in KB-wide convention + schema/ontology:

| # | Decision | Verdict |
|---|---|---|
| 1 | Keep COMMUNITY_LEVEL + pairwise | ✅ keep — 6 records mix scopes; the scope enum is designed for it |
| 2 | acetate → CHEBI:15366 "acetic acid" | ❌ **change → CHEBI:30089 "acetate"** (69 records vs 7) |
| 3 | Mh→Rc relief = SYNTROPHY | ✅ keep — textbook interspecies-H₂-transfer syntrophy (130× in KB) |
| 4 | COMPETITION directed Dv→Mh | ✅ keep — KB sets source_taxon on COMPETITION |
| 5 | Sulfate cascade as `downstream` | ✅ keep — `downstream` used in 56 records for causal chains |
| 6 | Hypothesis → KNOWLEDGE_GAP | ✅ keep — enum: a missing causal/evidentiary link (EMERGING_HYPOTHESIS = under active community discussion) |

## This PR

Re-grounds **acetate → CHEBI:30089 "acetate"** (the anion) in both places it appears
in `Cellulose_Methane_Quad_Culture_SynCom` — the new Rc→Mc interaction metabolite and
the pre-existing `related_ingredients` entry — matching the KB's dominant convention
(30089 in 69 records / 112 instances vs 15366 in 7) and keeping the record internally
consistent. The anion is also the physiologically apt species at neutral pH.

## Verification

- `linkml-validate` — clean
- id↔label — **passed** (CHEBI:30089 "acetate" canonical)
- `validate-references` — **passes** (full text cached in #227)

🤖 Generated with [Claude Code](https://claude.com/claude-code)