### PR TITLE
Curate causal graphs for 4 syntrophy/DIET cocultures (000183/188/189/297)

### DIFF
--- a/docs/communities/DIETsimp_Lignocellulose_to_Methane_DIET_Consortia.html
+++ b/docs/communities/DIETsimp_Lignocellulose_to_Methane_DIET_Consortia.html
@@ -409,6 +409,7 @@
                     </span>
                 </div>
                 
+                
             </div>
         </section>
 
@@ -771,6 +772,47 @@
 
         <!-- Associated Datasets -->
         
+        <section id="discussions">
+            <h2>Knowledge gaps &amp; discussions <span class="muted">(1)</span></h2>
+            
+            <div class="discussion">
+                <h3>
+                    <span class="role-badge">KNOWLEDGE_GAP</span>
+                    <span class="role-badge">OPEN</span>
+                    Are the S. globosa→M. mazei and C. aceticum→M. mazei DIET pathways experimentally validated (direct interspecies electron transfer vs H2/formate mediation), and is there any causal dependency between the two parallel donor→methanogen relationships?
+
+                </h3>
+                <p class="prewrap">An Edison causal-graph pass (PMID:42229598) found no justifiable directed causal edge for this consortium: both interactions are recorded as &#34;Proposed DIET pathway&#34;, the primary full text was inaccessible, and no perturbation (donor-removal, inhibitor, mono-/co-culture, or knockout) evidence was retrieved. The source supports two parallel donor→methanogen proposals, not a causal dependency of one on the other, so no `downstream` edge was added. Neutral-red-mediated electron delivery to M. mazei reported in a different system must not be imported here without exact-system verification.
+</p>
+                
+                <p class="muted small">Attaches to: <code>ecological_interactions#DIET syntrophy from S. globosa to M. mazei</code>, <code>ecological_interactions#DIET syntrophy from C. aceticum to M. mazei</code></p>
+                
+                
+                
+                <details class="evidence-list">
+                    <summary class="muted small">1 evidence item(s)</summary>
+                    
+                    <div class="evidence">
+                        <div class="evidence-head">
+                            <span class="badge small">IN_VITRO</span>
+                            <span class="badge small">PARTIAL</span>
+                            
+                                
+                                
+                                <a href="https://pubmed.ncbi.nlm.nih.gov/42229598/" rel="nofollow noreferrer">PMID:42229598</a>
+                                
+                            
+                        </div>
+                        <p class="snippet small prewrap">during anaerobic digestion of lignocellulose that S. globosa and C. aceticum metabolized intermediates</p>
+                        <p class="muted small prewrap">The consortium role is stated at the level of intermediate metabolism / proposed DIET, without a validated or perturbation-tested causal mechanism — the basis for the knowledge gap.</p>
+                    </div>
+                    
+                </details>
+                
+                
+            </div>
+            
+        </section>
 
         <!-- Environmental Factors -->
         

--- a/docs/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.html
+++ b/docs/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.html
@@ -409,6 +409,7 @@
                     </span>
                 </div>
                 
+                
             </div>
         </section>
 
@@ -631,6 +632,15 @@
                 
 
                 
+                <div class="interaction-flow">
+                    <strong>Downstream Effects:</strong>
+                    
+                    <div class="flow-item">
+                        <span class="flow-arrow">→</span> Reductive Dechlorination by Dehalococcoides
+                    </div>
+                    
+                </div>
+                
 
                 
                 <h4>Evidence</h4>
@@ -801,6 +811,15 @@
                 </ul>
                 
 
+                
+                <div class="interaction-flow">
+                    <strong>Downstream Effects:</strong>
+                    
+                    <div class="flow-item">
+                        <span class="flow-arrow">→</span> Reductive Dechlorination by Dehalococcoides
+                    </div>
+                    
+                </div>
                 
 
                 

--- a/docs/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.html
+++ b/docs/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.html
@@ -409,6 +409,7 @@
                     </span>
                 </div>
                 
+                
             </div>
         </section>
 
@@ -645,6 +646,15 @@
                 
 
                 
+                <div class="interaction-flow">
+                    <strong>Downstream Effects:</strong>
+                    
+                    <div class="flow-item">
+                        <span class="flow-arrow">→</span> Population Ratio Convergence During Growth
+                    </div>
+                    
+                </div>
+                
 
                 
                 <h4>Evidence</h4>
@@ -815,6 +825,47 @@
 
         <!-- Associated Datasets -->
         
+        <section id="discussions">
+            <h2>Knowledge gaps &amp; discussions <span class="muted">(1)</span></h2>
+            
+            <div class="discussion">
+                <h3>
+                    <span class="role-badge">KNOWLEDGE_GAP</span>
+                    <span class="role-badge">OPEN</span>
+                    Does syntrophic aggregation / cell-to-cell attraction causally enhance butyrate oxidation or methanogenesis in this coculture, and is direct interspecies electron transfer (e.g. the reported carbon-nanotube methane stimulation) involved rather than only H2/formate transfer?
+
+                </h3>
+                <p class="prewrap">Aggregation and disturbance-resistant cell-to-cell attraction are observed, but no experiment demonstrates that aggregation increases butyrate oxidation or methane production in this exact coculture, so no aggregation→enhancement `downstream` edge was added. Likewise, carbon-nanotube acceleration of methane production is reported, but DIET &#34;does not always explain the enhancement of methane production&#34; and was not directly proven here, so a DIET mechanism is not asserted.
+</p>
+                
+                <p class="muted small">Attaches to: <code>ecological_interactions#Syntrophic Aggregation and Cell-to-Cell Attraction</code></p>
+                
+                
+                
+                <details class="evidence-list">
+                    <summary class="muted small">1 evidence item(s)</summary>
+                    
+                    <div class="evidence">
+                        <div class="evidence-head">
+                            <span class="badge small">IN_VITRO</span>
+                            <span class="badge small">PARTIAL</span>
+                            
+                                
+                                
+                                <a href="https://pubmed.ncbi.nlm.nih.gov/34603271/" rel="nofollow noreferrer">PMID:34603271</a>
+                                
+                            
+                        </div>
+                        <p class="snippet small prewrap">suggesting the cell-to-cell attraction between Syntrophomonas and Methanococcus</p>
+                        <p class="muted small prewrap">Attraction/aggregation is observed, but its causal contribution to metabolic performance is untested — the basis for the knowledge gap.</p>
+                    </div>
+                    
+                </details>
+                
+                
+            </div>
+            
+        </section>
 
         <!-- Environmental Factors -->
         

--- a/docs/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.html
+++ b/docs/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.html
@@ -409,6 +409,7 @@
                     </span>
                 </div>
                 
+                
             </div>
         </section>
 
@@ -765,6 +766,15 @@
                 
 
                 
+                <div class="interaction-flow">
+                    <strong>Downstream Effects:</strong>
+                    
+                    <div class="flow-item">
+                        <span class="flow-arrow">→</span> Fermenter-Stimulated Butyrate Oxidation and Methane Production
+                    </div>
+                    
+                </div>
+                
 
                 
                 <h4>Evidence</h4>
@@ -829,6 +839,15 @@
                 </ul>
                 
 
+                
+                <div class="interaction-flow">
+                    <strong>Downstream Effects:</strong>
+                    
+                    <div class="flow-item">
+                        <span class="flow-arrow">→</span> Fermenter-Stimulated Butyrate Oxidation and Methane Production
+                    </div>
+                    
+                </div>
                 
 
                 
@@ -919,6 +938,47 @@
             </table>
         </section>
         
+        <section id="discussions">
+            <h2>Knowledge gaps &amp; discussions <span class="muted">(1)</span></h2>
+            
+            <div class="discussion">
+                <h3>
+                    <span class="role-badge">KNOWLEDGE_GAP</span>
+                    <span class="role-badge">OPEN</span>
+                    Does T. flocculiformis ES5 improve the S. wolfei / M. hungatei syntrophy via co-aggregation-based spatial bridging (possible DIET) or via the observed proteomic changes, and is either mechanism causal rather than correlative?
+
+                </h3>
+                <p class="prewrap">The ES5-driven increase in butyrate consumption (120%) and methane (150%) is perturbation-supported, but the mediating mechanism is unresolved: aggregation and the partner proteome response are observed correlates, not demonstrated causal mediators (the two `downstream` edges here are flagged HYPOTHESIZED accordingly). Direct interspecies electron transfer was not experimentally demonstrated for this tri-culture, and the exact ES5 bridging role remains an open question per the source.
+</p>
+                
+                <p class="muted small">Attaches to: <code>ecological_interactions#Aggregation With Syntrophic Partners</code>, <code>ecological_interactions#Proteome Response in the Syntrophic Partners</code></p>
+                
+                
+                
+                <details class="evidence-list">
+                    <summary class="muted small">1 evidence item(s)</summary>
+                    
+                    <div class="evidence">
+                        <div class="evidence-head">
+                            <span class="badge small">IN_VITRO</span>
+                            <span class="badge small">PARTIAL</span>
+                            
+                                
+                                
+                                <a href="https://pubmed.ncbi.nlm.nih.gov/35699440/" rel="nofollow noreferrer">PMID:35699440</a>
+                                
+                            
+                        </div>
+                        <p class="snippet small prewrap">T. flocculiformis ES5 to aggregate with the syntrophic partners</p>
+                        <p class="muted small prewrap">Aggregation is reported as an association accompanying the ES5 effect, without a demonstrated causal-mediation or DIET mechanism — the basis for the knowledge gap.</p>
+                    </div>
+                    
+                </details>
+                
+                
+            </div>
+            
+        </section>
 
         <!-- Environmental Factors -->
         

--- a/kb/communities/DIETsimp_Lignocellulose_to_Methane_DIET_Consortia.yaml
+++ b/kb/communities/DIETsimp_Lignocellulose_to_Methane_DIET_Consortia.yaml
@@ -237,3 +237,32 @@ growth_media:
     snippet: during anaerobic digestion of lignocellulose that S. globosa and C. aceticum
       metabolized intermediates
     explanation: Confirms cultivation is anaerobic (anaerobic digestion of lignocellulose).
+discussions:
+- discussion_id: kg-dietsimp-proposed-diet-no-causal-edge
+  prompt: >
+    Are the S. globosa→M. mazei and C. aceticum→M. mazei DIET pathways
+    experimentally validated (direct interspecies electron transfer vs
+    H2/formate mediation), and is there any causal dependency between the two
+    parallel donor→methanogen relationships?
+  kind: KNOWLEDGE_GAP
+  status: OPEN
+  attaches_to:
+  - ecological_interactions#DIET syntrophy from S. globosa to M. mazei
+  - ecological_interactions#DIET syntrophy from C. aceticum to M. mazei
+  rationale: >
+    An Edison causal-graph pass (PMID:42229598) found no justifiable directed
+    causal edge for this consortium: both interactions are recorded as "Proposed
+    DIET pathway", the primary full text was inaccessible, and no perturbation
+    (donor-removal, inhibitor, mono-/co-culture, or knockout) evidence was
+    retrieved. The source supports two parallel donor→methanogen proposals, not a
+    causal dependency of one on the other, so no `downstream` edge was added.
+    Neutral-red-mediated electron delivery to M. mazei reported in a different
+    system must not be imported here without exact-system verification.
+  evidence:
+  - reference: PMID:42229598
+    supports: PARTIAL
+    evidence_source: IN_VITRO
+    snippet: during anaerobic digestion of lignocellulose that S. globosa and C. aceticum
+      metabolized intermediates
+    explanation: The consortium role is stated at the level of intermediate metabolism / proposed
+      DIET, without a validated or perturbation-tested causal mechanism — the basis for the knowledge gap.

--- a/kb/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.yaml
@@ -141,6 +141,13 @@ ecological_interactions:
     term:
       id: GO:0044419
       label: biological process involved in interspecies interaction between organisms
+  downstream:
+  - target: Reductive Dechlorination by Dehalococcoides
+    description: >
+      Hydrogen produced during syntrophic butyrate oxidation by S. wolfei
+      supplies the electron donor D. mccartyi 195 uses for TCE dechlorination;
+      the coupling is demonstrated by nanomolar aqueous H2 during dechlorination
+      and the strain-195 minimum H2 threshold.
   evidence:
   - reference: PMID:25576615
     supports: SUPPORT
@@ -230,6 +237,13 @@ ecological_interactions:
     term:
       id: GO:0044419
       label: biological process involved in interspecies interaction between organisms
+  downstream:
+  - target: Reductive Dechlorination by Dehalococcoides
+    description: >
+      Cell aggregation shortens the interspecies distance and sustains the
+      hydrogen flux required for the observed TCE dechlorination rates
+      (supported by the reported need for aggregation; lower-confidence than the
+      direct H2-threshold edge).
   evidence:
   - reference: PMID:25576615
     supports: SUPPORT

--- a/kb/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.yaml
+++ b/kb/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.yaml
@@ -133,6 +133,13 @@ ecological_interactions:
     term:
       id: GO:0015948
       label: methanogenesis
+  downstream:
+  - target: Population Ratio Convergence During Growth
+    description: >
+      The thermodynamically required syntrophic coupling of butyrate oxidation to
+      hydrogenotrophic methanogenesis drives coordinated partner growth — cultures
+      inoculated at different initial cell ratios converge to a relatively constant
+      Syntrophomonas:Methanococcus ratio over time.
   evidence:
   - reference: PMID:34603271
     supports: SUPPORT
@@ -362,3 +369,29 @@ metal_relevance: NOT_APPLICABLE
 metal_notes: >
   No metal or rare earth element transformation role is curated for this
   methanogenic butyrate-oxidizing coculture.
+discussions:
+- discussion_id: kg-aggregation-and-diet-unverified
+  prompt: >
+    Does syntrophic aggregation / cell-to-cell attraction causally enhance
+    butyrate oxidation or methanogenesis in this coculture, and is direct
+    interspecies electron transfer (e.g. the reported carbon-nanotube methane
+    stimulation) involved rather than only H2/formate transfer?
+  kind: KNOWLEDGE_GAP
+  status: OPEN
+  attaches_to:
+  - ecological_interactions#Syntrophic Aggregation and Cell-to-Cell Attraction
+  rationale: >
+    Aggregation and disturbance-resistant cell-to-cell attraction are observed,
+    but no experiment demonstrates that aggregation increases butyrate oxidation or
+    methane production in this exact coculture, so no aggregation→enhancement
+    `downstream` edge was added. Likewise, carbon-nanotube acceleration of methane
+    production is reported, but DIET "does not always explain the enhancement of
+    methane production" and was not directly proven here, so a DIET mechanism is
+    not asserted.
+  evidence:
+  - reference: PMID:34603271
+    supports: PARTIAL
+    evidence_source: IN_VITRO
+    snippet: suggesting the cell-to-cell attraction between Syntrophomonas and Methanococcus
+    explanation: Attraction/aggregation is observed, but its causal contribution to metabolic
+      performance is untested — the basis for the knowledge gap.

--- a/kb/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.yaml
+++ b/kb/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.yaml
@@ -199,6 +199,13 @@ ecological_interactions:
     term:
       id: GO:0044419
       label: biological process involved in interspecies interaction between organisms
+  downstream:
+  - target: Fermenter-Stimulated Butyrate Oxidation and Methane Production
+    description: >
+      HYPOTHESIZED — ES5 co-aggregation with S. wolfei and M. hungatei may
+      spatially facilitate the improved butyrate oxidation and methane
+      production, but the aggregation is an observed correlate of the ES5 effect
+      and was NOT demonstrated to causally mediate the rate increases.
   evidence:
   - reference: PMID:35699440
     supports: SUPPORT
@@ -231,6 +238,14 @@ ecological_interactions:
     term:
       id: GO:0006635
       label: fatty acid beta-oxidation
+  downstream:
+  - target: Fermenter-Stimulated Butyrate Oxidation and Methane Production
+    description: >
+      HYPOTHESIZED — the ES5-associated proteomic changes (activation of
+      additional butyryl-CoA dehydrogenase and electron-transfer flavoprotein in
+      S. wolfei; signal-transducing systems in M. hungatei) may underlie the
+      improved butyrate oxidation, but the proteome response is correlative and
+      was NOT shown to be the causal mediator of the improved performance.
   evidence:
   - reference: PMID:35699440
     supports: SUPPORT
@@ -416,3 +431,29 @@ metal_relevance: NOT_APPLICABLE
 metal_notes: >
   No metal or rare earth element transformation role is curated for this
   fermenter-stimulated methanogenic butyrate coculture.
+discussions:
+- discussion_id: kg-es5-mediation-mechanism-unresolved
+  prompt: >
+    Does T. flocculiformis ES5 improve the S. wolfei / M. hungatei syntrophy via
+    co-aggregation-based spatial bridging (possible DIET) or via the observed
+    proteomic changes, and is either mechanism causal rather than correlative?
+  kind: KNOWLEDGE_GAP
+  status: OPEN
+  attaches_to:
+  - ecological_interactions#Aggregation With Syntrophic Partners
+  - ecological_interactions#Proteome Response in the Syntrophic Partners
+  rationale: >
+    The ES5-driven increase in butyrate consumption (120%) and methane (150%) is
+    perturbation-supported, but the mediating mechanism is unresolved: aggregation
+    and the partner proteome response are observed correlates, not demonstrated
+    causal mediators (the two `downstream` edges here are flagged HYPOTHESIZED
+    accordingly). Direct interspecies electron transfer was not experimentally
+    demonstrated for this tri-culture, and the exact ES5 bridging role remains an
+    open question per the source.
+  evidence:
+  - reference: PMID:35699440
+    supports: PARTIAL
+    evidence_source: IN_VITRO
+    snippet: T. flocculiformis ES5 to aggregate with the syntrophic partners
+    explanation: Aggregation is reported as an association accompanying the ES5 effect, without a
+      demonstrated causal-mediation or DIET mechanism — the basis for the knowledge gap.


### PR DESCRIPTION
Edison causal-graph runs (PaperQA3 causal-edge mode) for four syntrophy/DIET cocultures that lacked `downstream` edges. Curated **conservatively**, honoring each run's disposition. `InteractionDownstream` carries `target` + causal `description` only; evidence stays on parent nodes — **no new snippets or terms**. Pages regenerated.

| Record | Source | Result |
|--------|--------|--------|
| **000183** Dehalococcoides–Syntrophomonas TCE dechlorination | PMID:25576615 | 2 edges → dechlorination: H₂ from syntrophic butyrate oxidation (demonstrated — nM H₂ + strain-195 threshold) + aggregation-shortened distance (lower-confidence) |
| **000188** Trichococcus–Syntrophomonas–Methanospirillum butyrate | PMID:35699440 | 2 **HYPOTHESIZED** mediator edges → ES5-stimulation node (aggregation + proteome are correlates, not proven mediators) + KNOWLEDGE_GAP on ES5 bridging/DIET |
| **000189** Syntrophomonas–Methanococcus butyrate | PMID:34603271 | 1 edge — syntrophic coupling → population-ratio convergence + KNOWLEDGE_GAP (aggregation→enhancement untested; DIET not established for CNT effect) |
| **000297** DIETsimp lignocellulose→methane | PMID:42229598 | **No edge justified** — two parallel proposed/unverified DIET pathways, no causal dependency; recorded as KNOWLEDGE_GAP |

**5 downstream edges + 3 knowledge-gap discussions** across 4 records; ~65/304 records now carry causal edges. Excluded/unverified elements (DIET-for-CNT, aggregation→enhancement, neutral-red import) left out per each run's caution.

Continues the causal thread (#226/#229/#230/#243/#246/#249). Provenance bundles under `research/communities/…-causal.*` (gitignored). The six already-wired matches (000031–033 DIET, 000068–070 syntrophies) were left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)