### PR TITLE
Add a /goal prompt for working the backlog end to end

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,9 @@ vocab/                            # controlled-vocabulary staging files (e.g. cu
 conf/oak_config.yaml             # OAK ontology adapter config (NCBITaxon, ENVO, CHEBI, GO)
 references_cache/                # Cached PubMed abstracts (committed for reproducibility)
 scripts/                         # Utility scripts for curation (not part of package)
+prompts/                         # Reusable agent prompts, pasted whole (e.g. `/goal`);
+                                 #   backlog-loop.goal.md drives the issue->PR->review->
+                                 #   merge cycle. Kept under the 4000-char /goal limit.
 ```
 
 ## Key Patterns

--- a/prompts/backlog-loop.goal.md
+++ b/prompts/backlog-loop.goal.md
@@ -1,0 +1,64 @@
+Work the CommunityMech backlog to completion, one issue at a time.
+
+## Loop
+
+1. **Reconcile, then prioritize.** Never relay `NEXT_TASKS.md` verbatim — check every
+   claim against `gh pr list --state merged`, `gh issue list`, and the code. Classify
+   each: DONE / actionable / in-flight / upstream-blocked. Rank the open issues by
+   value and pick the top actionable one. Update `NEXT_TASKS.md` every pass.
+
+2. **Respect dependencies before starting.** Ask what this fix touches and whether an
+   open PR already touches it. If issue B is only correct after PR A, do A first or
+   branch B off A and say so in the PR body. Never run two PRs editing the same
+   detector, slot, or workflow in parallel. State the chain when you report.
+
+3. **Branch before the first edit.** Never commit to `main`.
+
+4. **Measure; do not inherit the premise.** Repeatedly earned here: issue text is often
+   wrong. #273 called four auditor false positives "genuine dangling references" and
+   scheduled curation around it; #276's premise was wrong too. Quantify over the whole
+   KB before proposing a fix, and report what you measured, not what you assumed.
+
+5. **Verify side effects, not exit codes.** Run `just qc`. For anything that gates CI,
+   prove *both* branches live: a temporary canary commit that breaks one record,
+   confirm the job reddens at the intended step, then revert. For new detectors,
+   mutation-test — substitute plausible wrong implementations and confirm a test
+   fails. Check both sides of any two-sided check (source *and* target). A test using
+   a relative path can pass while auditing nothing; assert the sweep was non-empty.
+
+6. **Commit, push, open a PR.** The body states what you measured, what changed, and
+   what you deliberately did not do.
+
+7. **Review adversarially**, as a separate read-only pass — not a restatement of what
+   you just wrote. Spawn a subagent for independent eyes. Re-review commits that
+   landed *after* the previous review: review fixes are themselves unreviewed code,
+   and that is where the last three real defects came from.
+
+8. **File every finding as a GitHub issue**, including "won't fix". Then triage: fix
+   what belongs in this PR, leave the rest filed, and say which is which and why.
+
+9. **Merge** (squash) once CI is green and findings are addressed, **delete the branch**
+   local and remote, sync `main`, re-reconcile, and go again.
+
+## Pause and ask when
+
+- A curation or schema decision has no obvious default ("should hosts be taxonomy
+  members?").
+- The work would delete or rewrite curated content.
+- Two readings of an issue lead to materially different work.
+- A change would redden `main`, or an @-mention seems needed — never @-mention anyone
+  without explicit per-mention permission.
+
+Ask one concrete question with a recommendation, then proceed on the answer.
+
+## Gotchas
+
+- `gh pr edit --body` is broken here. Use
+  `gh api repos/OWNER/REPO/pulls/N -X PATCH -F body=@file`.
+- "Not fixed: #N" in a commit **closes** #N — GitHub parses the substring `fixed: #N`.
+  Write "Deferred: #N".
+- Use explicit paths with `git add`; never `git add -A` (it has swept unrelated work
+  into a PR).
+- `just install` is broken; use `uv sync --extra dev`.
+- `linkml-validate` is blind to duplicate YAML keys and duplicate `preferred_term`s.
+- Report honestly. If a test fails, show it. If you skipped a step, say so.

--- a/prompts/backlog-loop.goal.md
+++ b/prompts/backlog-loop.goal.md
@@ -1,64 +1,73 @@
-Work the CommunityMech backlog to completion, one issue at a time.
+Work the CommunityMech backlog, one issue at a time, **in this repo only** — never edit
+sibling repos (CultureMech/MIM/TraitMech), even for cross-Mech sync; report divergence.
 
 ## Loop
 
-1. **Reconcile, then prioritize.** Never relay `NEXT_TASKS.md` verbatim — check every
-   claim against `gh pr list --state merged`, `gh issue list`, and the code. Classify
-   each: DONE / actionable / in-flight / upstream-blocked. Rank the open issues by
-   value and pick the top actionable one. Update `NEXT_TASKS.md` every pass.
+1. **Reconcile and prioritize** with the `next-tasks` skill — invoke it, don't restate
+   it. Pick the top actionable issue; upstream-blocked items stay listed, never picked.
 
-2. **Respect dependencies before starting.** Ask what this fix touches and whether an
-   open PR already touches it. If issue B is only correct after PR A, do A first or
-   branch B off A and say so in the PR body. Never run two PRs editing the same
-   detector, slot, or workflow in parallel. State the chain when you report.
+2. **Check dependencies before starting.** What does this fix touch, and does an open
+   PR touch it? If B is only correct after A, do A first, or branch B off A and say so.
+   **One branch and one PR in flight at a time**, start to merge — no parallel PRs.
 
-3. **Branch before the first edit.** Never commit to `main`.
+3. **Branch before any edit**, `NEXT_TASKS.md` included; its update rides on this
+   issue's branch. Never edit `main`. Check `main`'s CI is green first, so a
+   pre-existing failure isn't blamed on your PR.
 
-4. **Measure; do not inherit the premise.** Repeatedly earned here: issue text is often
-   wrong. #273 called four auditor false positives "genuine dangling references" and
-   scheduled curation around it; #276's premise was wrong too. Quantify over the whole
-   KB before proposing a fix, and report what you measured, not what you assumed.
+4. **Measure; don't inherit the premise.** Issue text is often wrong: #273 called four
+   auditor false positives "genuine dangling references" and scheduled curation around
+   it. Quantify over the KB first, and report what you measured.
 
-5. **Verify side effects, not exit codes.** Run `just qc`. For anything that gates CI,
-   prove *both* branches live: a temporary canary commit that breaks one record,
-   confirm the job reddens at the intended step, then revert. For new detectors,
-   mutation-test — substitute plausible wrong implementations and confirm a test
-   fails. Check both sides of any two-sided check (source *and* target). A test using
-   a relative path can pass while auditing nothing; assert the sweep was non-empty.
+5. **Canary anything costly or gating.** A paid sweep (deep-research, Edison) runs
+   *one* real unit end to end and verifies the artifact on disk before any fan-out. A
+   CI gate gets both branches proved: a temporary commit **on your branch, never
+   `main`**, breaking one record; confirm the job reddens at the intended step; revert,
+   and confirm the revert landed before merging.
 
-6. **Commit, push, open a PR.** The body states what you measured, what changed, and
-   what you deliberately did not do.
+6. **Verify side effects, not exit codes.** `just qc` is seven recipes over 311
+   records and can redden for unrelated reasons — if so, scope to what you touched.
+   Mutation-test new checks: substitute wrong implementations, confirm a test fails.
+   Cover **both** sides of two-sided checks. A test on a relative path can pass while
+   auditing nothing — assert the sweep was non-empty.
 
-7. **Review adversarially**, as a separate read-only pass — not a restatement of what
-   you just wrote. Spawn a subagent for independent eyes. Re-review commits that
-   landed *after* the previous review: review fixes are themselves unreviewed code,
-   and that is where the last three real defects came from.
+7. **Commit, push, open a PR** saying what you measured, what changed, and what you
+   deliberately did not do.
 
-8. **File every finding as a GitHub issue**, including "won't fix". Then triage: fix
-   what belongs in this PR, leave the rest filed, and say which is which and why.
+8. **Review adversarially** — a separate read-only pass, subagent for independent eyes.
+   Re-review commits that landed after the previous review: review fixes are themselves
+   unreviewed code, and that is where the last three defects came from (#322 → #333).
 
-9. **Merge** (squash) once CI is green and findings are addressed, **delete the branch**
-   local and remote, sync `main`, re-reconcile, and go again.
+9. **File every finding as an issue**, won't-fix included. Fix what belongs in this PR;
+   say what you left and why. If the review shows the premise was wrong, **close the PR
+   unmerged** and re-file — that is a success (#315 did this to #273).
+
+10. **Squash-merge, delete the branch both sides**, sync, re-reconcile, go again.
+    Running this prompt authorizes merges *inside* this loop only.
+
+**Do not merge — stop and report — if** CI is red or never finishes, the branch
+conflicts with `main`, review findings are unresolved, or the change would redden
+`main`.
+
+**Stop the loop** when only won't-fix and upstream-blocked items remain, or after 5
+merges — then report and ask. Issues you filed in step 9 never feed the same pass.
 
 ## Pause and ask when
 
-- A curation or schema decision has no obvious default ("should hosts be taxonomy
-  members?").
-- The work would delete or rewrite curated content.
-- Two readings of an issue lead to materially different work.
-- A change would redden `main`, or an @-mention seems needed — never @-mention anyone
-  without explicit per-mention permission.
+A curation or schema decision has no obvious default; work would delete or rewrite
+curated content; two readings mean materially different work; money would be spent; or
+an @-mention seems needed (never without explicit per-mention permission). Ask one
+question with a recommendation.
 
-Ask one concrete question with a recommendation, then proceed on the answer.
+## Gotchas — fix these here when they stop being true
 
-## Gotchas
-
-- `gh pr edit --body` is broken here. Use
-  `gh api repos/OWNER/REPO/pulls/N -X PATCH -F body=@file`.
-- "Not fixed: #N" in a commit **closes** #N — GitHub parses the substring `fixed: #N`.
-  Write "Deferred: #N".
-- Use explicit paths with `git add`; never `git add -A` (it has swept unrelated work
-  into a PR).
-- `just install` is broken; use `uv sync --extra dev`.
-- `linkml-validate` is blind to duplicate YAML keys and duplicate `preferred_term`s.
-- Report honestly. If a test fails, show it. If you skipped a step, say so.
+- `gh pr edit --body` fails (gh 2.97.0): use
+  `gh api repos/{owner}/{repo}/pulls/N -X PATCH -F body=@file` — literal braces; gh
+  substitutes them.
+- `Not fixed: #N` in a commit **closes** #N — GitHub parses `fixed: #N`. Write
+  `Deferred: #N`.
+- `git add` explicit paths only; `git add -A` has swept unrelated work into a PR.
+- `just install` fails (#290): `uv sync --extra dev`.
+- Duplicate YAML keys and duplicate `preferred_term`s are invisible to
+  `linkml-validate`; they are caught by `test_no_duplicate_yaml_keys.py` and
+  `DUPLICATE_TAXON_NAME`, so run the tests, not just the validator.
+- Report honestly: failing test, show it; skipped step, say so.


### PR DESCRIPTION
Closes #340. Closes #341. Closes #342. Closes #343. Closes #344.

Adds `prompts/backlog-loop.goal.md` — a reusable `/goal` prompt that reconciles and prioritizes the open issues, then takes the top one through branch → measure → verify → PR → adversarial review → file issues → address → squash-merge → delete branch → re-reconcile.

**3987 characters**, inside the 4000-char `/goal` limit, so it pastes whole.

## The review changed this substantially

I wrote the first version as prose. The review read it as *executable instructions for an autonomous agent* — the right test — and found the loop unsafe in three ways. All five issues are fixed here.

### It could merge forever, unattended (#340)

The first draft stated squash-merge as an unconditional per-iteration action, with **no merge clause in the pause list** and no acknowledgement that `CLAUDE.md` reserves merging to the user.

It also could not terminate. Step 8 files an issue for every review finding, which step 1 re-ranks and feeds back in — demonstrated by this very session: reviewing #332 produced #333 and #334; reviewing #316 produced #328.

Now: merges are scoped ("running this prompt authorizes merges *inside* this loop only"), with an explicit **do-not-merge list** (red or hanging CI, branch conflicts with `main`, unresolved findings, anything that would redden `main`), a **stop condition** (only won't-fix and upstream-blocked remain, or 5 merges → report and ask), and a rule that issues filed in step 9 never feed the same pass.

Two missing failure modes added: check `main`'s CI is green *before* branching, so a pre-existing failure isn't blamed on the PR; and **close the PR unmerged** when the review shows the premise was wrong — which is exactly what #315 did to #273, the case the prompt itself cites as its cautionary tale.

### It could spend money, and edit three other repos (#341)

An autonomous loop picking "the top actionable item" could select one that fans out a billed deep-research sweep across 311 records with no human in it. The canary rule now covers **paid sweeps**, not just CI gates — one real unit, artifact verified on disk, then fan out — and money is a pause condition.

`NEXT_TASKS.md` instructs cross-Mech sync with CultureMech/MIM/TraitMech, an obligation the loop would have inherited implicitly through "update NEXT_TASKS.md every pass". Now forbidden outright in the first line.

### The rescue command was wrong (#342)

`gh api repos/OWNER/REPO/pulls/N` 404s — gh substitutes `{owner}`/`{repo}`, not uppercase placeholders. Since this is offered as the workaround for a broken `gh pr edit`, a wrong form is worse than none. Corrected and verified: `gh api repos/{owner}/{repo}/pulls/339` resolves.

Two gotchas were also stale in their *implication*: "linkml-validate is blind to duplicate keys" read as "nothing catches these", when both are now gated by `test_no_duplicate_yaml_keys.py` and `DUPLICATE_TAXON_NAME`. And the section now carries an instruction to fix itself — #290 (`just install`) is open and is plausibly the loop's own first pick, which would have silently invalidated its own advice.

### Internal contradictions (#343)

Step 1 told the agent to update `NEXT_TASKS.md`; step 3, two steps later, said never edit before branching. The backlog update now explicitly rides on the issue's branch. Step 1 restated the `next-tasks` skill rather than invoking it, dropping two of its rules — now it invokes it. "One issue at a time" was undercut by a much narrower ban on *"two PRs editing the same detector"*; now one branch and one PR, start to merge. Upstream-blocked items are dispositioned, and the canary is pinned to the PR branch with a confirm-the-revert-landed step.

### Discoverability (#344)

`prompts/` is a new top-level directory that nothing referenced. `CLAUDE.md`'s architecture block now lists it.

## Verification

- Every factual claim in the gotchas independently re-checked, and all confirmed true today: `gh pr edit --body` broken; `"Not fixed: #N"` closes #N (verified against #328's timeline and commit `d987f048`); `git add -A` swept unrelated work into #286; `just install` fails with *"Group `dev` is not defined"*; duplicate keys/`preferred_term`s invisible to the validator.
- Every anecdote verified against the actual issues: #273/#313/#315, #322/#333, #276.
- Docs-only change; only `vendored-sync` runs, the other workflows being path-filtered. `MERGEABLE`/`CLEAN`.
