### PR TITLE
Curate 2 regolith plant-microbe community records (000310-000311)

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -317,23 +317,38 @@ in #228), `Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy` (#229),
 the RECORD's canonical taxon ids (Edison groundings have had errors, e.g. sulfite →
 CHEBI:16731 *(E)-cinnamaldehyde* instead of CHEBI:17359).
 
-## Space-regolith community curation (in progress — branch `feat/space-regolith-records`)
+## Space-regolith community curation (curatable subset DONE, 9/16)
 
 Scout report `reports/scout_space_regolith.md` lists **16 defined-community
-candidates**. **5 curated** (CommunityMech:000303–000307): BioRock basalt biomining
-(#1; folds in vanadium #6 PMID:33868198 + cell-conc #7 PMID:33154740 as evidence),
-lettuce PGPB SynCom (#2), P-solubilizers for *N. benthamiana* (#3), Anabaena/MGS-1
-anaerobic-digestion methanogen consortium (#4), BioAsteroid ISS chondrite biomining
-(#5; #16 is its preprint — cite the published npj Microgravity version).
+candidates**. **9 curated** (CommunityMech:000303–000311):
+- **000303–000307** (earlier): BioRock basalt biomining (#1; folds in vanadium #6
+  PMID:33868198 + cell-conc #7 PMID:33154740 as evidence), lettuce PGPB SynCom (#2),
+  P-solubilizers for *N. benthamiana* (#3), Anabaena/MGS-1 anaerobic-digestion
+  methanogen consortium (#4), BioAsteroid ISS chondrite biomining (#5; #16 is its
+  preprint — cite the published npj Microgravity version).
+- **000308 Mars Meteorite EETA79001 Growth Panel** (#11, PMID:38665180) and **000309
+  Mars Regolith Cyanobacteria/Microalga Biofertilizer Panel** (#10, PMID:35865930) —
+  PR #232. Both are individual-screening panels (members never co-cultured) → no
+  `ecological_interactions` block (accepted honest pattern; 3 other records also have
+  none).
+- **000310 Moss-Microbe Complex Regolith Biofertilizer** (#8,
+  doi:10.1016/j.ecolind.2025.114023; abstract cached via OpenAlex→DOI `.md`) and
+  **000311 Legume-Rhizobia Mars Simulant Symbiosis** (#12, PMID:34879082) — PR #233.
+  These carry real grounded interactions (COLONIZATION_FACILITATION / MUTUALISM;
+  nodulation GO:0009877 + N-fixation GO:0009399).
 
-**Remaining candidates to curate** (~8 distinct new records; prioritize defined
-multi-microbe communities): #10 cyanobacteria panel (PMID:35865930), #11 Mars-meteorite
-4-organism panel (PMID:38665180), #9 AMF+PGPB tomato multi-kingdom (PMID:41597718),
-#8 moss-derived microbiome (EPMC AGRICOLA IND609292674), #15 sealed mini-ecosystems
-(PMID:39487149), #12 legume–rhizobia mutualism (PMID:34879082), #13 microbial-fertilizer
-consortia (PMID:41829787; composition partly undefined — lower priority), #14 AMF chickpea
-(PMID:41786794; loosely defined — lower priority). Match the existing regolith records'
-house style: `ecological_state: ENGINEERED`, `community_origin: SYNTHETIC`,
-`environment_term` → ENVO:01001405 "laboratory environment" with `modeled_environment`
-→ ENVO:01000747 "regolith"; every member/interaction evidence snippet fuzzy-matches a
-cached abstract/OA full text. See [[space-regolith-scouting-gap]].
+**Remaining 4 candidates are NOT curatable as defined microbial communities** — their
+membership is commercial or undefined, so members can't be grounded to NCBITaxon:
+- #9 AMF+PGPB tomato (PMID:41597718): commercial AMF formulation "TM-73MR" + undefined
+  "PBB"; no named species.
+- #13 microbial-fertilizer consortia (PMID:41829787): three commercial fertilizer
+  products, composition undefined.
+- #14 AMF chickpea (PMID:41786794): AMF + vermicompost microbiome, community loosely
+  defined.
+- #15 sealed mini-ecosystems (PMID:39487149): Biosphere-2-style enclosures that
+  *quantify proliferating* communities without defined membership.
+These are logged for completeness; revisit only if a follow-up study names their
+members. **The defined-community subset of the scout report is complete.** House style
+for any future regolith record: `ecological_state: ENGINEERED`, `community_origin:
+SYNTHETIC`, `environment_term` → ENVO:01001405 "laboratory environment" with
+`modeled_environment` → ENVO:01000747 "regolith". See [[space-regolith-scouting-gap]].

--- a/kb/communities/Legume_Rhizobia_Mars_Simulant_Symbiosis.yaml
+++ b/kb/communities/Legume_Rhizobia_Mars_Simulant_Symbiosis.yaml
@@ -1,0 +1,165 @@
+id: CommunityMech:000311
+name: Legume-Rhizobia Mars Simulant Symbiosis
+description: >
+  A model legume-rhizobia nitrogen-fixing symbiosis tested for its ability to establish
+  on Mars soil simulants. The community pairs the model legume Medicago truncatula with
+  two of its symbiotic rhizobial partners, Sinorhizobium meliloti and Sinorhizobium
+  medicae. Plants were grown on different grades of the Mojave Mars Simulant (MMS-1:
+  Coarse, Fine, Unsorted, Superfine) and the MMS-2 simulant. Root nodules developed on
+  M. truncatula roots grown on the Mars simulants comparably to plants grown on sand,
+  and nifH (a reporter gene for nitrogen fixation) expression was detected inside the
+  nodules, demonstrating that the simulants can support the legume-rhizobia symbiosis.
+  Total plant mass was higher on MMS-2 than on MMS-1 and its grain-size variants,
+  indicating that simulant chemical composition matters more than grain size; MMS-2
+  Superfine was recommended for future studies. The system is a model for beneficial
+  plant-microbe associations enabling sustainable, nitrogen-fixing agriculture on Mars,
+  exploiting the nitrogen present in the martian atmosphere.
+ecological_state: ENGINEERED
+community_origin: SYNTHETIC
+community_category: RHIZOSPHERE
+engineering_design:
+  objective: >
+    Determine whether the legume-rhizobia nitrogen-fixing symbiosis can be established
+    on Mars soil simulants, using the model legume Medicago truncatula and its
+    Sinorhizobium partners across different simulant grades.
+  assembly_strategy: >
+    Inoculate the model legume Medicago truncatula with its symbiotic rhizobia
+    (Sinorhizobium meliloti and Sinorhizobium medicae) and grow the plants on different
+    grades of the Mojave Mars Simulant (MMS-1 Coarse/Fine/Unsorted/Superfine) and the
+    MMS-2 simulant, with sand as a comparison substrate.
+  perturbation_design: >
+    Mars soil simulant type and grain size (MMS-1 grades vs MMS-2) were the designed
+    variables, tested for effects on nodulation, nitrogen-fixation gene expression, and
+    plant mass.
+  measurement_endpoints:
+  - Root nodule development on M. truncatula across simulant grades (vs sand)
+  - nifH nitrogen-fixation reporter-gene expression inside nodules
+  - Lateral root and nodule numbers, and total plant mass, by simulant
+  evidence:
+  - reference: PMID:34879082
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: investigated the establishment of the legume-rhizobia symbiosis on different Mars soil simulants
+    explanation: States the objective of establishing the legume-rhizobia symbiosis on Mars soil simulants.
+  - reference: PMID:34879082
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: model legume, Medicago truncatula, and its symbiotic partners, Sinorhizobium meliloti and Sinorhizobium medicae
+    explanation: Supports the assembly of M. truncatula with its two Sinorhizobium symbionts.
+environment_term:
+  preferred_term: Mars soil-simulant legume growth assay (laboratory culture)
+  term:
+    id: ENVO:01001405
+    label: laboratory environment
+  notes: >
+    The community is a controlled laboratory growth assay establishing the
+    legume-rhizobia symbiosis on Mars soil simulants (Mojave Mars Simulant MMS-1 grades
+    and MMS-2), not a sampled natural community. The ENVO grounding reflects the
+    controlled experimental setting; the martian regolith-simulant context is captured
+    in modeled_environment and environmental_factors.
+modeled_environment:
+- preferred_term: regolith
+  term:
+    id: ENVO:01000747
+    label: regolith
+taxonomy:
+- taxon_term:
+    preferred_term: Sinorhizobium meliloti
+    term:
+      id: NCBITaxon:382
+      label: Sinorhizobium meliloti
+    notes: >
+      A symbiotic nitrogen-fixing rhizobium partner of Medicago truncatula; ontology
+      grounding is species-level.
+  functional_role:
+  - SYNTROPHIC_PARTNER
+  evidence:
+  - reference: PMID:34879082
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: symbiotic partners, Sinorhizobium meliloti and Sinorhizobium medicae
+    explanation: Names Sinorhizobium meliloti as a rhizobial symbiont in the study.
+- taxon_term:
+    preferred_term: Sinorhizobium medicae
+    term:
+      id: NCBITaxon:110321
+      label: Sinorhizobium medicae
+    notes: >
+      A symbiotic nitrogen-fixing rhizobium partner of Medicago truncatula; ontology
+      grounding is species-level.
+  functional_role:
+  - SYNTROPHIC_PARTNER
+  evidence:
+  - reference: PMID:34879082
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Sinorhizobium meliloti and Sinorhizobium medicae
+    explanation: Names Sinorhizobium medicae as a rhizobial symbiont in the study.
+ecological_interactions:
+- name: Legume-rhizobia nitrogen-fixing symbiosis on Mars simulants
+  description: >
+    The rhizobia Sinorhizobium meliloti and Sinorhizobium medicae nodulate the roots of
+    the model legume Medicago truncatula grown on Mars soil simulants and fix
+    atmospheric nitrogen inside the nodules, providing fixed nitrogen to the host in
+    exchange for plant photosynthate. Root nodules developed comparably to sand-grown
+    controls and nifH nitrogen-fixation reporter-gene expression was detected in the
+    nodules, showing the mutualism is functional on the simulants.
+  interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
+  source_taxon:
+    preferred_term: Sinorhizobium spp. (rhizobial symbionts)
+    term:
+      id: NCBITaxon:382
+      label: Sinorhizobium meliloti
+    notes: >
+      Represents the two rhizobial symbionts (S. meliloti and S. medicae); grounded to
+      S. meliloti as the representative nodulating partner.
+  target_taxon:
+    preferred_term: Medicago truncatula (host legume)
+    term:
+      id: NCBITaxon:3880
+      label: Medicago truncatula
+  biological_processes:
+  - preferred_term: nodulation
+    term:
+      id: GO:0009877
+      label: nodulation
+  - preferred_term: nitrogen fixation
+    term:
+      id: GO:0009399
+      label: nitrogen fixation
+  evidence:
+  - reference: PMID:34879082
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: root nodules could develop on M. truncatula roots when grown on these Mars soil simulants
+    explanation: Supports functional nodulation of the host legume on Mars soil simulants.
+  - reference: PMID:34879082
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: detected nifH (a reporter gene for nitrogen fixation) expression inside these nodules
+    explanation: Supports active nitrogen fixation (nifH expression) inside the nodules.
+environmental_factors:
+- name: Mojave Mars Simulant grades (MMS-1) and MMS-2 substrate
+  value: MMS-1 (Coarse/Fine/Unsorted/Superfine) and MMS-2
+  description: >
+    The symbiosis was tested across different grades of the Mojave Mars Simulant (MMS-1:
+    Coarse, Fine, Unsorted, Superfine) and the MMS-2 simulant; plant mass was higher on
+    MMS-2, indicating chemical composition matters more than grain size.
+  evidence:
+  - reference: PMID:34879082
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "different grades of the Mojave Mars Simulant (MMS)-1: Coarse, Fine, Unsorted, Superfine, and the MMS-2 simulant"
+    explanation: Supports the Mars soil simulant grades used as growth substrates.
+- name: Atmospheric nitrogen as fixation substrate
+  value: Nitrogen present in the Mars atmosphere
+  description: >
+    The presence of nitrogen in the Mars atmosphere makes the legume-rhizobia
+    nitrogen-fixation association a route to nitrogen input for martian agriculture.
+  evidence:
+  - reference: PMID:34879082
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The presence of nitrogen in the Mars atmosphere offers the possibility to take advantage of this important plant-microbe association
+    explanation: Supports atmospheric nitrogen as the fixation substrate motivating the symbiosis on Mars.

--- a/kb/communities/Moss_Microbe_Complex_Regolith_Biofertilizer.yaml
+++ b/kb/communities/Moss_Microbe_Complex_Regolith_Biofertilizer.yaml
@@ -1,0 +1,202 @@
+id: CommunityMech:000310
+name: Moss-Microbe Complex Regolith Biofertilizer
+description: >
+  A moss-microbe complex evaluated as a bio-based biofertilizer for improving crop
+  growth on lunar and Martian soil simulants. The complex comprises the moss Hypnum
+  plumaeforme together with plant growth-promoting bacteria isolated from it —
+  Pseudomonas monteilii and Bacillus cereus — selected for phosphate solubilization,
+  indole-3-acetic acid (IAA) production, and siderophore synthesis. Using barley
+  (Hordeum vulgare) as a model crop, the study compared moss alone, microbes alone, and
+  their combined application under extreme edaphic conditions represented by lunar
+  (LHS) and Martian (MGS) soil simulants. The moss-microbe co-treatment significantly
+  enhanced shoot biomass, dry weight, organic matter, available phosphate, and cation
+  exchange capacity; in the dense, low-porosity Martian simulant the moss functioned as
+  a biological buffer that facilitated microbial colonization and restored plant growth.
+  16S rRNA profiling confirmed the stable presence of the genera Pseudomonas, Bacillus,
+  and Devosia in moss-treated soils, and metabolite profiling revealed accumulation of
+  growth-related compounds (D-ribose, D-gluconate), suggesting the complex reprograms
+  rhizosphere metabolism. The system is an In-Situ Resource Utilization model for
+  extraterrestrial farming and land restoration.
+ecological_state: ENGINEERED
+community_origin: SYNTHETIC
+community_category: RHIZOSPHERE
+engineering_design:
+  objective: >
+    Test whether a moss-microbe complex (Hypnum plumaeforme plus moss-derived plant
+    growth-promoting bacteria) can act as a biofertilizer that improves crop growth and
+    soil quality on lunar and Martian soil simulants.
+  assembly_strategy: >
+    Isolate plant growth-promoting bacteria (Pseudomonas monteilii, Bacillus cereus)
+    from the moss Hypnum plumaeforme, selecting for phosphate solubilization, IAA
+    production, and siderophore synthesis; then apply moss alone, microbes alone, and
+    the combined moss-microbe complex to barley grown on lunar (LHS) and Martian (MGS)
+    soil simulants.
+  perturbation_design: >
+    Treatment (moss alone / microbes alone / combined moss-microbe complex) and
+    simulant type (lunar LHS vs Martian MGS) were the designed variables, tested for
+    effects on barley growth and soil properties under extreme edaphic conditions.
+  measurement_endpoints:
+  - Barley shoot biomass, dry weight, and growth response on LHS/MGS simulants
+  - Soil organic matter, available phosphate, and cation exchange capacity (CEC)
+  - Microbial colonization and stable genus presence by 16S rRNA profiling
+  - Rhizosphere metabolite accumulation (D-ribose, D-gluconate)
+  evidence:
+  - reference: doi:10.1016/j.ecolind.2025.114023
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: moss-microbe complex, composed of Hypnum plumaeforme and its associated microorganisms, as a bio-based biofertilizer
+    explanation: States the design goal of testing a moss-microbe complex as a biofertilizer.
+  - reference: doi:10.1016/j.ecolind.2025.114023
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: assessed the effects of moss alone, microbes alone, and their combined application
+    explanation: Supports the moss-alone / microbes-alone / combined assembly-and-perturbation design.
+environment_term:
+  preferred_term: lunar/Martian soil-simulant biofertilizer pot assay (laboratory culture)
+  term:
+    id: ENVO:01001405
+    label: laboratory environment
+  notes: >
+    The community is a controlled biofertilizer pot assay on lunar (LHS) and Martian
+    (MGS) soil simulants, not a sampled natural community. The ENVO grounding reflects
+    the controlled experimental setting; the extraterrestrial regolith-simulant context
+    is captured in modeled_environment and environmental_factors.
+modeled_environment:
+- preferred_term: regolith
+  term:
+    id: ENVO:01000747
+    label: regolith
+taxonomy:
+- taxon_term:
+    preferred_term: Pseudomonas monteilii
+    term:
+      id: NCBITaxon:76759
+      label: Pseudomonas monteilii
+    notes: >
+      A plant growth-promoting bacterium isolated from the moss Hypnum plumaeforme;
+      selected for phosphate solubilization, IAA production, and siderophore synthesis.
+      Ontology grounding is species-level.
+  evidence:
+  - reference: doi:10.1016/j.ecolind.2025.114023
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Beneficial microbial strains (Pseudomonas monteilii and Bacillus cereus) were isolated from the moss
+    explanation: Names Pseudomonas monteilii as a moss-derived plant growth-promoting strain.
+- taxon_term:
+    preferred_term: Bacillus cereus
+    term:
+      id: NCBITaxon:1396
+      label: Bacillus cereus
+    notes: >
+      A plant growth-promoting bacterium isolated from the moss Hypnum plumaeforme;
+      selected for phosphate solubilization, IAA production, and siderophore synthesis.
+      Ontology grounding is species-level.
+  evidence:
+  - reference: doi:10.1016/j.ecolind.2025.114023
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Beneficial microbial strains (Pseudomonas monteilii and Bacillus cereus) were isolated from the moss
+    explanation: Names Bacillus cereus as a moss-derived plant growth-promoting strain.
+- taxon_term:
+    preferred_term: Devosia sp.
+    term:
+      id: NCBITaxon:46913
+      label: Devosia
+    notes: >
+      Detected by 16S rRNA profiling as a stably present genus in moss-treated soils
+      (not isolated/selected as an inoculant); ontology grounding is genus-level.
+  evidence:
+  - reference: doi:10.1016/j.ecolind.2025.114023
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: stable presence of key genera, including Pseudomonas, Bacillus, and Devosia, in moss-treated soils
+    explanation: Names Devosia among the genera stably present in moss-treated simulant soils.
+ecological_interactions:
+- name: Moss-facilitated microbial colonization on Martian simulant
+  description: >
+    In the Martian (MGS) simulant, whose high bulk density and low porosity impeded
+    microbial effectiveness, the moss Hypnum plumaeforme functioned as a biological
+    buffer that facilitated colonization by the plant growth-promoting bacteria and
+    restored plant growth responses. The moss thereby acts as a key facilitator of
+    plant-microbe interactions under harsh regolith-simulant conditions.
+  interaction_type: COLONIZATION_FACILITATION
+  scope: COMMUNITY_LEVEL
+  source_taxon:
+    preferred_term: Hypnum plumaeforme (moss host)
+    term:
+      id: NCBITaxon:49761
+      label: Hypnum
+    notes: >
+      Source names the moss Hypnum plumaeforme; NCBI Taxonomy has the genus Hypnum but
+      not this species, so ontology grounding is genus-level.
+  evidence:
+  - reference: doi:10.1016/j.ecolind.2025.114023
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: moss functioned as a biological buffer that facilitated microbial colonization
+    explanation: Supports the moss facilitating microbial colonization on the Martian simulant.
+  - reference: doi:10.1016/j.ecolind.2025.114023
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: moss acts not merely as an organic input but as a key facilitator of plant-microbe interactions under harsh conditions
+    explanation: Supports the moss as a facilitator of plant-microbe interactions under harsh regolith-simulant conditions.
+- name: Moss-microbe co-treatment enhances barley growth and soil quality
+  description: >
+    Combined application of moss and its associated bacteria (versus moss alone or
+    microbes alone) significantly enhanced barley shoot biomass, dry weight, soil
+    organic matter, available phosphate, and cation exchange capacity, indicating a
+    community-level synergy of the moss-microbe complex improving plant growth and soil
+    functionality on the simulants.
+  interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
+  target_taxon:
+    preferred_term: Hordeum vulgare (barley model crop)
+    term:
+      id: NCBITaxon:4513
+      label: Hordeum vulgare
+  evidence:
+  - reference: doi:10.1016/j.ecolind.2025.114023
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: moss-microbe co-treatment significantly enhanced shoot biomass, dry weight, organic matter content, available phosphate, and cation exchange capacity
+    explanation: Supports the community-level synergy of moss plus microbes enhancing plant growth and soil quality.
+environmental_factors:
+- name: Lunar (LHS) and Martian (MGS) soil simulants
+  value: LHS and MGS soil simulants
+  description: >
+    The moss-microbe complex was tested on lunar (LHS) and Martian (MGS) soil simulants
+    as extreme edaphic conditions; the Martian simulant's high bulk density and low
+    porosity impeded microbial effectiveness until buffered by the moss.
+  evidence:
+  - reference: doi:10.1016/j.ecolind.2025.114023
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: extreme edaphic conditions represented by lunar (LHS) and Martian (MGS) soil simulants
+    explanation: Supports the lunar and Martian soil simulants as the extreme edaphic growth substrates.
+related_ingredients:
+- preferred_term: D-ribose
+  chebi_term:
+    id: CHEBI:16988
+    label: D-ribose
+  relevance: >
+    D-ribose accumulated as a growth-related metabolite in moss-microbe-treated
+    rhizosphere, part of the metabolic reprogramming attributed to the complex.
+  evidence:
+  - reference: doi:10.1016/j.ecolind.2025.114023
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: accumulation of growth-related compounds such as D-ribose and D-gluconate
+    explanation: Names D-ribose among the accumulated growth-related rhizosphere metabolites.
+- preferred_term: D-gluconic acid
+  chebi_term:
+    id: CHEBI:33198
+    label: D-gluconic acid
+  relevance: >
+    D-gluconate accumulated as a growth-related metabolite in moss-microbe-treated
+    rhizosphere; gluconate is a hallmark of bacterial phosphate solubilization.
+  evidence:
+  - reference: doi:10.1016/j.ecolind.2025.114023
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: accumulation of growth-related compounds such as D-ribose and D-gluconate
+    explanation: Names D-gluconate among the accumulated growth-related rhizosphere metabolites.

--- a/references_cache/DOI_10.1016_j.ecolind.2025.114023.md
+++ b/references_cache/DOI_10.1016_j.ecolind.2025.114023.md
@@ -1,0 +1,27 @@
+---
+reference_id: DOI:10.1016/j.ecolind.2025.114023
+title: Moss-derived microbiome improves crop growth in lunar and Martian soil simulants
+authors:
+- Jaehong Park
+- Dongwoo Kang
+- Jeong Woo Jang
+- Seri Choi
+- Subong Jeong
+- Sechan Kim
+- Doyeon Kim
+journal: Ecological Indicators
+year: '2025'
+doi: 10.1016/j.ecolind.2025.114023
+content_type: unavailable
+---
+
+# Moss-derived microbiome improves crop growth in lunar and Martian soil simulants
+**Authors:** Jaehong Park, Dongwoo Kang, Jeong Woo Jang, Seri Choi, Subong Jeong, Sechan Kim, Doyeon Kim
+**Journal:** Ecological Indicators (2025)
+**DOI:** [10.1016/j.ecolind.2025.114023](https://doi.org/10.1016/j.ecolind.2025.114023)
+
+## Content
+
+## Abstract (OpenAlex)
+
+This study evaluates the potential of a moss–microbe complex, composed of Hypnum plumaeforme and its associated microorganisms, as a bio-based biofertilizer for improving crop growth and soil quality. Beneficial microbial strains ( Pseudomonas monteilii and Bacillus cereus ) were isolated from the moss and selected based on key plant growth-promoting traits, including phosphate solubilization, indole-3-acetic acid (IAA) production, and siderophore synthesis. Using barley as a model crop, we assessed the effects of moss alone, microbes alone, and their combined application under extreme edaphic conditions represented by lunar (LHS) and Martian (MGS) soil simulants. The moss–microbe co-treatment significantly enhanced shoot biomass, dry weight, organic matter content, available phosphate, and cation exchange capacity (CEC). Notably, in MGS, where high bulk density and low porosity impeded microbial effectiveness, moss functioned as a biological buffer that facilitated microbial colonization and restored plant growth responses.16S rRNA profiling confirmed the stable presence of key genera, including Pseudomonas , Bacillus , and Devosia , in moss-treated soils. Metabolite profiling further revealed the significant accumulation of growth-related compounds such as D-ribose and D-gluconate, suggesting that the moss–microbe complex may reprogram rhizosphere metabolism. Collectively, these findings indicate that moss acts not merely as an organic input but as a key facilitator of plant–microbe interactions under harsh conditions. Our study demonstrates that the moss–microbe complex offers a sustainable and environmentally friendly biofertilizer strategy capable of simultaneously enhancing plant growth and soil functionality, with strong translational potential for land restoration, sustainable agriculture, and extraterrestrial farming.

--- a/references_cache/PMID_34879082.txt
+++ b/references_cache/PMID_34879082.txt
@@ -1,0 +1,44 @@
+1. PLoS One. 2021 Dec 8;16(12):e0259957. doi: 10.1371/journal.pone.0259957. 
+eCollection 2021.
+
+The legume-rhizobia symbiosis can be supported on Mars soil simulants.
+
+Rainwater R(1), Mukherjee A(1).
+
+Author information:
+(1)Department of Biology, University of Central Arkansas, Conway, AR, United 
+States of America.
+
+Legumes (soybeans, peas, lentils, etc.) play important roles in agriculture on 
+Earth because of their food value and their ability to form a mutualistic 
+beneficial association with rhizobia bacteria. In this association, the host 
+plant benefits from atmospheric nitrogen fixation by rhizobia. The presence of 
+nitrogen in the Mars atmosphere offers the possibility to take advantage of this 
+important plant-microbe association. While some studies have shown that Mars 
+soil simulants can support plant growth, none have investigated if these soils 
+can support the legume-rhizobia symbiosis. In this study, we investigated the 
+establishment of the legume-rhizobia symbiosis on different Mars soil simulants 
+(different grades of the Mojave Mars Simulant (MMS)-1: Coarse, Fine, Unsorted, 
+Superfine, and the MMS-2 simulant). We used the model legume, Medicago 
+truncatula, and its symbiotic partners, Sinorhizobium meliloti and Sinorhizobium 
+medicae, in these experiments. Our results show that root nodules could develop 
+on M. truncatula roots when grown on these Mars soil simulants and were 
+comparable to those formed on plants that were grown on sand. We also detected 
+nifH (a reporter gene for nitrogen fixation) expression inside these nodules. 
+Our results indicate that the different Mars soil simulants used in this study 
+can support legume-rhizobia symbiosis. While the average number of lateral roots 
+and nodule numbers were comparable on plants grown on the different soil 
+simulants, total plant mass was higher in plants grown on MMS-2 soil than on 
+MMS-1 soil and its variants. Our results imply that the chemical composition of 
+the simulants is more critical than their grain size for plant mass. Based on 
+these results, we recommend that the MMS-2 Superfine soil simulant is a better 
+fit than the MMS-1 soil and it's variants for future studies. Our findings can 
+serve as an excellent resource for future studies investigating beneficial 
+plant-microbe associations for sustainable agriculture on Mars.
+
+DOI: 10.1371/journal.pone.0259957
+PMCID: PMC8654199
+PMID: 34879082 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors have declared that no competing 
+interests exist.


### PR DESCRIPTION
Continues space-regolith curation with the two remaining candidates that are
**genuinely multi-microbe, interaction-bearing** communities (scout report #8, #12).

### New records
- **000310 — Moss-Microbe Complex Regolith Biofertilizer**
  (doi:10.1016/j.ecolind.2025.114023): the moss *Hypnum plumaeforme* + PGP
  bacteria *Pseudomonas monteilii* and *Bacillus cereus* isolated from it
  (+ *Devosia* by 16S) as a biofertilizer on lunar (LHS) / Martian (MGS)
  simulants. Two grounded interactions: moss **facilitates microbial
  colonization** (COLONIZATION_FACILITATION) on the dense MGS simulant, and the
  moss-microbe **co-treatment enhances barley growth** (MUTUALISM).
- **000311 — Legume-Rhizobia Mars Simulant Symbiosis** (PMID:34879082):
  *Medicago truncatula* + *Sinorhizobium meliloti* / *S. medicae* N-fixing
  symbiosis on Mojave Mars Simulant grades (MMS-1 Coarse/Fine/Unsorted/Superfine,
  MMS-2). Grounded MUTUALISM with **nodulation** (GO:0009877) + **nitrogen
  fixation** (GO:0009399; nifH expression detected in nodules).

### Curation notes
- Taxa grounded to canonical NCBI Taxonomy; *Hypnum plumaeforme* absent at
  species level → grounded genus-level (*Hypnum*) with a note. PGPB `functional_role`
  omitted (no PGPB-appropriate `FunctionalRoleEnum` value; SYNTROPHIC_PARTNER would
  misrepresent them).
- The moss paper is **non-OA with no CrossRef abstract**, so the reference
  validator's fetch yields metadata only. Its **real abstract (via OpenAlex)** is
  appended to the committed DOI cache (`DOI_10.1016_j.ecolind.2025.114023.md`) for
  snippet validation — same reproducibility pattern as the OA full-text caches.

Validates locally: `linkml-validate`, id-label (`--labels`),
`just validate-references`; 249 tests pass. Regolith progress: **9/16** scouted
candidates curated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)