### PR TITLE
Reconcile the two snippet gates: fix audit cache handling, add RENDERING bucket

### DIFF
--- a/justfile
+++ b/justfile
@@ -78,9 +78,25 @@ audit-writers *args:
 cache-fulltext *pmids:
     PYTHONPATH=src uv run python scripts/cache_fulltext.py {{pmids}}
 
-# Validate evidence references in a community file
+# Validate evidence references in a community file.
+#
+# NB on the output (issue #257): the tool's "Total checks: N" line counts
+# ISSUES, not checks performed — a clean file prints "Total checks: 0", which
+# reads like "nothing was validated". It IS validating (a fabricated snippet
+# fails it); only the label is wrong, and it lives in the pip package.
+#
+# Its matching is strict-substring, so it also reports faithful quotes whose
+# CACHE carries a PDF/XML extraction artefact (record "10% CO 2" vs cached
+# "10% CO2", "beta-5" vs "β-5"). `scripts/evidence_snippet_audit.py` counts that
+# class separately as RENDERING; validator errors == RENDERING + MISMATCH there.
+# Do not "fix" a RENDERING hit by editing the snippet to match the cache.
 validate-references FILE:
     uv run linkml-reference-validator validate data {{FILE}} -s src/communitymech/schema/communitymech.yaml --config conf/reference_validator.yaml
+
+# Snippet audit across ALL records (the tool that actually reconciles with
+# validate-references). Buckets: MATCH / RENDERING / WEAK / MISMATCH / NOCONTENT.
+audit-snippets *args:
+    uv run python scripts/evidence_snippet_audit.py {{args}}
 
 # Validate references in all community files
 validate-references-all:

--- a/scripts/evidence_snippet_audit.py
+++ b/scripts/evidence_snippet_audit.py
@@ -6,11 +6,16 @@ kb/communities/*.yaml, locate the reference's cache file, strip the circular
 "Quoted snippets used in curated records" list (so we match only against real
 abstract text), normalize whitespace, and classify:
 
-  MATCH      - snippet is a (near-)substring of the real cached text
+  MATCH      - snippet is a literal (whitespace-normalized) substring of the text
+  RENDERING  - matches only after punctuation/whitespace/Greek normalization
+               (e.g. record "10% CO 2" vs cached "10% CO2"): a faithful quote of
+               the paper whose cache carries a PDF/XML extraction artefact. This
+               is the class `just validate-references` reports as an error
   MISMATCH   - real abstract content exists but the snippet is absent (suspect)
   NOCONTENT  - cache missing or stub-only (no abstract body to verify against)
 
-Usage: uv run python scripts/evidence_snippet_audit.py [--list-mismatch] [--list-nocontent]
+Usage: uv run python scripts/evidence_snippet_audit.py [--list-mismatch]
+       [--list-nocontent] [--list-rendering]
 """
 import re
 import sys
@@ -24,13 +29,24 @@ COMM = Path("kb/communities")
 CACHE = Path("references_cache")
 LIST_MM = "--list-mismatch" in sys.argv
 LIST_NC = "--list-nocontent" in sys.argv
+LIST_RD = "--list-rendering" in sys.argv
 
 # Sections that contain curated/paraphrased snippets, not the real abstract.
 # Stripping them prevents circular self-matching.
+# Markers that introduce the REAL source text in a .md cache: the NCBI BioC PMC
+# re-fetch header, and the marker appended by scripts/cache_fulltext.py. These
+# must (a) terminate a curated-snippet section and (b) count as a real-content
+# signal — without them a genuine full text that merely lacks YAML frontmatter
+# was discarded, and the audit fell back to a short abstract .txt and reported
+# every full-text snippet as a MISMATCH.
+FULLTEXT_MARKER = re.compile(
+    r"^(Full text \(re-fetched|=====\s*OPEN-ACCESS FULL TEXT)", re.MULTILINE
+)
 SNIPPET_SECTION = re.compile(
     r"(Quoted snippets used in curated records:|Key evidence used:|"
     r"Key snippets used in curated records:|Cached source notes:|"
-    r"Snippets used in curated records:).*?(?=\nURL:|\nDOI:|\n## |\Z)",
+    r"Snippets used in curated records:).*?"
+    r"(?=\nURL:|\nDOI:|\n## |\nFull text \(re-fetched|\n=====\s*OPEN-ACCESS FULL TEXT|\Z)",
     re.DOTALL | re.IGNORECASE,
 )
 FRONTMATTER = re.compile(r"\A---\n.*?\n---\n", re.DOTALL)
@@ -93,8 +109,11 @@ def cache_text(reference: str) -> tuple[str, bool]:
             continue
         if UNAVAILABLE.search(t):
             continue                          # explicitly no abstract body
-        # Only trust a .md as a real abstract with an explicit signal
-        if not (REAL_CT.search(t) or CONTENT_HEADING.search(t)):
+        # Only trust a .md as a real abstract with an explicit signal. A cached
+        # full text counts: several were fetched without YAML frontmatter or a
+        # `## Content` heading and were being discarded as stubs.
+        if not (REAL_CT.search(t) or CONTENT_HEADING.search(t)
+                or FULLTEXT_MARKER.search(t)):
             continue                          # stub (notes + curated snippets only)
         fm = FRONTMATTER.sub("", t)           # drop YAML frontmatter
         stripped = SNIPPET_SECTION.sub("", fm)  # drop curated-snippet sections
@@ -129,6 +148,7 @@ def walk(node, path, out):
 stats = defaultdict(int)
 file_mismatch = defaultdict(list)
 file_nocontent = defaultdict(int)
+file_rendering = defaultdict(int)
 cache_cache = {}
 
 for f in sorted(COMM.glob("*.yaml")):
@@ -155,7 +175,20 @@ for f in sorted(COMM.glob("*.yaml")):
             if frags and all(coverage(f, content) >= 0.9 for f in frags):
                 cov = 1.0
         if cov >= 0.9:
-            stats["MATCH"] += 1
+            # Split literal quotes from ones that only match after punctuation /
+            # whitespace / Greek normalisation (e.g. record "10% CO 2" vs cached
+            # "10% CO2", "beta-5" vs "β-5"). Both are faithful quotes of the
+            # PAPER — the spacing is a PDF/XML extraction artefact in the CACHE —
+            # but `just validate-references` does strict substring matching and
+            # reports exactly this class as an error. Counting it separately is
+            # what reconciles the two gates (issue #257); do NOT "fix" these by
+            # rewriting snippets to match the cache, which would propagate
+            # artefacts like "mg/ L" into the records.
+            if norm(snip) in norm(content):
+                stats["MATCH"] += 1
+            else:
+                stats["RENDERING"] += 1
+                file_rendering[f.name] += 1
         elif cov >= 0.6:
             stats["WEAK"] += 1
             file_mismatch[f.name].append((path, ref, round(cov, 2), snip[:70], "WEAK"))
@@ -165,7 +198,7 @@ for f in sorted(COMM.glob("*.yaml")):
 
 total = sum(stats.values())
 print(f"# {total} evidence snippets scanned across {len(list(COMM.glob('*.yaml')))} files")
-for k in ("MATCH", "WEAK", "MISMATCH", "NOCONTENT"):
+for k in ("MATCH", "RENDERING", "WEAK", "MISMATCH", "NOCONTENT"):
     print(f"  {k:<10} {stats[k]}")
 
 print(f"\n# Files with MISMATCH/WEAK (content present but snippet absent) — fabrication suspects")
@@ -179,6 +212,12 @@ if LIST_MM:
     for fn, rows in ranked:
         for path, ref, cov, snip, kind in rows:
             print(f"  [{kind} cov={cov}] {fn} {ref}\n      {snip}...")
+
+if LIST_RD:
+    print("\n# Files by RENDERING (faithful quote; differs from cache only by")
+    print("# punctuation/whitespace/Greek — this is what validate-references flags)")
+    for fn, n in sorted(file_rendering.items(), key=lambda x: -x[1])[:30]:
+        print(f"  {n:>2}  {fn}")
 
 if LIST_NC:
     print(f"\n# Top files by NOCONTENT (unverifiable; cache stub/missing)")


### PR DESCRIPTION
Closes #257.

`evidence_snippet_audit.py` and `just validate-references` disagreed **1 vs 14** on the same file. The cause was **two bugs in the audit**, both producing false MISMATCHes, plus one genuine difference in matching strictness that is now surfaced instead of hidden.

### Bug 1 — a real full text was discarded as a stub
A `.md` cache was trusted only with `content_type:` frontmatter or a `## Content` heading. Several were fetched with **neither** — they begin `Full text (re-fetched … via NCBI BioC PMC)` — including a **200 KB**, a **138 KB** and an **88 KB** full text. **55 files, 642 KB total.** The audit silently fell back to the short abstract `.txt` and flagged every full-text snippet as absent.

### Bug 2 — the curated-snippet stripper ate real text
`SNIPPET_SECTION` terminated on `\nURL:`, `\nDOI:`, `\n## ` or EOF. In a cache laid out **notes → snippets → full text**, it consumed the full text too. The full-text markers are now terminators.

| | before | after |
|---|---|---|
| MISMATCH | 166 | **140** |
| NOCONTENT | 794 | **756** |
| hCom2 mismatches | 14 | **0** |

### New RENDERING bucket — this is the actual reconciliation
The residual disagreement is snippets matching only after punctuation/whitespace/Greek normalization — record `10% CO 2 , 5% H 2` vs cached `10% CO2, 5% H2`; `beta-5` vs `β-5`. These are **faithful quotes of the paper** whose **cache** carries a PDF/XML extraction artefact, and they are precisely what `validate-references` reports.

Counting them separately (**62** repo-wide, `--list-rendering`) makes the gates reconcile:

> **validator errors == RENDERING + MISMATCH**

Verified on hCom2: audit reports 1 RENDERING / 0 MISMATCH, validator reports 1 error — the same snippet, now correctly classified as an artefact rather than a fabrication suspect.

### What I deliberately did NOT do
I drafted a script to rewrite those 62 snippets to match the cache exactly. Its dry run produced rewrites like `cDCE (4 to 5 mg/L)` → `cDCE (4 to 5 mg/ L)` and `group 5 (prmABC` → `group 5 ( prmAB`.

That propagates extraction artefacts **into the records** to satisfy a tool. The script was discarded and the reasoning left in-code so it isn't retried.

### Total checks label
Counting issues rather than checks lives in the pip package and can't be patched here. The justfile recipe now says so, and explains how to read a RENDERING hit. Added `just audit-snippets`.

### Verification
266 tests pass; no new ruff findings (5 pre-existing in `scripts/`, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)