### PR TITLE
Keep the audit running past an unreadable file; pin its report labels (#281, #282)

### DIFF
--- a/src/communitymech/network/auditor.py
+++ b/src/communitymech/network/auditor.py
@@ -87,6 +87,23 @@ class NetworkIntegrityAuditor:
                 if not check_only:
                     self.report_community_issues(yaml_file.stem, issues)
 
+        # Catching per file keeps one bad record from ending the sweep, but it
+        # would also turn a bug in this auditor into "every record is bad data".
+        # Nothing legitimate makes *all* of them unreadable at once, so treat
+        # that as a tool failure and let it out: the CLI turns it into exit 2
+        # with no report, which the network-quality workflow reports as a crash
+        # rather than as findings.
+        unreadable = sum(
+            1
+            for community_issues in self.issues.values()
+            if any(issue["type"] == IssueType.UNREADABLE for issue in community_issues)
+        )
+        if len(yaml_files) > 1 and unreadable == len(yaml_files):
+            raise RuntimeError(
+                f"every one of the {len(yaml_files)} community files failed to audit — "
+                f"this is a failure of the auditor, not of the data"
+            )
+
         if not check_only:
             print(f"\n{'='*80}")
             print(f"Summary: {communities_with_issues}/{len(yaml_files)} communities have issues")

--- a/src/communitymech/network/auditor.py
+++ b/src/communitymech/network/auditor.py
@@ -25,6 +25,19 @@ class IssueType(str, Enum):
     UNKNOWN_SOURCE = "UNKNOWN_SOURCE"
     UNKNOWN_TARGET = "UNKNOWN_TARGET"
     DISCONNECTED = "DISCONNECTED"
+    UNREADABLE = "UNREADABLE"
+
+
+def _type_label(issue_type) -> str:
+    """Render an issue type as its bare value, on every Python.
+
+    ``IssueType`` is a ``str``-mixin enum, and the mixin's ``__format__``
+    switched in Python 3.11 from emitting the *value* to emitting the qualified
+    ``IssueType.NAME``. Interpolating a member directly therefore produced
+    different report text under 3.10 (CI) than under 3.14 (a dev venv). Entries
+    are occasionally plain strings, so fall back to the object itself.
+    """
+    return getattr(issue_type, "value", issue_type)
 
 
 class NetworkIntegrityAuditor:
@@ -53,7 +66,20 @@ class NetworkIntegrityAuditor:
         communities_with_issues = 0
 
         for yaml_file in yaml_files:
-            issues = self.audit_community(yaml_file)
+            # One unreadable file must not abort the sweep. Before this, a single
+            # malformed YAML propagated out of the loop, so the remaining records
+            # went unaudited *and* no report was written — the audit produced
+            # nothing precisely when something was wrong. Record it as a finding
+            # against that record instead and carry on.
+            try:
+                issues = self.audit_community(yaml_file)
+            except Exception as exc:
+                issues = [
+                    {
+                        "type": IssueType.UNREADABLE,
+                        "message": f"Could not audit this file: {' '.join(str(exc).split())}",
+                    }
+                ]
             if issues:
                 self.issues[yaml_file.stem] = issues
                 communities_with_issues += 1
@@ -245,6 +271,7 @@ class NetworkIntegrityAuditor:
 
         # Report each type
         for issue_type in [
+            IssueType.UNREADABLE,
             IssueType.ID_MISMATCH,
             IssueType.MISSING_SOURCE,
             IssueType.UNKNOWN_SOURCE,
@@ -261,6 +288,8 @@ class NetworkIntegrityAuditor:
                         )
                     elif issue_type == IssueType.DISCONNECTED:
                         print(f"    • {issue['taxon']} ({issue['taxon_id']})")
+                    elif issue_type == IssueType.UNREADABLE:
+                        print(f"    • {issue['message']}")
                     else:
                         print(f"    • [{issue.get('interaction', 'N/A')}] {issue['message']}")
 
@@ -290,7 +319,7 @@ class NetworkIntegrityAuditor:
                 f.write(f"\n{community}\n")
                 f.write("-" * 80 + "\n")
                 for issue in community_issues:
-                    f.write(f"  {issue['type']}: {issue['message']}\n")
+                    f.write(f"  {_type_label(issue['type'])}: {issue['message']}\n")
                     if issue["type"] == "ID_MISMATCH":
                         f.write(
                             f"    Expected: {issue['expected_id']}, Found: {issue['actual_id']}\n"

--- a/tests/test_network_auditor.py
+++ b/tests/test_network_auditor.py
@@ -444,3 +444,32 @@ def test_type_label_is_version_independent():
     assert _type_label(IssueType.UNREADABLE) == "UNREADABLE"
     # Some call sites hold plain strings rather than members.
     assert _type_label("ID_MISMATCH") == "ID_MISMATCH"
+
+
+def test_all_files_unreadable_is_treated_as_a_tool_failure(temp_communities_dir):
+    """Catching per file must not turn an auditor bug into "all data is bad".
+
+    Nothing legitimate makes every record unreadable at once, so that case is
+    raised rather than reported as findings — the CLI turns it into exit 2 with
+    no report, which the network-quality workflow surfaces as a crash.
+    """
+    _write_malformed(temp_communities_dir, "broken_one")
+    _write_malformed(temp_communities_dir, "broken_two")
+
+    auditor = NetworkIntegrityAuditor(communities_dir=temp_communities_dir)
+    with pytest.raises(RuntimeError, match="failure of the auditor, not of the data"):
+        auditor.audit_all()
+
+
+def test_a_lone_unreadable_file_is_still_a_finding(temp_communities_dir):
+    """The all-failed guard must not fire on a single-file directory.
+
+    One bad file out of one is an ordinary data finding, not evidence that the
+    auditor is broken.
+    """
+    _write_malformed(temp_communities_dir)
+
+    auditor = NetworkIntegrityAuditor(communities_dir=temp_communities_dir)
+    all_issues = auditor.audit_all()
+
+    assert [i["type"] for i in all_issues["broken"]] == [IssueType.UNREADABLE]

--- a/tests/test_network_auditor.py
+++ b/tests/test_network_auditor.py
@@ -324,3 +324,123 @@ def test_taxonomy_lookup(temp_communities_dir, valid_community):
     assert lookup["Escherichia coli"]["id"] == "NCBITaxon:562"
     assert "Pseudomonas aeruginosa" in lookup
     assert lookup["Pseudomonas aeruginosa"]["id"] == "NCBITaxon:287"
+
+
+# ---------------------------------------------------------------------------
+# Regressions: an unreadable file must not abort the sweep (#281), and report
+# labels must not depend on the Python version (#282).
+# ---------------------------------------------------------------------------
+
+
+def _write_malformed(directory: Path, stem: str = "broken") -> Path:
+    """Write a YAML file that `yaml.safe_load` cannot parse."""
+    path = directory / f"{stem}.yaml"
+    path.write_text("name: broken\ntaxonomy: [\n  - bad: {\n")
+    return path
+
+
+def test_unreadable_file_is_recorded_instead_of_raising(temp_communities_dir):
+    """A malformed YAML becomes a finding rather than an exception.
+
+    It used to propagate out of ``audit_all``'s loop into the CLI's blanket
+    handler, which exited 2 without writing a report.
+    """
+    _write_malformed(temp_communities_dir)
+
+    auditor = NetworkIntegrityAuditor(communities_dir=temp_communities_dir)
+    all_issues = auditor.audit_all()
+
+    assert "broken" in all_issues
+    assert [i["type"] for i in all_issues["broken"]] == [IssueType.UNREADABLE]
+    assert "Could not audit this file" in all_issues["broken"][0]["message"]
+
+
+def test_one_unreadable_file_does_not_hide_the_others(temp_communities_dir, valid_community):
+    """The rest of the sweep still runs — the actual regression behind #281.
+
+    A single bad record used to take the audit down with it, so the other files'
+    findings were never computed and the report was never written.
+    """
+    valid_community["taxonomy"].append(
+        {
+            "taxon_term": {
+                "preferred_term": "Disconnected",
+                "term": {"id": "NCBITaxon:999", "label": "Disconnected"},
+            }
+        }
+    )
+    (temp_communities_dir / "has_findings.yaml").write_text(yaml.dump(valid_community))
+    _write_malformed(temp_communities_dir)
+
+    auditor = NetworkIntegrityAuditor(communities_dir=temp_communities_dir)
+    all_issues = auditor.audit_all()
+
+    assert "broken" in all_issues
+    assert [i["type"] for i in all_issues["has_findings"]] == [IssueType.DISCONNECTED]
+
+
+def test_unreadable_file_still_writes_a_report(temp_communities_dir, tmp_path):
+    """`--report` must produce a file even when a record cannot be parsed."""
+    _write_malformed(temp_communities_dir)
+    report = tmp_path / "audit.txt"
+
+    auditor = NetworkIntegrityAuditor(communities_dir=temp_communities_dir)
+    auditor.audit_all()
+    auditor.write_report(output_path=report)
+
+    assert report.exists()
+    assert "UNREADABLE:" in report.read_text()
+
+
+def test_unreadable_is_listed_in_the_console_report_order():
+    """Guards against adding an IssueType that `report_community_issues` drops.
+
+    That function iterates a hard-coded list of types; anything missing from it
+    is silently absent from console output while still counting in the total.
+    """
+    import inspect
+
+    source = inspect.getsource(NetworkIntegrityAuditor.report_community_issues)
+    for member in IssueType:
+        assert f"IssueType.{member.name}" in source, (
+            f"{member.name} is not handled by report_community_issues, so it "
+            f"would count toward the total but never be printed."
+        )
+
+
+def test_report_labels_are_bare_enum_values(temp_communities_dir, valid_community, tmp_path):
+    """Report labels are the enum *value*, on every Python (#282).
+
+    ``IssueType`` is a ``str``-mixin enum, and that mixin's ``__format__``
+    switched in 3.11 from the value to the qualified ``IssueType.NAME``. The
+    report interpolated a member directly, so CI (3.10) and a dev venv (3.14)
+    produced different text for identical input.
+    """
+    valid_community["taxonomy"].append(
+        {
+            "taxon_term": {
+                "preferred_term": "Disconnected",
+                "term": {"id": "NCBITaxon:999", "label": "Disconnected"},
+            }
+        }
+    )
+    (temp_communities_dir / "test.yaml").write_text(yaml.dump(valid_community))
+    report = tmp_path / "audit.txt"
+
+    auditor = NetworkIntegrityAuditor(communities_dir=temp_communities_dir)
+    auditor.audit_all()
+    auditor.write_report(output_path=report)
+
+    text = report.read_text()
+    assert "IssueType." not in text, "report leaked the qualified enum name"
+    assert "DISCONNECTED: Taxon 'Disconnected' has no interactions" in text
+
+
+def test_type_label_is_version_independent():
+    """The helper returns the value for members and passes strings through."""
+    from communitymech.network.auditor import _type_label
+
+    assert _type_label(IssueType.UNKNOWN_SOURCE) == "UNKNOWN_SOURCE"
+    assert _type_label(IssueType.UNREADABLE) == "UNREADABLE"
+    # Some call sites hold plain strings rather than members.
+    assert _type_label("ID_MISMATCH") == "ID_MISMATCH"


### PR DESCRIPTION
Fixes #281. Fixes #282. Both were found while verifying #274, and both live in the same handful of lines of `network/auditor.py`.

## #281 — one bad file took the whole sweep down

`audit_all` called `audit_community` with no per-file handling, so a community YAML that `yaml.safe_load` cannot parse propagated out of the loop into the CLI's blanket handler, which exited 2. Three consequences, worst last:

1. the remaining records were never audited,
2. **no report was written**, and
3. exit 2 is indistinguishable from exit 1 to a caller that only checks for non-zero.

The audit produced nothing at exactly the moment something was wrong — and a malformed record is a plausible thing for a curator to commit.

A malformed file is now recorded as an `UNREADABLE` finding against that record and the sweep continues. Verified against a directory holding one broken file plus two real records:

```
EXIT=1 (findings, not 2)      report written? YES

ANME_SRB_…_Consortia
  UNKNOWN_SOURCE: Source taxon 'ANME-1' not found in taxonomy section
  …4 issues

Broken
  UNREADABLE: Could not audit this file: while parsing a flow node expected…
```

`UNREADABLE` is also added to the hard-coded list `report_community_issues` iterates. A type missing from that list counts toward the total but is **never printed** — a silent-omission trap this shape of code invites — so one of the new tests asserts every `IssueType` member is handled there, and will fail on the next type someone adds.

## #282 — the report text depended on the interpreter

`write_report` interpolated the enum member directly. `IssueType` is a `str`-mixin enum, and that mixin's `__format__` switched in Python 3.11 from emitting the value to emitting the qualified `IssueType.NAME`. So CI on 3.10 wrote `UNKNOWN_SOURCE` where a dev venv on 3.14 wrote `IssueType.UNKNOWN_SOURCE`, for identical input. It became user-visible when #274 started publishing this report as an artifact and pasting it into PR comments.

Now routed through a small `_type_label` helper that takes `.value`, with a plain-string fallback since some call sites hold strings rather than members.

The value form is the correct target: it matches the enum's declared value, it matches what `to_json` already emitted (a `str` subclass serialises by value, so JSON was never affected), and it matches every pre-3.11 report. **Confirmation:** a report generated locally on 3.14 is now byte-identical to the artifact CI produced on 3.10 in run [30604391167](https://github.com/CultureBotAI/CommunityMech/actions/runs/30604391167).

## Verification

- 281 tests pass; `black`, `ruff` and `mypy` clean.
- Six regression tests added to `tests/test_network_auditor.py`, reusing that module's existing fixtures.
- **Mutation-checked rather than assumed:** reverting the per-file guard fails three of them, reverting the label fix fails one. My first attempt at the second mutation silently failed to apply and the suite stayed green — worth noting, since that is exactly how a test that does not actually bite gets mistaken for a passing one. Re-run with a verified anchor, it fails as intended.

## Note for #273

This adds a sixth `IssueType`. When severity levels land there, `UNREADABLE` is unambiguously error-severity — a file that cannot be parsed is never a soft finding, unlike `DISCONNECTED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Self-review: the per-file guard could disguise an auditor bug as bad data

Catching per file keeps one bad record from ending the sweep — but it also means *any* exception raised inside `audit_community` becomes a finding against every record. I simulated that by injecting a `TypeError` into `audit_community` and running against the real KB:

```
305 UNREADABLE findings, report written
  AMD_Acidophile_Heterotroph_Network
    UNREADABLE: Could not audit this file: simulated auditor bug
  … × 305
```

A broken auditor presented as 305 broken records. That is **harder** to diagnose than the crash it replaced, because the failure is uniform and reads like a data catastrophe rather than a code path.

Nothing legitimate makes every record unreadable at once, so that case now raises. The CLI turns it into exit 2 with no report — precisely the "crash, not findings" state the workflow was taught to surface loudly in #274. Re-simulated after the fix: **exit 2, no report written.** Guarded on `len(yaml_files) > 1`, so a single-file directory containing one bad file stays an ordinary finding rather than being read as evidence the tool is broken.

Two more tests, mutation-checked: disabling the guard fails the tool-failure test while the lone-bad-file test keeps passing — that distinction is the whole point of the guard.

**283 tests pass**; `black`, `ruff`, `mypy` clean. The normal-path report remains byte-identical to the CI artifact.
