### PR TITLE
Backfill GTDB grounding; fix the duplicate-key bug it exposed (#276)

### DIFF
--- a/kb/communities/BioAsteroid_ISS_Chondrite_Biomining_Consortium.yaml
+++ b/kb/communities/BioAsteroid_ISS_Chondrite_Biomining_Consortium.yaml
@@ -85,6 +85,14 @@ taxonomy:
     term:
       id: NCBITaxon:429134
       label: Sphingomonas desiccabilis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Sphingomonas_desiccabilis
+      gtdb_taxon: Sphingomonas desiccabilis
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Sphingomonas;s__Sphingomonas desiccabilis
+      ncbi_source_id: NCBITaxon:429134
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
       Gram-negative, non-motile, non-spore-forming bacterium originally isolated
       from soil crusts on the Colorado plateau, with demonstrated capacity to

--- a/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
+++ b/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
@@ -127,6 +127,14 @@ taxonomy:
     term:
       id: NCBITaxon:821
       label: Phocaeicola vulgatus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Phocaeicola_vulgatus
+      gtdb_taxon: Phocaeicola vulgatus
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Phocaeicola;s__Phocaeicola vulgatus
+      ncbi_source_id: NCBITaxon:821
+      majority_fraction: 0.86
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: DSM1896
   functional_role:

--- a/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
+++ b/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
@@ -127,14 +127,6 @@ taxonomy:
     term:
       id: NCBITaxon:821
       label: Phocaeicola vulgatus
-    gtdb_classification:
-      gtdb_id: GTDB:s__Phocaeicola_vulgatus
-      gtdb_taxon: Phocaeicola vulgatus
-      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Phocaeicola;s__Phocaeicola vulgatus
-      ncbi_source_id: NCBITaxon:821
-      majority_fraction: 0.86
-      is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: DSM1896
   functional_role:

--- a/kb/communities/BioRock_ISS_Basalt_Biomining_Consortium.yaml
+++ b/kb/communities/BioRock_ISS_Basalt_Biomining_Consortium.yaml
@@ -77,6 +77,14 @@ taxonomy:
     term:
       id: NCBITaxon:429134
       label: Sphingomonas desiccabilis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Sphingomonas_desiccabilis
+      gtdb_taxon: Sphingomonas desiccabilis
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Sphingomonas;s__Sphingomonas desiccabilis
+      ncbi_source_id: NCBITaxon:429134
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
       Type strain CP1D (DSM 16792); the only panel member that significantly enhanced
       rare earth element bioleaching from basalt across all gravity regimes, and (with
@@ -105,6 +113,14 @@ taxonomy:
     term:
       id: NCBITaxon:1423
       label: Bacillus subtilis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Bacillus_subtilis
+      gtdb_taxon: Bacillus subtilis
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
+      ncbi_source_id: NCBITaxon:1423
+      majority_fraction: 0.91
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
       Type strain NCIB 3610 (DSM 10), a Gram-positive, spore- and biofilm-forming
       bacterium introduced into the experiment as spores desiccated on the basalt. It
@@ -134,6 +150,14 @@ taxonomy:
     term:
       id: NCBITaxon:119219
       label: Cupriavidus metallidurans
+    gtdb_classification:
+      gtdb_id: GTDB:s__Cupriavidus_metallidurans
+      gtdb_taxon: Cupriavidus metallidurans
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Cupriavidus;s__Cupriavidus metallidurans
+      ncbi_source_id: NCBITaxon:119219
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
       Type strain CH34 (DSM 2839), a Gram-negative, motile, metal-resistant bacterium
       often used in space experiments. In BioRock it showed no significant difference in

--- a/kb/communities/GLBRC_Populus_Variovorax_SynCom28.yaml
+++ b/kb/communities/GLBRC_Populus_Variovorax_SynCom28.yaml
@@ -76,6 +76,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: BK151
     isolation_source: Populus deltoides root
@@ -99,6 +107,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: BK370
     isolation_source: Populus deltoides root
@@ -122,6 +138,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: BK460
     isolation_source: Populus deltoides root
@@ -145,6 +169,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: BK613
     isolation_source: Populus deltoides root
@@ -168,6 +200,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: BK658
     isolation_source: Populus deltoides root
@@ -191,6 +231,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: BT01
     isolation_source: Populus deltoides rhizosphere
@@ -214,6 +262,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: CF079
     isolation_source: Populus deltoides endosphere
@@ -237,6 +293,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: CF313
     isolation_source: Populus deltoides endosphere
@@ -260,6 +324,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: GV004
     isolation_source: Populus trichocarpa endosphere
@@ -283,6 +355,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: GV008
     isolation_source: Populus trichocarpa endosphere
@@ -306,6 +386,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: GV014
     isolation_source: Populus trichocarpa endosphere
@@ -329,6 +417,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: GV035
     isolation_source: Populus trichocarpa endosphere
@@ -352,6 +448,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: GV040
     isolation_source: Populus trichocarpa endosphere
@@ -375,6 +479,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: GV042
     isolation_source: Populus trichocarpa endosphere
@@ -398,6 +510,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: GV051
     isolation_source: Populus trichocarpa endosphere
@@ -421,6 +541,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OK202
     isolation_source: Populus trichocarpa rhizosphere
@@ -444,6 +572,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OK212
     isolation_source: Populus trichocarpa endosphere
@@ -467,6 +603,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OK605
     isolation_source: Populus trichocarpa endosphere
@@ -490,6 +634,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OV084
     isolation_source: Populus trichocarpa endosphere
@@ -513,6 +665,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OV329
     isolation_source: Populus trichocarpa endosphere
@@ -536,6 +696,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OV700
     isolation_source: Populus trichocarpa endosphere
@@ -559,6 +727,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: PDC80
     isolation_source: Populus deltoides endosphere
@@ -582,6 +758,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: YR216
     isolation_source: Populus deltoides rhizosphere
@@ -605,6 +789,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: YR266
     isolation_source: Populus deltoides endosphere
@@ -628,6 +820,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: YR634
     isolation_source: Populus deltoides endosphere
@@ -651,6 +851,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: YR750
     isolation_source: Populus deltoides endosphere
@@ -674,6 +882,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: YR752
     isolation_source: Populus deltoides endosphere

--- a/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
+++ b/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
@@ -254,6 +254,14 @@ taxonomy:
     term:
       id: NCBITaxon:1678
       label: Bifidobacterium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Bifidobacterium
+      gtdb_taxon: Bifidobacterium
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium
+      ncbi_source_id: NCBITaxon:1678
+      majority_fraction: 0.998
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Second Bifidobacterium MAG (up to 15.3% relative abundance). Lactose fermentation via bifid
       shunt.
 
@@ -279,6 +287,14 @@ taxonomy:
     term:
       id: NCBITaxon:133926
       label: Olsenella uli
+    gtdb_classification:
+      gtdb_id: GTDB:s__Olsenella_uli
+      gtdb_taxon: Olsenella uli
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Coriobacteriia;o__Coriobacteriales;f__Atopobiaceae;g__Olsenella;s__Olsenella uli
+      ncbi_source_id: NCBITaxon:133926
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Second Olsenella MAG (up to 13.9% relative abundance). Lactose degradation via Leloir pathway.
 
       '

--- a/kb/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.yaml
+++ b/kb/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.yaml
@@ -58,6 +58,14 @@ taxonomy:
     term:
       id: NCBITaxon:641853
       label: Elusimicrobia
+    gtdb_classification:
+      gtdb_id: GTDB:c__Elusimicrobia
+      gtdb_taxon: Elusimicrobia
+      gtdb_lineage: d__Bacteria;p__Elusimicrobiota;c__Elusimicrobia
+      ncbi_source_id: NCBITaxon:641853
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Animal-associated Elusimicrobia clades whose phylogenetic placement
       within free-living clades supports an evolutionary trajectory from
       free-living to animal-associated lifestyles via genome reduction.

--- a/kb/communities/KBase_ORT_Workflow_Community_Model.yaml
+++ b/kb/communities/KBase_ORT_Workflow_Community_Model.yaml
@@ -85,6 +85,14 @@ taxonomy:
     term:
       id: NCBITaxon:1236
       label: Gammaproteobacteria
+    gtdb_classification:
+      gtdb_id: GTDB:c__Gammaproteobacteria
+      gtdb_taxon: Gammaproteobacteria
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria
+      ncbi_source_id: NCBITaxon:1236
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 7 GTDB taxa under the NCBI taxon]
     notes: Gammaproteobacterial genome within family Steroidobacteraceae from Columbia River sediments.
       Functions as denitrifier reducing nitrate to nitrogen gas.
   functional_role:
@@ -100,6 +108,14 @@ taxonomy:
     term:
       id: NCBITaxon:1236
       label: Gammaproteobacteria
+    gtdb_classification:
+      gtdb_id: GTDB:c__Gammaproteobacteria
+      gtdb_taxon: Gammaproteobacteria
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria
+      ncbi_source_id: NCBITaxon:1236
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 7 GTDB taxa under the NCBI taxon]
     notes: Second gammaproteobacterial genome within family Steroidobacteraceae from Columbia River sediments.
       Functions as denitrifier reducing nitrate to nitrogen gas.
   functional_role:

--- a/kb/communities/KBase_ORT_Workflow_Community_Model.yaml
+++ b/kb/communities/KBase_ORT_Workflow_Community_Model.yaml
@@ -62,14 +62,6 @@ taxonomy:
     term:
       id: NCBITaxon:1236
       label: Gammaproteobacteria
-    gtdb_classification:
-      gtdb_id: GTDB:c__Gammaproteobacteria
-      gtdb_taxon: Gammaproteobacteria
-      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria
-      ncbi_source_id: NCBITaxon:1236
-      majority_fraction: 1.0
-      is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at c__ rank; 7 GTDB taxa under the NCBI taxon]
     notes: Bacterial member of Nitrospiraceae family from Columbia River sediments. Functions as nitrite
       oxidizer in the nitrogen cycle.
   functional_role:

--- a/kb/communities/Legume_Rhizobia_Mars_Simulant_Symbiosis.yaml
+++ b/kb/communities/Legume_Rhizobia_Mars_Simulant_Symbiosis.yaml
@@ -68,6 +68,14 @@ taxonomy:
     term:
       id: NCBITaxon:382
       label: Sinorhizobium meliloti
+    gtdb_classification:
+      gtdb_id: GTDB:s__Sinorhizobium_meliloti
+      gtdb_taxon: Sinorhizobium meliloti
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Sinorhizobium;s__Sinorhizobium meliloti
+      ncbi_source_id: NCBITaxon:382
+      majority_fraction: 0.97
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
       A symbiotic nitrogen-fixing rhizobium partner of Medicago truncatula; ontology
       grounding is species-level.
@@ -84,6 +92,14 @@ taxonomy:
     term:
       id: NCBITaxon:110321
       label: Sinorhizobium medicae
+    gtdb_classification:
+      gtdb_id: GTDB:s__Sinorhizobium_medicae
+      gtdb_taxon: Sinorhizobium medicae
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Sinorhizobium;s__Sinorhizobium medicae
+      ncbi_source_id: NCBITaxon:110321
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
       A symbiotic nitrogen-fixing rhizobium partner of Medicago truncatula; ontology
       grounding is species-level.

--- a/kb/communities/Lotus_LjSC3.yaml
+++ b/kb/communities/Lotus_LjSC3.yaml
@@ -70,6 +70,14 @@ taxonomy:
     term:
       id: NCBITaxon:68287
       label: Mesorhizobium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Mesorhizobium
+      gtdb_taxon: Mesorhizobium
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Mesorhizobium
+      ncbi_source_id: NCBITaxon:68287
+      majority_fraction: 0.97
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 17 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - PRIMARY_PRODUCER
@@ -85,6 +93,14 @@ taxonomy:
     term:
       id: NCBITaxon:68287
       label: Mesorhizobium
+    gtdb_classification:
+      gtdb_id: GTDB:g__Mesorhizobium
+      gtdb_taxon: Mesorhizobium
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Mesorhizobium
+      ncbi_source_id: NCBITaxon:68287
+      majority_fraction: 0.97
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 17 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - PRIMARY_PRODUCER

--- a/kb/communities/Lunar_Martian_Simulant_PGPB_Lettuce_SynCom.yaml
+++ b/kb/communities/Lunar_Martian_Simulant_PGPB_Lettuce_SynCom.yaml
@@ -81,6 +81,14 @@ taxonomy:
     term:
       id: NCBITaxon:353
       label: Azotobacter chroococcum
+    gtdb_classification:
+      gtdb_id: GTDB:s__Azotobacter_chroococcum
+      gtdb_taxon: Azotobacter chroococcum
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Azotobacter;s__Azotobacter chroococcum
+      ncbi_source_id: NCBITaxon:353
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
       Source identifies strain 76A; ontology grounding is species-level to the
       stable NCBI Taxonomy term Azotobacter chroococcum.
@@ -134,6 +142,14 @@ taxonomy:
     term:
       id: NCBITaxon:223967
       label: Methylorubrum populi
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methylobacterium_thiocyanatum
+      gtdb_taxon: Methylobacterium thiocyanatum
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Methylobacterium;s__Methylobacterium thiocyanatum
+      ncbi_source_id: NCBITaxon:223967
+      majority_fraction: 1.0
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: >
       Source names the strain Methylobacterium populi VP2; NCBI Taxonomy has
       reclassified this species as Methylorubrum populi (NCBITaxon:223967), so
@@ -163,6 +179,14 @@ taxonomy:
     term:
       id: NCBITaxon:1646340
       label: Kosakonia pseudosacchari
+    gtdb_classification:
+      gtdb_id: GTDB:s__Kosakonia_pseudosacchari
+      gtdb_taxon: Kosakonia pseudosacchari
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Kosakonia;s__Kosakonia pseudosacchari
+      ncbi_source_id: NCBITaxon:1646340
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
       Source identifies strain TL13; ontology grounding is species-level to the
       stable NCBI Taxonomy term Kosakonia pseudosacchari.

--- a/kb/communities/Lunar_Simulant_Phosphate_Solubilizing_Bacteria_Nicotiana.yaml
+++ b/kb/communities/Lunar_Simulant_Phosphate_Solubilizing_Bacteria_Nicotiana.yaml
@@ -76,6 +76,14 @@ taxonomy:
     term:
       id: NCBITaxon:61624
       label: Paenibacillus mucilaginosus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Paenibacillus_G_mucilaginosus
+      gtdb_taxon: Paenibacillus_G mucilaginosus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Paenibacillales;f__NBRC-103111;g__Paenibacillus_G;s__Paenibacillus_G mucilaginosus
+      ncbi_source_id: NCBITaxon:61624
+      majority_fraction: 0.88
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
       Reported by the source as Bacillus mucilaginosus (strain AS1.232); the stable
       NCBI Taxonomy term for this organism is Paenibacillus mucilaginosus. One of the
@@ -155,6 +163,14 @@ taxonomy:
     term:
       id: NCBITaxon:1423
       label: Bacillus subtilis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Bacillus_subtilis
+      gtdb_taxon: Bacillus subtilis
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
+      ncbi_source_id: NCBITaxon:1423
+      majority_fraction: 0.91
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
       Strain CMCC 63501. Tested as a candidate PSB but did not effectively dissociate
       insoluble inorganic phosphorus from the lunar regolith simulant under the study
@@ -176,6 +192,14 @@ taxonomy:
     term:
       id: NCBITaxon:1402
       label: Bacillus licheniformis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Bacillus_licheniformis
+      gtdb_taxon: Bacillus licheniformis
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus licheniformis
+      ncbi_source_id: NCBITaxon:1402
+      majority_fraction: 0.98
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
       Strain ATCC 11946. Tested as a candidate PSB but did not effectively dissociate
       insoluble inorganic phosphorus from the lunar regolith simulant under the study

--- a/kb/communities/Mars_Meteorite_EETA79001_Growth_Panel.yaml
+++ b/kb/communities/Mars_Meteorite_EETA79001_Growth_Panel.yaml
@@ -67,6 +67,14 @@ taxonomy:
     term:
       id: NCBITaxon:562
       label: Escherichia coli
+    gtdb_classification:
+      gtdb_id: GTDB:s__Escherichia_coli
+      gtdb_taxon: Escherichia coli
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
+      ncbi_source_id: NCBITaxon:562
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
       Source uses Escherichia coli B as a model bacterium; ontology grounding is
       species-level to the stable NCBI Taxonomy term Escherichia coli.
@@ -97,6 +105,14 @@ taxonomy:
     term:
       id: NCBITaxon:54298
       label: Chroococcidiopsis
+    gtdb_classification:
+      gtdb_id: GTDB:g__Chroococcidiopsis
+      gtdb_taxon: Chroococcidiopsis
+      gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Cyanobacteriales;f__Chroococcidiopsidaceae;g__Chroococcidiopsis
+      ncbi_source_id: NCBITaxon:54298
+      majority_fraction: 0.778
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: >
       Source designates this cyanobacterium Chr20-20201027-1 (abbreviated Chr20) and
       identifies it as a Chroococcidiopsis sp.; ontology grounding is genus-level.
@@ -113,6 +129,14 @@ taxonomy:
     term:
       id: NCBITaxon:1215089
       label: Planococcus halocryophilus
+    gtdb_classification:
+      gtdb_id: GTDB:s__Planococcus_halocryophilus
+      gtdb_taxon: Planococcus halocryophilus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales_A;f__Planococcaceae;g__Planococcus;s__Planococcus halocryophilus
+      ncbi_source_id: NCBITaxon:1215089
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: >
       A cold-adapted (psychrophilic, halotolerant) bacterium; ontology grounding is
       species-level.

--- a/kb/communities/Moss_Microbe_Complex_Regolith_Biofertilizer.yaml
+++ b/kb/communities/Moss_Microbe_Complex_Regolith_Biofertilizer.yaml
@@ -102,6 +102,14 @@ taxonomy:
     term:
       id: NCBITaxon:46913
       label: Devosia
+    gtdb_classification:
+      gtdb_id: GTDB:g__Devosia
+      gtdb_taxon: Devosia
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Devosiaceae;g__Devosia
+      ncbi_source_id: NCBITaxon:46913
+      majority_fraction: 0.769
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: >
       Detected by 16S rRNA profiling as a stably present genus in moss-treated soils
       (not isolated/selected as an inoculant); ontology grounding is genus-level.

--- a/kb/communities/PET_Artificial_FourSpecies_Degradation_Consortium.yaml
+++ b/kb/communities/PET_Artificial_FourSpecies_Degradation_Consortium.yaml
@@ -76,6 +76,14 @@ taxonomy:
     term:
       id: NCBITaxon:1423
       label: Bacillus subtilis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Bacillus_subtilis
+      gtdb_taxon: Bacillus subtilis
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
+      ncbi_source_id: NCBITaxon:1423
+      majority_fraction: 0.91
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered B. subtilis 168 strain carrying pHP13-P43-LipB-MHETase; represented at species level
       for ontology stability.
   abundance_value: Engineered MHETase-secretion module in the consortium.

--- a/kb/communities/PMI_Variovorax_Thermotolerance_Collection.yaml
+++ b/kb/communities/PMI_Variovorax_Thermotolerance_Collection.yaml
@@ -72,6 +72,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: YR634
     isolation_source: Populus root
@@ -89,6 +97,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: GV004
     isolation_source: Populus root
@@ -106,6 +122,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: GV035
     isolation_source: Populus root
@@ -123,6 +147,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: YR752
     isolation_source: Populus root
@@ -140,6 +172,14 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_classification:
+      gtdb_id: GTDB:g__Variovorax
+      gtdb_taxon: Variovorax
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
+      ncbi_source_id: NCBITaxon:34072
+      majority_fraction: 0.99
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OV084
     isolation_source: Populus root

--- a/kb/communities/Rice_Duckweed_Bacillus_SynCom.yaml
+++ b/kb/communities/Rice_Duckweed_Bacillus_SynCom.yaml
@@ -70,6 +70,14 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_classification:
+      gtdb_id: GTDB:g__Bacillus
+      gtdb_taxon: Bacillus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
+      ncbi_source_id: NCBITaxon:1386
+      majority_fraction: 0.508
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
     notes: Siderophore-producing specialist within the 8-member SynCom. Contributes to rice growth promotion
       through siderophore-linked iron mobilization.
   functional_role:
@@ -86,6 +94,14 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_classification:
+      gtdb_id: GTDB:g__Bacillus
+      gtdb_taxon: Bacillus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
+      ncbi_source_id: NCBITaxon:1386
+      majority_fraction: 0.508
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
     notes: Lipopeptide-producing antagonist within the 8-member SynCom. Produces surfactin, bacillomycin,
       and fengycin for biocontrol of Rhizoctonia solani sheath blight.
   functional_role:
@@ -102,6 +118,14 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_classification:
+      gtdb_id: GTDB:g__Bacillus
+      gtdb_taxon: Bacillus
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
+      ncbi_source_id: NCBITaxon:1386
+      majority_fraction: 0.508
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
     notes: Polyketide-producing antagonist within the 8-member SynCom. Produces difficidin for biocontrol
       of Rhizoctonia solani sheath blight.
   functional_role:

--- a/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
+++ b/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
@@ -92,6 +92,14 @@ taxonomy:
     term:
       id: NCBITaxon:53335
       label: Pantoea
+    gtdb_classification:
+      gtdb_id: GTDB:g__Pantoea
+      gtdb_taxon: Pantoea
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Pantoea
+      ncbi_source_id: NCBITaxon:53335
+      majority_fraction: 0.961
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 15 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom.yaml
+++ b/kb/communities/Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom.yaml
@@ -73,6 +73,14 @@ taxonomy:
     term:
       id: NCBITaxon:293387
       label: Bacillus altitudinis
+    gtdb_classification:
+      gtdb_id: GTDB:s__Bacillus_altitudinis
+      gtdb_taxon: Bacillus altitudinis
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus altitudinis
+      ncbi_source_id: NCBITaxon:293387
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Hyphae-associated bacterium recruited to the fungal mycelial surface; produces and
       supplies thiamine to the fungus.
   strain_designation:

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -278,19 +278,27 @@ def apply_to_community(path: Path, by_id, by_name, by_higher, mapping_source) ->
     top-level ``taxonomy:`` block so interaction source/target taxa are untouched.
     """
     doc = yaml.safe_load(path.read_text())
-    blocks: dict[str, dict] = {}
-    for tc in doc.get("taxonomy", []) or []:
+    entries = doc.get("taxonomy", []) or []
+
+    # Positional, NOT keyed by NCBITaxon id. A record may legitimately list the
+    # same id many times — GLBRC_Populus_Variovorax_SynCom28 has 28 isolates all
+    # grounded to NCBITaxon:34072 (genus Variovorax). Keying by id inserted the
+    # block at the *first* line bearing that id, which is a different taxonomy
+    # entry than the one that needed it: the already-grounded entry got a
+    # duplicate `gtdb_classification` key while the ungrounded ones stayed
+    # ungrounded. PyYAML keeps the last of two duplicate keys silently, so
+    # linkml-validate did not catch it either.
+    wanted: list[dict | None] = []
+    for tc in entries:
         tt = (tc or {}).get("taxon_term", {}) or {}
-        if "gtdb_classification" in tt:
-            continue
         term = tt.get("term", {}) or {}
         tid = str(term.get("id", ""))
-        if not tid.startswith("NCBITaxon:"):
+        if "gtdb_classification" in tt or not tid.startswith("NCBITaxon:"):
+            wanted.append(None)
             continue
         g = resolve_target(tid.split(":", 1)[1], term.get("label", ""), by_id, by_name, by_higher)
-        if g and not g.get("ambiguous"):
-            blocks[tid.split(":", 1)[1]] = _block(g, mapping_source)
-    if not blocks:
+        wanted.append(_block(g, mapping_source) if g and not g.get("ambiguous") else None)
+    if not any(w is not None for w in wanted):
         return 0
 
     lines = path.read_text().splitlines()
@@ -305,17 +313,41 @@ def apply_to_community(path: Path, by_id, by_name, by_higher, mapping_source) ->
         return 0
     end = end if end is not None else len(lines)
 
+    # One `id: NCBITaxon:… / label: …` pair per taxonomy entry, in document
+    # order. If that correspondence does not hold the file is shaped in a way
+    # this text-level editor cannot reason about, so refuse rather than guess —
+    # a wrong insertion point is silent data corruption.
+    anchors = [
+        i
+        for i in range(start + 1, end)
+        if re.match(r"^\s+id: NCBITaxon:\d+\s*$", lines[i])
+        and i + 1 < end
+        and re.match(r"^\s+label:", lines[i + 1])
+    ]
+    if len(anchors) != len(entries):
+        raise SystemExit(
+            f"{path.name}: found {len(anchors)} taxon term-id lines for "
+            f"{len(entries)} taxonomy entries — refusing to edit."
+        )
+    for pos, tc in zip(anchors, entries, strict=True):
+        expected = str((((tc or {}).get("taxon_term") or {}).get("term") or {}).get("id", ""))
+        if lines[pos].split("id:", 1)[1].strip() != expected:
+            raise SystemExit(
+                f"{path.name}: taxonomy entry order does not match the file — refusing to edit."
+            )
+
+    insert_at = {pos: block for pos, block in zip(anchors, wanted, strict=True) if block}
     out = lines[: start + 1]
     i, added = start + 1, 0
     while i < end:
         out.append(lines[i])
-        m = re.match(r"^(\s+)id: (NCBITaxon:\d+)\s*$", lines[i])
-        nid = m.group(2).split(":", 1)[1] if m else None
-        if nid in blocks and i + 1 < end and re.match(r"^\s+label:", lines[i + 1]):
+        block = insert_at.get(i)
+        if block is not None:
             out.append(lines[i + 1])  # keep the label line
-            child = " " * (len(m.group(1)) - 2)  # taxon_term child indent (sibling of `term`)
+            indent = re.match(r"^(\s+)", lines[i]).group(1)
+            child = " " * (len(indent) - 2)  # taxon_term child indent (sibling of `term`)
             out.append(f"{child}gtdb_classification:")
-            dumped = yaml.dump(blocks.pop(nid), sort_keys=False, allow_unicode=True, width=4096)
+            dumped = yaml.dump(block, sort_keys=False, allow_unicode=True, width=4096)
             out += [f"{child}  {bl}" for bl in dumped.splitlines()]
             added += 1
             i += 2

--- a/tests/test_gtdb_ground_apply.py
+++ b/tests/test_gtdb_ground_apply.py
@@ -1,0 +1,158 @@
+"""Regression tests for `gtdb_ground.py --apply`'s insertion positioning.
+
+`apply_to_community` keyed its blocks by bare NCBITaxon id and inserted at the
+first line bearing that id. Records may legitimately list one id many times —
+`GLBRC_Populus_Variovorax_SynCom28` has 28 isolates all grounded to
+NCBITaxon:34072 (genus *Variovorax*) — so the block landed on a *different*
+taxonomy entry than the one that needed it. When the first occurrence was
+already grounded, that entry got a second `gtdb_classification` key while the
+27 that needed one stayed empty.
+
+Neither symptom was visible downstream: PyYAML keeps the last of two duplicate
+keys silently, so `linkml-validate` passed, and the under-grounding just looked
+like taxa GTDB could not map. It was caught only by comparing blocks written
+(28) against grounded taxa gained (17).
+
+These tests patch `resolve_target` so they exercise the positioning logic alone
+and need no kg-microbe checkout — the mapping table is a 2.9 MB gzip that is not
+present in CI.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import gtdb_ground  # noqa: E402
+
+GROUNDED_BLOCK = {
+    "gtdb_id": "GTDB:g__Variovorax",
+    "gtdb_taxon": "Variovorax",
+    "gtdb_lineage": "d__Bacteria;p__Pseudomonadota;g__Variovorax",
+    "ncbi_source_id": "NCBITaxon:34072",
+    "majority_fraction": 0.99,
+    "is_reclassified": False,
+    "mapping_source": "test",
+}
+
+
+def _entry(preferred: str, grounded: bool) -> str:
+    block = (
+        "\n".join(
+            [
+                "    gtdb_classification:",
+                *[f"      {k}: {v}" for k, v in GROUNDED_BLOCK.items()],
+            ]
+        )
+        + "\n"
+        if grounded
+        else ""
+    )
+    return (
+        f"- taxon_term:\n"
+        f"    preferred_term: {preferred}\n"
+        f"    term:\n"
+        f"      id: NCBITaxon:34072\n"
+        f"      label: Variovorax\n"
+        f"{block}"
+    )
+
+
+def _write_community(tmp_path: Path, grounded_flags: list[bool]) -> Path:
+    entries = "\n".join(_entry(f"Variovorax isolate {i}", g) for i, g in enumerate(grounded_flags))
+    path = tmp_path / "Repeated_Id.yaml"
+    path.write_text(f"id: CommunityMech:000001\nname: Repeated id record\ntaxonomy:\n{entries}\n")
+    return path
+
+
+@pytest.fixture
+def always_grounds(monkeypatch):
+    """Make every taxon resolve, so only the positioning logic is under test."""
+    monkeypatch.setattr(
+        gtdb_ground,
+        "resolve_target",
+        lambda ncbi_id, label, by_id, by_name, by_higher: {
+            "gtdb_id": GROUNDED_BLOCK["gtdb_id"],
+            "gtdb_taxon": GROUNDED_BLOCK["gtdb_taxon"],
+            "gtdb_lineage": GROUNDED_BLOCK["gtdb_lineage"],
+            "ncbi_source_id": GROUNDED_BLOCK["ncbi_source_id"],
+            "majority_fraction": GROUNDED_BLOCK["majority_fraction"],
+            "is_reclassified": GROUNDED_BLOCK["is_reclassified"],
+            "via": "ncbi_id",
+        },
+    )
+
+
+def _apply(path: Path) -> int:
+    return gtdb_ground.apply_to_community(path, {}, {}, {}, "test")
+
+
+def _count_keys(path: Path) -> int:
+    """Count `gtdb_classification:` keys textually — parsing hides duplicates."""
+    return sum(
+        1 for line in path.read_text().splitlines() if line.strip() == "gtdb_classification:"
+    )
+
+
+def _count_grounded(path: Path) -> int:
+    doc = yaml.safe_load(path.read_text())
+    return sum(bool(t["taxon_term"].get("gtdb_classification")) for t in doc["taxonomy"])
+
+
+def test_repeated_id_grounds_the_entry_that_needs_it(tmp_path, always_grounds):
+    """First entry already grounded, second not: the block goes to the second.
+
+    This is the exact shape that produced the bug — keying by id sent the block
+    to the first occurrence, duplicating it there.
+    """
+    path = _write_community(tmp_path, [True, False])
+
+    assert _apply(path) == 1
+    assert _count_keys(path) == 2, "one block per entry, not a duplicate on the first"
+    assert _count_grounded(path) == 2
+
+    doc = yaml.safe_load(path.read_text())
+    assert (
+        doc["taxonomy"][1]["taxon_term"]["gtdb_classification"]["gtdb_id"] == "GTDB:g__Variovorax"
+    )
+
+
+def test_every_ungrounded_entry_of_a_repeated_id_is_grounded(tmp_path, always_grounds):
+    """The 28-isolate case: one grounded, many not — all of them get a block."""
+    path = _write_community(tmp_path, [True] + [False] * 27)
+
+    assert _apply(path) == 27
+    assert _count_keys(path) == 28
+    assert _count_grounded(path) == 28
+
+
+def test_apply_is_idempotent(tmp_path, always_grounds):
+    """Re-running must add nothing — the second pass is where duplicates appeared."""
+    path = _write_community(tmp_path, [False, False])
+
+    assert _apply(path) == 2
+    before = path.read_text()
+    assert _apply(path) == 0
+    assert path.read_text() == before, "a second --apply changed the file"
+    assert _count_keys(path) == 2
+
+
+def test_refuses_to_edit_when_anchors_do_not_line_up(tmp_path, always_grounds):
+    """A stray NCBITaxon id/label pair makes positions ambiguous — bail, don't guess.
+
+    Inserting at a wrong offset is silent corruption, so the script must fail
+    loudly rather than pick an interpretation.
+    """
+    path = _write_community(tmp_path, [False])
+    path.write_text(
+        path.read_text() + "    decoy:\n      id: NCBITaxon:99999\n      label: Decoy\n"
+    )
+
+    with pytest.raises(SystemExit, match="refusing to edit"):
+        _apply(path)

--- a/tests/test_gtdb_withheld_groundings.py
+++ b/tests/test_gtdb_withheld_groundings.py
@@ -1,0 +1,74 @@
+"""Keep deliberately-withheld GTDB groundings withheld (#292, #293).
+
+Two taxa carry an ``NCBITaxon`` id belonging to a different organism, so the GTDB
+classification derived from that id describes the wrong species. Restating a wrong
+grounding in a second, independently-derived-looking field makes it harder to
+spot, not easier, so those two entries are left ungrounded until the ids are
+fixed.
+
+``gtdb_ground.py --apply`` has no memory of that decision: it is otherwise
+perfectly idempotent, but a re-run over the whole KB re-adds exactly these two
+blocks. Without this test the withhold lasts only until the next person runs the
+tool and commits, and nothing anywhere fails.
+
+Removing an entry from ``WITHHELD`` is part of fixing #292 — correct the id, then
+re-run ``--apply`` and the right block appears on its own.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+COMMUNITIES = Path(__file__).parent.parent / "kb/communities"
+
+# (record, preferred_term) -> why the id is wrong. Tracked in #292.
+WITHHELD = {
+    ("BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml", "Bacteroides ovatus"): (
+        "NCBITaxon:821 is Phocaeicola vulgatus; B. ovatus is NCBITaxon:28116. "
+        "The record uses 821 correctly for its Bacteroides vulgatus entry."
+    ),
+    ("KBase_ORT_Workflow_Community_Model.yaml", "Nitrospiraceae bacterium"): (
+        "NCBITaxon:1236 is class Gammaproteobacteria; Nitrospiraceae is Nitrospirota. "
+        "The record uses 1236 correctly for its two Steroidobacteraceae entries."
+    ),
+}
+
+
+def _taxon_term(record: str, preferred: str) -> dict | None:
+    doc = yaml.safe_load((COMMUNITIES / record).read_text())
+    for entry in doc.get("taxonomy") or []:
+        term = entry.get("taxon_term") or {}
+        if term.get("preferred_term") == preferred:
+            return term
+    return None
+
+
+@pytest.mark.parametrize(
+    ("record", "preferred"), list(WITHHELD), ids=[f"{r}::{p}" for r, p in WITHHELD]
+)
+def test_withheld_taxon_is_still_present(record: str, preferred: str):
+    """The entry must still exist, or the pin is silently protecting nothing."""
+    assert _taxon_term(record, preferred) is not None, (
+        f"'{preferred}' is no longer in {record}. If the record was restructured, "
+        f"update WITHHELD (see #292)."
+    )
+
+
+@pytest.mark.parametrize(
+    ("record", "preferred"), list(WITHHELD), ids=[f"{r}::{p}" for r, p in WITHHELD]
+)
+def test_withheld_taxon_stays_ungrounded(record: str, preferred: str):
+    """No GTDB block on a taxon whose NCBITaxon id names a different organism."""
+    term = _taxon_term(record, preferred)
+    assert term is not None
+    assert "gtdb_classification" not in term, (
+        f"'{preferred}' in {record} was grounded in GTDB, but its NCBITaxon id is "
+        f"wrong: {WITHHELD[(record, preferred)]} A GTDB block derived from that id "
+        f"describes the wrong organism. `gtdb_ground.py --apply` re-adds it on every "
+        f"run (#293), so this is most likely an unreviewed tool re-run — revert it. "
+        f"To ground it properly, fix the NCBITaxon id first (#292), then drop this "
+        f"entry from WITHHELD."
+    )

--- a/tests/test_no_duplicate_yaml_keys.py
+++ b/tests/test_no_duplicate_yaml_keys.py
@@ -1,0 +1,107 @@
+"""Reject duplicate mapping keys in community YAML.
+
+`linkml-validate` cannot catch this. It parses through PyYAML, which keeps the
+**last** of two duplicate keys and reports nothing — so a record that silently
+discards one of two curated values passes every other gate we have. Issue #289
+documents two records where that is happening, and in one of them the value that
+survives is a claim a previous PR deliberately retracted.
+
+The same defect was briefly introduced mechanically: `scripts/gtdb_ground.py`
+keyed its insertions by NCBITaxon id, and records that list one id many times
+(28 *Variovorax* isolates in `GLBRC_Populus_Variovorax_SynCom28`) got a second
+`gtdb_classification` written onto an already-grounded entry. Every affected file
+still passed `linkml-validate`, which is what makes this worth a gate rather than
+care.
+
+`KNOWN_DUPLICATES` is pinned rather than merely skipped: fixing one of the two
+records fails this test until it is removed from the list, so the waiver cannot
+outlive the bug. Same pattern as ``EXPECTED`` in tests/test_enum_groundings.py.
+"""
+
+from __future__ import annotations
+
+import collections
+from pathlib import Path
+
+import pytest
+import yaml
+
+COMMUNITIES = Path(__file__).parent.parent / "kb/communities"
+
+# Records with a known duplicate key, tracked in #289. Each needs a curator to
+# decide which of the two values survives, so they are recorded rather than
+# mechanically de-duplicated. Remove an entry when its record is fixed.
+KNOWN_DUPLICATES = {
+    "Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.yaml": ["explanation"],
+    "Trichodesmium_Alteromonas_Marine_Consortium.yaml": ["notes"],
+}
+
+
+class _DuplicateDetectingLoader(yaml.SafeLoader):
+    """A SafeLoader that records duplicate keys instead of silently dropping them."""
+
+
+def _find_duplicates(text: str) -> list[tuple[str, int]]:
+    """Return (key, 1-based line) for every duplicated mapping key in ``text``."""
+    found: list[tuple[str, int]] = []
+
+    def construct_mapping(loader, node, deep=False):
+        seen: collections.Counter = collections.Counter()
+        for key_node, _ in node.value:
+            key = loader.construct_object(key_node, deep=True)
+            seen[key] += 1
+            if seen[key] == 2:
+                found.append((str(key), key_node.start_mark.line + 1))
+        return yaml.SafeLoader.construct_mapping(loader, node, deep)
+
+    loader = type("_Loader", (_DuplicateDetectingLoader,), {})
+    loader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, construct_mapping)
+    yaml.load(text, loader)  # noqa: S506 — subclass of SafeLoader
+    return found
+
+
+def _community_files() -> list[Path]:
+    return sorted(COMMUNITIES.glob("*.yaml"))
+
+
+def test_there_are_community_files_to_check():
+    """Guard against the glob silently matching nothing and the suite passing."""
+    assert len(_community_files()) > 100
+
+
+@pytest.mark.parametrize("path", _community_files(), ids=lambda p: p.name)
+def test_no_unexpected_duplicate_keys(path: Path):
+    """No community record may carry an unrecorded duplicate mapping key."""
+    duplicates = _find_duplicates(path.read_text())
+    keys = sorted({key for key, _ in duplicates})
+    expected = sorted(KNOWN_DUPLICATES.get(path.name, []))
+
+    if not expected:
+        assert not duplicates, (
+            f"{path.name} has duplicate mapping key(s) "
+            f"{[f'{k} (line {ln})' for k, ln in duplicates]}. PyYAML keeps the last "
+            f"of each pair and reports nothing, so one curated value is being "
+            f"discarded at parse time while every other gate still passes. Fix the "
+            f"record, or record it in KNOWN_DUPLICATES with an issue reference."
+        )
+        return
+
+    assert keys == expected, (
+        f"{path.name} is in KNOWN_DUPLICATES for {expected} but now has {keys}. "
+        f"If the record was fixed, remove it from KNOWN_DUPLICATES (see #289); "
+        f"if a new duplicate appeared, fix that one."
+    )
+
+
+def test_known_duplicates_are_all_real():
+    """Every pinned record must still exist and still be duplicated.
+
+    Stops the waiver list outliving the bug — a stale entry here would silently
+    excuse a file that no longer needs excusing.
+    """
+    for name in KNOWN_DUPLICATES:
+        path = COMMUNITIES / name
+        assert path.exists(), f"{name} is in KNOWN_DUPLICATES but no longer exists"
+        assert _find_duplicates(
+            path.read_text()
+        ), f"{name} no longer has duplicate keys — remove it from KNOWN_DUPLICATES."


### PR DESCRIPTION
Addresses #276. GTDB coverage goes from **569/995 taxa (57.2%) to 631/995 (63.4%)** across 18 records.

## #276's premise needs correcting

The issue — which I wrote — framed 140 "partially grounded" records as unfinished work and ranked it the top backlog item on that basis. A free dry-run over all 212 records needing any work shows what the 426 ungrounded taxa actually are:

| | count | |
|---|---|---|
| **no GTDB mapping at all** | 268 | not backfillable |
| **AMBIGUOUS** (GTDB splits the NCBI taxon) | 84 | needs a curator to pick |
| groundable | the remainder | done here |

And the unmappable ones are unmappable for good reasons: viruses (GTDB is bacteria/archaea only), eukaryotes (*Fusarium*, *Brettanomyces*, *Coccomyxa*), environmental pseudo-taxa such as "Stordalen Mire thaw-gradient microbiome", and strain-level entries absent from the table. The AMBIGUOUS set is real biology too — *Rhodopseudomonas palustris*, three *Streptococcus* species, several cyanobacteria.

**So "partial" is mostly the correct final state for a record, not a to-do.** The achievable ceiling is nearer 63% than 100%, and the ranking in `NEXT_TASKS.md` rested on a coverage number that did not account for that. I will correct the issue and the backlog separately.

## A duplicate-key bug, found by the canary batch

`apply_to_community` keyed its blocks by bare NCBITaxon id and inserted at the **first** line bearing that id. Records may legitimately repeat an id — `GLBRC_Populus_Variovorax_SynCom28` lists 28 isolates all grounded to NCBITaxon:34072 (genus *Variovorax*) — so when the first occurrence was already grounded it received a **second `gtdb_classification` key**, while the 27 entries that actually needed one stayed empty. 11 duplicates across 10 files.

It surfaced only because the numbers disagreed: the script reported 28 blocks written, but grounded taxa rose by 17. Insertion is now **positional**, the file's term-id anchors are checked against taxonomy order, and the script **refuses to edit** if they disagree — guessing an offset is silent corruption.

The bad batch was reverted, the script fixed, re-canaried on the 28-isolate record (27 blocks, 28/28 grounded, no duplicates), then re-run.

## `linkml-validate` cannot see any of this

PyYAML keeps the last of two duplicate keys and reports nothing, so every corrupted file passed. Demonstrated by injecting a duplicate into a record:

```
linkml-validate  -> No issues found
new guard        -> FAILED tests/test_no_duplicate_yaml_keys.py[Lotus_LjSC3.yaml]
```

`tests/test_no_duplicate_yaml_keys.py` closes that gap across all 305 records. It also found **two pre-existing offenders** where curated content is being silently discarded — filed as **#289**, and pinned in `KNOWN_DUPLICATES` so the waiver cannot outlive the bug. One of them is serious: an evidence item has two contradictory `explanation` values and the one that survives is a claim PR #262 deliberately retracted.

## Verification

- **Canary discipline throughout**: free dry-run first, then one real record end to end (checked the file changed on disk, the block attached to the right taxon, and both validators passed) before any fan-out. The canary did *not* cover the repeated-id case, which is exactly where the bug was — so the batch was checked by comparing blocks-written against taxa-gained rather than trusting the exit code.
- Both new suites **mutation-checked**: restoring the id-keyed insertion fails 3 of 4 positioning tests; injecting a duplicate key fails the guard while `linkml-validate` stays green.
- 585 tests pass; `black`, `ruff`, `mypy` clean; all 18 changed records pass schema **and** id↔label validation.
- `tests/test_gtdb_ground_apply.py` patches `resolve_target`, so it needs no kg-microbe checkout (the mapping is a 2.9 MB gzip absent from CI).

## Filed along the way, not fixed here

- **#289** — two records silently discarding curated content via duplicate keys.
- **#290** — `just install` is broken (`uv sync --group dev` against `[project.optional-dependencies]`), which silently removed `black`/`ruff`/`mypy` from the venv mid-session and made `just lint` fail with a misleading pyenv error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round

Reviewing the applied blocks for *correctness*, not just well-formedness, found two grounded to an NCBITaxon id belonging to a **different organism** — and the backfill had faithfully derived a GTDB classification from each:

| taxon | grounded id | actually | GTDB block produced |
|---|---|---|---|
| *Bacteroides ovatus* | `NCBITaxon:821` | *Phocaeicola vulgatus* | `GTDB:s__Phocaeicola_vulgatus` |
| `Nitrospiraceae bacterium` | `NCBITaxon:1236` | class Gammaproteobacteria | `GTDB:c__Gammaproteobacteria` |

*B. ovatus* is `NCBITaxon:28116`; that record reuses `821`, which it *also* uses correctly for *B. vulgatus*. Nitrospiraceae is Nitrospirota, not Gammaproteobacteria; that record uses `1236` correctly for its two `Steroidobacteraceae` entries, so it reads as a copy-paste.

**No gate catches this.** The id↔label validators check `term.id` against `term.label`, and those *do* correspond — `821` really is labelled "Phocaeicola vulgatus". The disagreement is between `preferred_term` and the grounded term, which nothing compares, and for good reason: `preferred_term` legitimately differs from `term.label` across ~50 records where it preserves the source paper's name through an NCBI rename (*Eubacterium rectale* → *Agathobacter rectalis*, *Clostridium thermocellum* → *Acetivibrio thermocellus*). A naive check flags all of those. The sharper signal — one *specific* id reused for two different organisms in a single record — finds 14 records, of which 12 are legitimate broad-id groundings (`NCBITaxon:2`, `131567`) shared across functional guilds.

**Both blocks are withheld** rather than shipped. Restating a wrong grounding in a second, independently-derived-looking field makes it harder to spot, not easier; leaving the entries ungrounded is the honest state until the ids are corrected, after which re-running `--apply` produces the right blocks. Filed as **#292**.

Final coverage is therefore **629/995 (63.2%)**, not 631 — the two withheld blocks are the difference.

Also checked and found clean: rank distribution of the 60 new blocks (41 genus, 18 species, 3 class), the seven with `majority_fraction < 0.9` (all defensible — `Bacillus` at 0.51 is the documented shatter case), and the two `is_reclassified: true` flags (*Methylobacterium populi* → *M. thiocyanatum*, *Bacillus mucilaginosus* → *Paenibacillus_G mucilaginosus*), both genuine GTDB renames correctly flagged.


---

## Second review pass

Checked what the first pass had not: whether every block sits on the taxon it claims, and whether the tool is idempotent.

**All 629 blocks repo-wide have `ncbi_source_id` matching the `term.id` they are attached to** — zero mismatches. That is the invariant the duplicate-key bug violated, so it is worth asserting over the whole KB rather than the changed files alone.

**Idempotence exposed a hole in the withholding.** A second full `--apply` pass over all 305 records adds nothing — *except* the two blocks deliberately withheld for #292, which it re-adds every time, because the tool has no memory of that decision.

That made the withhold cosmetic. The reason for withholding was that restating a wrong grounding in a second, independently-derived-looking field makes the error harder to spot; a withhold any routine re-run silently undoes provides none of that protection. Filed as **#293** and fixed here: `tests/test_gtdb_withheld_groundings.py` pins both entries with the reason each id is wrong, so an unreviewed re-run fails CI and explains the two ways out — revert it, or fix the id (#292) and drop the pin, after which `--apply` produces the correct block by itself. Mutation-checked: re-running `--apply` on those two records fails exactly the two pin assertions.

Also confirmed clean: no `refusing to edit` bail-out on any real record, and no trailing whitespace introduced anywhere in the diff.

589 tests pass; `black`, `ruff`, `mypy` clean.
