### PR TITLE
ORNL Clostridium-Desulfovibrio-Geobacter trophic model: curate causal graph

### DIFF
--- a/docs/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.html
+++ b/docs/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.html
@@ -409,6 +409,7 @@
                     </span>
                 </div>
                 
+                
             </div>
         </section>
 
@@ -690,6 +691,19 @@
                 
 
                 
+                <div class="interaction-flow">
+                    <strong>Downstream Effects:</strong>
+                    
+                    <div class="flow-item">
+                        <span class="flow-arrow">→</span> Sulfate-Linked Dependence of D. vulgaris
+                    </div>
+                    
+                    <div class="flow-item">
+                        <span class="flow-arrow">→</span> Fumarate-Linked Dependence of G. sulfurreducens
+                    </div>
+                    
+                </div>
+                
 
                 
                 <h4>Evidence</h4>
@@ -919,6 +933,45 @@
 
         <!-- Associated Datasets -->
         
+        <section id="discussions">
+            <h2>Knowledge gaps &amp; discussions <span class="muted">(1)</span></h2>
+            
+            <div class="discussion">
+                <h3>
+                    <span class="role-badge">KNOWLEDGE_GAP</span>
+                    <span class="role-badge">OPEN</span>
+                    Which exact C. cellulolyticum fermentation products are transferred to D. vulgaris and G. sulfurreducens, and is the electron-acceptor to cross-feeding coupling perturbation-demonstrated rather than only abstract-level implied?
+
+                </h3>
+                <p class="prewrap">The curated donor-to-partner causal edges rest on the abstract statement that the partners &#34;derived carbon and energy from the metabolic products&#34; of C. cellulolyticum; the primary full text (doi:10.1186/1471-2180-10-149) was not retrievable, so the exact exchanged metabolites and any sulfate/fumarate-removal or inhibitor perturbation evidence remain unresolved. Products reported for a related two-species C. cellulolyticum / G. sulfurreducens fuel-cell system (acetate, ethanol, H2) must NOT be imported here without exact-system verification.
+</p>
+                
+                <p class="muted small">Attaches to: <code>ecological_interactions#Sulfate-Linked Dependence of D. vulgaris</code>, <code>ecological_interactions#Fumarate-Linked Dependence of G. sulfurreducens</code></p>
+                
+                
+                
+                <details class="evidence-list">
+                    <summary class="muted small">1 evidence item(s)</summary>
+                    
+                    <div class="evidence">
+                        <div class="evidence-head">
+                            <span class="badge small">IN_VITRO</span>
+                            <span class="badge small">PARTIAL</span>
+                            
+                                
+                                doi:10.1186/1471-2180-10-149
+                            
+                        </div>
+                        <p class="snippet small prewrap">D. vulgaris and G. sulfurreducens derived carbon and energy from the metabolic products</p>
+                        <p class="muted small prewrap">The cross-feeding is stated only at the level of &#34;metabolic products&#34; without naming the exact exchanged compounds — the basis for filing this as a knowledge gap.</p>
+                    </div>
+                    
+                </details>
+                
+                
+            </div>
+            
+        </section>
 
         <!-- Environmental Factors -->
         

--- a/kb/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.yaml
+++ b/kb/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.yaml
@@ -166,6 +166,20 @@ ecological_interactions:
     term:
       id: GO:0006113
       label: fermentation
+  downstream:
+  - target: Sulfate-Linked Dependence of D. vulgaris
+    description: >
+      C. cellulolyticum cellobiose-fermentation products are the carbon/energy
+      (electron-donor) source D. vulgaris consumes while reducing its supplied
+      sulfate acceptor; the fermentation cross-feeding is required for
+      D. vulgaris's sulfate-linked growth. (Abstract-level / directly implied,
+      not perturbation-demonstrated.)
+  - target: Fumarate-Linked Dependence of G. sulfurreducens
+    description: >
+      The same fermentation products support G. sulfurreducens, which reduces
+      its supplied fumarate acceptor; the cross-feeding is required for its
+      fumarate-linked growth. (Abstract-level / directly implied, not
+      perturbation-demonstrated.)
   evidence:
   - reference: doi:10.1186/1471-2180-10-149
     supports: SUPPORT
@@ -404,3 +418,31 @@ metal_relevance: NOT_APPLICABLE
 metal_notes: >
   No metal or rare earth amendments or direct metal-reduction measurements are curated for this
   abstract-supported record.
+discussions:
+- discussion_id: kg-ornl-exchanged-products-and-edge-strength
+  prompt: >
+    Which exact C. cellulolyticum fermentation products are transferred to
+    D. vulgaris and G. sulfurreducens, and is the electron-acceptor to
+    cross-feeding coupling perturbation-demonstrated rather than only
+    abstract-level implied?
+  kind: KNOWLEDGE_GAP
+  status: OPEN
+  attaches_to:
+  - ecological_interactions#Sulfate-Linked Dependence of D. vulgaris
+  - ecological_interactions#Fumarate-Linked Dependence of G. sulfurreducens
+  rationale: >
+    The curated donor-to-partner causal edges rest on the abstract statement that
+    the partners "derived carbon and energy from the metabolic products" of
+    C. cellulolyticum; the primary full text (doi:10.1186/1471-2180-10-149) was not
+    retrievable, so the exact exchanged metabolites and any sulfate/fumarate-removal
+    or inhibitor perturbation evidence remain unresolved. Products reported for a
+    related two-species C. cellulolyticum / G. sulfurreducens fuel-cell system
+    (acetate, ethanol, H2) must NOT be imported here without exact-system
+    verification.
+  evidence:
+  - reference: doi:10.1186/1471-2180-10-149
+    supports: PARTIAL
+    evidence_source: IN_VITRO
+    snippet: D. vulgaris and G. sulfurreducens derived carbon and energy from the metabolic products
+    explanation: The cross-feeding is stated only at the level of "metabolic products" without
+      naming the exact exchanged compounds — the basis for filing this as a knowledge gap.


### PR DESCRIPTION
Adds directed `downstream` causal edges to **CommunityMech:000176** from an Edison causal-graph run (PaperQA3; doi:10.1186/1471-2180-10-149, Miller et al. 2010).

## Conservative by design
The primary full text could not be retrieved, so the run justified only **two abstract-level / directly-implied edges** (no perturbation evidence). Honored that:

| From | To | Basis |
|------|----|-------|
| Cellobiose Fermentation Supports Partner Growth | Sulfate-Linked Dependence of D. vulgaris | C. cellulolyticum products are the electron donor D. vulgaris consumes while reducing supplied sulfate |
| Cellobiose Fermentation Supports Partner Growth | Fumarate-Linked Dependence of G. sulfurreducens | same products; G. sulfurreducens reduces supplied fumarate |

Each edge description carries the "(directly implied, not perturbation-demonstrated)" caveat. The modeled **Electron Donor and Acceptor Limitation** node is left **isolated** per the disposition.

## Knowledge gap recorded
Added a `KNOWLEDGE_GAP` discussion: the exact exchanged fermentation products and any sulfate/fumarate-removal or inhibitor evidence remain unresolved pending the primary full text; products from a related two-species fuel-cell system (acetate/ethanol/H2) must **not** be imported without exact-system verification.

`InteractionDownstream` carries target + description only; the discussion reuses an in-record verbatim snippet. **Schema validates; no new terms.** Page regenerated (2 edges render).

Continues the causal thread (#226/#229/#230/#243/#246).

🤖 Generated with [Claude Code](https://claude.com/claude-code)