### PR TITLE
Repair network-quality.yml so it parses, and make the LLM job manual-only (#272)

### DIFF
--- a/.github/workflows/network-quality.yml
+++ b/.github/workflows/network-quality.yml
@@ -72,16 +72,27 @@ jobs:
         continue-on-error: true
 
       - name: Upload audit report
-        if: steps.audit.outcome == 'failure'
+        if: hashFiles('reports/network_audit.txt') != ''
         uses: actions/upload-artifact@v4
         with:
           name: network-audit-report
           path: reports/network_audit.txt
 
+      # Three outcomes have to be told apart, because two of them look identical
+      # through `steps.audit.outcome` alone:
+      #   clean     — exit 0
+      #   findings  — exit 1, report written        → reporting-only (see #273)
+      #   crash     — exit 2, no report written     → must be loud
+      # A malformed community YAML produces the third (issue #281 — one bad file
+      # aborts the whole audit), and that is exactly when this check matters
+      # most, so it must not be reported as "findings" or swallowed.
+      # `hashFiles` is empty when the file does not exist.
       - name: Write job summary
         if: always()
         run: |
-          if [ "${{ steps.audit.outcome }}" = "failure" ]; then
+          if [ "${{ steps.audit.outcome }}" != "failure" ]; then
+            echo "## Network integrity: no issues found" >> "$GITHUB_STEP_SUMMARY"
+          elif [ -f reports/network_audit.txt ]; then
             {
               echo "## Network integrity findings"
               echo
@@ -92,11 +103,23 @@ jobs:
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "## Network integrity: no issues found" >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo "## Network integrity audit failed to run"
+              echo
+              echo "\`audit-network\` exited non-zero without writing a report, which"
+              echo "means it crashed rather than finding issues — a malformed"
+              echo "community YAML will do this. See the audit step log."
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
+      # Left non-fatal on purpose: a pull request from a fork gets a read-only
+      # token, and failing to post a comment must not redden a reporting-only job.
       - name: Comment on PR with findings
-        if: steps.audit.outcome == 'failure' && github.event_name == 'pull_request'
+        if: >-
+          steps.audit.outcome == 'failure'
+          && hashFiles('reports/network_audit.txt') != ''
+          && github.event_name == 'pull_request'
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -125,6 +148,15 @@ jobs:
               repo: context.repo.repo,
               body,
             });
+
+      # Deliberately after the reporting steps, so the summary is written before
+      # the job goes red. Findings are reporting-only; a crash is not.
+      - name: Fail if the audit could not run
+        if: steps.audit.outcome == 'failure' && hashFiles('reports/network_audit.txt') == ''
+        run: |
+          echo "audit-network exited non-zero and wrote no report." >&2
+          echo "That is a crash, not a set of findings — see the audit step log above." >&2
+          exit 1
 
   # LLM-assisted repair suggestions. Manual-only: this calls the Anthropic API
   # and writes PR comments, so it must never be triggered by an ordinary push.

--- a/.github/workflows/network-quality.yml
+++ b/.github/workflows/network-quality.yml
@@ -1,5 +1,19 @@
 name: Network Quality Check
 
+# Reports network integrity findings (dangling interaction references and
+# taxa with no interactions) for changed community records.
+#
+# This workflow could not be parsed by GitHub until #272 and so had never run.
+# It is deliberately **reporting-only**: `communitymech audit-network` currently
+# finds 26 issues across 8 records, 22 of which are DISCONNECTED (a taxon with
+# no curated interaction), which is a curation-completeness signal rather than a
+# broken reference. Failing on those would redden `main` on every KB push. See
+# #273 for triaging the findings and restoring the hard gate afterwards.
+#
+# The LLM repair-suggestion job calls the Anthropic API and posts comments, so
+# it runs only when explicitly requested via workflow_dispatch — never
+# automatically on a push or pull request.
+
 on:
   pull_request:
     paths:
@@ -12,6 +26,16 @@ on:
       - manual-network-curation
     paths:
       - 'kb/communities/*.yaml'
+  workflow_dispatch:
+    inputs:
+      suggest_repairs:
+        description: 'Also generate LLM repair suggestions (calls the Anthropic API — incurs cost)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   audit-network:
@@ -35,57 +59,85 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
+      # `--report` writes the detailed report *and* exits 1 when issues exist,
+      # so one invocation gives us both the artifact and the outcome. The step
+      # is allowed to fail; every downstream condition keys off
+      # `steps.audit.outcome`, not `failure()`, because `continue-on-error`
+      # keeps the job green and would make `failure()` permanently false.
       - name: Run network integrity audit
         id: audit
         run: |
-          uv run communitymech audit-network --check-only
-        continue-on-error: true
-
-      - name: Generate detailed report
-        if: failure()
-        run: |
           mkdir -p reports
           uv run communitymech audit-network --report reports/network_audit.txt
-          uv run communitymech audit-network --json > reports/network_audit.json
+        continue-on-error: true
 
-      - name: Upload audit reports
-        if: failure()
+      - name: Upload audit report
+        if: steps.audit.outcome == 'failure'
         uses: actions/upload-artifact@v4
         with:
-          name: network-audit-reports
-          path: |
-            reports/network_audit.txt
-            reports/network_audit.json
+          name: network-audit-report
+          path: reports/network_audit.txt
 
-      - name: Comment on PR with issues
-        if: failure() && github.event_name == 'pull_request'
+      - name: Write job summary
+        if: always()
+        run: |
+          if [ "${{ steps.audit.outcome }}" = "failure" ]; then
+            {
+              echo "## Network integrity findings"
+              echo
+              echo "Reporting only — this check does not fail the build (see issue #273)."
+              echo
+              echo '```'
+              head -c 60000 reports/network_audit.txt
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## Network integrity: no issues found" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Comment on PR with findings
+        if: steps.audit.outcome == 'failure' && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
             const report = fs.readFileSync('reports/network_audit.txt', 'utf8');
             const maxLength = 60000;
-            const truncatedReport = report.length > maxLength
+            const truncated = report.length > maxLength
               ? report.substring(0, maxLength) + '\n\n... (truncated)'
               : report;
 
-            github.rest.issues.createComment({
+            const body = [
+              '## Network integrity findings',
+              '',
+              'Reporting only — this check does not fail the build (see issue #273).',
+              '',
+              '```',
+              truncated,
+              '```',
+              '',
+              'The full report is attached to the workflow run as an artifact.',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `## ❌ Network Integrity Issues Detected\n\n\`\`\`\n${truncatedReport}\n\`\`\`\n\n📊 Download full reports from the workflow artifacts.`
+              body,
             });
 
-      - name: Fail if issues found
-        if: steps.audit.outcome == 'failure'
-        run: exit 1
-
-  # LLM-assisted repair suggestions (requires ANTHROPIC_API_KEY secret)
+  # LLM-assisted repair suggestions. Manual-only: this calls the Anthropic API
+  # and writes PR comments, so it must never be triggered by an ordinary push.
   suggest-repairs:
     runs-on: ubuntu-latest
     needs: audit-network
-    if: failure()
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.suggest_repairs }}
     name: Generate Repair Suggestions
+
+    # `secrets` is not available in a step-level `if`, so surface the presence
+    # of the key as a job-level env var and test that instead.
+    env:
+      HAS_ANTHROPIC_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
 
     steps:
       - name: Checkout repository
@@ -104,8 +156,14 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
+      - name: Fail early if the API key is missing
+        if: env.HAS_ANTHROPIC_KEY != 'true'
+        run: |
+          echo "ANTHROPIC_API_KEY is not configured for this repository." >&2
+          echo "Set the secret before requesting repair suggestions." >&2
+          exit 1
+
       - name: Generate LLM repair suggestions
-        if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
@@ -114,47 +172,9 @@ jobs:
             --output reports/repair_suggestions.yaml \
             --max-communities 20 \
             --max-issues 3
-        continue-on-error: true
 
       - name: Upload repair suggestions
-        if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: network-repair-suggestions
           path: reports/repair_suggestions.yaml
-
-      - name: Comment on PR with suggestions summary
-        if: github.event_name == 'pull_request' && secrets.ANTHROPIC_API_KEY != ''
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            try {
-              const report = fs.readFileSync('reports/repair_suggestions.yaml', 'utf8');
-              const yaml = require('js-yaml');
-              const data = yaml.load(report);
-
-              const summary = `## 🤖 LLM Repair Suggestions Available
-
-**Communities with Issues**: ${data.communities_with_issues}
-**Total Suggestions**: ${data.total_suggestions}
-**Estimated Cost**: $${data.cost_estimate.total_cost_usd.toFixed(2)}
-
-📥 Download the full repair report from the workflow artifacts.
-
-**Next Steps**:
-1. Download \`network-repair-suggestions\` artifact
-2. Review suggested repairs
-3. Set \`approved: true\` for suggestions to apply
-4. Run \`just apply-batch-repairs reports/repair_suggestions.yaml\`
-`;
-
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: summary
-              });
-            } catch (error) {
-              console.log('Could not post suggestions summary:', error);
-            }


### PR DESCRIPTION
Fixes #272. Follow-up work is tracked in #273.

GitHub could not parse `.github/workflows/network-quality.yml`, so all 15 of its most recent runs — including every recent push to `main` — failed in 0 seconds with "This run likely failed because of a workflow file issue." The network integrity audit this workflow defines has never once executed.

## Three defects, only the first of which is visible

**It did not parse.** The `Comment on PR with suggestions summary` step built its message with a JavaScript template literal whose lines 139–150 were written at column 0, outside the `script: |` block scalar. YAML read `**Communities with Issues**` as an alias and rejected the file.

Simply indenting those lines would have fixed the parse and introduced a formatting bug, because the indentation becomes part of the template literal — every line of the posted comment would have carried twelve leading spaces and rendered as a code block. Where a message is still needed it is now assembled from an array joined with newlines. The offending step is removed entirely: it only ever made sense on a pull request, and the job containing it is no longer triggered by one.

**Three conditions were invalid.** `secrets.ANTHROPIC_API_KEY != ''` appeared in step-level `if:` expressions, where the `secrets` context is not available. The key's presence is now exposed as a job-level `env` var and tested through `env`, which is.

**Three more could never have fired.** `Generate detailed report`, `Upload audit reports` and `Comment on PR with issues` were guarded by `failure()`, while the audit step sets `continue-on-error: true` — which keeps the job green and leaves `failure()` permanently false. Had the file parsed, the workflow would have run and silently produced none of the reports or comments it advertises. Every downstream condition now keys off `steps.audit.outcome`.

## Two judgment calls

**The audit reports without failing.** Running it locally finds 26 issues across 8 records, and they are not one kind of problem: 22 are `DISCONNECTED` (a taxon with no curated interaction — a completeness signal, since a record may legitimately list a member whose interactions are not yet curated) and 4 are genuine dangling references in the ANME/SRB record. Restoring the hard fail would therefore turn `main` red on every push touching `kb/communities/` on the strength of 22 soft findings. The job reports and uploads its artifact instead, and #273 tracks fixing the 4 real ones, giving the auditor severity levels, and turning the gate back on.

**The LLM job no longer runs automatically.** `suggest-repairs` fired whenever the audit failed and calls the Anthropic API for up to 20 records; with 26 standing findings that meant every push. It is now `workflow_dispatch`-only behind an explicit opt-in input, and fails fast with a clear message when the key is missing rather than silently skipping every step. If it should run automatically once the backlog is clear, that is worth deciding then rather than inheriting it from a workflow that never ran.

## Also

The JSON artifact is dropped. `audit-network --json` prints the human-readable report to stdout *before* the JSON, so `--json > reports/network_audit.json` could only ever have written a file that is not valid JSON. The CLI defect is part of #273; the `.txt` report is unaffected and is still uploaded.

An explicit `permissions:` block was added — the workflow posts PR comments and had been relying on whatever the repository default happened to be.

## Verification

- The file now parses; only `name`, `on`, `permissions` and `jobs` sit at column 0.
- The exact audit invocation the workflow runs was executed locally: it exits 1 and writes a 69-line report, so `steps.audit.outcome` will be `failure` and the artifact and comment steps will fire.
- `reports/*.txt` is already gitignored, so the run leaves no working-tree residue.
- This PR touches only the workflow file; GitHub will validate it on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round: the reporting-only job still went red on the input it most needs to handle

Reviewing this before merge turned up a defect in the fix itself, on the one case that matters most.

`audit-network` exits **2 and writes no report** when a single community YAML fails to parse — one bad file aborts the loop over all 305 records. Reproduced:

```
printf 'name: broken\ntaxonomy: [\n  - bad: {\n' > /tmp/badkb/Broken.yaml
uv run communitymech audit-network --communities-dir /tmp/badkb --report /tmp/out.txt
# → exit 2, /tmp/out.txt absent
```

`steps.audit.outcome` is `failure` there exactly as it is for real findings, so the previous revision ran `head -c 60000` against a file that does not exist. `head` exits 1, GitHub runs `run:` steps under `bash -e`, so the step failed — a **red "reporting-only" job whose summary claimed findings and showed none**. The PR-comment step would have thrown on the same missing file. A malformed community YAML is a plausible thing for a curator to commit, and it is precisely when this check earns its keep.

There are three outcomes and only two were being distinguished:

| | exit | report | treatment |
|---|---|---|---|
| clean | 0 | written | "no issues found" |
| findings | 1 | written | reporting-only, per #273 |
| **crash** | 2 | **absent** | **must be loud** |

The summary now branches on all three and cannot fail in any of them — verified by extracting the script from the YAML and running each case, which exits 0/0/0 with the right heading. A final step fails the job **only** in the crash case, placed after the reporting steps so the summary is written before the job goes red. Artifact upload and the PR comment now key off the report existing rather than the exit status, which also means a clean run uploads its report.

The PR comment is now `continue-on-error`: a pull request from a fork gets a read-only token, and a failed comment must not redden a job whose entire premise is that it does not fail.

**Filed #281** for the underlying CLI behaviour — aborting the whole audit on one unparseable file, suppressing the report for the other 304 records. The right fix is to catch per file and record the parse failure as a finding against that record, which composes with the severity levels proposed in #273. What is in this PR is a guard around that behaviour, not a fix for it.
