### PR TITLE
Pelotomaculum-Methanocella propionate syntrophy: curate causal graph

### DIFF
--- a/docs/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.html
+++ b/docs/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.html
@@ -409,6 +409,7 @@
                     </span>
                 </div>
                 
+                
             </div>
         </section>
 
@@ -655,6 +656,15 @@
                 
 
                 
+                <div class="interaction-flow">
+                    <strong>Downstream Effects:</strong>
+                    
+                    <div class="flow-item">
+                        <span class="flow-arrow">→</span> Catabolism and Methanogenesis Upregulation in Coculture
+                    </div>
+                    
+                </div>
+                
 
                 
                 <h4>Evidence</h4>
@@ -725,6 +735,19 @@
                 </ul>
                 
 
+                
+                <div class="interaction-flow">
+                    <strong>Downstream Effects:</strong>
+                    
+                    <div class="flow-item">
+                        <span class="flow-arrow">→</span> Formate and Electron Bifurcation Strategy
+                    </div>
+                    
+                    <div class="flow-item">
+                        <span class="flow-arrow">→</span> Signal Transduction and Amino Acid Exchange
+                    </div>
+                    
+                </div>
                 
 
                 
@@ -798,6 +821,19 @@
                 </ul>
                 
 
+                
+                <div class="interaction-flow">
+                    <strong>Downstream Effects:</strong>
+                    
+                    <div class="flow-item">
+                        <span class="flow-arrow">→</span> Propionate Oxidation Coupled to Methanogenesis
+                    </div>
+                    
+                    <div class="flow-item">
+                        <span class="flow-arrow">→</span> Propionate Oxidation Coupled to Methanogenesis
+                    </div>
+                    
+                </div>
                 
 
                 

--- a/kb/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.yaml
+++ b/kb/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.yaml
@@ -149,6 +149,13 @@ ecological_interactions:
     term:
       id: GO:0015948
       label: methanogenesis
+  downstream:
+  - target: Catabolism and Methanogenesis Upregulation in Coculture
+    description: >
+      Establishing the syntrophic coculture (versus monoculture) drives the
+      concerted transcriptional upregulation of catabolic genes — the
+      methylmalonyl-CoA pathway in P. thermopropionicum and methanogenesis
+      genes in M. conradii.
   evidence:
   - reference: PMID:30038609
     supports: SUPPORT
@@ -185,6 +192,17 @@ ecological_interactions:
     term:
       id: GO:0015948
       label: methanogenesis
+  downstream:
+  - target: Formate and Electron Bifurcation Strategy
+    description: >
+      The catabolic upregulation includes formate dehydrogenase and flavin-based
+      electron bifurcation/confurcation genes in both partners, activating
+      formate as an alternate interspecies electron carrier alongside H2.
+  - target: Signal Transduction and Amino Acid Exchange
+    description: >
+      The same coculture transcriptional shift upregulates flagellum-induced
+      signal transduction and amino-acid exchange that accompany syntrophic
+      growth.
   evidence:
   - reference: PMID:30038609
     supports: SUPPORT
@@ -222,6 +240,19 @@ ecological_interactions:
     term:
       id: GO:0044419
       label: biological process involved in interspecies interaction between organisms
+  downstream:
+  - target: Propionate Oxidation Coupled to Methanogenesis
+    description: >
+      Interspecies formate and H2 transfer to M. conradii sustains
+      hydrogenotrophic methanogenesis, keeping the shared electron-carrier
+      partial pressure low and thermodynamically pulling P. thermopropionicum
+      propionate oxidation; inhibiting methanogenesis with 2-BES abolished both
+      methane production and propionate oxidation.
+  - target: Propionate Oxidation Coupled to Methanogenesis
+    description: >
+      NEGATIVE (product inhibition) — accumulation of excess formate inhibits
+      syntrophic activity and halts propionate oxidation, so formate transfer
+      must stay balanced by continuous methanogenic consumption.
   evidence:
   - reference: PMID:30038609
     supports: SUPPORT


### PR DESCRIPTION
## What

Adds directed `downstream` causal edges to the four existing `ecological_interactions` of **CommunityMech:000190** (`Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture`), from an Edison causal-graph run (PaperQA3 causal-edge mode; single source **PMID:30038609** / DOI:10.3389/fmicb.2018.01551).

`InteractionDownstream` carries `target` + a causal `description` only (no evidence field) — the supporting evidence stays on the parent interaction nodes, whose existing snippets already validate against the cached abstract. **No new evidence snippets or terms were introduced.**

## Causal wiring (syntrophic feedback loop 1→2→3→1 + negative edge)

| From | To | Sign | Basis (abstract-grounded) |
|------|----|----|---------------------------|
| Propionate Oxidation Coupled to Methanogenesis | Catabolism & Methanogenesis Upregulation | + | Syntrophic coculture drives the concerted catabolic/methanogenesis transcriptional shift |
| Catabolism & Methanogenesis Upregulation | Formate & Electron Bifurcation Strategy | + | Upregulated FDH + flavin electron-bifurcation genes activate formate/H2 electron transfer |
| Catabolism & Methanogenesis Upregulation | Signal Transduction & Amino Acid Exchange | + | Same shift upregulates flagellar signaling + amino-acid exchange |
| Formate & Electron Bifurcation Strategy | Propionate Oxidation Coupled to Methanogenesis | + | Formate/H2 transfer sustains methanogenesis, thermodynamically pulling propionate oxidation; 2-BES abolishes both |
| Formate & Electron Bifurcation Strategy | Propionate Oxidation Coupled to Methanogenesis | − | Product inhibition: excess formate halts syntrophic activity |

All taxa use the record's canonical NCBITaxon ids (110500 / 1175444).

## Verification

- `just validate` → No issues found.
- Reference validator behaves identically to prior causal records (no new snippets).
- Record HTML page regenerated (single file) — downstream edges render.

Continues the causal-graph curation thread (after #226/#229/#230). Provenance bundle under `research/communities/…-causal.*` (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)