### PR TITLE
Rhodopseudomonas-Geobacter magnetite redox: curate causal graph

### DIFF
--- a/docs/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.html
+++ b/docs/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.html
@@ -409,6 +409,7 @@
                     </span>
                 </div>
                 
+                
             </div>
         </section>
 
@@ -643,6 +644,15 @@
                 
 
                 
+                <div class="interaction-flow">
+                    <strong>Downstream Effects:</strong>
+                    
+                    <div class="flow-item">
+                        <span class="flow-arrow">→</span> Biogeochemical Battery Function
+                    </div>
+                    
+                </div>
+                
 
                 
                 <h4>Evidence</h4>
@@ -718,6 +728,19 @@
                 
 
                 
+                <div class="interaction-flow">
+                    <strong>Downstream Effects:</strong>
+                    
+                    <div class="flow-item">
+                        <span class="flow-arrow">→</span> Anaerobic Magnetite Fe(III) Reduction
+                    </div>
+                    
+                    <div class="flow-item">
+                        <span class="flow-arrow">→</span> Biogeochemical Battery Function
+                    </div>
+                    
+                </div>
+                
 
                 
                 <h4>Evidence</h4>
@@ -783,6 +806,19 @@
                 </ul>
                 
 
+                
+                <div class="interaction-flow">
+                    <strong>Downstream Effects:</strong>
+                    
+                    <div class="flow-item">
+                        <span class="flow-arrow">→</span> Phototrophic Magnetite Fe(II) Oxidation
+                    </div>
+                    
+                    <div class="flow-item">
+                        <span class="flow-arrow">→</span> Biogeochemical Battery Function
+                    </div>
+                    
+                </div>
                 
 
                 

--- a/kb/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.yaml
+++ b/kb/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.yaml
@@ -143,6 +143,12 @@ ecological_interactions:
     term:
       id: GO:0006826
       label: iron ion transport
+  downstream:
+  - target: Biogeochemical Battery Function
+    description: >
+      Magnetite-mediated electron sharing between the phototrophic Fe(II)
+      oxidizer and the anaerobic Fe(III) reducer manifests as the emergent,
+      reusable mineral electron-storage system (the "battery").
   evidence:
   - reference: PMID:25814583
     supports: SUPPORT
@@ -178,6 +184,16 @@ ecological_interactions:
     term:
       id: GO:0015979
       label: photosynthesis
+  downstream:
+  - target: Anaerobic Magnetite Fe(III) Reduction
+    description: >
+      Light-driven oxidation of magnetite Fe(II) to Fe(III) supplies the
+      oxidized Fe(III) that G. sulfurreducens subsequently uses as its anaerobic
+      electron acceptor.
+  - target: Biogeochemical Battery Function
+    description: >
+      TIE-1 phototrophic Fe(II) oxidation is one half of the reversible redox
+      cycling that charges magnetite toward its oxidized state.
   evidence:
   - reference: PMID:25814583
     supports: SUPPORT
@@ -213,6 +229,17 @@ ecological_interactions:
     term:
       id: GO:0006826
       label: iron ion transport
+  downstream:
+  - target: Phototrophic Magnetite Fe(II) Oxidation
+    description: >
+      G. sulfurreducens reduction of magnetite Fe(III) regenerates the reduced
+      Fe(II) electron donor for TIE-1, closing the reversible redox loop (the
+      process is reversible in co-cultures).
+  - target: Biogeochemical Battery Function
+    description: >
+      Fe(III) reduction is the complementary half-reaction that restores the
+      mineral's reduced electron-storage capacity, making the magnetite store
+      reusable.
   evidence:
   - reference: PMID:25814583
     supports: SUPPORT


### PR DESCRIPTION
Adds directed `downstream` causal edges to the four `ecological_interactions` of **CommunityMech:000268** from an Edison causal-graph run (PaperQA3; **PMID:25814583** Byrne et al. 2015 *Science* + doi:10.1126/science.aaa4834).

**Wiring — reversible magnetite "battery" loop:**
- Phototrophic Magnetite Fe(II) Oxidation → Anaerobic Magnetite Fe(III) Reduction (TIE-1 photo-oxidation supplies the Fe(III) acceptor Geobacter reduces)
- Anaerobic Magnetite Fe(III) Reduction → Phototrophic Magnetite Fe(II) Oxidation (Geobacter regenerates the Fe(II) donor; reversible in co-cultures — closes the 2⇄3 loop)
- Phototrophic Oxidation, Anaerobic Reduction, and Magnetite-Mediated Electron Sharing → Biogeochemical Battery Function (two half-reactions + electron sharing = emergent reusable mineral electron store)

`InteractionDownstream` carries target + causal description only; evidence stays on the parent nodes (existing PMID:25814583 snippets). No new snippets or terms; canonical NCBITaxon ids.

**Verification:** `just validate` clean; HTML page regenerated (5 edges render). **First causal record curated via a normal `just research-community-causal` run after the `.env`-precedence fix (#245)** — no `env -u`.

Continues the causal thread (#226/#229/#230/#243).

🤖 Generated with [Claude Code](https://claude.com/claude-code)