### PR TITLE
Resolve both duplicate-key records; empty the waiver list (#289)

### DIFF
--- a/kb/communities/Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.yaml
+++ b/kb/communities/Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.yaml
@@ -210,7 +210,6 @@ ecological_interactions:
     explanation: PARTIAL - this is the paper's generic background about Geobacter species in
       prior literature, NOT a finding about this coculture. It was previously cited here as
       demonstrating contact-mediated transfer between these two organisms, which it does not.
-    explanation: Establishes the mechanism of electron transfer via physical contact
 - name: Glycerol Fermentation with Electron-Transfer-Induced Metabolic Shift
   description: 'Clostridium pasteurianum ferments glycerol, and upon receiving electrons
     from G. sulfurreducens, undergoes a dramatic metabolic shift that redirects

--- a/kb/communities/Trichodesmium_Alteromonas_Marine_Consortium.yaml
+++ b/kb/communities/Trichodesmium_Alteromonas_Marine_Consortium.yaml
@@ -131,6 +131,10 @@ ecological_interactions:
       label: iron(2+)
     notes: Iron acquisition was one inferred interaction axis; ferrous iron is used as a conservative
       CHEBI grounding for iron availability.
+  - preferred_term: reactive oxygen species
+    term:
+      id: CHEBI:26523
+      label: reactive oxygen species
     notes: Reactive oxygen species detoxification is an inferred interaction process.
   evidence:
   - reference: PMID:28440800

--- a/tests/test_no_duplicate_yaml_keys.py
+++ b/tests/test_no_duplicate_yaml_keys.py
@@ -28,13 +28,10 @@ import yaml
 
 COMMUNITIES = Path(__file__).parent.parent / "kb/communities"
 
-# Records with a known duplicate key, tracked in #289. Each needs a curator to
-# decide which of the two values survives, so they are recorded rather than
-# mechanically de-duplicated. Remove an entry when its record is fixed.
-KNOWN_DUPLICATES = {
-    "Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.yaml": ["explanation"],
-    "Trichodesmium_Alteromonas_Marine_Consortium.yaml": ["notes"],
-}
+# Empty since #289 was fixed: both records that needed a curator decision have
+# had one. Add an entry here only with an issue reference, and only when the
+# choice of which value survives genuinely cannot be made in the same change.
+KNOWN_DUPLICATES: dict[str, list[str]] = {}
 
 
 class _DuplicateDetectingLoader(yaml.SafeLoader):


### PR DESCRIPTION
Fixes #289.

Two records carried a duplicate mapping key. PyYAML keeps the **last** of a pair and reports nothing, so in each case one curated value was being discarded at parse time while every gate stayed green.

## Geobacter/Clostridium — a retracted claim was winning

The PMID:28287150 evidence item had two `explanation` values. Git shows how: PR **#262** ("Re-scope 000031 away from DIET: the contact/nanowire mechanism was never sourced") *inserted* its correction but left the old line in place as unchanged context —

```diff
     snippet: Direct interspecies electron transfer (DIET) mechanism has been recently
       characterised with Geobacter species which couple the electron balance with
       other species through physical contacts
+    explanation: PARTIAL - this is the paper's generic background about Geobacter species in
+      prior literature, NOT a finding about this coculture. It was previously cited here as
+      demonstrating contact-mediated transfer between these two organisms, which it does not.
     explanation: Establishes the mechanism of electron transfer via physical contact
```

— so the value that actually parsed was **the very claim #262 set out to retract**. Its re-scoping was inert in the data while looking applied in the file.

Which value survives is settled by the record, not by preference. The surviving text must be the one beginning `PARTIAL -`: the item's own `supports: PARTIAL` agrees with it, and that text explicitly describes the other as the wording it replaced ("It was previously cited here as demonstrating contact-mediated transfer … which it does not"). The stale line is deleted.

## Trichodesmium/Alteromonas — an orphaned note, not a redundant one

The `iron(2+)` metabolite had two `notes`, and the ROS one was winning, so the note explaining the iron CHEBI grounding was being lost.

The obvious fix — delete the loser — would have been wrong. The ROS note is not surplus: the same interaction cites *"detoxification of reactive oxygen species"* as evidence, and the record already curates reactive oxygen species as a compound (`CHEBI:26523`) with its own relevance statement. The interaction's metabolite list was simply **missing that third entry**, and the note had nowhere to live.

So the note is given its proper home — a `reactive oxygen species` metabolite grounded to the CHEBI term the record already uses — and the iron note is restored to `iron(2+)`. Both curated statements are preserved rather than one being dropped.

## Waiver list is now empty

`KNOWN_DUPLICATES` is `{}`: **zero duplicate keys repo-wide**. The comment above it states the bar for adding one back — an issue reference, and only when the choice genuinely cannot be made in the same change.

## Filed, not fixed here

**#295** — the same DIET-background snippet is still cited as `supports: SUPPORT` with **no explanation** in this record's *other* interaction, so #262's judgement was applied to one occurrence and not the other. The record now simultaneously holds that the snippet is generic background establishing nothing about this coculture, and that it fully supports a second interaction. That is a `supports`-level curation call rather than duplicate-key data loss, and it wants the curator who made #262's decision.

(Worth noting the missing `explanation` is not itself the defect — 84 of 1300 evidence items repo-wide have none.)

## Verification

- 589 tests pass; `black`, `ruff`, `mypy` clean.
- Both records pass schema **and** id↔label validation, which also confirms the new `CHEBI:26523` term/label pair.
- The duplicate-key guard from #291 now runs with an empty waiver and passes across all 305 records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review pass

**Checked the ROS placement rather than assuming it.** The schema defines the slot as "Metabolites **involved in** the interaction" — not *exchanged* — so ROS qualifies, and the entry reuses `CHEBI:26523`, a grounding the record had already committed to for this compound. But the note itself calls ROS detoxification a *process*, and `EcologicalInteraction` has a `biological_processes` slot for exactly that.

I checked whether that slot was the better home and deliberately did not use it: this interaction has **no** `biological_processes` at all, and the record grounds nothing to GO anywhere. Choosing a GO term would mean introducing a new grounded claim on a record whose sourcing is explicitly inferential (`evidence_source: COMPUTATIONAL`, "inferred interaction axis"), which is not what a duplicate-key repair should do. Recorded as **#297** so the choice is deliberate rather than inherited.

**Confirmed the deletion was safe.** The Geobacter line removed is the retracted claim itself, and git history preserves it; nothing else in the record cites it.

**Confirmed the guard is not merely passing vacuously.** `KNOWN_DUPLICATES` is empty *and* the parametrised test still runs across all 305 records, with `test_there_are_community_files_to_check` guarding against the glob silently matching nothing.
