### PR TITLE
Dehalococcoides syntrophy: add causal downstream edges

### DIFF
--- a/kb/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.yaml
+++ b/kb/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.yaml
@@ -163,6 +163,11 @@ ecological_interactions:
     term:
       id: GO:0009061
       label: anaerobic respiration
+  downstream:
+  - target: Enhanced TCE Dechlorination By Syntrophic Support
+    description: H2 and acetate from DvH lactate fermentation feed the obligately
+      H2-consuming D. mccartyi strain 195, enabling and accelerating reductive TCE
+      dechlorination (the community's bioremediation function).
   evidence:
   - reference: PMID:21881617
     supports: SUPPORT
@@ -260,6 +265,11 @@ ecological_interactions:
     term:
       id: GO:0009061
       label: anaerobic respiration
+  downstream:
+  - target: Enhanced TCE Dechlorination By Syntrophic Support
+    description: Under high sulfate, DvH sulfate reduction diverts reducing equivalents
+      and generates sulfide, whose toxicity suppresses reductive TCE dechlorination —
+      opposing the syntrophic support edge.
   evidence:
   - reference: PMID:28159790
     supports: SUPPORT


### PR DESCRIPTION
Curates the Edison causal-graph run into the already-well-grounded
`Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy` record.

The record's three `ecological_interactions` were already fully grounded
(NCBITaxon/GO/CHEBI + PMID evidence). The clean value-add from the causal
run is two directed `downstream` edges making the mechanism explicit:

- **Lactate Fermentation Supports Dhc Growth** (SYNTROPHY) → **Enhanced
  TCE Dechlorination By Syntrophic Support**: H2 + acetate from DvH lactate
  fermentation feed the obligately H2-consuming *D. mccartyi* 195,
  enabling/accelerating reductive TCE dechlorination.
- **Sulfate-Reduction Perturbation Of Dechlorination** (COMPETITION) →
  *suppresses* **Enhanced TCE Dechlorination**: under high sulfate, DvH
  sulfate reduction diverts reducing equivalents and generates toxic
  sulfide.

No new taxa/metabolite/process terms; both edges reuse existing evidence
(PMID:21881617, PMID:28159790).

Validates locally: `linkml-validate`, id-label (`--labels`),
`just validate-references` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)