### PR TITLE
Make DISCONNECTED mean what its name says (#304)

### DIFF
--- a/src/communitymech/network/auditor.py
+++ b/src/communitymech/network/auditor.py
@@ -149,12 +149,20 @@ class NetworkIntegrityAuditor:
         # Check each interaction
         interactions = data.get("ecological_interactions", [])
 
-        # Track which taxa are connected
-        connected_taxa = set()
+        # Track which taxa are connected, keyed by preferred_term like taxonomy_by_term
+        connected_taxa: set[str] = set()
 
         for idx, interaction in enumerate(interactions):
             int_name = interaction.get("name", f"Interaction {idx+1}")
             scope = interaction.get("scope", "PAIRWISE")
+
+            # A COMMUNITY_LEVEL interaction asserts a relationship holding across
+            # the community rather than between a named pair, so every member
+            # participates in it. Without this, such interactions contributed no
+            # connections at all and every taxon in the 107 records that use them
+            # exclusively counted as disconnected by construction (#304).
+            if scope == "COMMUNITY_LEVEL":
+                connected_taxa.update(taxonomy_by_term)
 
             # Check source_taxon (only required for PAIRWISE interactions)
             source = interaction.get("source_taxon")
@@ -246,17 +254,22 @@ class NetworkIntegrityAuditor:
                             }
                         )
 
-        # Check for disconnected taxa. Skip taxa that carry standalone
-        # abundance_level or functional_role metadata — they describe community
-        # membership without requiring a pairwise interaction edge.
+        # Check for disconnected taxa: members that take part in no interaction
+        # of any scope.
+        #
+        # There used to be an exemption here for taxa carrying abundance_level or
+        # functional_role, standing in for "described as a member even without an
+        # edge". With COMMUNITY_LEVEL interactions now crediting their members,
+        # that proxy is unnecessary — and it was harmful. It exempted 931 of 1007
+        # taxa, so the rule effectively reported "lacks metadata" rather than
+        # "lacks interactions", and it rewarded filling those slots: removing a
+        # fabricated abundance_level created findings (#304).
         all_taxa = set(taxonomy_by_term.keys())
         disconnected = all_taxa - connected_taxa
 
         if disconnected and interactions:  # Only flag if there ARE interactions
             for taxon in sorted(disconnected):
                 taxon_data = taxonomy_by_term[taxon]["taxon_data"]
-                if taxon_data.get("abundance_level") or taxon_data.get("functional_role"):
-                    continue
                 issues.append(
                     {
                         "type": IssueType.DISCONNECTED,

--- a/tests/test_network_auditor.py
+++ b/tests/test_network_auditor.py
@@ -223,37 +223,75 @@ def test_no_disconnected_if_no_interactions(temp_communities_dir, valid_communit
     assert len(disconnected_issues) == 0, "Should not flag disconnected if no interactions"
 
 
-def test_disconnected_skipped_when_abundance_or_role_present(temp_communities_dir, valid_community):
-    """Taxa carrying abundance_level or functional_role describe community
-    membership and should not be flagged as DISCONNECTED."""
-    valid_community["taxonomy"].append(
-        {
-            "taxon_term": {
-                "preferred_term": "Membership-only taxon",
-                "term": {"id": "NCBITaxon:99999", "label": "Membership-only taxon"},
-            },
-            "abundance_level": "ABUNDANT",
-        }
-    )
-    valid_community["taxonomy"].append(
-        {
-            "taxon_term": {
-                "preferred_term": "Role-only taxon",
-                "term": {"id": "NCBITaxon:88888", "label": "Role-only taxon"},
-            },
-            "functional_role": ["PRIMARY_DEGRADER"],
-        }
-    )
+def test_membership_metadata_no_longer_exempts_from_disconnected(
+    temp_communities_dir, valid_community
+):
+    """abundance_level / functional_role do not exempt a taxon (#304).
+
+    They used to. That proxy stood in for "described as a member even without an
+    edge", but it exempted 931 of 1007 taxa, so DISCONNECTED effectively reported
+    "lacks metadata" rather than "lacks interactions" — and it rewarded filling
+    those slots, since removing a fabricated abundance_level created findings.
+    Membership without an edge is now expressed by a COMMUNITY_LEVEL interaction,
+    which credits its members (see the test below).
+    """
+    for pref, tid, extra in [
+        ("Membership-only taxon", "NCBITaxon:99999", {"abundance_level": "ABUNDANT"}),
+        ("Role-only taxon", "NCBITaxon:88888", {"functional_role": ["PRIMARY_DEGRADER"]}),
+    ]:
+        valid_community["taxonomy"].append(
+            {"taxon_term": {"preferred_term": pref, "term": {"id": tid, "label": pref}}, **extra}
+        )
 
     test_file = temp_communities_dir / "test_membership.yaml"
-    with open(test_file, "w") as f:
-        yaml.dump(valid_community, f)
+    test_file.write_text(yaml.dump(valid_community))
 
-    auditor = NetworkIntegrityAuditor(communities_dir=temp_communities_dir)
-    issues = auditor.audit_community(test_file)
+    issues = NetworkIntegrityAuditor(communities_dir=temp_communities_dir).audit_community(
+        test_file
+    )
+    flagged = {i["taxon"] for i in issues if i["type"] == IssueType.DISCONNECTED}
 
-    disconnected_issues = [i for i in issues if i["type"] == IssueType.DISCONNECTED]
-    assert disconnected_issues == []
+    assert flagged == {"Membership-only taxon", "Role-only taxon"}, (
+        "carrying abundance_level or functional_role must no longer suppress a "
+        "DISCONNECTED finding; the rule reports connectivity, not slot completeness"
+    )
+
+
+def test_community_level_interaction_connects_every_member(temp_communities_dir, valid_community):
+    """A COMMUNITY_LEVEL interaction credits all members (#304).
+
+    Such an interaction has no source_taxon or target_taxon by design, so it
+    previously contributed no connections and every taxon in a record using them
+    exclusively was disconnected by construction — 107 of 302 records with
+    interactions.
+    """
+    valid_community["taxonomy"].append(
+        {
+            "taxon_term": {
+                "preferred_term": "Edgeless member",
+                "term": {"id": "NCBITaxon:77777", "label": "Edgeless member"},
+            }
+        }
+    )
+    valid_community["ecological_interactions"] = [
+        {
+            "name": "Community-wide effect",
+            "interaction_type": "NICHE_PARTITIONING",
+            "scope": "COMMUNITY_LEVEL",
+        }
+    ]
+
+    test_file = temp_communities_dir / "test_community_level.yaml"
+    test_file.write_text(yaml.dump(valid_community))
+
+    issues = NetworkIntegrityAuditor(communities_dir=temp_communities_dir).audit_community(
+        test_file
+    )
+
+    assert [i for i in issues if i["type"] == IssueType.DISCONNECTED] == [], (
+        "a COMMUNITY_LEVEL interaction asserts a relationship across the whole "
+        "community, so no member should count as disconnected"
+    )
 
 
 def test_audit_all_communities(temp_communities_dir, valid_community):


### PR DESCRIPTION
Fixes #304. Implements the first remedy from `proposals/absence_semantics.md` (PR #309) — both halves, which must ship together.

## What was wrong

Two rules interacted to make `DISCONNECTED` report something other than disconnection:

1. **`COMMUNITY_LEVEL` interactions credited nothing.** They have no `source_taxon`/`target_taxon` by design, so they contributed no connections — and every taxon in the **107 of 302** records using them exclusively counted as disconnected by construction.
2. **An exemption for `abundance_level`/`functional_role`** hid that, by excusing **931 of 1007 taxa**. So the rule effectively reported *"lacks metadata"*, not *"lacks interactions"*.

The second was actively harmful: removing a **fabricated** `abundance_level` from a record *created* findings, so a curator optimising against the audit would put the guesses back.

## Result matches the prediction exactly

| configuration | DISCONNECTED |
|---|---:|
| before | 32 |
| credit `COMMUNITY_LEVEL` only | 1 — vacuous |
| drop the exemption only | 390 — noise |
| **both, as shipped** | **19** |

Network issues overall go **49 → 23** (the 4 dangling references in the ANME/SRB record are untouched, as they should be).

## The 19 that remain are real

Spot-checked two: a *"Desulfovibrio piger comparator"* and *"Sporomusa spp. in KB-1"* — both listed in `taxonomy` while taking part in no interaction of any scope. That is exactly the curation gap the rule should surface. Meanwhile records like `Bay_Area_Sewage` and `Crucian_Carp`, previously flagged **only** because their interactions are `COMMUNITY_LEVEL`, correctly drop off.

## Tests

The obsolete `test_disconnected_skipped_when_abundance_or_role_present` — which pinned the behaviour being removed — is replaced by two tests fixing the new semantics, each mutation-checked.

Worth noting: reverting the `COMMUNITY_LEVEL` credit also breaks two **pre-existing** tests (`test_unknown_source_skipped_for_community_level_scope` and its target counterpart). That is direct evidence the halves are coupled rather than independent increments — the proposal argued this from simulation, and the test suite demonstrates it.

## Downstream

**This unblocks #273**, which could not sensibly decide whether to restore the network gate while `DISCONNECTED` measured something other than its name. With 19 genuine findings across 9 records, that decision is now tractable.

908 tests pass; `black`, `ruff`, `mypy` clean. No data changed — this is auditor logic only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round

The change is deliberately coarse in one respect, and it is better to state the size of that than to leave it to be discovered from a surprising audit result later.

**The credit is all-or-nothing.** A `COMMUNITY_LEVEL` interaction now connects *every* member of the record, because the schema gives `EcologicalInteraction` no way to say which members participate — it has `source_taxon` and `target_taxon` and nothing else.

| | count |
|---|---:|
| records with ≥1 `COMMUNITY_LEVEL` interaction | 156 |
| …which **also** carry pairwise edges | 46 |
| **taxa credited *solely* by the new rule** | **412** of 518 in those records |

The 46 mixed records are where it bites: a taxon with no pairwise edge is credited by an unrelated community-level interaction elsewhere in the same record. In `GLBRC_Populus_Variovorax_SynCom28` (28 taxa), one community-level interaction makes `DISCONNECTED` unreachable for all of them.

**It is still the right call**, because both alternatives were measured and are worse — 1 finding (vacuous) or 390 (noise) versus 19 genuine ones. The coarseness buys a rule that means what its name says. Filed as **#312** with a possible refinement (an optional `participating_taxa` list), which overlaps #307's question of how to express what a community-level statement is *about* and should be designed with it rather than separately.

**Also verified rather than assumed:** the 19 remaining findings are genuine — spot-checked a *"Desulfovibrio piger comparator"* and *"Sporomusa spp. in KB-1"*, both in `taxonomy` while participating in no interaction of any scope.

908 tests pass; `black`, `ruff`, `mypy` clean.


## Second review round: what else consumes DISCONNECTED

Checking downstream consumers surfaced something bigger than this PR, filed as **#313**.

There are **two** `NetworkIntegrityAuditor` implementations. `src/communitymech/network/auditor.py` is the live one; `scripts/audit_network_integrity.py` is a standalone copy that `notes/PHASE_1_COMPLETION.md` explicitly says *"can be removed (functionality migrated to module)"*. It was not removed, and the two have since drifted **in opposite directions**:

| check | module (live) | script (orphaned) |
|---|---|---|
| `UNREADABLE` (added #281) | **yes** | no |
| `DANGLING_EDGE` / `DANGLING_ANCHOR` (added #260) | **no** | yes |
| `DISCONNECTED` semantics | fixed here | still the old rule |

**The consequence: dangling-edge detection is not running anywhere.** #260 added it to close #258 — to the script, which nothing invokes. It appears in no justfile recipe and no workflow. The module never inspects `downstream` edges at all.

Running the orphaned script today finds no dangling edges, so nothing has regressed yet. But the guard built to keep it that way is unconnected, and causal-edge curation is active (248 records still lack `downstream` edges). #313 proposes porting the two detectors into the module and then deleting the script as originally intended — deleting first would silently discard the #260 work.

Not fixed here: this PR is scoped to `DISCONNECTED` semantics, and porting a detector needs its own tests. It is worth doing alongside #273, since restoring a hard gate over a checker that cannot see dangling edges would bake the gap in.

Also confirmed clean: `repair_strategies.py` and `generate_validation_report.py` consume `DISCONNECTED` only by type and count, so neither depended on the removed exemption; the report file the orphaned script writes is already gitignored.
