### PR TITLE
docs: render the 4 regolith community pages (000308-000311)

### DIFF
--- a/docs/browser.html
+++ b/docs/browser.html
@@ -512,7 +512,7 @@
                     <button id="search-clear" class="clear-btn" title="Clear search">✕</button>
                 </div>
                 <div class="search-results-count">
-                    Showing <span id="results-count">300</span> of 300 communities
+                    Showing <span id="results-count">304</span> of 304 communities
                 </div>
 
                 <!-- Active filters summary -->
@@ -5022,6 +5022,37 @@
                         </div>
                     </a>
                     
+                    <a href="communities/Legume_Rhizobia_Mars_Simulant_Symbiosis.html"
+                       class="community-card"
+                       data-id="Legume_Rhizobia_Mars_Simulant_Symbiosis"
+                       data-name="legume-rhizobia mars simulant symbiosis"
+                       data-description="a model legume-rhizobia nitrogen-fixing symbiosis tested for its ability to establish on mars soil simulants. the community pairs the model legume medicago truncatula with two of its symbiotic rhizobial partners, sinorhizobium meliloti and sinorhizobium medicae. plants were grown on different grades of the mojave mars simulant (mms-1: coarse, fine, unsorted, superfine) and the mms-2 simulant. root nodules developed on m. truncatula roots grown on the mars simulants comparably to plants grown on sand, and nifh (a reporter gene for nitrogen fixation) expression was detected inside the nodules, demonstrating that the simulants can support the legume-rhizobia symbiosis. total plant mass was higher on mms-2 than on mms-1 and its grain-size variants, indicating that simulant chemical composition matters more than grain size; mms-2 superfine was recommended for future studies. the system is a model for beneficial plant-microbe associations enabling sustainable, nitrogen-fixing agriculture on mars, exploiting the nitrogen present in the martian atmosphere.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="2">
+                        <h2>Legume-Rhizobia Mars Simulant Symbiosis</h2>
+                        <p class="description">A model legume-rhizobia nitrogen-fixing symbiosis tested for its ability to establish on Mars soil simulants. The community pairs the model legume Medicago truncatula with two of its symbiotic rhizobial partners, Sinorhizobium meliloti and Sinorhizobium medicae. Plants were grown on different grades of the Mojave Mars Simulant (MMS-1: Coarse, Fine, Unsorted, Superfine) and the MMS-2 simulant. Root nodules developed on M. truncatula roots grown on the Mars simulants comparably to plants grown on sand, and nifH (a reporter gene for nitrogen fixation) expression was detected inside the nodules, demonstrating that the simulants can support the legume-rhizobia symbiosis. Total plant mass was higher on MMS-2 than on MMS-1 and its grain-size variants, indicating that simulant chemical composition matters more than grain size; MMS-2 Superfine was recommended for future studies. The system is a model for beneficial plant-microbe associations enabling sustainable, nitrogen-fixing agriculture on Mars, exploiting the nitrogen present in the martian atmosphere.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    2
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
                     <a href="communities/Lotus_LjSC3.html"
                        class="community-card"
                        data-id="Lotus_LjSC3"
@@ -5323,6 +5354,68 @@
                                 <span class="badge badge-ENGINEERED">ENGINEERED</span>
                             </div>
                             <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Mars_Meteorite_EETA79001_Growth_Panel.html"
+                       class="community-card"
+                       data-id="Mars_Meteorite_EETA79001_Growth_Panel"
+                       data-name="mars meteorite eeta79001 microbial growth panel"
+                       data-description="a defined four-member panel of microorganisms tested for their ability to grow on actual martian regolith, supplied as sawdust of the mars meteorite eeta79001, rather than on a terrestrial simulant. the panel comprises the bacterium escherichia coli b, the two cyanobacteria eucapsis sp. and chroococcidiopsis sp. strain chr20-20201027-1, and the cold-adapted bacterium planococcus halocryophilus. each organism was cultivated separately on eeta79001 sawdust for up to 23 days under terrestrial conditions across regolith:water ratios from 4:1 to 1:10; the study demonstrates that real martian regolith can support microbial growth and does not contain bactericidal agents. the panel is an astrobiology / in-situ resource utilization model relevant to putative martian life and to bio-sustainable human habitats on mars. members were assayed individually, so the record captures a shared capacity to grow on martian regolith rather than measured interspecies interactions.
+"
+                       data-category="EXTREME_ENVIRONMENT"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Mars Meteorite EETA79001 Microbial Growth Panel</h2>
+                        <p class="description">A defined four-member panel of microorganisms tested for their ability to grow on actual martian regolith, supplied as sawdust of the Mars meteorite EETA79001, rather than on a terrestrial simulant. The panel comprises the bacterium Escherichia coli B, the two cyanobacteria Eucapsis sp. and Chroococcidiopsis sp. strain Chr20-20201027-1, and the cold-adapted bacterium Planococcus halocryophilus. Each organism was cultivated separately on EETA79001 sawdust for up to 23 days under terrestrial conditions across regolith:water ratios from 4:1 to 1:10; the study demonstrates that real martian regolith can support microbial growth and does not contain bactericidal agents. The panel is an astrobiology / In-Situ Resource Utilization model relevant to putative martian life and to bio-sustainable human habitats on Mars. Members were assayed individually, so the record captures a shared capacity to grow on martian regolith rather than measured interspecies interactions.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">EXTREME_ENVIRONMENT</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Mars_Regolith_Cyanobacteria_Biofertilizer_Panel.html"
+                       class="community-card"
+                       data-id="Mars_Regolith_Cyanobacteria_Biofertilizer_Panel"
+                       data-name="mars regolith cyanobacteria/microalga biofertilizer panel"
+                       data-description="a defined four-member panel of photosynthetic microorganisms evaluated for their ability to grow using only martian resources (water and mars global simulant mgs-1 regolith extract) under an earth-like atmosphere, as candidates to support mars colonization through oxygen and biomass production. the panel comprises three cyanobacteria — anabaena cylindrica, nostoc muscorum (ncbi taxonomy: desmonostoc muscorum), and arthrospira platensis (ncbi taxonomy: limnospira platensis) — and the green microalga chlorella vulgaris. each species was grown separately in a martian regolith extract culture medium and monitored for 25 days by optical density and fluorometric parameters; nostoc muscorum grew best, while arthrospira platensis and chlorella vulgaris did not thrive on the regolith extract. end-of-life biomass was then tested as a biofertilizing agent for the macrophyte lemna minor, stimulating plant biomass to levels comparable to standard synthetic medium. the panel is an in-situ resource utilization model for bioregenerative life support on mars. members were assayed individually, so the record captures a shared capacity to grow on martian regolith resources rather than measured interspecies interactions.
+"
+                       data-category="EXTREME_ENVIRONMENT"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Mars Regolith Cyanobacteria/Microalga Biofertilizer Panel</h2>
+                        <p class="description">A defined four-member panel of photosynthetic microorganisms evaluated for their ability to grow using only martian resources (water and Mars Global Simulant MGS-1 regolith extract) under an Earth-like atmosphere, as candidates to support Mars colonization through oxygen and biomass production. The panel comprises three cyanobacteria — Anabaena cylindrica, Nostoc muscorum (NCBI Taxonomy: Desmonostoc muscorum), and Arthrospira platensis (NCBI Taxonomy: Limnospira platensis) — and the green microalga Chlorella vulgaris. Each species was grown separately in a martian regolith extract culture medium and monitored for 25 days by optical density and fluorometric parameters; Nostoc muscorum grew best, while Arthrospira platensis and Chlorella vulgaris did not thrive on the regolith extract. End-of-life biomass was then tested as a biofertilizing agent for the macrophyte Lemna minor, stimulating plant biomass to levels comparable to standard synthetic medium. The panel is an In-Situ Resource Utilization model for bioregenerative life support on Mars. Members were assayed individually, so the record captures a shared capacity to grow on martian regolith resources rather than measured interspecies interactions.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">EXTREME_ENVIRONMENT</span>
                         </div>
                     </a>
                     
@@ -5782,6 +5875,37 @@
                                 <span class="badge badge-ENGINEERED">ENGINEERED</span>
                             </div>
                             <span class="badge badge-category">LIGNOCELLULOSE</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Moss_Microbe_Complex_Regolith_Biofertilizer.html"
+                       class="community-card"
+                       data-id="Moss_Microbe_Complex_Regolith_Biofertilizer"
+                       data-name="moss-microbe complex regolith biofertilizer"
+                       data-description="a moss-microbe complex evaluated as a bio-based biofertilizer for improving crop growth on lunar and martian soil simulants. the complex comprises the moss hypnum plumaeforme together with plant growth-promoting bacteria isolated from it — pseudomonas monteilii and bacillus cereus — selected for phosphate solubilization, indole-3-acetic acid (iaa) production, and siderophore synthesis. using barley (hordeum vulgare) as a model crop, the study compared moss alone, microbes alone, and their combined application under extreme edaphic conditions represented by lunar (lhs) and martian (mgs) soil simulants. the moss-microbe co-treatment significantly enhanced shoot biomass, dry weight, organic matter, available phosphate, and cation exchange capacity; in the dense, low-porosity martian simulant the moss functioned as a biological buffer that facilitated microbial colonization and restored plant growth. 16s rrna profiling confirmed the stable presence of the genera pseudomonas, bacillus, and devosia in moss-treated soils, and metabolite profiling revealed accumulation of growth-related compounds (d-ribose, d-gluconate), suggesting the complex reprograms rhizosphere metabolism. the system is an in-situ resource utilization model for extraterrestrial farming and land restoration.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Moss-Microbe Complex Regolith Biofertilizer</h2>
+                        <p class="description">A moss-microbe complex evaluated as a bio-based biofertilizer for improving crop growth on lunar and Martian soil simulants. The complex comprises the moss Hypnum plumaeforme together with plant growth-promoting bacteria isolated from it — Pseudomonas monteilii and Bacillus cereus — selected for phosphate solubilization, indole-3-acetic acid (IAA) production, and siderophore synthesis. Using barley (Hordeum vulgare) as a model crop, the study compared moss alone, microbes alone, and their combined application under extreme edaphic conditions represented by lunar (LHS) and Martian (MGS) soil simulants. The moss-microbe co-treatment significantly enhanced shoot biomass, dry weight, organic matter, available phosphate, and cation exchange capacity; in the dense, low-porosity Martian simulant the moss functioned as a biological buffer that facilitated microbial colonization and restored plant growth. 16S rRNA profiling confirmed the stable presence of the genera Pseudomonas, Bacillus, and Devosia in moss-treated soils, and metabolite profiling revealed accumulation of growth-related compounds (D-ribose, D-gluconate), suggesting the complex reprograms rhizosphere metabolism. The system is an In-Situ Resource Utilization model for extraterrestrial farming and land restoration.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
                         </div>
                     </a>
                     

--- a/docs/communities/Legume_Rhizobia_Mars_Simulant_Symbiosis.html
+++ b/docs/communities/Legume_Rhizobia_Mars_Simulant_Symbiosis.html
@@ -1,0 +1,1062 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Legume-Rhizobia Mars Simulant Symbiosis - CommunityMech</title>
+    <style>
+        :root {
+            --primary: #3D7DD6;
+            --secondary: #64748b;
+            --background: #f8fafc;
+            --card: #ffffff;
+            --border: #e2e8f0;
+            --text: #1e293b;
+            --text-muted: #64748b;
+            --success: #10b981;
+            --warning: #f59e0b;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background: var(--background);
+            color: var(--text);
+            line-height: 1.6;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 2rem;
+        }
+
+        header {
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
+            padding: 1.5rem 0;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            color: var(--primary);
+            font-size: 2rem;
+            margin-bottom: 0.5rem;
+        }
+
+        h2 {
+            color: var(--text);
+            font-size: 1.5rem;
+            margin: 2rem 0 1rem;
+            border-bottom: 1px solid var(--border);
+            padding-bottom: 0.5rem;
+        }
+
+        h3 {
+            color: var(--text);
+            font-size: 1.25rem;
+            margin: 1.5rem 0 0.75rem;
+        }
+
+        .metadata {
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .metadata-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 1rem;
+            margin-top: 1rem;
+        }
+
+        .metadata-item {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .metadata-label {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin-bottom: 0.25rem;
+        }
+
+        .metadata-value {
+            color: var(--text);
+            font-size: 1rem;
+        }
+
+        .badge {
+            display: inline-block;
+            padding: 0.25rem 0.75rem;
+            border-radius: 12px;
+            font-size: 0.875rem;
+            font-weight: 500;
+        }
+
+        .badge-engineered { background: #dbeafe; color: #1e40af; }
+        .badge-natural { background: #d1fae5; color: #065f46; }
+
+        .description {
+            background: var(--card);
+            border-left: 4px solid var(--primary);
+            padding: 1rem 1.5rem;
+            margin: 1rem 0;
+            border-radius: 4px;
+        }
+
+        table {
+            width: 100%;
+            background: var(--card);
+            border-radius: 8px;
+            overflow: hidden;
+            border: 1px solid var(--border);
+            margin: 1rem 0;
+        }
+
+        th, td {
+            padding: 0.75rem 1rem;
+            text-align: left;
+        }
+
+        th {
+            background: #f1f5f9;
+            font-weight: 600;
+            color: var(--text);
+            border-bottom: 2px solid var(--border);
+        }
+
+        tr:not(:last-child) td {
+            border-bottom: 1px solid var(--border);
+        }
+
+        .term-link {
+            color: var(--primary);
+            text-decoration: none;
+            font-family: 'Courier New', monospace;
+            font-size: 0.875rem;
+        }
+
+        .term-link:hover {
+            text-decoration: underline;
+        }
+
+        .interaction-card {
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 1.5rem;
+            margin: 1rem 0;
+        }
+
+        .interaction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 1rem;
+        }
+
+        .interaction-type {
+            padding: 0.25rem 0.75rem;
+            background: #f0fdf4;
+            color: #166534;
+            border-radius: 4px;
+            font-size: 0.875rem;
+            font-weight: 500;
+        }
+
+        .interaction-flow {
+            background: var(--background);
+            color: var(--text);
+            border-left: 3px solid var(--primary);
+            padding: 1rem;
+            margin: 1rem 0;
+            border-radius: 4px;
+        }
+
+        .flow-item {
+            margin: 0.5rem 0;
+        }
+
+        .flow-arrow {
+            color: var(--primary);
+            margin: 0 0.5rem;
+        }
+
+        .evidence-list {
+            list-style: none;
+            margin: 0.5rem 0;
+        }
+
+        .evidence-item {
+            background: var(--background);
+            color: var(--text);
+            border-left: 3px solid #ca8a04;
+            padding: 0.75rem;
+            margin: 0.5rem 0;
+            border-radius: 4px;
+        }
+
+        .empty-state {
+            background: #f8fafc;
+            border: 1px dashed #cbd5e1;
+            border-radius: 8px;
+            padding: 2rem;
+            text-align: center;
+            color: #64748b;
+        }
+
+        .empty-state p {
+            margin: 0.5rem 0;
+        }
+
+        .empty-state-note {
+            font-size: 0.875rem;
+            color: #94a3b8;
+        }
+
+        .pmid-link {
+            color: var(--primary);
+            text-decoration: none;
+            font-weight: 500;
+        }
+
+        .pmid-link:hover {
+            text-decoration: underline;
+        }
+
+        .snippet {
+            color: var(--text-muted);
+            font-style: italic;
+            font-size: 0.875rem;
+            margin-top: 0.5rem;
+        }
+
+        .roles-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }
+
+        .role-badge {
+            padding: 0.25rem 0.5rem;
+            background: #ede9fe;
+            color: #5b21b6;
+            border-radius: 4px;
+            font-size: 0.75rem;
+            font-weight: 500;
+        }
+
+        .dataset-description {
+            color: var(--text-muted);
+            font-size: 0.875rem;
+        }
+
+        footer {
+            margin-top: 3rem;
+            padding-top: 2rem;
+            border-top: 1px solid var(--border);
+            text-align: center;
+            color: var(--text-muted);
+            font-size: 0.875rem;
+        }
+
+        .back-link {
+            display: inline-block;
+            color: var(--primary);
+            text-decoration: none;
+            margin-bottom: 1rem;
+        }
+
+        .back-link:hover {
+            text-decoration: underline;
+        }
+
+        /* Network diagram */
+        .network-container {
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 1rem;
+            margin: 1rem 0 2rem;
+            position: relative;
+        }
+
+        .network-container svg {
+            width: 100%;
+            display: block;
+        }
+
+        .network-legend {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+            padding: 0.75rem 0 0;
+            border-top: 1px solid var(--border);
+            margin-top: 0.5rem;
+            font-size: 0.8rem;
+            color: var(--text-muted);
+        }
+
+        .legend-item {
+            display: flex;
+            align-items: center;
+            gap: 0.35rem;
+        }
+
+        .legend-swatch {
+            width: 14px;
+            height: 14px;
+            border-radius: 3px;
+            display: inline-block;
+        }
+
+        .legend-circle {
+            border-radius: 50%;
+        }
+
+        .network-tooltip {
+            position: absolute;
+            background: rgba(30, 41, 59, 0.95);
+            color: #f8fafc;
+            padding: 0.5rem 0.75rem;
+            border-radius: 6px;
+            font-size: 0.8rem;
+            line-height: 1.4;
+            pointer-events: none;
+            opacity: 0;
+            transition: opacity 0.15s;
+            max-width: 280px;
+            z-index: 10;
+        }
+
+        .network-tooltip strong {
+            color: #93c5fd;
+        }
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
+            <h1>Legume-Rhizobia Mars Simulant Symbiosis</h1>
+        </div>
+    </header>
+
+    <main class="container">
+        <!-- Metadata Overview -->
+        <section class="metadata">
+            <div class="metadata-grid">
+                <div class="metadata-item">
+                    <span class="metadata-label">Community ID</span>
+                    <span class="metadata-value">
+                        <code style="background: var(--border); color: var(--text); padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.9rem;">CommunityMech:000311</code>
+                    </span>
+                </div>
+
+                <div class="metadata-item">
+                    <span class="metadata-label">Ecological State</span>
+                    <span class="metadata-value">
+                        <span class="badge badge-engineered">
+                            ENGINEERED
+                        </span>
+                    </span>
+                </div>
+
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Environment</span>
+                    <span class="metadata-value">
+                        Mars soil-simulant legume growth assay (laboratory culture)
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01001405"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:01001405
+                        </a>
+                    </span>
+                </div>
+                
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        regolith
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01000747"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:01000747
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
+            </div>
+        </section>
+
+        <!-- Description -->
+        
+        <section class="description">
+            <p>A model legume-rhizobia nitrogen-fixing symbiosis tested for its ability to establish on Mars soil simulants. The community pairs the model legume Medicago truncatula with two of its symbiotic rhizobial partners, Sinorhizobium meliloti and Sinorhizobium medicae. Plants were grown on different grades of the Mojave Mars Simulant (MMS-1: Coarse, Fine, Unsorted, Superfine) and the MMS-2 simulant. Root nodules developed on M. truncatula roots grown on the Mars simulants comparably to plants grown on sand, and nifH (a reporter gene for nitrogen fixation) expression was detected inside the nodules, demonstrating that the simulants can support the legume-rhizobia symbiosis. Total plant mass was higher on MMS-2 than on MMS-1 and its grain-size variants, indicating that simulant chemical composition matters more than grain size; MMS-2 Superfine was recommended for future studies. The system is a model for beneficial plant-microbe associations enabling sustainable, nitrogen-fixing agriculture on Mars, exploiting the nitrogen present in the martian atmosphere.
+</p>
+        </section>
+        
+
+        <!-- Taxonomy -->
+        
+        <section>
+            <h2>Taxonomy</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Taxon</th>
+                        <th>Ontology ID</th>
+                        <th>Functional Roles</th>
+                        <th>Abundance</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    
+                    <tr>
+                        <td>
+                            <strong>Sinorhizobium meliloti</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=382"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:382
+                            </a>
+                        </td>
+                        <td>
+                            
+                            <div class="roles-list">
+                                
+                                <span class="role-badge">SYNTROPHIC_PARTNER</span>
+                                
+                            </div>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34879082/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:34879082</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"symbiotic partners, Sinorhizobium meliloti and Sinorhizobium medicae"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td>
+                            <strong>Sinorhizobium medicae</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=110321"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:110321
+                            </a>
+                        </td>
+                        <td>
+                            
+                            <div class="roles-list">
+                                
+                                <span class="role-badge">SYNTROPHIC_PARTNER</span>
+                                
+                            </div>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34879082/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:34879082</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"Sinorhizobium meliloti and Sinorhizobium medicae"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                </tbody>
+            </table>
+        </section>
+        
+
+        <!-- Ecological Interactions -->
+        <section>
+            <h2>Ecological Interactions</h2>
+        
+
+            <!-- Network Diagram -->
+            <div class="network-container" id="network-container">
+                <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
+                <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
+                    <title id="network-svg-title">Ecological interaction network for Legume-Rhizobia Mars Simulant Symbiosis</title>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, syntrophy, competition, commensalism).</desc>
+                </svg>
+                <div class="network-legend">
+                    <div class="legend-item">
+                        <span class="legend-swatch legend-circle" style="background: #3b82f6;"></span> Taxon
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #22c55e;"></span> Cross-feeding
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #3b82f6;"></span> Mutualism
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #a855f7;"></span> Syntrophy
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #ef4444;"></span> Competition
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #f97316;"></span> Commensalism
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #14b8a6;"></span> Niche partitioning
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #eab308;"></span> Colonization facilitation
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #fb7185;"></span> Strain competition
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #dc2626;"></span> Predation
+                    </div>
+                </div>
+            </div>
+
+            
+            <div class="interaction-card">
+                <div class="interaction-header">
+                    <h3>Legume-rhizobia nitrogen-fixing symbiosis on Mars simulants</h3>
+                    <span class="interaction-type">MUTUALISM</span>
+                </div>
+
+                
+                <p><strong>Source Taxon:</strong> Sinorhizobium spp. (rhizobial symbionts)</p>
+                
+
+                
+                <p><strong>Target Taxon:</strong> Medicago truncatula (host legume)</p>
+                
+
+                
+
+                
+                <p><strong>Biological Processes:</strong></p>
+                <ul>
+                    
+                    <li>
+                        nodulation
+                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0009877"
+                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0009877</a>)
+                    </li>
+                    
+                    <li>
+                        nitrogen fixation
+                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0009399"
+                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0009399</a>)
+                    </li>
+                    
+                </ul>
+                
+
+                
+
+                
+                <h4>Evidence</h4>
+                <ul class="evidence-list">
+                    
+                    <li class="evidence-item">
+                        <div>
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34879082/"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:34879082</a>
+                            
+                            - SUPPORT (IN_VITRO)
+                        </div>
+                        
+                        <div class="snippet">"root nodules could develop on M. truncatula roots when grown on these Mars soil simulants"</div>
+                        
+                    </li>
+                    
+                    <li class="evidence-item">
+                        <div>
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34879082/"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:34879082</a>
+                            
+                            - SUPPORT (IN_VITRO)
+                        </div>
+                        
+                        <div class="snippet">"detected nifH (a reporter gene for nitrogen fixation) expression inside these nodules"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+        
+        </section>
+
+        <!-- Associated Datasets -->
+        
+
+        <!-- Environmental Factors -->
+        
+
+        
+        <section>
+            <h2>Environmental Factors</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Factor</th>
+                        <th>Value</th>
+                        <th>Unit</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    
+                    <tr>
+                        <td><strong>Mojave Mars Simulant grades (MMS-1) and MMS-2 substrate</strong></td>
+                        <td>MMS-1 (Coarse/Fine/Unsorted/Superfine) and MMS-2</td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="3">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34879082/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:34879082</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"different grades of the Mojave Mars Simulant (MMS)-1: Coarse, Fine, Unsorted, Superfine, and the MMS-2 simulant"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td><strong>Atmospheric nitrogen as fixation substrate</strong></td>
+                        <td>Nitrogen present in the Mars atmosphere</td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="3">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34879082/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:34879082</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"The presence of nitrogen in the Mars atmosphere offers the possibility to take advantage of this important plant-microbe association"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                </tbody>
+            </table>
+        </section>
+        
+
+        <!-- Growth Media -->
+        
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>Generated by CommunityMech | <a href="https://github.com/CultureBotAI/CommunityMech">View on GitHub</a></p>
+        </div>
+    </footer>
+
+    
+    <script src="../d3.v7.min.js"></script>
+    <script>
+    (function() {
+        var interactionColors = {
+            CROSS_FEEDING: "#22c55e",
+            MUTUALISM: "#3b82f6",
+            SYNTROPHY: "#a855f7",
+            COMPETITION: "#ef4444",
+            COMMENSALISM: "#f97316",
+            PREDATION: "#dc2626",
+            NICHE_PARTITIONING: "#14b8a6",
+            STRAIN_COMPETITION: "#fb7185",
+            COLONIZATION_FACILITATION: "#eab308"
+        };
+
+        // Build taxon lookup keyed by preferred_term
+        var taxonData = {};
+        
+        taxonData["Sinorhizobium meliloti"] = {
+            id: "NCBITaxon:382",
+            label: "Sinorhizobium meliloti",
+            abundance: "UNKNOWN",
+            roles: ["SYNTROPHIC_PARTNER"]
+        };
+        
+        taxonData["Sinorhizobium medicae"] = {
+            id: "NCBITaxon:110321",
+            label: "Sinorhizobium medicae",
+            abundance: "UNKNOWN",
+            roles: ["SYNTROPHIC_PARTNER"]
+        };
+        
+
+        // Build nodes and links
+        var nodes = [];
+        var links = [];
+        var taxonNodeIds = {};
+
+        // Add taxon nodes
+        Object.keys(taxonData).forEach(function(key) {
+            var t = taxonData[key];
+            var nodeId = "taxon:" + key;
+            taxonNodeIds[key] = nodeId;
+            nodes.push({
+                id: nodeId,
+                label: t.label,
+                type: "taxon",
+                abundance: t.abundance,
+                roles: t.roles,
+                ontologyId: t.id
+            });
+        });
+
+        // Add interaction nodes and edges
+        
+        (function() {
+            var intId = "interaction:0";
+            var intType = "MUTUALISM";
+            var metabolites = [];
+            
+            var processes = [];
+            
+            
+            processes.push("nodulation");
+            
+            processes.push("nitrogen fixation");
+            
+            
+            var evidenceCount = 2;
+
+            nodes.push({
+                id: intId,
+                label: "Legume-rhizobia nitrogen-fixing symbiosis on Mars simulants",
+                type: "interaction",
+                interactionType: intType,
+                metabolites: metabolites,
+                processes: processes,
+                evidenceCount: evidenceCount
+            });
+
+            
+            var srcKey = "Sinorhizobium spp. (rhizobial symbionts)";
+            if (taxonNodeIds[srcKey]) {
+                links.push({ source: taxonNodeIds[srcKey], target: intId });
+            }
+            
+
+            
+            var tgtKey = "Medicago truncatula (host legume)";
+            if (taxonNodeIds[tgtKey]) {
+                links.push({ source: intId, target: taxonNodeIds[tgtKey] });
+            }
+            
+        })();
+        
+
+        // Remove taxon nodes with no connections
+        var connectedIds = new Set();
+        links.forEach(function(l) {
+            connectedIds.add(typeof l.source === "object" ? l.source.id : l.source);
+            connectedIds.add(typeof l.target === "object" ? l.target.id : l.target);
+        });
+        nodes = nodes.filter(function(n) {
+            return n.type === "interaction" || connectedIds.has(n.id);
+        });
+
+        // D3 setup
+        var container = document.getElementById("network-container");
+        var svg = d3.select("#network-svg");
+        var width = container.clientWidth - 32;
+        // Dynamic height based on node count: minimum 500px, add 40px per node
+        var nodeCount = 3;
+        var height = Math.max(500, 400 + nodeCount * 20);
+        svg.attr("width", width).attr("height", height);
+
+        // Arrow marker
+        svg.append("defs").append("marker")
+            .attr("id", "arrowhead")
+            .attr("viewBox", "0 -5 10 10")
+            .attr("refX", 20)
+            .attr("refY", 0)
+            .attr("markerWidth", 6)
+            .attr("markerHeight", 6)
+            .attr("orient", "auto")
+            .append("path")
+            .attr("d", "M0,-5L10,0L0,5")
+            .attr("fill", "#94a3b8");
+
+        var simulation = d3.forceSimulation(nodes)
+            .force("link", d3.forceLink(links).id(function(d) { return d.id; }).distance(100))
+            .force("charge", d3.forceManyBody().strength(-400))
+            .force("center", d3.forceCenter(width / 2, height / 2))
+            .force("collision", d3.forceCollide().radius(40))
+            .force("x", d3.forceX(width / 2).strength(0.05))
+            .force("y", d3.forceY(height / 2).strength(0.05));
+
+        var link = svg.append("g")
+            .selectAll("line")
+            .data(links)
+            .join("line")
+            .attr("stroke", "#94a3b8")
+            .attr("stroke-width", 1.5)
+            .attr("marker-end", "url(#arrowhead)");
+
+        var node = svg.append("g")
+            .selectAll("g")
+            .data(nodes)
+            .join("g")
+            .style("cursor", "pointer");
+
+        // Taxon nodes: circles
+        node.filter(function(d) { return d.type === "taxon"; })
+            .append("circle")
+            .attr("r", function(d) { return d.abundance === "DOMINANT" ? 18 : 12; })
+            .attr("fill", "#3b82f6")
+            .attr("stroke", "#1e40af")
+            .attr("stroke-width", 1.5);
+
+        // Interaction nodes: rounded rects
+        node.filter(function(d) { return d.type === "interaction"; })
+            .append("rect")
+            .attr("width", 28)
+            .attr("height", 18)
+            .attr("x", -14)
+            .attr("y", -9)
+            .attr("rx", 5)
+            .attr("fill", function(d) { return interactionColors[d.interactionType] || "#6b7280"; })
+            .attr("stroke", function(d) {
+                var c = d3.color(interactionColors[d.interactionType] || "#6b7280");
+                return c ? c.darker(0.5) : "#4b5563";
+            })
+            .attr("stroke-width", 1.5);
+
+        // Labels for taxa (positioned below circle)
+        node.filter(function(d) { return d.type === "taxon"; })
+            .append("text")
+            .text(function(d) {
+                var parts = d.label.split(" ");
+                return parts.length >= 2 ? parts[0][0] + ". " + parts.slice(1).join(" ") : d.label;
+            })
+            .attr("text-anchor", "middle")
+            .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
+            .attr("font-size", "10px")
+            .style("fill", "var(--net-label, #475569)");
+
+        // Labels for interactions (multi-line, centered in rectangle)
+        node.filter(function(d) { return d.type === "interaction"; })
+            .each(function(d) {
+                var textElem = d3.select(this).append("text")
+                    .attr("text-anchor", "middle")
+                    .attr("font-size", "9px")
+                    .style("fill", "var(--net-label, #475569)")
+                    .style("pointer-events", "none");
+
+                // Word-wrap text to fit in rectangle (max ~24 chars per line)
+                var words = d.label.split(/\s+/);
+                var line = "";
+                var lines = [];
+                var maxWidth = 24;
+
+                for (var i = 0; i < words.length; i++) {
+                    var testLine = line + (line ? " " : "") + words[i];
+                    if (testLine.length > maxWidth && line.length > 0) {
+                        lines.push(line);
+                        line = words[i];
+                    } else {
+                        line = testLine;
+                    }
+                }
+                if (line) lines.push(line);
+
+                // Limit to 3 lines maximum
+                if (lines.length > 3) {
+                    lines = lines.slice(0, 3);
+                    lines[2] = lines[2].substring(0, 21) + "...";
+                }
+
+                // Add tspan for each line
+                var lineHeight = 11;
+                var startY = -(lines.length - 1) * lineHeight / 2;
+                lines.forEach(function(lineText, i) {
+                    textElem.append("tspan")
+                        .attr("x", 0)
+                        .attr("dy", i === 0 ? startY : lineHeight)
+                        .text(lineText);
+                });
+            });
+
+        // Tooltip
+        var tooltip = d3.select("#network-tooltip");
+
+        node.on("mouseenter", function(event, d) {
+            tooltip.selectAll("*").remove();
+            if (d.type === "taxon") {
+                tooltip.append("strong").text(d.label);
+                tooltip.append("br");
+                tooltip.append("span").text(d.ontologyId);
+                tooltip.append("br");
+                tooltip.append("span").text("Abundance: " + d.abundance);
+                if (d.roles.length) {
+                    tooltip.append("br");
+                    tooltip.append("span").text("Roles: " + d.roles.join(", "));
+                }
+            } else {
+                tooltip.append("strong").text(d.label);
+                tooltip.append("br");
+                tooltip.append("span").text(d.interactionType);
+                if (d.metabolites.length) {
+                    tooltip.append("br");
+                    tooltip.append("span").text("Metabolites: " + d.metabolites.join(", "));
+                }
+                if (d.processes.length) {
+                    tooltip.append("br");
+                    tooltip.append("span").text("Processes: " + d.processes.join(", "));
+                }
+                tooltip.append("br");
+                tooltip.append("span").text("Evidence items: " + d.evidenceCount);
+            }
+            tooltip.style("opacity", 1)
+                .style("left", (event.offsetX + 12) + "px")
+                .style("top", (event.offsetY - 12) + "px");
+        })
+        .on("mousemove", function(event) {
+            tooltip.style("left", (event.offsetX + 12) + "px")
+                .style("top", (event.offsetY - 12) + "px");
+        })
+        .on("mouseleave", function() {
+            tooltip.style("opacity", 0);
+        });
+
+        // Tick
+        simulation.on("tick", function() {
+            link.attr("x1", function(d) { return d.source.x; })
+                .attr("y1", function(d) { return d.source.y; })
+                .attr("x2", function(d) { return d.target.x; })
+                .attr("y2", function(d) { return d.target.y; });
+
+            node.attr("transform", function(d) {
+                // Constrain nodes within safe boundaries
+                // Account for: node size, label text, and extra padding
+                var nodeRadius = (d.type === "taxon" && d.abundance === "DOMINANT") ? 18 :
+                                (d.type === "taxon") ? 12 : 14; // interaction nodes
+                var labelOffset = d.type === "taxon" ? 35 : 0; // taxon labels below node
+
+                var marginTop = 40;
+                var marginBottom = 60; // extra space for labels
+                var marginSide = 80; // space for long names
+
+                d.x = Math.max(marginSide, Math.min(width - marginSide, d.x));
+                d.y = Math.max(marginTop, Math.min(height - marginBottom, d.y));
+                return "translate(" + d.x + "," + d.y + ")";
+            });
+        });
+
+        // Stabilize after 300 ticks then stop
+        simulation.alpha(1).alphaDecay(0.02);
+        for (var i = 0; i < 300; i++) simulation.tick();
+        simulation.stop();
+
+        // Apply final positions
+        link.attr("x1", function(d) { return d.source.x; })
+            .attr("y1", function(d) { return d.source.y; })
+            .attr("x2", function(d) { return d.target.x; })
+            .attr("y2", function(d) { return d.target.y; });
+
+        node.attr("transform", function(d) { return "translate(" + d.x + "," + d.y + ")"; });
+    })();
+    </script>
+    
+    <script src="../theme-toggle.js"></script>
+</body>
+</html>

--- a/docs/communities/Mars_Meteorite_EETA79001_Growth_Panel.html
+++ b/docs/communities/Mars_Meteorite_EETA79001_Growth_Panel.html
@@ -1,0 +1,703 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mars Meteorite EETA79001 Microbial Growth Panel - CommunityMech</title>
+    <style>
+        :root {
+            --primary: #3D7DD6;
+            --secondary: #64748b;
+            --background: #f8fafc;
+            --card: #ffffff;
+            --border: #e2e8f0;
+            --text: #1e293b;
+            --text-muted: #64748b;
+            --success: #10b981;
+            --warning: #f59e0b;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background: var(--background);
+            color: var(--text);
+            line-height: 1.6;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 2rem;
+        }
+
+        header {
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
+            padding: 1.5rem 0;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            color: var(--primary);
+            font-size: 2rem;
+            margin-bottom: 0.5rem;
+        }
+
+        h2 {
+            color: var(--text);
+            font-size: 1.5rem;
+            margin: 2rem 0 1rem;
+            border-bottom: 1px solid var(--border);
+            padding-bottom: 0.5rem;
+        }
+
+        h3 {
+            color: var(--text);
+            font-size: 1.25rem;
+            margin: 1.5rem 0 0.75rem;
+        }
+
+        .metadata {
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .metadata-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 1rem;
+            margin-top: 1rem;
+        }
+
+        .metadata-item {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .metadata-label {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin-bottom: 0.25rem;
+        }
+
+        .metadata-value {
+            color: var(--text);
+            font-size: 1rem;
+        }
+
+        .badge {
+            display: inline-block;
+            padding: 0.25rem 0.75rem;
+            border-radius: 12px;
+            font-size: 0.875rem;
+            font-weight: 500;
+        }
+
+        .badge-engineered { background: #dbeafe; color: #1e40af; }
+        .badge-natural { background: #d1fae5; color: #065f46; }
+
+        .description {
+            background: var(--card);
+            border-left: 4px solid var(--primary);
+            padding: 1rem 1.5rem;
+            margin: 1rem 0;
+            border-radius: 4px;
+        }
+
+        table {
+            width: 100%;
+            background: var(--card);
+            border-radius: 8px;
+            overflow: hidden;
+            border: 1px solid var(--border);
+            margin: 1rem 0;
+        }
+
+        th, td {
+            padding: 0.75rem 1rem;
+            text-align: left;
+        }
+
+        th {
+            background: #f1f5f9;
+            font-weight: 600;
+            color: var(--text);
+            border-bottom: 2px solid var(--border);
+        }
+
+        tr:not(:last-child) td {
+            border-bottom: 1px solid var(--border);
+        }
+
+        .term-link {
+            color: var(--primary);
+            text-decoration: none;
+            font-family: 'Courier New', monospace;
+            font-size: 0.875rem;
+        }
+
+        .term-link:hover {
+            text-decoration: underline;
+        }
+
+        .interaction-card {
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 1.5rem;
+            margin: 1rem 0;
+        }
+
+        .interaction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 1rem;
+        }
+
+        .interaction-type {
+            padding: 0.25rem 0.75rem;
+            background: #f0fdf4;
+            color: #166534;
+            border-radius: 4px;
+            font-size: 0.875rem;
+            font-weight: 500;
+        }
+
+        .interaction-flow {
+            background: var(--background);
+            color: var(--text);
+            border-left: 3px solid var(--primary);
+            padding: 1rem;
+            margin: 1rem 0;
+            border-radius: 4px;
+        }
+
+        .flow-item {
+            margin: 0.5rem 0;
+        }
+
+        .flow-arrow {
+            color: var(--primary);
+            margin: 0 0.5rem;
+        }
+
+        .evidence-list {
+            list-style: none;
+            margin: 0.5rem 0;
+        }
+
+        .evidence-item {
+            background: var(--background);
+            color: var(--text);
+            border-left: 3px solid #ca8a04;
+            padding: 0.75rem;
+            margin: 0.5rem 0;
+            border-radius: 4px;
+        }
+
+        .empty-state {
+            background: #f8fafc;
+            border: 1px dashed #cbd5e1;
+            border-radius: 8px;
+            padding: 2rem;
+            text-align: center;
+            color: #64748b;
+        }
+
+        .empty-state p {
+            margin: 0.5rem 0;
+        }
+
+        .empty-state-note {
+            font-size: 0.875rem;
+            color: #94a3b8;
+        }
+
+        .pmid-link {
+            color: var(--primary);
+            text-decoration: none;
+            font-weight: 500;
+        }
+
+        .pmid-link:hover {
+            text-decoration: underline;
+        }
+
+        .snippet {
+            color: var(--text-muted);
+            font-style: italic;
+            font-size: 0.875rem;
+            margin-top: 0.5rem;
+        }
+
+        .roles-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }
+
+        .role-badge {
+            padding: 0.25rem 0.5rem;
+            background: #ede9fe;
+            color: #5b21b6;
+            border-radius: 4px;
+            font-size: 0.75rem;
+            font-weight: 500;
+        }
+
+        .dataset-description {
+            color: var(--text-muted);
+            font-size: 0.875rem;
+        }
+
+        footer {
+            margin-top: 3rem;
+            padding-top: 2rem;
+            border-top: 1px solid var(--border);
+            text-align: center;
+            color: var(--text-muted);
+            font-size: 0.875rem;
+        }
+
+        .back-link {
+            display: inline-block;
+            color: var(--primary);
+            text-decoration: none;
+            margin-bottom: 1rem;
+        }
+
+        .back-link:hover {
+            text-decoration: underline;
+        }
+
+        /* Network diagram */
+        .network-container {
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 1rem;
+            margin: 1rem 0 2rem;
+            position: relative;
+        }
+
+        .network-container svg {
+            width: 100%;
+            display: block;
+        }
+
+        .network-legend {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+            padding: 0.75rem 0 0;
+            border-top: 1px solid var(--border);
+            margin-top: 0.5rem;
+            font-size: 0.8rem;
+            color: var(--text-muted);
+        }
+
+        .legend-item {
+            display: flex;
+            align-items: center;
+            gap: 0.35rem;
+        }
+
+        .legend-swatch {
+            width: 14px;
+            height: 14px;
+            border-radius: 3px;
+            display: inline-block;
+        }
+
+        .legend-circle {
+            border-radius: 50%;
+        }
+
+        .network-tooltip {
+            position: absolute;
+            background: rgba(30, 41, 59, 0.95);
+            color: #f8fafc;
+            padding: 0.5rem 0.75rem;
+            border-radius: 6px;
+            font-size: 0.8rem;
+            line-height: 1.4;
+            pointer-events: none;
+            opacity: 0;
+            transition: opacity 0.15s;
+            max-width: 280px;
+            z-index: 10;
+        }
+
+        .network-tooltip strong {
+            color: #93c5fd;
+        }
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
+            <h1>Mars Meteorite EETA79001 Microbial Growth Panel</h1>
+        </div>
+    </header>
+
+    <main class="container">
+        <!-- Metadata Overview -->
+        <section class="metadata">
+            <div class="metadata-grid">
+                <div class="metadata-item">
+                    <span class="metadata-label">Community ID</span>
+                    <span class="metadata-value">
+                        <code style="background: var(--border); color: var(--text); padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.9rem;">CommunityMech:000308</code>
+                    </span>
+                </div>
+
+                <div class="metadata-item">
+                    <span class="metadata-label">Ecological State</span>
+                    <span class="metadata-value">
+                        <span class="badge badge-engineered">
+                            ENGINEERED
+                        </span>
+                    </span>
+                </div>
+
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Environment</span>
+                    <span class="metadata-value">
+                        Mars meteorite EETA79001 regolith growth assay (laboratory culture)
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01001405"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:01001405
+                        </a>
+                    </span>
+                </div>
+                
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        regolith
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01000747"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:01000747
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
+            </div>
+        </section>
+
+        <!-- Description -->
+        
+        <section class="description">
+            <p>A defined four-member panel of microorganisms tested for their ability to grow on actual martian regolith, supplied as sawdust of the Mars meteorite EETA79001, rather than on a terrestrial simulant. The panel comprises the bacterium Escherichia coli B, the two cyanobacteria Eucapsis sp. and Chroococcidiopsis sp. strain Chr20-20201027-1, and the cold-adapted bacterium Planococcus halocryophilus. Each organism was cultivated separately on EETA79001 sawdust for up to 23 days under terrestrial conditions across regolith:water ratios from 4:1 to 1:10; the study demonstrates that real martian regolith can support microbial growth and does not contain bactericidal agents. The panel is an astrobiology / In-Situ Resource Utilization model relevant to putative martian life and to bio-sustainable human habitats on Mars. Members were assayed individually, so the record captures a shared capacity to grow on martian regolith rather than measured interspecies interactions.
+</p>
+        </section>
+        
+
+        <!-- Taxonomy -->
+        
+        <section>
+            <h2>Taxonomy</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Taxon</th>
+                        <th>Ontology ID</th>
+                        <th>Functional Roles</th>
+                        <th>Abundance</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    
+                    <tr>
+                        <td>
+                            <strong>Escherichia coli B</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=562"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:562
+                            </a>
+                        </td>
+                        <td>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38665180/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:38665180</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"Escherichia coli B"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td>
+                            <strong>Eucapsis sp.</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1521555"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:1521555
+                            </a>
+                        </td>
+                        <td>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38665180/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:38665180</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"the two cyanobacteria, Eucapsis and Chr20"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td>
+                            <strong>Chroococcidiopsis sp. Chr20-20201027-1</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=54298"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:54298
+                            </a>
+                        </td>
+                        <td>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38665180/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:38665180</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"Chr20-20201027-1, and P. halocryophilus"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td>
+                            <strong>Planococcus halocryophilus</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1215089"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:1215089
+                            </a>
+                        </td>
+                        <td>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38665180/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:38665180</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"Planococcus halocryophilus"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                </tbody>
+            </table>
+        </section>
+        
+
+        <!-- Ecological Interactions -->
+        <section>
+            <h2>Ecological Interactions</h2>
+        
+            <div class="empty-state">
+                <p>ℹ️ No detailed ecological interaction data is available for this community.</p>
+                <p class="empty-state-note">This record may be a metabolic model or minimal entry containing only taxonomy and external resource links.</p>
+            </div>
+        
+        </section>
+
+        <!-- Associated Datasets -->
+        
+
+        <!-- Environmental Factors -->
+        
+
+        
+        <section>
+            <h2>Environmental Factors</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Factor</th>
+                        <th>Value</th>
+                        <th>Unit</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    
+                    <tr>
+                        <td><strong>Actual martian regolith substrate (Mars meteorite EETA79001)</strong></td>
+                        <td>EETA79001 meteorite sawdust</td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="3">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38665180/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:38665180</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"actual martian regolith, in the form of Mars meteorite EETA79001 sawdust"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td><strong>Regolith-to-water ratio</strong></td>
+                        <td>4:1 to 1:10 (regolith:water)</td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="3">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38665180/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:38665180</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"regolith:water ratios from 4:1 to 1:10"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                </tbody>
+            </table>
+        </section>
+        
+
+        <!-- Growth Media -->
+        
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>Generated by CommunityMech | <a href="https://github.com/CultureBotAI/CommunityMech">View on GitHub</a></p>
+        </div>
+    </footer>
+
+    
+    <script src="../theme-toggle.js"></script>
+</body>
+</html>

--- a/docs/communities/Mars_Regolith_Cyanobacteria_Biofertilizer_Panel.html
+++ b/docs/communities/Mars_Regolith_Cyanobacteria_Biofertilizer_Panel.html
@@ -1,0 +1,703 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mars Regolith Cyanobacteria/Microalga Biofertilizer Panel - CommunityMech</title>
+    <style>
+        :root {
+            --primary: #3D7DD6;
+            --secondary: #64748b;
+            --background: #f8fafc;
+            --card: #ffffff;
+            --border: #e2e8f0;
+            --text: #1e293b;
+            --text-muted: #64748b;
+            --success: #10b981;
+            --warning: #f59e0b;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background: var(--background);
+            color: var(--text);
+            line-height: 1.6;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 2rem;
+        }
+
+        header {
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
+            padding: 1.5rem 0;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            color: var(--primary);
+            font-size: 2rem;
+            margin-bottom: 0.5rem;
+        }
+
+        h2 {
+            color: var(--text);
+            font-size: 1.5rem;
+            margin: 2rem 0 1rem;
+            border-bottom: 1px solid var(--border);
+            padding-bottom: 0.5rem;
+        }
+
+        h3 {
+            color: var(--text);
+            font-size: 1.25rem;
+            margin: 1.5rem 0 0.75rem;
+        }
+
+        .metadata {
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .metadata-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 1rem;
+            margin-top: 1rem;
+        }
+
+        .metadata-item {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .metadata-label {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin-bottom: 0.25rem;
+        }
+
+        .metadata-value {
+            color: var(--text);
+            font-size: 1rem;
+        }
+
+        .badge {
+            display: inline-block;
+            padding: 0.25rem 0.75rem;
+            border-radius: 12px;
+            font-size: 0.875rem;
+            font-weight: 500;
+        }
+
+        .badge-engineered { background: #dbeafe; color: #1e40af; }
+        .badge-natural { background: #d1fae5; color: #065f46; }
+
+        .description {
+            background: var(--card);
+            border-left: 4px solid var(--primary);
+            padding: 1rem 1.5rem;
+            margin: 1rem 0;
+            border-radius: 4px;
+        }
+
+        table {
+            width: 100%;
+            background: var(--card);
+            border-radius: 8px;
+            overflow: hidden;
+            border: 1px solid var(--border);
+            margin: 1rem 0;
+        }
+
+        th, td {
+            padding: 0.75rem 1rem;
+            text-align: left;
+        }
+
+        th {
+            background: #f1f5f9;
+            font-weight: 600;
+            color: var(--text);
+            border-bottom: 2px solid var(--border);
+        }
+
+        tr:not(:last-child) td {
+            border-bottom: 1px solid var(--border);
+        }
+
+        .term-link {
+            color: var(--primary);
+            text-decoration: none;
+            font-family: 'Courier New', monospace;
+            font-size: 0.875rem;
+        }
+
+        .term-link:hover {
+            text-decoration: underline;
+        }
+
+        .interaction-card {
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 1.5rem;
+            margin: 1rem 0;
+        }
+
+        .interaction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 1rem;
+        }
+
+        .interaction-type {
+            padding: 0.25rem 0.75rem;
+            background: #f0fdf4;
+            color: #166534;
+            border-radius: 4px;
+            font-size: 0.875rem;
+            font-weight: 500;
+        }
+
+        .interaction-flow {
+            background: var(--background);
+            color: var(--text);
+            border-left: 3px solid var(--primary);
+            padding: 1rem;
+            margin: 1rem 0;
+            border-radius: 4px;
+        }
+
+        .flow-item {
+            margin: 0.5rem 0;
+        }
+
+        .flow-arrow {
+            color: var(--primary);
+            margin: 0 0.5rem;
+        }
+
+        .evidence-list {
+            list-style: none;
+            margin: 0.5rem 0;
+        }
+
+        .evidence-item {
+            background: var(--background);
+            color: var(--text);
+            border-left: 3px solid #ca8a04;
+            padding: 0.75rem;
+            margin: 0.5rem 0;
+            border-radius: 4px;
+        }
+
+        .empty-state {
+            background: #f8fafc;
+            border: 1px dashed #cbd5e1;
+            border-radius: 8px;
+            padding: 2rem;
+            text-align: center;
+            color: #64748b;
+        }
+
+        .empty-state p {
+            margin: 0.5rem 0;
+        }
+
+        .empty-state-note {
+            font-size: 0.875rem;
+            color: #94a3b8;
+        }
+
+        .pmid-link {
+            color: var(--primary);
+            text-decoration: none;
+            font-weight: 500;
+        }
+
+        .pmid-link:hover {
+            text-decoration: underline;
+        }
+
+        .snippet {
+            color: var(--text-muted);
+            font-style: italic;
+            font-size: 0.875rem;
+            margin-top: 0.5rem;
+        }
+
+        .roles-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }
+
+        .role-badge {
+            padding: 0.25rem 0.5rem;
+            background: #ede9fe;
+            color: #5b21b6;
+            border-radius: 4px;
+            font-size: 0.75rem;
+            font-weight: 500;
+        }
+
+        .dataset-description {
+            color: var(--text-muted);
+            font-size: 0.875rem;
+        }
+
+        footer {
+            margin-top: 3rem;
+            padding-top: 2rem;
+            border-top: 1px solid var(--border);
+            text-align: center;
+            color: var(--text-muted);
+            font-size: 0.875rem;
+        }
+
+        .back-link {
+            display: inline-block;
+            color: var(--primary);
+            text-decoration: none;
+            margin-bottom: 1rem;
+        }
+
+        .back-link:hover {
+            text-decoration: underline;
+        }
+
+        /* Network diagram */
+        .network-container {
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 1rem;
+            margin: 1rem 0 2rem;
+            position: relative;
+        }
+
+        .network-container svg {
+            width: 100%;
+            display: block;
+        }
+
+        .network-legend {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+            padding: 0.75rem 0 0;
+            border-top: 1px solid var(--border);
+            margin-top: 0.5rem;
+            font-size: 0.8rem;
+            color: var(--text-muted);
+        }
+
+        .legend-item {
+            display: flex;
+            align-items: center;
+            gap: 0.35rem;
+        }
+
+        .legend-swatch {
+            width: 14px;
+            height: 14px;
+            border-radius: 3px;
+            display: inline-block;
+        }
+
+        .legend-circle {
+            border-radius: 50%;
+        }
+
+        .network-tooltip {
+            position: absolute;
+            background: rgba(30, 41, 59, 0.95);
+            color: #f8fafc;
+            padding: 0.5rem 0.75rem;
+            border-radius: 6px;
+            font-size: 0.8rem;
+            line-height: 1.4;
+            pointer-events: none;
+            opacity: 0;
+            transition: opacity 0.15s;
+            max-width: 280px;
+            z-index: 10;
+        }
+
+        .network-tooltip strong {
+            color: #93c5fd;
+        }
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
+            <h1>Mars Regolith Cyanobacteria/Microalga Biofertilizer Panel</h1>
+        </div>
+    </header>
+
+    <main class="container">
+        <!-- Metadata Overview -->
+        <section class="metadata">
+            <div class="metadata-grid">
+                <div class="metadata-item">
+                    <span class="metadata-label">Community ID</span>
+                    <span class="metadata-value">
+                        <code style="background: var(--border); color: var(--text); padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.9rem;">CommunityMech:000309</code>
+                    </span>
+                </div>
+
+                <div class="metadata-item">
+                    <span class="metadata-label">Ecological State</span>
+                    <span class="metadata-value">
+                        <span class="badge badge-engineered">
+                            ENGINEERED
+                        </span>
+                    </span>
+                </div>
+
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Environment</span>
+                    <span class="metadata-value">
+                        Mars regolith (MGS-1) extract culture assay (laboratory culture)
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01001405"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:01001405
+                        </a>
+                    </span>
+                </div>
+                
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        regolith
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01000747"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:01000747
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
+            </div>
+        </section>
+
+        <!-- Description -->
+        
+        <section class="description">
+            <p>A defined four-member panel of photosynthetic microorganisms evaluated for their ability to grow using only martian resources (water and Mars Global Simulant MGS-1 regolith extract) under an Earth-like atmosphere, as candidates to support Mars colonization through oxygen and biomass production. The panel comprises three cyanobacteria — Anabaena cylindrica, Nostoc muscorum (NCBI Taxonomy: Desmonostoc muscorum), and Arthrospira platensis (NCBI Taxonomy: Limnospira platensis) — and the green microalga Chlorella vulgaris. Each species was grown separately in a martian regolith extract culture medium and monitored for 25 days by optical density and fluorometric parameters; Nostoc muscorum grew best, while Arthrospira platensis and Chlorella vulgaris did not thrive on the regolith extract. End-of-life biomass was then tested as a biofertilizing agent for the macrophyte Lemna minor, stimulating plant biomass to levels comparable to standard synthetic medium. The panel is an In-Situ Resource Utilization model for bioregenerative life support on Mars. Members were assayed individually, so the record captures a shared capacity to grow on martian regolith resources rather than measured interspecies interactions.
+</p>
+        </section>
+        
+
+        <!-- Taxonomy -->
+        
+        <section>
+            <h2>Taxonomy</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Taxon</th>
+                        <th>Ontology ID</th>
+                        <th>Functional Roles</th>
+                        <th>Abundance</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    
+                    <tr>
+                        <td>
+                            <strong>Anabaena cylindrica</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1165"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:1165
+                            </a>
+                        </td>
+                        <td>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35865930/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:35865930</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"three species of cyanobacteria (Anabaena cylindrica, Nostoc muscorum, and Arthrospira platensis)"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td>
+                            <strong>Nostoc muscorum</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1179"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:1179
+                            </a>
+                        </td>
+                        <td>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35865930/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:35865930</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"N. muscorum showed the best growth performance"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td>
+                            <strong>Arthrospira platensis</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=118562"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:118562
+                            </a>
+                        </td>
+                        <td>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35865930/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:35865930</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"A. platensis and C. vulgaris were not able to thrive on Mars regolith extract"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td>
+                            <strong>Chlorella vulgaris</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=3077"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:3077
+                            </a>
+                        </td>
+                        <td>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35865930/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:35865930</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"a green microalga (Chlorella vulgaris)"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                </tbody>
+            </table>
+        </section>
+        
+
+        <!-- Ecological Interactions -->
+        <section>
+            <h2>Ecological Interactions</h2>
+        
+            <div class="empty-state">
+                <p>ℹ️ No detailed ecological interaction data is available for this community.</p>
+                <p class="empty-state-note">This record may be a metabolic model or minimal entry containing only taxonomy and external resource links.</p>
+            </div>
+        
+        </section>
+
+        <!-- Associated Datasets -->
+        
+
+        <!-- Environmental Factors -->
+        
+
+        
+        <section>
+            <h2>Environmental Factors</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Factor</th>
+                        <th>Value</th>
+                        <th>Unit</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    
+                    <tr>
+                        <td><strong>Mars regolith simulant (MGS-1) extract as sole nutrient resource</strong></td>
+                        <td>MGS-1 regolith extract culture medium</td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="3">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35865930/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:35865930</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"grow using only the resources existing in Mars, i.e., water and Martian regolith stimulant (MGS-1)"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td><strong>End-of-life biomass biofertilization of Lemna minor</strong></td>
+                        <td>Lemna minor dry-weight stimulation</td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="3">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35865930/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:35865930</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"possible contribution of end-of-life cyanobacteria/microalga as biofertilizing agents"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                </tbody>
+            </table>
+        </section>
+        
+
+        <!-- Growth Media -->
+        
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>Generated by CommunityMech | <a href="https://github.com/CultureBotAI/CommunityMech">View on GitHub</a></p>
+        </div>
+    </footer>
+
+    
+    <script src="../theme-toggle.js"></script>
+</body>
+</html>

--- a/docs/communities/Moss_Microbe_Complex_Regolith_Biofertilizer.html
+++ b/docs/communities/Moss_Microbe_Complex_Regolith_Biofertilizer.html
@@ -1,0 +1,1105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Moss-Microbe Complex Regolith Biofertilizer - CommunityMech</title>
+    <style>
+        :root {
+            --primary: #3D7DD6;
+            --secondary: #64748b;
+            --background: #f8fafc;
+            --card: #ffffff;
+            --border: #e2e8f0;
+            --text: #1e293b;
+            --text-muted: #64748b;
+            --success: #10b981;
+            --warning: #f59e0b;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background: var(--background);
+            color: var(--text);
+            line-height: 1.6;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 2rem;
+        }
+
+        header {
+            background: linear-gradient(135deg, #FBD3E3, #CBDDF6);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.10);
+            padding: 1.5rem 0;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            color: var(--primary);
+            font-size: 2rem;
+            margin-bottom: 0.5rem;
+        }
+
+        h2 {
+            color: var(--text);
+            font-size: 1.5rem;
+            margin: 2rem 0 1rem;
+            border-bottom: 1px solid var(--border);
+            padding-bottom: 0.5rem;
+        }
+
+        h3 {
+            color: var(--text);
+            font-size: 1.25rem;
+            margin: 1.5rem 0 0.75rem;
+        }
+
+        .metadata {
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .metadata-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 1rem;
+            margin-top: 1rem;
+        }
+
+        .metadata-item {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .metadata-label {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin-bottom: 0.25rem;
+        }
+
+        .metadata-value {
+            color: var(--text);
+            font-size: 1rem;
+        }
+
+        .badge {
+            display: inline-block;
+            padding: 0.25rem 0.75rem;
+            border-radius: 12px;
+            font-size: 0.875rem;
+            font-weight: 500;
+        }
+
+        .badge-engineered { background: #dbeafe; color: #1e40af; }
+        .badge-natural { background: #d1fae5; color: #065f46; }
+
+        .description {
+            background: var(--card);
+            border-left: 4px solid var(--primary);
+            padding: 1rem 1.5rem;
+            margin: 1rem 0;
+            border-radius: 4px;
+        }
+
+        table {
+            width: 100%;
+            background: var(--card);
+            border-radius: 8px;
+            overflow: hidden;
+            border: 1px solid var(--border);
+            margin: 1rem 0;
+        }
+
+        th, td {
+            padding: 0.75rem 1rem;
+            text-align: left;
+        }
+
+        th {
+            background: #f1f5f9;
+            font-weight: 600;
+            color: var(--text);
+            border-bottom: 2px solid var(--border);
+        }
+
+        tr:not(:last-child) td {
+            border-bottom: 1px solid var(--border);
+        }
+
+        .term-link {
+            color: var(--primary);
+            text-decoration: none;
+            font-family: 'Courier New', monospace;
+            font-size: 0.875rem;
+        }
+
+        .term-link:hover {
+            text-decoration: underline;
+        }
+
+        .interaction-card {
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 1.5rem;
+            margin: 1rem 0;
+        }
+
+        .interaction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 1rem;
+        }
+
+        .interaction-type {
+            padding: 0.25rem 0.75rem;
+            background: #f0fdf4;
+            color: #166534;
+            border-radius: 4px;
+            font-size: 0.875rem;
+            font-weight: 500;
+        }
+
+        .interaction-flow {
+            background: var(--background);
+            color: var(--text);
+            border-left: 3px solid var(--primary);
+            padding: 1rem;
+            margin: 1rem 0;
+            border-radius: 4px;
+        }
+
+        .flow-item {
+            margin: 0.5rem 0;
+        }
+
+        .flow-arrow {
+            color: var(--primary);
+            margin: 0 0.5rem;
+        }
+
+        .evidence-list {
+            list-style: none;
+            margin: 0.5rem 0;
+        }
+
+        .evidence-item {
+            background: var(--background);
+            color: var(--text);
+            border-left: 3px solid #ca8a04;
+            padding: 0.75rem;
+            margin: 0.5rem 0;
+            border-radius: 4px;
+        }
+
+        .empty-state {
+            background: #f8fafc;
+            border: 1px dashed #cbd5e1;
+            border-radius: 8px;
+            padding: 2rem;
+            text-align: center;
+            color: #64748b;
+        }
+
+        .empty-state p {
+            margin: 0.5rem 0;
+        }
+
+        .empty-state-note {
+            font-size: 0.875rem;
+            color: #94a3b8;
+        }
+
+        .pmid-link {
+            color: var(--primary);
+            text-decoration: none;
+            font-weight: 500;
+        }
+
+        .pmid-link:hover {
+            text-decoration: underline;
+        }
+
+        .snippet {
+            color: var(--text-muted);
+            font-style: italic;
+            font-size: 0.875rem;
+            margin-top: 0.5rem;
+        }
+
+        .roles-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }
+
+        .role-badge {
+            padding: 0.25rem 0.5rem;
+            background: #ede9fe;
+            color: #5b21b6;
+            border-radius: 4px;
+            font-size: 0.75rem;
+            font-weight: 500;
+        }
+
+        .dataset-description {
+            color: var(--text-muted);
+            font-size: 0.875rem;
+        }
+
+        footer {
+            margin-top: 3rem;
+            padding-top: 2rem;
+            border-top: 1px solid var(--border);
+            text-align: center;
+            color: var(--text-muted);
+            font-size: 0.875rem;
+        }
+
+        .back-link {
+            display: inline-block;
+            color: var(--primary);
+            text-decoration: none;
+            margin-bottom: 1rem;
+        }
+
+        .back-link:hover {
+            text-decoration: underline;
+        }
+
+        /* Network diagram */
+        .network-container {
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 1rem;
+            margin: 1rem 0 2rem;
+            position: relative;
+        }
+
+        .network-container svg {
+            width: 100%;
+            display: block;
+        }
+
+        .network-legend {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+            padding: 0.75rem 0 0;
+            border-top: 1px solid var(--border);
+            margin-top: 0.5rem;
+            font-size: 0.8rem;
+            color: var(--text-muted);
+        }
+
+        .legend-item {
+            display: flex;
+            align-items: center;
+            gap: 0.35rem;
+        }
+
+        .legend-swatch {
+            width: 14px;
+            height: 14px;
+            border-radius: 3px;
+            display: inline-block;
+        }
+
+        .legend-circle {
+            border-radius: 50%;
+        }
+
+        .network-tooltip {
+            position: absolute;
+            background: rgba(30, 41, 59, 0.95);
+            color: #f8fafc;
+            padding: 0.5rem 0.75rem;
+            border-radius: 6px;
+            font-size: 0.8rem;
+            line-height: 1.4;
+            pointer-events: none;
+            opacity: 0;
+            transition: opacity 0.15s;
+            max-width: 280px;
+            z-index: 10;
+        }
+
+        .network-tooltip strong {
+            color: #93c5fd;
+        }
+    /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+  :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+  :root:not([data-theme="light"]) th{background:#232a3d}
+  :root:not([data-theme="light"]) .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+  :root:not([data-theme="light"]) .interaction-flow{background:rgba(255,255,255,.04)}
+  :root:not([data-theme="light"]) .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+  :root:not([data-theme="light"]) .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+  :root:not([data-theme="light"]) .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+}
+:root[data-theme="dark"]{--primary:#6ea6f0; --secondary:#99a2b5; --background:#101420; --card:#1a1f2e; --border:#2a3142; --text:#e8ecf4; --text-muted:#99a2b5; --success:#34d399; --warning:#fbbf24; --net-label:#cbd5e1;}
+:root[data-theme="dark"] header{background:linear-gradient(135deg,#1d2740,#101420);border-bottom-color:#2a3142}
+:root[data-theme="dark"] th{background:#232a3d}
+:root[data-theme="dark"] .interaction-type{background:rgba(52,211,153,.14);color:#34d399}
+:root[data-theme="dark"] .interaction-flow{background:rgba(255,255,255,.04)}
+:root[data-theme="dark"] .evidence-item{background:rgba(251,191,36,.10);border-left-color:#fbbf24}
+:root[data-theme="dark"] .empty-state{background:rgba(255,255,255,.03);border-color:#2a3142;color:#99a2b5}
+:root[data-theme="dark"] .role-badge{background:rgba(180,153,240,.16);color:#c4b5fd}
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}
+</style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <a href="../browser.html" class="back-link">← Back to Communities</a>
+            <h1>Moss-Microbe Complex Regolith Biofertilizer</h1>
+        </div>
+    </header>
+
+    <main class="container">
+        <!-- Metadata Overview -->
+        <section class="metadata">
+            <div class="metadata-grid">
+                <div class="metadata-item">
+                    <span class="metadata-label">Community ID</span>
+                    <span class="metadata-value">
+                        <code style="background: var(--border); color: var(--text); padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.9rem;">CommunityMech:000310</code>
+                    </span>
+                </div>
+
+                <div class="metadata-item">
+                    <span class="metadata-label">Ecological State</span>
+                    <span class="metadata-value">
+                        <span class="badge badge-engineered">
+                            ENGINEERED
+                        </span>
+                    </span>
+                </div>
+
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Environment</span>
+                    <span class="metadata-value">
+                        lunar/Martian soil-simulant biofertilizer pot assay (laboratory culture)
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01001405"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:01001405
+                        </a>
+                    </span>
+                </div>
+                
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        regolith
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01000747"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:01000747
+                        </a>
+                        
+                        
+                    </span>
+                </div>
+                
+            </div>
+        </section>
+
+        <!-- Description -->
+        
+        <section class="description">
+            <p>A moss-microbe complex evaluated as a bio-based biofertilizer for improving crop growth on lunar and Martian soil simulants. The complex comprises the moss Hypnum plumaeforme together with plant growth-promoting bacteria isolated from it — Pseudomonas monteilii and Bacillus cereus — selected for phosphate solubilization, indole-3-acetic acid (IAA) production, and siderophore synthesis. Using barley (Hordeum vulgare) as a model crop, the study compared moss alone, microbes alone, and their combined application under extreme edaphic conditions represented by lunar (LHS) and Martian (MGS) soil simulants. The moss-microbe co-treatment significantly enhanced shoot biomass, dry weight, organic matter, available phosphate, and cation exchange capacity; in the dense, low-porosity Martian simulant the moss functioned as a biological buffer that facilitated microbial colonization and restored plant growth. 16S rRNA profiling confirmed the stable presence of the genera Pseudomonas, Bacillus, and Devosia in moss-treated soils, and metabolite profiling revealed accumulation of growth-related compounds (D-ribose, D-gluconate), suggesting the complex reprograms rhizosphere metabolism. The system is an In-Situ Resource Utilization model for extraterrestrial farming and land restoration.
+</p>
+        </section>
+        
+
+        <!-- Taxonomy -->
+        
+        <section>
+            <h2>Taxonomy</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Taxon</th>
+                        <th>Ontology ID</th>
+                        <th>Functional Roles</th>
+                        <th>Abundance</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    
+                    <tr>
+                        <td>
+                            <strong>Pseudomonas monteilii</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=76759"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:76759
+                            </a>
+                        </td>
+                        <td>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://doi.org/10.1016/j.ecolind.2025.114023"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.1016/j.ecolind.2025.114023</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"Beneficial microbial strains (Pseudomonas monteilii and Bacillus cereus) were isolated from the moss"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td>
+                            <strong>Bacillus cereus</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1396"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:1396
+                            </a>
+                        </td>
+                        <td>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://doi.org/10.1016/j.ecolind.2025.114023"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.1016/j.ecolind.2025.114023</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"Beneficial microbial strains (Pseudomonas monteilii and Bacillus cereus) were isolated from the moss"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td>
+                            <strong>Devosia sp.</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=46913"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:46913
+                            </a>
+                        </td>
+                        <td>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://doi.org/10.1016/j.ecolind.2025.114023"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.1016/j.ecolind.2025.114023</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"stable presence of key genera, including Pseudomonas, Bacillus, and Devosia, in moss-treated soils"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                </tbody>
+            </table>
+        </section>
+        
+
+        <!-- Ecological Interactions -->
+        <section>
+            <h2>Ecological Interactions</h2>
+        
+
+            <!-- Network Diagram -->
+            <div class="network-container" id="network-container">
+                <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
+                <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
+                    <title id="network-svg-title">Ecological interaction network for Moss-Microbe Complex Regolith Biofertilizer</title>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, syntrophy, competition, commensalism).</desc>
+                </svg>
+                <div class="network-legend">
+                    <div class="legend-item">
+                        <span class="legend-swatch legend-circle" style="background: #3b82f6;"></span> Taxon
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #22c55e;"></span> Cross-feeding
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #3b82f6;"></span> Mutualism
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #a855f7;"></span> Syntrophy
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #ef4444;"></span> Competition
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #f97316;"></span> Commensalism
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #14b8a6;"></span> Niche partitioning
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #eab308;"></span> Colonization facilitation
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #fb7185;"></span> Strain competition
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #dc2626;"></span> Predation
+                    </div>
+                </div>
+            </div>
+
+            
+            <div class="interaction-card">
+                <div class="interaction-header">
+                    <h3>Moss-facilitated microbial colonization on Martian simulant</h3>
+                    <span class="interaction-type">COLONIZATION_FACILITATION</span>
+                </div>
+
+                
+                <p><strong>Source Taxon:</strong> Hypnum plumaeforme (moss host)</p>
+                
+
+                
+
+                
+
+                
+
+                
+
+                
+                <h4>Evidence</h4>
+                <ul class="evidence-list">
+                    
+                    <li class="evidence-item">
+                        <div>
+                            
+                            <a href="https://doi.org/10.1016/j.ecolind.2025.114023"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.1016/j.ecolind.2025.114023</a>
+                            
+                            - SUPPORT (IN_VITRO)
+                        </div>
+                        
+                        <div class="snippet">"moss functioned as a biological buffer that facilitated microbial colonization"</div>
+                        
+                    </li>
+                    
+                    <li class="evidence-item">
+                        <div>
+                            
+                            <a href="https://doi.org/10.1016/j.ecolind.2025.114023"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.1016/j.ecolind.2025.114023</a>
+                            
+                            - SUPPORT (IN_VITRO)
+                        </div>
+                        
+                        <div class="snippet">"moss acts not merely as an organic input but as a key facilitator of plant-microbe interactions under harsh conditions"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="interaction-card">
+                <div class="interaction-header">
+                    <h3>Moss-microbe co-treatment enhances barley growth and soil quality</h3>
+                    <span class="interaction-type">MUTUALISM</span>
+                </div>
+
+                
+
+                
+                <p><strong>Target Taxon:</strong> Hordeum vulgare (barley model crop)</p>
+                
+
+                
+
+                
+
+                
+
+                
+                <h4>Evidence</h4>
+                <ul class="evidence-list">
+                    
+                    <li class="evidence-item">
+                        <div>
+                            
+                            <a href="https://doi.org/10.1016/j.ecolind.2025.114023"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.1016/j.ecolind.2025.114023</a>
+                            
+                            - SUPPORT (IN_VITRO)
+                        </div>
+                        
+                        <div class="snippet">"moss-microbe co-treatment significantly enhanced shoot biomass, dry weight, organic matter content, available phosphate, and cation exchange capacity"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+        
+        </section>
+
+        <!-- Associated Datasets -->
+        
+
+        <!-- Environmental Factors -->
+        
+
+        
+        <section>
+            <h2>Environmental Factors</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Factor</th>
+                        <th>Value</th>
+                        <th>Unit</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    
+                    <tr>
+                        <td><strong>Lunar (LHS) and Martian (MGS) soil simulants</strong></td>
+                        <td>LHS and MGS soil simulants</td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="3">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://doi.org/10.1016/j.ecolind.2025.114023"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.1016/j.ecolind.2025.114023</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"extreme edaphic conditions represented by lunar (LHS) and Martian (MGS) soil simulants"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                </tbody>
+            </table>
+        </section>
+        
+
+        <!-- Growth Media -->
+        
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>Generated by CommunityMech | <a href="https://github.com/CultureBotAI/CommunityMech">View on GitHub</a></p>
+        </div>
+    </footer>
+
+    
+    <script src="../d3.v7.min.js"></script>
+    <script>
+    (function() {
+        var interactionColors = {
+            CROSS_FEEDING: "#22c55e",
+            MUTUALISM: "#3b82f6",
+            SYNTROPHY: "#a855f7",
+            COMPETITION: "#ef4444",
+            COMMENSALISM: "#f97316",
+            PREDATION: "#dc2626",
+            NICHE_PARTITIONING: "#14b8a6",
+            STRAIN_COMPETITION: "#fb7185",
+            COLONIZATION_FACILITATION: "#eab308"
+        };
+
+        // Build taxon lookup keyed by preferred_term
+        var taxonData = {};
+        
+        taxonData["Pseudomonas monteilii"] = {
+            id: "NCBITaxon:76759",
+            label: "Pseudomonas monteilii",
+            abundance: "UNKNOWN",
+            roles: []
+        };
+        
+        taxonData["Bacillus cereus"] = {
+            id: "NCBITaxon:1396",
+            label: "Bacillus cereus",
+            abundance: "UNKNOWN",
+            roles: []
+        };
+        
+        taxonData["Devosia sp."] = {
+            id: "NCBITaxon:46913",
+            label: "Devosia sp.",
+            abundance: "UNKNOWN",
+            roles: []
+        };
+        
+
+        // Build nodes and links
+        var nodes = [];
+        var links = [];
+        var taxonNodeIds = {};
+
+        // Add taxon nodes
+        Object.keys(taxonData).forEach(function(key) {
+            var t = taxonData[key];
+            var nodeId = "taxon:" + key;
+            taxonNodeIds[key] = nodeId;
+            nodes.push({
+                id: nodeId,
+                label: t.label,
+                type: "taxon",
+                abundance: t.abundance,
+                roles: t.roles,
+                ontologyId: t.id
+            });
+        });
+
+        // Add interaction nodes and edges
+        
+        (function() {
+            var intId = "interaction:0";
+            var intType = "COLONIZATION_FACILITATION";
+            var metabolites = [];
+            
+            var processes = [];
+            
+            var evidenceCount = 2;
+
+            nodes.push({
+                id: intId,
+                label: "Moss-facilitated microbial colonization on Martian simulant",
+                type: "interaction",
+                interactionType: intType,
+                metabolites: metabolites,
+                processes: processes,
+                evidenceCount: evidenceCount
+            });
+
+            
+            var srcKey = "Hypnum plumaeforme (moss host)";
+            if (taxonNodeIds[srcKey]) {
+                links.push({ source: taxonNodeIds[srcKey], target: intId });
+            }
+            
+
+            
+        })();
+        
+        (function() {
+            var intId = "interaction:1";
+            var intType = "MUTUALISM";
+            var metabolites = [];
+            
+            var processes = [];
+            
+            var evidenceCount = 1;
+
+            nodes.push({
+                id: intId,
+                label: "Moss-microbe co-treatment enhances barley growth and soil quality",
+                type: "interaction",
+                interactionType: intType,
+                metabolites: metabolites,
+                processes: processes,
+                evidenceCount: evidenceCount
+            });
+
+            
+
+            
+            var tgtKey = "Hordeum vulgare (barley model crop)";
+            if (taxonNodeIds[tgtKey]) {
+                links.push({ source: intId, target: taxonNodeIds[tgtKey] });
+            }
+            
+        })();
+        
+
+        // Remove taxon nodes with no connections
+        var connectedIds = new Set();
+        links.forEach(function(l) {
+            connectedIds.add(typeof l.source === "object" ? l.source.id : l.source);
+            connectedIds.add(typeof l.target === "object" ? l.target.id : l.target);
+        });
+        nodes = nodes.filter(function(n) {
+            return n.type === "interaction" || connectedIds.has(n.id);
+        });
+
+        // D3 setup
+        var container = document.getElementById("network-container");
+        var svg = d3.select("#network-svg");
+        var width = container.clientWidth - 32;
+        // Dynamic height based on node count: minimum 500px, add 40px per node
+        var nodeCount = 5;
+        var height = Math.max(500, 400 + nodeCount * 20);
+        svg.attr("width", width).attr("height", height);
+
+        // Arrow marker
+        svg.append("defs").append("marker")
+            .attr("id", "arrowhead")
+            .attr("viewBox", "0 -5 10 10")
+            .attr("refX", 20)
+            .attr("refY", 0)
+            .attr("markerWidth", 6)
+            .attr("markerHeight", 6)
+            .attr("orient", "auto")
+            .append("path")
+            .attr("d", "M0,-5L10,0L0,5")
+            .attr("fill", "#94a3b8");
+
+        var simulation = d3.forceSimulation(nodes)
+            .force("link", d3.forceLink(links).id(function(d) { return d.id; }).distance(100))
+            .force("charge", d3.forceManyBody().strength(-400))
+            .force("center", d3.forceCenter(width / 2, height / 2))
+            .force("collision", d3.forceCollide().radius(40))
+            .force("x", d3.forceX(width / 2).strength(0.05))
+            .force("y", d3.forceY(height / 2).strength(0.05));
+
+        var link = svg.append("g")
+            .selectAll("line")
+            .data(links)
+            .join("line")
+            .attr("stroke", "#94a3b8")
+            .attr("stroke-width", 1.5)
+            .attr("marker-end", "url(#arrowhead)");
+
+        var node = svg.append("g")
+            .selectAll("g")
+            .data(nodes)
+            .join("g")
+            .style("cursor", "pointer");
+
+        // Taxon nodes: circles
+        node.filter(function(d) { return d.type === "taxon"; })
+            .append("circle")
+            .attr("r", function(d) { return d.abundance === "DOMINANT" ? 18 : 12; })
+            .attr("fill", "#3b82f6")
+            .attr("stroke", "#1e40af")
+            .attr("stroke-width", 1.5);
+
+        // Interaction nodes: rounded rects
+        node.filter(function(d) { return d.type === "interaction"; })
+            .append("rect")
+            .attr("width", 28)
+            .attr("height", 18)
+            .attr("x", -14)
+            .attr("y", -9)
+            .attr("rx", 5)
+            .attr("fill", function(d) { return interactionColors[d.interactionType] || "#6b7280"; })
+            .attr("stroke", function(d) {
+                var c = d3.color(interactionColors[d.interactionType] || "#6b7280");
+                return c ? c.darker(0.5) : "#4b5563";
+            })
+            .attr("stroke-width", 1.5);
+
+        // Labels for taxa (positioned below circle)
+        node.filter(function(d) { return d.type === "taxon"; })
+            .append("text")
+            .text(function(d) {
+                var parts = d.label.split(" ");
+                return parts.length >= 2 ? parts[0][0] + ". " + parts.slice(1).join(" ") : d.label;
+            })
+            .attr("text-anchor", "middle")
+            .attr("dy", function(d) { return d.abundance === "DOMINANT" ? 30 : 24; })
+            .attr("font-size", "10px")
+            .style("fill", "var(--net-label, #475569)");
+
+        // Labels for interactions (multi-line, centered in rectangle)
+        node.filter(function(d) { return d.type === "interaction"; })
+            .each(function(d) {
+                var textElem = d3.select(this).append("text")
+                    .attr("text-anchor", "middle")
+                    .attr("font-size", "9px")
+                    .style("fill", "var(--net-label, #475569)")
+                    .style("pointer-events", "none");
+
+                // Word-wrap text to fit in rectangle (max ~24 chars per line)
+                var words = d.label.split(/\s+/);
+                var line = "";
+                var lines = [];
+                var maxWidth = 24;
+
+                for (var i = 0; i < words.length; i++) {
+                    var testLine = line + (line ? " " : "") + words[i];
+                    if (testLine.length > maxWidth && line.length > 0) {
+                        lines.push(line);
+                        line = words[i];
+                    } else {
+                        line = testLine;
+                    }
+                }
+                if (line) lines.push(line);
+
+                // Limit to 3 lines maximum
+                if (lines.length > 3) {
+                    lines = lines.slice(0, 3);
+                    lines[2] = lines[2].substring(0, 21) + "...";
+                }
+
+                // Add tspan for each line
+                var lineHeight = 11;
+                var startY = -(lines.length - 1) * lineHeight / 2;
+                lines.forEach(function(lineText, i) {
+                    textElem.append("tspan")
+                        .attr("x", 0)
+                        .attr("dy", i === 0 ? startY : lineHeight)
+                        .text(lineText);
+                });
+            });
+
+        // Tooltip
+        var tooltip = d3.select("#network-tooltip");
+
+        node.on("mouseenter", function(event, d) {
+            tooltip.selectAll("*").remove();
+            if (d.type === "taxon") {
+                tooltip.append("strong").text(d.label);
+                tooltip.append("br");
+                tooltip.append("span").text(d.ontologyId);
+                tooltip.append("br");
+                tooltip.append("span").text("Abundance: " + d.abundance);
+                if (d.roles.length) {
+                    tooltip.append("br");
+                    tooltip.append("span").text("Roles: " + d.roles.join(", "));
+                }
+            } else {
+                tooltip.append("strong").text(d.label);
+                tooltip.append("br");
+                tooltip.append("span").text(d.interactionType);
+                if (d.metabolites.length) {
+                    tooltip.append("br");
+                    tooltip.append("span").text("Metabolites: " + d.metabolites.join(", "));
+                }
+                if (d.processes.length) {
+                    tooltip.append("br");
+                    tooltip.append("span").text("Processes: " + d.processes.join(", "));
+                }
+                tooltip.append("br");
+                tooltip.append("span").text("Evidence items: " + d.evidenceCount);
+            }
+            tooltip.style("opacity", 1)
+                .style("left", (event.offsetX + 12) + "px")
+                .style("top", (event.offsetY - 12) + "px");
+        })
+        .on("mousemove", function(event) {
+            tooltip.style("left", (event.offsetX + 12) + "px")
+                .style("top", (event.offsetY - 12) + "px");
+        })
+        .on("mouseleave", function() {
+            tooltip.style("opacity", 0);
+        });
+
+        // Tick
+        simulation.on("tick", function() {
+            link.attr("x1", function(d) { return d.source.x; })
+                .attr("y1", function(d) { return d.source.y; })
+                .attr("x2", function(d) { return d.target.x; })
+                .attr("y2", function(d) { return d.target.y; });
+
+            node.attr("transform", function(d) {
+                // Constrain nodes within safe boundaries
+                // Account for: node size, label text, and extra padding
+                var nodeRadius = (d.type === "taxon" && d.abundance === "DOMINANT") ? 18 :
+                                (d.type === "taxon") ? 12 : 14; // interaction nodes
+                var labelOffset = d.type === "taxon" ? 35 : 0; // taxon labels below node
+
+                var marginTop = 40;
+                var marginBottom = 60; // extra space for labels
+                var marginSide = 80; // space for long names
+
+                d.x = Math.max(marginSide, Math.min(width - marginSide, d.x));
+                d.y = Math.max(marginTop, Math.min(height - marginBottom, d.y));
+                return "translate(" + d.x + "," + d.y + ")";
+            });
+        });
+
+        // Stabilize after 300 ticks then stop
+        simulation.alpha(1).alphaDecay(0.02);
+        for (var i = 0; i < 300; i++) simulation.tick();
+        simulation.stop();
+
+        // Apply final positions
+        link.attr("x1", function(d) { return d.source.x; })
+            .attr("y1", function(d) { return d.source.y; })
+            .attr("x2", function(d) { return d.target.x; })
+            .attr("y2", function(d) { return d.target.y; });
+
+        node.attr("transform", function(d) { return "translate(" + d.x + "," + d.y + ")"; });
+    })();
+    </script>
+    
+    <script src="../theme-toggle.js"></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -75,7 +75,7 @@
     <h1>CommunityMech</h1>
     <p class="tagline">Microbial community knowledge base — curated, evidence-backed interaction networks.</p>
     <div class="stats">
-      <div class="stat"><b>300</b><span>communities</span></div>
+      <div class="stat"><b>304</b><span>communities</span></div>
       <div class="stat"><b>16</b><span>categories</span></div>
       <div class="stat"><b>512-D</b><span>v3 embeddings</span></div>
     </div>


### PR DESCRIPTION
## What

Generates the missing `docs/communities/*.html` pages for the four space-regolith records curated in #232/#233, and adds them to the faceted browser (`docs/browser.html`) + landing index (`docs/index.html`, count 300 → 304):

- `Mars_Meteorite_EETA79001_Growth_Panel` (000308)
- `Mars_Regolith_Cyanobacteria_Biofertilizer_Panel` (000309)
- `Moss_Microbe_Complex_Regolith_Biofertilizer` (000310)
- `Legume_Rhizobia_Mars_Simulant_Symbiosis` (000311)

## Why

These records shipped without rendered pages (304 YAML vs 300 HTML). Each carries a `modeled_environment → ENVO:01000747 "regolith"` block, which now renders as intended — closing the `modeled_environment` page-regen follow-up in NEXT_TASKS §2 for the records added since #221.

## Scope note

`just gen-html` also produced a whitespace-only inserted line on the other ~277 pages (pre-existing template-render drift, cosmetic). That churn is **intentionally left out** to keep this diff focused on the four new pages + browser/index. A separate mechanical re-render can absorb the whitespace drift if desired.

## Verification

- New pages render the regolith `modeled_environment` section (grep-confirmed).
- `docs/` is not a CI-gated path; doc-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)