### PR TITLE
Dangling-edge detection, DOI full-text caching, and a correction to the validate-references note

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -397,16 +397,24 @@ snippets match, zero new mismatches) and caching PMID:29611893 OA full text also
 3 pre-existing 000068 Methods-snippet mismatches (169→166 repo-wide); network-integrity audit
 clean for all 6. New reference caches: PMID:34939136, PMID:37650614.
 
-**Follow-ups this batch surfaced:**
-1. **000031 re-scoping decision** (above) — the highest-value open item.
+**Follow-ups this batch surfaced** (all now filed as issues):
+1. **000031 re-scoping decision** (#256) — the highest-value open item.
 2. **Li et al. 2024** (`doi:10.3390/w16243551`, *Water*) has exact-pair graded-formate
    perturbation data for 000068 (5–10 mM promotes, ≥30 mM inhibits; FDH/hydrogenase
-   transcript downregulation). **Not ingested**: the journal is not in PubMed and has no PMC
-   record, so `scripts/cache_fulltext.py` can't verify its snippets. Would need a
-   DOI-based full-text cache path.
-3. `just validate-references` is a **no-op** — it reports `Total checks: 0` even on untouched
-   files. `scripts/evidence_snippet_audit.py` is what actually validates snippets. Worth
-   fixing or documenting, since the justfile recipe implies coverage it isn't providing.
+   transcript downregulation). **Still not ingested** (#259). `cache_fulltext.py` now takes
+   DOIs, but this one has no Europe PMC record and MDPI returns HTTP 403 to programmatic
+   PDF download, so it needs a manual retrieval.
+3. **`just validate-references` reporting is misleading** (#257). ⚠️ **Correction to an
+   earlier note here**: it was previously recorded as a "no-op". That was wrong — the tool
+   does validate, and it does fail the build on a bad snippet (verified by injection test,
+   and it catches a real bad snippet in `hCom2_Complex_Gut_Microbiome.yaml`). The actual
+   problem is that `Total checks: N` counts *issues*, not checks, so a clean file prints
+   `Total checks: 0`, which reads as "nothing was validated". Separately, its coverage
+   disagrees with `evidence_snippet_audit.py` (1 issue vs 14 hard mismatches on the same
+   file), so the two need reconciling before either is authoritative.
+4. **14 dangling causal edges** repo-wide (#258) — `downstream.target` values naming no
+   existing interaction. Detection is now in `audit_network_integrity.py`
+   (`DANGLING_EDGE`/`DANGLING_ANCHOR`); the per-record curation triage is still open.
 
 NB: stray untracked `*.yaml.bak` backups still exist alongside these in `kb/communities/`
 (gitignored, not in the repo).

--- a/scripts/audit_network_integrity.py
+++ b/scripts/audit_network_integrity.py
@@ -139,6 +139,49 @@ class NetworkIntegrityAuditor:
                             "message": f"Target '{target_term}' has ID {target_id}, expected {expected_id}"
                         })
 
+        # Check causal-graph edges: every downstream.target must name an
+        # interaction that exists in this record, otherwise the edge dangles and
+        # the causal graph silently loses an arc. Same check for the
+        # `ecological_interactions#<name>` anchors used by Discussion.attaches_to.
+        interaction_names = {
+            interaction.get("name")
+            for interaction in interactions
+            if interaction.get("name")
+        }
+
+        for idx, interaction in enumerate(interactions):
+            int_name = interaction.get("name", f"Interaction {idx+1}")
+            for edge in interaction.get("downstream") or []:
+                target_name = edge.get("target")
+                if target_name and target_name not in interaction_names:
+                    issues.append({
+                        "type": "DANGLING_EDGE",
+                        "interaction": int_name,
+                        "target": target_name,
+                        "message": (
+                            f"downstream target '{target_name}' does not name any "
+                            f"interaction in this record"
+                        )
+                    })
+
+        for discussion in data.get("discussions") or []:
+            disc_id = discussion.get("discussion_id", "<no id>")
+            for anchor in discussion.get("attaches_to") or []:
+                prefix = "ecological_interactions#"
+                if anchor.startswith(prefix):
+                    anchor_name = anchor[len(prefix):]
+                    if anchor_name not in interaction_names:
+                        issues.append({
+                            "type": "DANGLING_ANCHOR",
+                            "interaction": disc_id,
+                            "target": anchor_name,
+                            "message": (
+                                f"discussion '{disc_id}' attaches to "
+                                f"'{anchor_name}', which does not name any "
+                                f"interaction in this record"
+                            )
+                        })
+
         # Check for disconnected taxa. Skip taxa that carry standalone
         # abundance_level or functional_role metadata — they describe community
         # membership without requiring a pairwise interaction edge.
@@ -170,7 +213,8 @@ class NetworkIntegrityAuditor:
             by_type[issue["type"]].append(issue)
 
         # Report each type
-        for issue_type in ["ID_MISMATCH", "MISSING_SOURCE", "UNKNOWN_SOURCE", "UNKNOWN_TARGET", "DISCONNECTED"]:
+        for issue_type in ["ID_MISMATCH", "MISSING_SOURCE", "UNKNOWN_SOURCE", "UNKNOWN_TARGET",
+                           "DANGLING_EDGE", "DANGLING_ANCHOR", "DISCONNECTED"]:
             if issue_type in by_type:
                 print(f"\n  {issue_type}:")
                 for issue in by_type[issue_type]:
@@ -179,6 +223,8 @@ class NetworkIntegrityAuditor:
                         print(f"      Expected: {issue['expected_id']}, Found: {issue['actual_id']}")
                     elif issue_type == "DISCONNECTED":
                         print(f"    • {issue['taxon']}")
+                    elif issue_type in ("DANGLING_EDGE", "DANGLING_ANCHOR"):
+                        print(f"    • [{issue['interaction']}] → {issue['target']}")
                     else:
                         print(f"    • [{issue.get('interaction', 'N/A')}] {issue['message']}")
 

--- a/scripts/cache_fulltext.py
+++ b/scripts/cache_fulltext.py
@@ -1,18 +1,28 @@
 #!/usr/bin/env python3
-"""Append open-access full text to a PMID's reference cache (for snippet validation).
+"""Append open-access full text to a reference cache entry (for snippet validation).
 
 `references_cache/PMID_<id>.txt` normally holds only the PubMed abstract, so
 `just validate-references` can't verify evidence snippets taken from a paper's
 Methods/Results. For **open-access** papers this fetches the full text from Europe
 PMC and appends it to the cache file, so full-text snippets validate as substrings.
 
-Only OA papers with full text in Europe PMC are cached; others are reported and
-skipped (never fabricated). Idempotent: a file that already carries the appended
-full-text marker is left unchanged.
+Accepts both PMIDs and DOIs. DOIs are resolved against Europe PMC by DOI, which
+covers OA papers that have a PMC record even when they carry no PMID. When a DOI
+has no Europe PMC full text, Unpaywall is queried so the message can name the OA
+location a curator would have to retrieve by hand — some publishers (MDPI, for one)
+return HTTP 403 to programmatic download, so those stay manual.
+
+Only text actually retrieved is cached; everything else is reported and skipped
+(never fabricated). Idempotent: a file that already carries the appended full-text
+marker is left unchanged.
+
+Set UNPAYWALL_EMAIL to your address to enable the Unpaywall lookup; its API
+rejects placeholder addresses with HTTP 422.
 
 Usage:
     PYTHONPATH=src uv run python scripts/cache_fulltext.py PMID:36847519
     PYTHONPATH=src uv run python scripts/cache_fulltext.py 36847519 38744211
+    PYTHONPATH=src uv run python scripts/cache_fulltext.py doi:10.1128/spectrum.00941-23
 """
 
 import html
@@ -63,6 +73,88 @@ def _fulltext(pmcid: str) -> str:
     return text.strip()
 
 
+def _pmcid_for_doi(doi: str) -> tuple[str | None, bool]:
+    """Return (pmcid, is_open_access) for a DOI via Europe PMC, or (None, False)."""
+    import json
+
+    q = urllib.parse.quote(f'DOI:"{doi}"')
+    data = json.loads(_get(f"{EPMC}/search?query={q}&format=json&resultType=core"))
+    results = data.get("resultList", {}).get("result", [])
+    if not results:
+        return None, False
+    r = results[0]
+    return r.get("pmcid"), r.get("isOpenAccess") == "Y" and r.get("inEPMC") == "Y"
+
+
+def _unpaywall_location(doi: str) -> str | None:
+    """Best OA URL for a DOI per Unpaywall, or None.
+
+    Only used to tell the curator where the text lives when Europe PMC has no
+    full text. Requires UNPAYWALL_EMAIL; the API 422s on placeholder addresses.
+    """
+    import json
+    import os
+
+    email = os.environ.get("UNPAYWALL_EMAIL")
+    if not email:
+        return None
+    try:
+        url = f"https://api.unpaywall.org/v2/{urllib.parse.quote(doi)}?email={urllib.parse.quote(email)}"
+        data = json.loads(_get(url))
+    except Exception:
+        return None
+    if not data.get("is_oa"):
+        return None
+    loc = data.get("best_oa_location") or {}
+    return loc.get("url_for_pdf") or loc.get("url") or loc.get("url_for_landing_page")
+
+
+def _doi_cache_path(doi: str) -> Path:
+    """The cache file the reference validator reads for this DOI.
+
+    Mirrors _cache_path: prefer the ``.md`` the validator reads, else the legacy
+    ``.txt``. Matches the existing on-disk convention, e.g.
+    ``DOI_10.1039_C3EE42189A.md``.
+    """
+    slug = doi.replace("/", "_")
+    md = CACHE_DIR / f"DOI_{slug}.md"
+    if md.exists():
+        return md
+    txt = CACHE_DIR / f"DOI_{slug}.txt"
+    if txt.exists():
+        return txt
+    lower_md = CACHE_DIR / f"doi_{slug}.md"
+    return lower_md if lower_md.exists() else md
+
+
+def cache_one_doi(doi: str) -> str:
+    doi = re.sub(r"^doi:", "", doi.strip(), flags=re.IGNORECASE)
+    cache = _doi_cache_path(doi)
+    if not cache.exists():
+        return f"[skip] {doi}: no abstract cache ({cache.name}); fetch the abstract first"
+    if MARKER in cache.read_text(encoding="utf-8"):
+        return f"[ok] {doi}: full text already cached"
+    pmcid, oa = _pmcid_for_doi(doi)
+    if not pmcid or not oa:
+        where = _unpaywall_location(doi)
+        if where:
+            return (
+                f"[skip] {doi}: no Europe PMC full text (pmcid={pmcid}, oa={oa}); "
+                f"Unpaywall OA location is {where} — retrieve by hand if the "
+                f"publisher blocks automated download"
+            )
+        return (
+            f"[skip] {doi}: no Europe PMC full text (pmcid={pmcid}, oa={oa}); "
+            f"set UNPAYWALL_EMAIL to look up an OA location"
+        )
+    text = _fulltext(pmcid)
+    sep = f"\n\n{MARKER} (Europe PMC {pmcid}) =====\n\n"
+    cache.write_text(
+        cache.read_text(encoding="utf-8").rstrip() + sep + text + "\n", encoding="utf-8"
+    )
+    return f"[cached] {doi}: appended {len(text)} chars of OA full text from {pmcid}"
+
+
 def _cache_path(pmid: str) -> Path:
     """The cache file the reference validator actually reads for this PMID.
 
@@ -96,8 +188,11 @@ def main() -> int:
     if len(sys.argv) < 2:
         print(__doc__)
         return 2
-    for pmid in sys.argv[1:]:
-        print(cache_one(pmid))
+    for ref in sys.argv[1:]:
+        if ref.lower().startswith("doi:") or ref.startswith("10."):
+            print(cache_one_doi(ref))
+        else:
+            print(cache_one(ref))
     return 0
 
 


### PR DESCRIPTION
Follow-up to #254. Addresses #258 and #259, and corrects the record on #257.

### #258 — dangling causal edges are now detected

`scripts/audit_network_integrity.py` gains two issue types:
- `DANGLING_EDGE` — a `downstream.target` naming no interaction in that record
- `DANGLING_ANCHOR` — a `Discussion.attaches_to` `ecological_interactions#<name>` anchor resolving to nothing

This was previously invisible: **14 dangling edges across 13 records were passing the audit clean.** Repo-wide issue count goes 26 → 40. Detection only — the per-record curation triage stays open on #258.

### #259 — cache_fulltext.py accepts DOIs

Resolves DOIs against Europe PMC by DOI, so OA papers with a PMC record but no PMID can now be cached. Writes to the `DOI_<slug>.md` convention the validator already reads, reusing the existing idempotence marker. Verified resolution: `10.1128/spectrum.00941-23 → PMC10580878`, `10.1111/1462-2920.14119 → PMC5947623`.

When Europe PMC has no full text, it queries Unpaywall (behind `UNPAYWALL_EMAIL` — the API returns 422 for placeholder addresses) so the skip message names the OA location a curator would fetch by hand.

⚠️ **This does not unblock the motivating case.** Li et al. 2024 (`doi:10.3390/w16243551`) has no Europe PMC record, and MDPI returns **HTTP 403** to programmatic PDF download. I deliberately did **not** add a PDF dependency, because it would not have helped — the block is the publisher, not the parser. That DOI still needs manual retrieval, and #259 stays open.

### #257 — correcting an inaccurate note I merged in #254

**`just validate-references` is not a no-op.** I reported it as one in #254; that was wrong. Two checks disprove it:
- injecting a fabricated snippet against a real cached PMID yields an ERROR
- it catches a genuine bad snippet in `hCom2_Complex_Gut_Microbiome.yaml` and exits 1

The misreading came from `Total checks: N` counting *issues*, not checks — so a clean file prints `Total checks: 0`, which reads as "nothing was validated". `NEXT_TASKS.md` is corrected here. The real problems stay open on #257: the misleading label, and coverage disagreeing with `evidence_snippet_audit.py` (1 issue vs 14 hard mismatches on the same 18-evidence-item file).

### Verification
- `just test` — 266 passed
- `just lint` — black/ruff/mypy clean
- `ruff scripts/` — 15 pre-existing errors before, 14 after; none introduced
- dangling-edge detector output cross-checked against an independent count (14/14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)