### PR TITLE
Move ARC's counter-selection out of the interaction graph (#300)

### DIFF
--- a/kb/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.yaml
+++ b/kb/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.yaml
@@ -29,6 +29,15 @@ engineering_design:
   - Peanut aflatoxin level in multi-year field trials
   - Peanut nodule number, nitrogenase activity, and nodule retention at harvest
   - Yield, checked for a super-nodulation penalty
+  notes: >
+    Counter-selection is part of the design and is recorded here rather than as an ecological
+    interaction. Three candidate Bacillus isolates inhibited Bradyrhizobium in coculture and were
+    excluded on that basis; the source does not say which isolates they were, so they cannot be
+    distinguished from the retained Bacillus members, which are all grounded at the same genus-level
+    NCBITaxon:1386. Curating the exclusion as a typed Bacillus -> Bradyrhizobium COMPETITION edge
+    would therefore assert, to any consumer reading only the interaction graph, that an ARC member
+    antagonises the very mutualist ARC was assembled to spare — the opposite of the finding. The
+    fact is kept, the misleading edge is not.
   evidence:
   - reference: PMID:42099455
     supports: SUPPORT
@@ -36,6 +45,15 @@ engineering_design:
     snippet: Based on the antifungal activity and rhizobial compatibility, finally, 3 Bacillus
     explanation: States the two-part selection criterion — antifungal activity together with
       rhizobial compatibility — that defines this community's assembly strategy.
+  - reference: PMID:42099455
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: 3 Bacillus inhibited Bradyrhizobium
+    explanation: >-
+      The counter-selection itself: three candidate Bacillus isolates antagonised the rhizobium and
+      were excluded. Carried on the design rather than on an interaction because the excluded
+      isolates are indistinguishable from the retained ones at the taxonomic resolution the source
+      provides.
 environment_term:
   preferred_term: peanut rhizosphere
   term:
@@ -108,7 +126,9 @@ taxonomy:
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 8 GTDB taxa under the NCBI taxon]
     notes: The nitrogen-fixing symbiont whose compatibility constrained community assembly, and
       whose nodulation ARC is designed to induce. Not an inoculated ARC member; it is the mutualist
-      the community must not antagonise.
+      the community must not antagonise. The counter-selection that excluded Bradyrhizobium-
+      antagonising candidates is recorded under engineering_design, not as an interaction — see the
+      note there.
   evidence:
   - reference: PMID:42099455
     supports: SUPPORT
@@ -173,33 +193,6 @@ ecological_interactions:
       at harvest
     explanation: Supports facilitation of the rhizobia-legume symbiosis as a community-level effect
       distinct from the antifungal activity.
-- name: Candidate-Strain Antagonism of Bradyrhizobium (Excluded from ARC)
-  description: >
-    Three Bacillus isolates inhibited Bradyrhizobium growth in coculture and were screened out on
-    that basis. The interaction is recorded because it is the constraint that shaped the community:
-    ARC's membership is the subset of effective antifungal strains that does not antagonise the
-    nitrogen-fixing mutualist.
-  interaction_type: COMPETITION
-  scope: PAIRWISE
-  source_taxon:
-    preferred_term: Bacillus (ARC strains Bl13-2C11, Ba13-20E05, Bm14-5G09)
-    term:
-      id: NCBITaxon:1386
-      label: Bacillus <firmicutes>
-  target_taxon:
-    preferred_term: Bradyrhizobium PHNZY-24-6
-    term:
-      id: NCBITaxon:374
-      label: Bradyrhizobium
-  evidence:
-  - reference: PMID:42099455
-    supports: PARTIAL
-    evidence_source: IN_VITRO
-    snippet: 3 Bacillus inhibited Bradyrhizobium
-    explanation: PARTIAL - the antagonism is reported for three candidate Bacillus isolates that
-      were consequently excluded from ARC, so it characterises the screening step rather than the
-      shipped community. It is recorded at genus level because the source does not name which
-      isolates were excluded.
 environmental_factors:
 - name: Multi-year multi-site field trial
   value: 4 years; 325 sites across 19 provinces


### PR DESCRIPTION
Fixes #300.

## The problem was in the graph, not the prose

`CommunityMech:000314` carried a typed `Bacillus → Bradyrhizobium` COMPETITION edge recording that three candidate *Bacillus* isolates inhibited the rhizobium and were excluded from the community on that basis.

The source names the **retained** isolates but not the **excluded** ones, so both sets ground to the same genus-level `NCBITaxon:1386`. A consumer reading only the typed edges therefore saw a community whose own member antagonises the very mutualist it was assembled to spare — the exact opposite of the finding.

The record already carried `supports: PARTIAL` and explanatory notes. That did not help: the misleading claim lives in the graph, and prose beside it does not reach anyone consuming the edges.

## Where it went instead

`CommunityEngineeringDesign` already has `notes` and `evidence`, so the counter-selection moves there with its snippet intact and an explanation of why it is not an interaction. **No schema change was needed** — this is option 3 of the three in #300.

Nothing is lost. The exclusion is what explains the community's membership, and it is now recorded as a property of the *design* rather than as a relation between two taxa. The *Bradyrhizobium* taxon note points at it, so the connection is findable from either end.

## Measured trade-off, and what it exposed

Removing the pairwise edge leaves the record with only `COMMUNITY_LEVEL` interactions, which the auditor credits with **no connections at all**. Network findings go **34 → 36**; both new ones are `DISCONNECTED`, the soft category.

Chasing that down produced a sharper finding, filed as **#304**: the `DISCONNECTED` rule exempts any taxon carrying `abundance_level` or `functional_role` (`auditor.py:258`). So removing this record's *fabricated* abundance values — correctly, during #298's review — is itself what exposed its taxa. **The audit currently scores a record better for carrying invented abundances than for honestly omitting them.**

That also explains why 107 of 302 all-`COMMUNITY_LEVEL` records do not already flood the audit: the exemption is doing the work, not the connectivity check. It is concrete evidence for the policy question #273 has to settle before that gate can be restored.

## Verification

- Record passes schema and id↔label; all 10 snippets remain verbatim.
- The interaction graph now contains only the two genuine community-level effects (pathogen suppression, nodulation facilitation).
- 591 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round

Rebased onto main so this runs against the snippet-truncation gate from #303; the record passes it.

Three things checked rather than assumed, none of which turned into a change:

**Is the counter-selection snippet now duplicated?** It appears twice — on `engineering_design.evidence` and on the *Bradyrhizobium* taxon entry. That is not a defect: **269 of 307 records (88%) reuse a snippet across assertions**, because one sentence legitimately supports several claims. Here the two uses are genuinely different — one records the design constraint, the other records why *Bradyrhizobium* is in the record at all.

**Does removing the edge create an inconsistency with other records?** Searching for interactions describing exclusion found six candidates, and all six are false positives on inspection — `Paraburkholderia Competitive Exclusion` is genuine *ecological* competitive exclusion, "excludes non-acidophilic contaminants" is an environmental effect, "excludes direct cell contact" describes an experimental control. **No other record models a screening result as an interaction**, so ARC was unique and this fix does not leave the KB inconsistent.

**Is `supports: SUPPORT` right on the moved evidence?** The original edge carried `PARTIAL`, correctly, because the snippet did not fully support the *interaction* claim it was attached to. Moved onto the design, the snippet directly states the fact it now supports — three isolates antagonised the rhizobium — so `SUPPORT` is the accurate level. The change in level is principled, not a relaxation.

## One consequence worth recording

The fact is now accurate but **no longer machine-queryable**. A consumer asking "which communities involve *Bradyrhizobium* antagonism" will not find ARC through the graph, because the only faithful place to put the constraint was prose.

That is the right trade for this record and the wrong situation in general: the schema can express what a community *is* but not what it was deliberately *not* — no home for screened-out candidates, compatibility constraints, or load-bearing negative results, which is how most SynComs are actually built. Filed as **#307** with a `counter_selection` sketch. Combined with #304, the honest modelling choice is currently penalised twice: it loses queryability *and* gains `DISCONNECTED` findings.

899 tests pass; lint clean; record passes schema and id↔label.
