### PR TITLE
Add the append-only curation-history layer

### DIFF
--- a/.github/workflows/curation-history.yaml
+++ b/.github/workflows/curation-history.yaml
@@ -1,0 +1,96 @@
+name: Curation history
+
+# Two-part check, deliberately asymmetric (see history/README.md):
+#
+#   * VALIDITY is blocking. A malformed history record fails like any other
+#     validation error.
+#   * PRESENCE is advisory. If a community record changes without a matching
+#     history record, this warns in the job summary and passes. A hard gate on
+#     provenance blocks legitimate work at inconvenient moments and trains
+#     people to route around it.
+#
+# Validation uses the VENDORED schema at src/communitymech/schema/history.yaml,
+# so this job has no dependency on the private culturebotai-claw repo. Only the
+# `just new-history` scaffolder needs claw, and that is a dev-time tool.
+
+on:
+  pull_request:
+    paths: &trigger_paths
+      - "kb/communities/**"
+      - "history/**"
+      - "src/communitymech/schema/history.yaml"
+      - ".github/workflows/curation-history.yaml"
+  push:
+    branches: [main]
+    paths: *trigger_paths
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: curation-history-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  history:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # need the merge base to diff against
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install deps
+        run: uv sync
+
+      - name: Validate history records (blocking)
+        run: |
+          set -euo pipefail
+          if [ ! -d history ] || [ -z "$(find history -name '*.yaml' -print -quit)" ]; then
+            echo "No history records to validate."
+            exit 0
+          fi
+          find history -name '*.yaml' -print0 \
+            | xargs -0 uv run linkml-validate \
+                --schema src/communitymech/schema/history.yaml \
+                --target-class HistoryRecord
+
+      - name: Check for missing history records (advisory)
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          base="origin/${{ github.base_ref }}"
+
+          # 'kb/communities/*.yaml', not '**/*.yaml': community records are flat
+          # in this repo, and a git pathspec of 'kb/communities/**/*.yaml' needs a
+          # literal slash after the '**' — it matches ZERO of the 305 records, so
+          # the check would silently always report "nothing changed". A single '*'
+          # in a git pathspec matches '/' too, so this still covers subdirectories
+          # if records are ever nested.
+          changed_communities=$(git diff --name-only "$base"...HEAD -- 'kb/communities/*.yaml' | wc -l | tr -d ' ')
+          new_history=$(git diff --name-only --diff-filter=A "$base"...HEAD -- 'history/**/*.yaml' | wc -l | tr -d ' ')
+
+          {
+            echo "## Curation history"
+            echo
+            echo "- community records changed: **$changed_communities**"
+            echo "- history records added: **$new_history**"
+            echo
+            if [ "$changed_communities" -gt 0 ] && [ "$new_history" -eq 0 ]; then
+              echo "> [!WARNING]"
+              echo "> This PR changes community records but adds no history record."
+              echo "> Scaffold one with \`just new-history\` — see \`history/README.md\`."
+              echo ">"
+              echo "> Advisory only; this does not block the build."
+            elif [ "$changed_communities" -gt 0 ]; then
+              echo "Provenance recorded for this change."
+            else
+              echo "No community records changed; nothing to record."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/history/README.md
+++ b/history/README.md
@@ -1,0 +1,124 @@
+# Curation history
+
+Append-only provenance for curation sessions. One record per session per target,
+written once and **never edited afterwards**. Corrections go in a new record that
+references the old one in its `details`.
+
+```
+history/<kind-dir>/<slug>/<TIMESTAMP>-<actor>-<shortid>.yaml
+```
+
+## Why this exists
+
+Nothing else in the repo records *which model, using which tool, changed what,
+why, and under which issue*. Git tells you a commit happened; it does not tell you
+that a membership claim was checked against a cached abstract, or which deep-research
+provider produced an interaction edge, or that a review deliberately changed nothing.
+
+That gap matters more as autonomous agents start doing the changing. See
+`culturebotai-claw/docs/AUTONOMOUS_LOOPS.md`.
+
+## Why the layout looks like that
+
+The directory-per-slug plus unguessable `shortid` is the whole design. Two agents
+curating the same community concurrently cannot write the same file, so this layer
+has **no merge-conflict surface**. A single shared changelog would conflict on every
+parallel PR; this never does.
+
+## Writing a record
+
+Do not hand-write the filename or the timestamp — scaffold it:
+
+```bash
+just new-history --kind record --slug Anammox_Granule_Metabolic_Interaction_Community \
+  --target-root kb/communities \
+  --event EDIT --outcome changed \
+  --sections members,interactions \
+  --summary "Ground two unmapped members to NCBITaxon" \
+  --model claude-opus-5 --agent-tool claude-code \
+  --issue https://github.com/CultureBotAI/CommunityMech/issues/<n> \
+  --details "What was done, what evidence was used, how it was validated."
+```
+
+Community records live flat under `kb/communities/`, so `--slug` is the record's
+filename stem and `--target-root kb/communities` resolves the target path to
+`kb/communities/<slug>.yaml`.
+
+Omit `--details` and you get a TODO placeholder to edit before committing —
+`just validate-history` **fails** while it is still there, so an unfilled record
+cannot slip through. The command prints the record path as its final stdout line,
+so scripts can capture it.
+
+`--kind record` and `--kind schema` can derive the target path from `--slug` plus
+`--target-root`. Every other kind needs an explicit `--path`, because only those
+two are reliably `.yaml`.
+
+Then validate and stage:
+
+```bash
+just validate-history history/records/Anammox_Granule_Metabolic_Interaction_Community/<file>.yaml
+git add history/
+```
+
+## The vocabulary
+
+`event`: `CREATE` · `EDIT` · `REVIEW` · `AUDIT` · `GENERAL`
+
+`outcome`: `changed` · `no_change` · `needs_followup` · `blocked`
+
+Outcome is **orthogonal** to event on purpose. A `REVIEW` that found nothing is
+`no_change` — a real result worth recording, because it says something was
+checked. An `EDIT` that hit a wall is `blocked`, and `details` must say what the
+wall was so the next session does not rediscover it.
+
+`kind`: `record` · `schema` · `mapping` · `report` · `infrastructure` · `other`
+(`other` requires an explicit `--path`).
+
+## How strictly this is enforced
+
+Deliberately split:
+
+- **Presence is advisory.** CI warns when a community record changes without a
+  matching history record. It does not block. A hard gate on provenance blocks
+  legitimate work at inconvenient moments and trains people to route around it.
+- **Validity is not.** If you write a record it must be schema-valid, and
+  `just validate-history` fails like any other validation error.
+
+## Where the schema lives
+
+Two copies, on purpose:
+
+- **Canonical**: `culturebotai-claw/shared/history/history.yaml`, with the
+  scaffolder at `culturebotai-claw/src/kg_microbe_history/`.
+- **Vendored here**: `src/communitymech/schema/history.yaml`, byte-identical.
+
+Check that identity rather than trusting this file — with a claw checkout:
+
+```bash
+diff "${CLAW_SRC:-../../culturebotai-claw/src}/../shared/history/history.yaml" \
+     src/communitymech/schema/history.yaml && echo "in sync"
+```
+
+(The `../../` default is not a typo: this clone is nested one level deeper than a
+plain sibling checkout, which is why every claw-reaching recipe in the justfile
+defaults `CLAW_SRC` to `../../culturebotai-claw/src`.)
+
+Writing the md5 into this prose instead would go stale the first time the schema
+gains a field and nobody updates the hash — a confident false negative. A runnable
+command cannot decay that way.
+
+The vendored copy exists so validation has **no dependency on claw**, which is
+private — a public repo's CI cannot check it out without a token. `just
+validate-history` and the `curation-history` workflow both use the local copy and
+work with no claw checkout at all.
+
+Only `just new-history` needs claw, via `CLAW_SRC`. That is a dev-time scaffolder,
+and anyone writing curation records has claw checked out.
+
+Changing the schema means changing the canonical copy and re-vendoring here — the
+same hub-and-spoke rule as `mech_shared.yaml`. This copy is **not** yet on
+`scripts/check_vendored_sync.sh`, so nothing enforces that rule automatically.
+Adding it is not a one-liner: that check diffs against the public
+`CultureBotAI/CultureMech` hub over tokenless `raw.githubusercontent`, and this
+file's canonical copy lives in claw, which is private. Until a public canonical
+copy exists in the hub, the `diff` above is the check.

--- a/history/infrastructure/curation-history/2026-08-01T041621Z-claude-code-0cc374.yaml
+++ b/history/infrastructure/curation-history/2026-08-01T041621Z-claude-code-0cc374.yaml
@@ -1,0 +1,34 @@
+history_version: 1
+target:
+  kind: infrastructure
+  path: history/README.md
+  slug: curation-history
+session:
+  id: 2026-08-01T041621Z-claude-code-0cc374
+  timestamp: '2026-08-01T04:16:21Z'
+  actors:
+  - type: ai_agent
+    name: claude-code
+    model: claude-opus-5
+    agent_tool: claude-code
+events:
+- type: CREATE
+  outcome: changed
+  sections:
+  - history
+  - justfile
+  - ci
+  summary: Port the append-only curation-history layer from TraitMech
+  details: 'Vendored culturebotai-claw/shared/history/history.yaml byte-identical to src/communitymech/schema/history.yaml
+    (md5 3742bc2068b637868c48aba406f6569d, matching TraitMech''s copy), so validation needs
+    no claw checkout. Added justfile recipes new-history (scaffolder via CLAW_SRC, gated on
+    the repo''s existing _require-claw so a missing claw fails loudly rather than skipping)
+    and validate-history (linkml-validate against the vendored schema). Enabled ''set positional-arguments
+    := true'' — no pre-existing recipe used $1/$@, verified by grep, so nothing else changes.
+    Added history/README.md and .github/workflows/curation-history.yaml, with record validity
+    blocking and missing-record presence advisory. The advisory diff uses the git pathspec
+    kb/communities/*.yaml, not **/*.yaml: community records are flat here, and the ** form
+    matches zero of the 305 records, which would have made the check silently always report
+    no changes. Verified: just --list parses at 67 recipes (65 + 2); a scaffolded record validates;
+    a record scaffolded without --details fails validate-history on the TODO pattern; CLAW_SRC=/nonexistent
+    fails new-history; validate-history with an empty or nonexistent target exits 2.'

--- a/justfile
+++ b/justfile
@@ -3,6 +3,12 @@
 
 set dotenv-load := true
 
+# Binds recipe arguments to "$@" in shebang recipes so multi-word arguments keep
+# their quoting. Needed by `new-history`, whose --summary/--details are prose;
+# plain `{{args}}` interpolation splits them on whitespace. No existing recipe
+# uses $1/$@, so enabling this changes nothing else.
+set positional-arguments := true
+
 # Shared tooling lives in the culturebotai-claw checkout. Override CLAW_SRC when
 # claw is not the default sibling directory — CI checks it out elsewhere.
 claw_src := env_var_or_default("CLAW_SRC", "../../culturebotai-claw/src")
@@ -463,3 +469,44 @@ gen-community-pages *args:
 gen-discussions-data: (_require-claw "kg_microbe_discussions")
     PYTHONPATH={{claw_src}} uv run python \
       -m kg_microbe_discussions --config conf/discussions_config.yaml --output app/discussions
+
+# The scaffolder is shared tooling and lives in claw; this fails loudly when
+# claw is missing rather than silently skipping, because a skipped provenance
+# write is indistinguishable from one that was never attempted.
+
+# Scaffold an append-only curation-history record (see history/README.md)
+new-history *args: (_require-claw "kg_microbe_history")
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # "$@" not {{args}} — see `set positional-arguments` at the top of this file.
+    # `uv run python`, not `python3`: bare python3 is whatever the machine puts
+    # first on PATH, not the project venv.
+    PYTHONPATH="{{claw_src}}" uv run python -m kg_microbe_history new "$@"
+
+# No claw checkout needed here — that is the point of vendoring the schema.
+
+# Validate curation-history records against the vendored history schema
+validate-history target="history":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    target="{{target}}"
+    if [ -z "$target" ]; then
+      echo "validate-history: empty target. Pass a record path or a directory." >&2
+      exit 2
+    fi
+    if [ ! -e "$target" ]; then
+      echo "validate-history: '$target' does not exist." >&2
+      exit 2
+    fi
+    if [ -d "$target" ]; then
+      if [ -z "$(find "$target" -name '*.yaml' -print -quit)" ]; then
+        echo "No history records under '$target'."
+        exit 0
+      fi
+      find "$target" -name '*.yaml' -print0 \
+        | xargs -0 uv run linkml-validate \
+            --schema src/communitymech/schema/history.yaml --target-class HistoryRecord
+    else
+      uv run linkml-validate \
+        --schema src/communitymech/schema/history.yaml --target-class HistoryRecord "$target"
+    fi

--- a/src/communitymech/schema/history.yaml
+++ b/src/communitymech/schema/history.yaml
@@ -1,0 +1,265 @@
+id: https://w3id.org/kg-microbe/history
+name: mech_history
+title: Mech curation-history module — append-only provenance records
+description: >-
+  Append-only provenance for curation sessions across the Mech knowledge bases
+  (CultureMech / MIM / CommunityMech / TraitMech). Ported from
+  monarch-initiative/dismech's `history/` layer.
+
+  One record per session per target, written once and never edited. Records live
+  at `history/<kind-dir>/<slug>/<TIMESTAMP>-<actor>-<shortid>.yaml`. The
+  directory-per-slug layout with an unguessable `shortid` is the whole point:
+  concurrent agents curating the same record never write the same file, so the
+  layer has ZERO merge-conflict surface. Compare a single shared CHANGELOG,
+  which conflicts on every parallel PR.
+
+  This answers a question nothing else in the fleet can: which model, using which
+  tool, changed what, why, and under which issue. That matters more as autonomous
+  agents start doing the changing — see culturebotai-claw docs/AUTONOMOUS_LOOPS.md.
+
+  ENFORCEMENT IS DELIBERATELY SPLIT. Presence of a record is *advisory* — CI
+  warns, it does not block, because a hard gate on provenance blocks legitimate
+  work at inconvenient moments and trains people to route around it. But if a
+  record IS written it must be schema-valid, and that check is hard.
+
+  Do not hand-write records or filenames. Scaffold with `just new-history`, which
+  guarantees a schema-valid skeleton and a collision-free name, then edit the
+  `details` field.
+
+license: BSD-3-Clause
+default_range: string
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  mech_history: https://w3id.org/kg-microbe/history/
+
+default_prefix: mech_history
+
+imports:
+  - linkml:types
+
+# ============================== Enums ==============================
+
+enums:
+
+  HistoryTargetKindEnum:
+    description: >-
+      What kind of thing the session acted on. Repo-agnostic: each Mech maps its
+      own record type onto one of these, and `other` exists so a repo never has
+      to invent an enum value to record real work.
+    permissible_values:
+      record:
+        description: >-
+          A knowledge-base record — a CultureMech media recipe, a MIM ingredient,
+          a CommunityMech community, a TraitMech trait.
+      schema:
+        description: A LinkML schema or schema module.
+      mapping:
+        description: A mapping artifact such as an SSSOM file or a grounding table.
+      report:
+        description: A generated report, audit, dashboard, or ranking artifact.
+      infrastructure:
+        description: >-
+          Tooling, CI, justfile recipes, skills — changes to how the repo works
+          rather than to what it knows.
+      other:
+        description: >-
+          Anything not covered above. Requires an explicit path when scaffolding,
+          since the target cannot be derived from a slug.
+
+  HistoryActorTypeEnum:
+    description: Who or what performed the session.
+    permissible_values:
+      human:
+        description: A person working directly.
+      ai_agent:
+        description: >-
+          An LLM-driven agent, whether human-supervised or autonomous. Record the
+          model and the harness in `model` / `agent_tool`.
+      automation:
+        description: >-
+          A deterministic script or scheduled job with no model in the loop —
+          a cron scan, a regeneration step.
+      other:
+        description: Anything else.
+
+  HistoryEventTypeEnum:
+    description: >-
+      What the session did. Kept deliberately small; reach for `outcome` rather
+      than inventing a new type for "tried and failed".
+    permissible_values:
+      GENERAL:
+        description: Unclassified or legacy. Prefer a specific type.
+      CREATE:
+        description: Created a target that did not previously exist.
+      EDIT:
+        description: Modified an existing target.
+      REVIEW:
+        description: >-
+          Reviewed a target. May or may not have produced edits — say which via
+          `outcome`.
+      AUDIT:
+        description: >-
+          Structured inspection, compliance check, or triage across one or many
+          targets.
+
+  HistoryOutcomeEnum:
+    description: >-
+      What actually happened. Orthogonal to event type on purpose: it lets you
+      record a REVIEW that changed nothing (`no_change`) or an EDIT that got
+      stuck (`blocked`) without multiplying event types.
+    permissible_values:
+      changed:
+        description: The target was modified.
+      no_change:
+        description: >-
+          The session ran to completion and deliberately changed nothing. This is
+          a real result, not a non-event — it records that something was checked.
+      needs_followup:
+        description: Partial progress; specific remaining work is named in `details`.
+      blocked:
+        description: >-
+          Could not proceed. `details` must say what blocked it, so the next
+          session does not rediscover the same wall.
+
+# ============================== Classes ==============================
+
+classes:
+
+  HistoryRecord:
+    tree_root: true
+    description: >-
+      One curation session against one target. Append-only: write it once, never
+      edit it. Corrections go in a new record that references the old one in its
+      `details`.
+    attributes:
+      history_version:
+        description: Schema version of this record. Currently always 1.
+        range: integer
+        required: true
+        ifabsent: int(1)
+      target:
+        range: HistoryTarget
+        required: true
+      session:
+        range: HistorySession
+        required: true
+      links:
+        range: HistoryLinks
+        required: false
+      events:
+        description: >-
+          What happened, in order. At least one — a record with no events carries
+          no information.
+        range: HistoryEvent
+        required: true
+        multivalued: true
+        minimum_cardinality: 1
+        inlined_as_list: true
+
+  HistoryTarget:
+    description: What the session acted on.
+    attributes:
+      kind:
+        range: HistoryTargetKindEnum
+        required: true
+      slug:
+        description: >-
+          Stable identifier for the target within its kind — usually the record
+          filename stem. Also the directory name under `history/<kind-dir>/`.
+        required: false
+      path:
+        description: Repo-relative path to the target.
+        required: true
+
+  HistorySession:
+    description: When the session ran and who ran it.
+    attributes:
+      id:
+        description: >-
+          Stable session identifier. Always equals the record's filename stem, so
+          a record can be located from its id alone.
+        required: true
+      timestamp:
+        description: ISO-8601 UTC start time.
+        required: true
+        pattern: '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+\-]\d{2}:\d{2})$'
+      actors:
+        description: >-
+          Everyone involved. A list even when there is one actor, because
+          human-plus-agent sessions are the common case and retrofitting a list
+          later would break every existing record.
+        range: HistoryActor
+        required: true
+        multivalued: true
+        minimum_cardinality: 1
+        inlined_as_list: true
+
+  HistoryActor:
+    description: A participant in the session.
+    attributes:
+      type:
+        range: HistoryActorTypeEnum
+        required: true
+      name:
+        description: >-
+          Identifier for the actor — a GitHub login for a human, a harness name
+          such as `claude-code` or `codex` for an agent.
+        required: true
+      model:
+        description: >-
+          Model identifier when the actor is an AI agent, e.g. `claude-opus-5`.
+          This is the field that makes the layer worth having; fill it in.
+        required: false
+      agent_tool:
+        description: Harness that ran the model, e.g. `claude-code`, `codex`.
+        required: false
+      agent_version:
+        description: Version of the harness, when known.
+        required: false
+
+  HistoryLinks:
+    description: Pointers to related discussion. All optional.
+    attributes:
+      issues:
+        range: uri
+        multivalued: true
+      prs:
+        range: uri
+        multivalued: true
+      urls:
+        range: uri
+        multivalued: true
+
+  HistoryEvent:
+    description: One thing the session did.
+    attributes:
+      type:
+        range: HistoryEventTypeEnum
+        required: true
+      outcome:
+        range: HistoryOutcomeEnum
+        required: true
+      sections:
+        description: >-
+          Which parts of the target were touched, in the target's own vocabulary
+          (e.g. `composition`, `causal_graphs`, `ontology_mapping`).
+        multivalued: true
+        required: false
+      summary:
+        description: One short line. Shows up in listings; keep it scannable.
+        required: true
+      details:
+        description: >-
+          The substance, and the reason this layer exists. Required, because a
+          record without it is just a timestamp. Write what a colleague picking
+          this up cold would need: what was done, what evidence or provider was
+          used, how it was validated, and anything deliberately left undone.
+
+          The pattern rejects the scaffolder's TODO placeholder. That check lives
+          in the schema rather than only in the CLI so that a repo validating with
+          plain `linkml-validate` against its vendored copy — which is how the
+          spokes do it, to avoid depending on this private repo — catches an
+          unfilled record too.
+        required: true
+        pattern: '^(?!TODO: replace this placeholder)'


### PR DESCRIPTION
Ports the curation-history provenance layer proven in TraitMech. Nothing in this repo records *which model, using which tool, changed what, why, and under which issue*. Git records that a commit happened; it does not record that a membership claim was checked against a cached abstract, which deep-research provider produced an interaction edge, or that a review deliberately changed nothing. That gap widens as agents do more of the changing.

## What's here

Four surfaces, mirroring TraitMech:

- **`src/communitymech/schema/history.yaml`** — the canonical schema from `culturebotai-claw/shared/history/history.yaml`, vendored byte-identical (`md5 3742bc2068b637868c48aba406f6569d`, the same hash TraitMech carries). Vendored because claw is private and a public repo's CI cannot check it out without a token, so validation here has no claw dependency at all.
- **`just new-history`** — scaffolds a record. The scaffolder is shared tooling in claw, resolved through `CLAW_SRC` and gated on this repo's existing `_require-claw`, so a missing claw fails loudly rather than skipping. There is no skip path.
- **`just validate-history [target]`** — `linkml-validate` against the vendored copy. Defaults to `history/`.
- **`history/README.md`** and **`.github/workflows/curation-history.yaml`** — record *validity* is blocking; a changed community record with *no* history record is only advisory, warned in the job summary.

## Two things that needed adapting from TraitMech

**`set positional-arguments := true`.** `new-history` takes prose `--summary`/`--details`, which plain `{{args}}` interpolation splits on whitespace. Checked first whether enabling it would break anything: `grep '\$[0-9@*]' justfile` returns nothing, so no pre-existing recipe uses `$1`/`$@`/`$*` and this changes nothing else. Existing arg-taking recipes (`validate`, `repair-references`, `gen-community-pages`) were re-run afterwards and interpolate unchanged.

**The advisory pathspec.** TraitMech uses `data/traits/**/*.yaml`; the direct translation `kb/communities/**/*.yaml` matches **zero** of this repo's 305 community records, because they are flat and a git pathspec needs a literal slash after the `**`. Left as-is, the presence check would have reported "no community records changed" forever while looking healthy. Uses `kb/communities/*.yaml` instead — a single `*` in a git pathspec matches `/` too, so this still covers subdirectories if records are ever nested.

## Verified

| check | result |
|---|---|
| `just --list` parses | 67 recipes, was 65 — exactly the two additions |
| vendored schema vs canonical | `diff` clean, md5 matches |
| scaffold + `just validate-history` | `No issues found` |
| scaffold **without** `--details` | fails on the schema's `^(?!TODO: replace this placeholder)` pattern |
| `CLAW_SRC=/nonexistent just new-history` | exit 1, names the missing module |
| `just validate-history ""` / nonexistent path | exit 2 each |
| empty history dir | exit 0, "No history records under ..." |
| existing `just validate <file>` | `No issues found` (positional-arguments regression check) |

The one history record in this PR describes this port and nothing else.

Note for whoever merges: `just install` (`uv sync --group dev`) is broken on `main` — `pyproject.toml` has no `dependency-groups` table. Unrelated to this PR; plain `uv sync` works and is what CI uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)