### PR TITLE
Guard duplicate preferred_term, and stop it manufacturing a spurious ID_MISMATCH (#328)

### DIFF
--- a/.github/workflows/network-quality.yml
+++ b/.github/workflows/network-quality.yml
@@ -132,7 +132,7 @@ jobs:
             errors|warnings)
               if [ "${{ steps.audit.outputs.result }}" = "errors" ]; then
                 heading="## Network integrity: broken references"
-                note="These fail the build: something the record names does not exist (a taxon, causal-edge target or discussion anchor), an id disagrees with its taxonomy entry, or a record could not be parsed. Only [error] lines gate."
+                note="These fail the build: something the record names does not exist (a taxon, causal-edge target or discussion anchor), an id disagrees with its taxonomy entry, two taxonomy entries share one name, or a record could not be parsed. Only [error] lines gate."
               else
                 heading="## Network integrity findings"
                 note="Warnings only — a member with no interaction yet, or a participant matched by ontology id rather than by name, or one on a community-level interaction that resolves to no member. Reported, but does not fail the build."
@@ -217,7 +217,7 @@ jobs:
                   : '## Network integrity findings',
                 '',
                 isError
-                  ? 'These fail the build: something the record names does not exist (a taxon, causal-edge target or discussion anchor), an id disagrees with its taxonomy entry, or a record could not be parsed. Only [error] lines gate.'
+                  ? 'These fail the build: something the record names does not exist (a taxon, causal-edge target or discussion anchor), an id disagrees with its taxonomy entry, two taxonomy entries share one name, or a record could not be parsed. Only [error] lines gate.'
                   : 'Warnings only — a member with no interaction yet, or a participant matched by ontology id rather than by name, or one on a community-level interaction that resolves to no member. Reported, but does not fail the build.',
                 '',
                 '```',

--- a/src/communitymech/network/auditor.py
+++ b/src/communitymech/network/auditor.py
@@ -36,11 +36,13 @@ class IssueType(str, Enum):
 # `network/validators.py`.
 #
 # The split is between *the record contradicting itself* and *the record being
-# incomplete*. Everything at error level names something that is not there: an
-# interaction citing a taxon the record does not list, a causal edge or
-# discussion anchor pointing at an interaction that does not exist, an id that
-# disagrees with the taxonomy entry it refers to. Those are objectively broken
-# and no amount of further curation makes them correct.
+# incomplete*. Error level covers two ways of contradicting itself: naming
+# something that is not there — an interaction citing a taxon the record does
+# not list, a causal edge or discussion anchor pointing at an interaction that
+# does not exist, an id that disagrees with the taxonomy entry it refers to —
+# and naming one thing twice, where two taxonomy entries share a display name so
+# only one of them is reachable. Both are objectively broken, and no amount of
+# further curation makes them correct.
 #
 # `NAME_MISMATCH` and `DISCONNECTED` are different in kind. The first says the
 # participant was matched by its ontology id because its name matched no entry:
@@ -236,7 +238,13 @@ class NetworkIntegrityAuditor:
         taxonomy_by_term: dict[str, dict] = {}
         taxonomy_keys_by_id: dict[str, list[str]] = defaultdict(list)
         for taxon in data.get("taxonomy") or []:
-            term = taxon.get("taxon_term", {})
+            # A null entry, or one that is not a mapping, used to raise
+            # AttributeError here and surface as an error-severity UNREADABLE
+            # naming a Python type — the per-entry twin of the whole-file case
+            # fixed in #329 (#338).
+            if not isinstance(taxon, dict):
+                continue
+            term = taxon.get("taxon_term") or {}
             preferred = term.get("preferred_term") or term.get("term", {}).get("label")
             taxon_id = term.get("term", {}).get("id")
 
@@ -256,9 +264,9 @@ class NetworkIntegrityAuditor:
                             "taxon_id": taxon_id,
                             "first_id": taxonomy_by_term[preferred]["id"],
                             "message": (
-                                f"Two taxonomy entries share the name '{preferred}' "
+                                f"Taxonomy name '{preferred}' is used more than once "
                                 f"({taxonomy_by_term[preferred]['id']} and {taxon_id}); "
-                                f"only the last is reachable by name"
+                                f"only the last entry is reachable by name"
                             ),
                         }
                     )
@@ -598,6 +606,11 @@ class NetworkIntegrityAuditor:
                         )
                     elif issue_type == IssueType.DISCONNECTED:
                         print(f"    • {issue['taxon']} ({issue['taxon_id']})")
+                    elif issue_type == IssueType.DUPLICATE_TAXON_NAME:
+                        # Record-scoped, like DISCONNECTED: it belongs to no
+                        # interaction, so the generic branch rendered it with a
+                        # literal "[N/A]" prefix (#335).
+                        print(f"    • {issue['message']}")
                     elif issue_type == IssueType.UNREADABLE:
                         print(f"    • {issue['message']}")
                     else:

--- a/src/communitymech/network/auditor.py
+++ b/src/communitymech/network/auditor.py
@@ -25,6 +25,7 @@ class IssueType(str, Enum):
     UNKNOWN_SOURCE = "UNKNOWN_SOURCE"
     UNKNOWN_TARGET = "UNKNOWN_TARGET"
     NAME_MISMATCH = "NAME_MISMATCH"
+    DUPLICATE_TAXON_NAME = "DUPLICATE_TAXON_NAME"
     DANGLING_EDGE = "DANGLING_EDGE"
     DANGLING_ANCHOR = "DANGLING_ANCHOR"
     DISCONNECTED = "DISCONNECTED"
@@ -58,6 +59,7 @@ SEVERITY: dict[str, str] = {
     "UNKNOWN_SOURCE": "error",
     "UNKNOWN_TARGET": "error",
     "NAME_MISMATCH": "warning",
+    "DUPLICATE_TAXON_NAME": "error",
     "DANGLING_EDGE": "error",
     "DANGLING_ANCHOR": "error",
     "DISCONNECTED": "warning",
@@ -231,7 +233,7 @@ class NetworkIntegrityAuditor:
 
         # Build taxonomy lookup by preferred_term, plus a secondary index by
         # ontology id.
-        taxonomy_by_term = {}
+        taxonomy_by_term: dict[str, dict] = {}
         taxonomy_keys_by_id: dict[str, list[str]] = defaultdict(list)
         for taxon in data.get("taxonomy") or []:
             term = taxon.get("taxon_term", {})
@@ -239,6 +241,27 @@ class NetworkIntegrityAuditor:
             taxon_id = term.get("term", {}).get("id")
 
             if preferred:
+                # Two entries under one display name make the record ambiguous
+                # and silently cost it a member: this dict is last-write-wins,
+                # so the earlier entry vanishes from every name lookup and can
+                # never be connected by an interaction. It also made the
+                # ID_MISMATCH check compare against whichever entry happened to
+                # win, manufacturing an error-severity finding out of a valid id
+                # (#328).
+                if preferred in taxonomy_by_term:
+                    issues.append(
+                        {
+                            "type": IssueType.DUPLICATE_TAXON_NAME,
+                            "taxon": preferred,
+                            "taxon_id": taxon_id,
+                            "first_id": taxonomy_by_term[preferred]["id"],
+                            "message": (
+                                f"Two taxonomy entries share the name '{preferred}' "
+                                f"({taxonomy_by_term[preferred]['id']} and {taxon_id}); "
+                                f"only the last is reachable by name"
+                            ),
+                        }
+                    )
                 taxonomy_by_term[preferred] = {
                     "id": taxon_id,
                     "label": term.get("term", {}).get("label"),
@@ -358,9 +381,14 @@ class NetworkIntegrityAuditor:
                                 ),
                             }
                         )
-                    # Check ID mismatch
+                    # Only meaningful for a *name* match: it asks whether
+                    # the id agrees with the entry the name picked out. When the
+                    # id is what resolved the participant, it agrees by
+                    # construction — and comparing anyway read the id off a
+                    # last-write-wins entry, so a duplicate name produced a
+                    # spurious error-severity finding (#328).
                     expected_id = taxonomy_by_term[source_key]["id"]
-                    if source_id != expected_id:
+                    if not source_by_id and source_id != expected_id:
                         issues.append(
                             {
                                 "type": IssueType.ID_MISMATCH,
@@ -428,9 +456,14 @@ class NetworkIntegrityAuditor:
                                 ),
                             }
                         )
-                    # Check ID mismatch
+                    # Only meaningful for a *name* match: it asks whether
+                    # the id agrees with the entry the name picked out. When the
+                    # id is what resolved the participant, it agrees by
+                    # construction — and comparing anyway read the id off a
+                    # last-write-wins entry, so a duplicate name produced a
+                    # spurious error-severity finding (#328).
                     expected_id = taxonomy_by_term[target_key]["id"]
-                    if target_id != expected_id:
+                    if not target_by_id and target_id != expected_id:
                         issues.append(
                             {
                                 "type": IssueType.ID_MISMATCH,
@@ -545,6 +578,7 @@ class NetworkIntegrityAuditor:
         # Report each type
         for issue_type in [
             IssueType.UNREADABLE,
+            IssueType.DUPLICATE_TAXON_NAME,
             IssueType.ID_MISMATCH,
             IssueType.MISSING_SOURCE,
             IssueType.UNKNOWN_SOURCE,

--- a/tests/test_network_auditor.py
+++ b/tests/test_network_auditor.py
@@ -1167,7 +1167,15 @@ def test_report_is_written_before_the_process_exits(
 # ---------------------------------------------------------------------------
 
 
-def _duplicate_name_community(source_id):
+def _duplicate_name_community(participant_id, role="source_taxon"):
+    """Two taxonomy entries named X; one interaction participant resolved by id.
+
+    `role` is a parameter because the source and target branches are separate
+    code paths: the first version of this fixture only ever built a
+    `source_taxon`, so reverting the target-side guard passed the whole suite
+    (#333) — the same one-sided-coverage defect this module found in the
+    ID_MISMATCH detector itself.
+    """
     return {
         "name": "Duplicate name",
         "taxonomy": [
@@ -1178,9 +1186,9 @@ def _duplicate_name_community(source_id):
             {
                 "name": "An interaction",
                 "interaction_type": "COMPETITION",
-                "source_taxon": {
+                role: {
                     "preferred_term": "Y",
-                    "term": {"id": source_id, "label": "X"},
+                    "term": {"id": participant_id, "label": "X"},
                 },
             }
         ],
@@ -1253,8 +1261,17 @@ def test_id_mismatch_still_fires_for_a_name_matched_participant(
 
 
 def test_the_kb_has_no_duplicate_taxon_names():
-    """Guards the assumption that made DUPLICATE_TAXON_NAME safe at error severity."""
-    auditor = NetworkIntegrityAuditor(communities_dir=Path("kb/communities"))
+    """Guards the assumption that made DUPLICATE_TAXON_NAME safe at error severity.
+
+    Resolved against this file, not the working directory. With a relative path
+    `Path.glob` yields nothing from anywhere but the repo root — raising no
+    error — so the test audited zero records and passed vacuously (#334). It is
+    the sole support for gating on this finding, so an empty sweep must fail.
+    """
+    communities = Path(__file__).parent.parent / "kb/communities"
+    assert len(list(communities.glob("*.yaml"))) > 100, "audited an empty or wrong directory"
+
+    auditor = NetworkIntegrityAuditor(communities_dir=communities)
     auditor.audit_all(quiet=True)
 
     offenders = sorted(
@@ -1286,3 +1303,114 @@ def test_id_mismatch_fires_on_the_target_side_too(temp_communities_dir, valid_co
     assert len(mismatches) == 1
     assert mismatches[0]["role"] == "target"
     assert issue_severity(mismatches[0]) == "error"
+
+
+def test_duplicate_name_does_not_manufacture_a_target_id_mismatch(temp_communities_dir):
+    """The target side of the guard, which the source-only fixture never reached.
+
+    Reverting `not target_by_id` passed all 939 tests before this existed.
+    """
+    test_file = temp_communities_dir / "test_dupe_target.yaml"
+    with open(test_file, "w") as f:
+        yaml.dump(_duplicate_name_community("NCBITaxon:100", role="target_taxon"), f)
+
+    issues = NetworkIntegrityAuditor(communities_dir=temp_communities_dir).audit_community(
+        test_file
+    )
+
+    assert not [
+        issue for issue in issues if issue["type"] == IssueType.ID_MISMATCH
+    ], f"a valid id must not be reported as a mismatch, got {issues}"
+    assert [issue["type"] for issue in issues].count(IssueType.DUPLICATE_TAXON_NAME) == 1
+
+
+def test_duplicate_detection_uses_the_label_when_preferred_term_is_absent(temp_communities_dir):
+    """The key falls back to `term.label`, and that branch was unpinned (#337).
+
+    Unreachable for schema-valid records — `preferred_term` is required on
+    TaxonTerm — but the fallback exists in the code, so it is exercised here.
+    """
+    community = {
+        "name": "Label fallback",
+        "taxonomy": [
+            {"taxon_term": {"preferred_term": "X", "term": {"id": "NCBITaxon:100", "label": "X"}}},
+            {"taxon_term": {"term": {"id": "NCBITaxon:200", "label": "X"}}},
+        ],
+    }
+
+    test_file = temp_communities_dir / "test_label_fallback.yaml"
+    with open(test_file, "w") as f:
+        yaml.dump(community, f)
+
+    issues = NetworkIntegrityAuditor(communities_dir=temp_communities_dir).audit_community(
+        test_file
+    )
+
+    assert [issue["type"] for issue in issues] == [IssueType.DUPLICATE_TAXON_NAME]
+
+
+def test_three_entries_sharing_a_name_are_all_reported(temp_communities_dir):
+    """Chained pairwise, so every collision stays detectable as each is fixed."""
+    community = {
+        "name": "Triple",
+        "taxonomy": [
+            {"taxon_term": {"preferred_term": "X", "term": {"id": taxon_id, "label": "X"}}}
+            for taxon_id in ("NCBITaxon:100", "NCBITaxon:200", "NCBITaxon:300")
+        ],
+    }
+
+    test_file = temp_communities_dir / "test_triple.yaml"
+    with open(test_file, "w") as f:
+        yaml.dump(community, f)
+
+    issues = NetworkIntegrityAuditor(communities_dir=temp_communities_dir).audit_community(
+        test_file
+    )
+
+    assert len(issues) == 2
+    assert all(issue["type"] == IssueType.DUPLICATE_TAXON_NAME for issue in issues)
+    assert "used more than once" in issues[0]["message"]
+
+
+def test_a_null_taxon_term_is_not_a_parse_failure(temp_communities_dir):
+    """`taxon_term:` with no value is valid YAML and must not gate as UNREADABLE (#338)."""
+    community = {
+        "name": "Null taxon_term",
+        "taxonomy": [
+            {"taxon_term": None},
+            {"taxon_term": {"preferred_term": "X", "term": {"id": "NCBITaxon:100", "label": "X"}}},
+        ],
+    }
+
+    test_file = temp_communities_dir / "test_null_taxon_term.yaml"
+    with open(test_file, "w") as f:
+        yaml.dump(community, f)
+
+    issues = NetworkIntegrityAuditor(communities_dir=temp_communities_dir).audit_community(
+        test_file
+    )
+
+    assert issues == []
+
+
+def test_duplicate_taxon_name_is_not_rendered_as_an_interaction(
+    temp_communities_dir, valid_community, capsys
+):
+    """It is record-scoped, so the console must not prefix it with '[N/A]' (#335)."""
+    community = dict(valid_community)
+    community["taxonomy"].append(
+        {
+            "taxon_term": {
+                "preferred_term": "Escherichia coli",
+                "term": {"id": "NCBITaxon:562", "label": "Escherichia coli"},
+            }
+        }
+    )
+    with open(temp_communities_dir / "dupe.yaml", "w") as f:
+        yaml.dump(community, f)
+
+    NetworkIntegrityAuditor(communities_dir=temp_communities_dir).audit_all()
+    out = capsys.readouterr().out
+
+    assert "DUPLICATE_TAXON_NAME" in out
+    assert "[N/A]" not in out

--- a/tests/test_network_auditor.py
+++ b/tests/test_network_auditor.py
@@ -1160,3 +1160,129 @@ def test_report_is_written_before_the_process_exits(
 
     assert result.exit_code == EXIT_ERRORS
     assert report.exists() and report.stat().st_size > 0
+
+
+# ---------------------------------------------------------------------------
+# Duplicate preferred_term within one record (#328)
+# ---------------------------------------------------------------------------
+
+
+def _duplicate_name_community(source_id):
+    return {
+        "name": "Duplicate name",
+        "taxonomy": [
+            {"taxon_term": {"preferred_term": "X", "term": {"id": taxon_id, "label": "X"}}}
+            for taxon_id in ("NCBITaxon:100", "NCBITaxon:200")
+        ],
+        "ecological_interactions": [
+            {
+                "name": "An interaction",
+                "interaction_type": "COMPETITION",
+                "source_taxon": {
+                    "preferred_term": "Y",
+                    "term": {"id": source_id, "label": "X"},
+                },
+            }
+        ],
+    }
+
+
+def test_duplicate_preferred_term_is_reported(temp_communities_dir):
+    """Two entries under one name cost the record a member, silently.
+
+    `taxonomy_by_term` is last-write-wins, so the earlier entry vanishes from
+    every name lookup and no interaction can ever connect it.
+    """
+    test_file = temp_communities_dir / "test_dupe.yaml"
+    with open(test_file, "w") as f:
+        yaml.dump(_duplicate_name_community("NCBITaxon:100"), f)
+
+    issues = NetworkIntegrityAuditor(communities_dir=temp_communities_dir).audit_community(
+        test_file
+    )
+
+    dupes = [issue for issue in issues if issue["type"] == IssueType.DUPLICATE_TAXON_NAME]
+    assert len(dupes) == 1
+    assert dupes[0]["taxon"] == "X"
+    assert {dupes[0]["first_id"], dupes[0]["taxon_id"]} == {"NCBITaxon:100", "NCBITaxon:200"}
+    assert issue_severity(dupes[0]) == "error"
+
+
+def test_duplicate_name_does_not_manufacture_an_id_mismatch(temp_communities_dir):
+    """The id fallback resolved this participant, so its id agrees by construction.
+
+    Comparing anyway read the id off whichever duplicate entry won, turning a
+    perfectly valid `NCBITaxon:100` into an error-severity ID_MISMATCH against
+    the *other* entry's id (#328).
+    """
+    test_file = temp_communities_dir / "test_dupe_idmismatch.yaml"
+    with open(test_file, "w") as f:
+        yaml.dump(_duplicate_name_community("NCBITaxon:100"), f)
+
+    issues = NetworkIntegrityAuditor(communities_dir=temp_communities_dir).audit_community(
+        test_file
+    )
+
+    assert not [
+        issue for issue in issues if issue["type"] == IssueType.ID_MISMATCH
+    ], f"a valid id must not be reported as a mismatch, got {issues}"
+
+
+def test_id_mismatch_still_fires_for_a_name_matched_participant(
+    temp_communities_dir, valid_community
+):
+    """The guard must not disarm ID_MISMATCH where it is the whole point.
+
+    A participant whose name matches its entry but whose id does not is the
+    copy-paste error, and it still gates.
+    """
+    community = dict(valid_community)
+    community["ecological_interactions"][0]["source_taxon"]["term"]["id"] = "NCBITaxon:9999"
+
+    test_file = temp_communities_dir / "test_still_fires.yaml"
+    with open(test_file, "w") as f:
+        yaml.dump(community, f)
+
+    issues = NetworkIntegrityAuditor(communities_dir=temp_communities_dir).audit_community(
+        test_file
+    )
+
+    mismatches = [issue for issue in issues if issue["type"] == IssueType.ID_MISMATCH]
+    assert len(mismatches) == 1
+    assert issue_severity(mismatches[0]) == "error"
+
+
+def test_the_kb_has_no_duplicate_taxon_names():
+    """Guards the assumption that made DUPLICATE_TAXON_NAME safe at error severity."""
+    auditor = NetworkIntegrityAuditor(communities_dir=Path("kb/communities"))
+    auditor.audit_all(quiet=True)
+
+    offenders = sorted(
+        community
+        for community, issues in auditor.issues.items()
+        if any(issue["type"] == IssueType.DUPLICATE_TAXON_NAME for issue in issues)
+    )
+    assert offenders == [], f"records with a duplicate preferred_term: {offenders}"
+
+
+def test_id_mismatch_fires_on_the_target_side_too(temp_communities_dir, valid_community):
+    """Deleting the target-side ID_MISMATCH check passed the whole suite.
+
+    Only the source side was ever covered, so half of this detector could have
+    been removed unnoticed.
+    """
+    community = dict(valid_community)
+    community["ecological_interactions"][0]["target_taxon"]["term"]["id"] = "NCBITaxon:9999"
+
+    test_file = temp_communities_dir / "test_target_mismatch.yaml"
+    with open(test_file, "w") as f:
+        yaml.dump(community, f)
+
+    issues = NetworkIntegrityAuditor(communities_dir=temp_communities_dir).audit_community(
+        test_file
+    )
+
+    mismatches = [issue for issue in issues if issue["type"] == IssueType.ID_MISMATCH]
+    assert len(mismatches) == 1
+    assert mismatches[0]["role"] == "target"
+    assert issue_severity(mismatches[0]) == "error"


### PR DESCRIPTION
Closes #328. Closes #333. Closes #334. Closes #335. Closes #336. Closes #337. Closes #338.

Deferred out of the second review of #316 as wanting its own guard.

## The defect

Two taxonomy entries sharing a `preferred_term` manufactured an **error-severity** finding — one that fails the build — out of a perfectly valid id:

```
taxonomy: X/NCBITaxon:100, X/NCBITaxon:200 ; interaction source 'Y'/NCBITaxon:100
→ [warning] NAME_MISMATCH: Source 'Y' ... resolved to 'X' by source_id NCBITaxon:100
→ [error]   ID_MISMATCH:   Source 'Y' has ID NCBITaxon:100, expected NCBITaxon:200
```

`NCBITaxon:100` *is* the id of a taxonomy entry named X. Nothing is inconsistent.

## Two causes, two fixes

**1. `ID_MISMATCH` ran on an id-resolved participant.** The check asks whether an id agrees with the entry its *name* picked out. When the id is what resolved the participant they agree by construction, so the check has nothing to say — and running it anyway read the expected id off `taxonomy_by_term`, which is last-write-wins, comparing against whichever duplicate won the race. Now guarded to name matches only; it still fires for the copy-paste error it exists to catch, on both sides.

**2. The duplicate name was itself an unreported defect.** Because that dict is last-write-wins, the earlier entry disappears from every name lookup: **no interaction can ever connect it**, and the record quietly has one fewer reachable member than it lists. Now `DUPLICATE_TAXON_NAME` at error severity.

Error severity is safe because no record in the KB has one — verified by an independent parse of all 311 records, not only via the auditor, and pinned by a test.

Distinct from `tests/test_no_duplicate_yaml_keys.py`, which guards duplicate *mapping keys*; this is duplicate `preferred_term` **values** across sibling entries — valid YAML, and invisible to `linkml-validate`.

## Review findings, and two that matter (#333-#338)

**#333 — I made the exact mistake this PR was celebrating catching.** The original mutation table claimed "revert the ID_MISMATCH guard ✓", but the fixture built only a `source_taxon`, so the **target**-side guard was never exercised: reverting it passed all 939 tests. That is structurally the same one-sided-coverage defect this PR found one level *down* — where disarming the target-side ID_MISMATCH detector passed 52 tests — reintroduced one level *up*, for the guard. The fixture now takes a role parameter; both sides are pinned.

**#334 — the test carrying this PR's safety claim could audit nothing.** The KB guard used a relative `Path("kb/communities")`, and `Path.glob` on a missing directory yields nothing *without raising*, so from any working directory but the repo root it audited zero records and asserted `[] == []` — passing in 1s instead of 5s. It is the sole support for gating on this finding at error severity. Now resolved against `__file__` (the convention the three other KB-wide test modules already use) and asserting the sweep was non-empty. Verified to fail loudly when pointed at a missing directory.

The rest are small:

- **#335** — the finding rendered as `• [N/A] Two taxonomy entries share...` in the console, because it is record-scoped and fell through to the generic interaction branch; and its message said "Two taxonomy entries" when three or more can collide (3 entries → 2 findings, chained pairwise).
- **#336** — the SEVERITY table's stated rationale described error level as only "names something that is not there", which does not cover naming one thing *twice*. Corrected in the module and in the workflow's curator-facing note.
- **#337** — the `term.label` fallback in the duplicate key was unpinned. Unreachable for schema-valid records (`preferred_term` is required), but the branch exists, so it is now tested.
- **#338** — a null `taxon_term` raised `AttributeError` and surfaced as an error-severity `UNREADABLE` naming a Python type. The per-entry twin of the whole-file case fixed in #329.

## Verification

Fifteen mutations across two rounds. Round one caught 11 of 13; the two survivors — reverting the target-side guard, and restricting the duplicate key to an explicit `preferred_term` — both now fail.

The review also ran a differential fuzz of this branch against `main`: 19,683 exhaustive cases plus 6,000 randomized ones, finding **zero** inputs where `main` reports something this branch drops without also emitting `DUPLICATE_TAXON_NAME`. The guard is inert except under exactly the condition that now errors.

- KB unchanged: 55 findings, **0 error** — byte-identical to `main`
- `just lint`, `mypy`: clean
- Full suite: **944 passed, 9 skipped**
- 11 new tests
