### PR TITLE
Make the CommunityMech id a primary key again, and gate it (#310)

### DIFF
--- a/.claude/skills/manage-identifiers/SKILL.md
+++ b/.claude/skills/manage-identifiers/SKILL.md
@@ -56,15 +56,25 @@ including the single-file and registry variants — is in
 [`reference/finding-highest-id.md`](reference/finding-highest-id.md) and
 [`reference/minting-and-adding.md`](reference/minting-and-adding.md).
 
-### 1. Find the highest existing ID (scan the directory)
+### 1. Find the highest existing ID (scan **every** id-bearing directory)
+
+`kb/communities/` is not the whole id space. `data/isolates/` carries
+`CommunityMech:` ids too, and scanning only the first is what let four ids get
+used twice (#310, #346) — the isolates held ids that later records re-minted.
 
 ```bash
-grep -rh 'id: CommunityMech:' kb/communities/ | cut -d: -f3 | sort -n | tail -1
+grep -rh 'id: CommunityMech:' kb/communities/ data/isolates/ | cut -d: -f3 | sort -n | tail -1
 ```
 
 ```python
-highest = find_highest_id_multi_file(Path('kb/communities'), 'CommunityMech')
+highest = max(
+    find_highest_id_multi_file(Path(d), 'CommunityMech')
+    for d in ('kb/communities', 'data/isolates')
+)
 ```
+
+`tests/test_id_uniqueness.py` fails the build if a mint collides anyway, but it
+is a backstop — mint from the full space in the first place.
 
 ### 2. Mint the next ID
 

--- a/.claude/skills/manage-identifiers/SKILL.md
+++ b/.claude/skills/manage-identifiers/SKILL.md
@@ -17,7 +17,7 @@ never change once assigned and are never reused.
 
 CommunityMech is a **multi-file collection**: each community is its own YAML file under
 `kb/communities/`, with an `id` of the form `CommunityMech:NNNNNN` (zero-padded 6-digit,
-`000001`–`999999`). Finding the next ID means scanning the directory; adding a record means
+`000001`–`999999`). Finding the next ID means scanning every id-bearing directory; adding a record means
 writing a new file (no shared metadata to update).
 
 > The same identifier infrastructure is shared with MediaIngredientMech (single-file
@@ -63,7 +63,8 @@ including the single-file and registry variants — is in
 used twice (#310, #346) — the isolates held ids that later records re-minted.
 
 ```bash
-grep -rh 'id: CommunityMech:' kb/communities/ data/isolates/ | cut -d: -f3 | sort -n | tail -1
+grep -rhoE --include='*.yaml' 'CommunityMech:[0-9]{6}' \
+  kb/communities/ data/isolates/ | cut -d: -f2 | sort -n | tail -1
 ```
 
 ```python

--- a/.claude/skills/manage-identifiers/reference/cross-repo.md
+++ b/.claude/skills/manage-identifiers/reference/cross-repo.md
@@ -167,8 +167,10 @@ rebuild_registry(
 **Add single community**:
 ```python
 # 1. Find next ID
-communities_dir = Path('kb/communities')
-highest = find_highest_id_multi_file(communities_dir, 'CommunityMech')
+highest = max(
+    find_highest_id_multi_file(Path(d), 'CommunityMech')
+    for d in ('kb/communities', 'data/isolates')   # the whole id space (#310, #353)
+)
 next_id = generate_xmech_id('CommunityMech', highest + 1)
 
 # 2. Create record (see Workflow 2 above)

--- a/.claude/skills/manage-identifiers/reference/finding-highest-id.md
+++ b/.claude/skills/manage-identifiers/reference/finding-highest-id.md
@@ -95,8 +95,10 @@ def find_highest_id_multi_file(
     return max_id
 
 # Usage
-communities_dir = Path('kb/communities')
-highest = find_highest_id_multi_file(communities_dir, 'CommunityMech')
+highest = max(
+    find_highest_id_multi_file(Path(d), 'CommunityMech')
+    for d in ('kb/communities', 'data/isolates')   # the whole id space (#310, #353)
+)
 print(f"Highest ID: {highest}")  # Output: 78
 ```
 
@@ -130,9 +132,11 @@ print(f"Highest ID: {highest}")  # Output: 15431
 
 **Quick bash approach**:
 ```bash
-# CommunityMech (single directory)
-grep -rh 'id: CommunityMech:' kb/communities/ | \
-  cut -d: -f3 | sort -n | tail -1
+# CommunityMech (every id-bearing directory).
+# --include is load-bearing: without it this reads gitignored *.yaml.bak files
+# and can report an id far above the real maximum, minting a huge gap (#353).
+grep -rhoE --include='*.yaml' 'CommunityMech:[0-9]{6}' \
+  kb/communities/ data/isolates/ | cut -d: -f2 | sort -n | tail -1
 
 # CultureMech (nested directories)
 find data/normalized_yaml -name "*.yaml" -exec grep -h 'id: CultureMech:' {} \; | \

--- a/.claude/skills/manage-identifiers/reference/minting-and-adding.md
+++ b/.claude/skills/manage-identifiers/reference/minting-and-adding.md
@@ -88,6 +88,10 @@ def mint_next_id(
     return generate_xmech_id(prefix, next_number)
 ```
 
+> **Caution:** `mint_next_id` scans one directory. CommunityMech ids also live
+> in `data/isolates/`, so for that repo take the max over both — scanning only
+> `kb/communities/` is what produced four duplicate ids (#310, #353).
+
 ### Quick Mint Examples
 
 **MediaIngredientMech** (single-file):
@@ -104,8 +108,10 @@ print(f"Next ID: {next_id}")  # MediaIngredientMech:000113
 ```python
 from pathlib import Path
 
-communities_dir = Path('kb/communities')
-highest = find_highest_id_multi_file(communities_dir, 'CommunityMech')
+highest = max(
+    find_highest_id_multi_file(Path(d), 'CommunityMech')
+    for d in ('kb/communities', 'data/isolates')   # the whole id space (#310, #353)
+)
 next_id = generate_xmech_id('CommunityMech', highest + 1)
 print(f"Next ID: {next_id}")  # CommunityMech:000079
 ```
@@ -195,8 +201,10 @@ from pathlib import Path
 from datetime import datetime, timezone
 
 # Step 1: Find next ID
-communities_dir = Path('kb/communities')
-highest = find_highest_id_multi_file(communities_dir, 'CommunityMech')
+highest = max(
+    find_highest_id_multi_file(Path(d), 'CommunityMech')
+    for d in ('kb/communities', 'data/isolates')   # the whole id space (#310, #353)
+)
 next_id = generate_xmech_id('CommunityMech', highest + 1)
 
 # Step 2: Create new record

--- a/.claude/skills/manage-identifiers/reference/utility-module.md
+++ b/.claude/skills/manage-identifiers/reference/utility-module.md
@@ -173,3 +173,7 @@ if __name__ == "__main__":
     print(f"Next CommunityMech ID: {next_id}")
 ```
 
+> **Caution:** `mint_next_id` scans one directory. CommunityMech ids also live
+> in `data/isolates/`, so for that repo take the max over both — scanning only
+> `kb/communities/` is what produced four duplicate ids (#310, #353).
+

--- a/.github/workflows/validate-strict.yaml
+++ b/.github/workflows/validate-strict.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     paths: &trigger_paths
       - "kb/communities/**"
+      # data/isolates carries CommunityMech ids too. It was outside every
+      # workflow's paths filter, which is half of why four ids ended up used
+      # twice (#310) — editing an isolate has to re-run the uniqueness gate.
+      - "data/isolates/**"
       - "src/communitymech/schema/**"
       - "src/communitymech/**/*.py"
       - "scripts/**/*.py"

--- a/data/isolates/Aspergillus_Indium_LED_Recovery.yaml
+++ b/data/isolates/Aspergillus_Indium_LED_Recovery.yaml
@@ -1,4 +1,4 @@
-id: CommunityMech:000271
+id: CommunityMech:000320
 name: Aspergillus Indium LED Recovery Platform
 description: 'An engineered fungal monoculture bioplatform based on Aspergillus niger for sustainable recovery of indium from
   waste liquid crystal display (LCD) and light-emitting diode (LED) panels through indirect bioleaching. This system represents

--- a/data/isolates/BioModels_MODEL2204300002_Kefir_Rothia_Model.yaml
+++ b/data/isolates/BioModels_MODEL2204300002_Kefir_Rothia_Model.yaml
@@ -1,4 +1,4 @@
-id: CommunityMech:000272
+id: CommunityMech:000321
 name: BioModels MODEL2204300002 Kefir Rothia Model
 description: >-
   BioModels record MODEL2204300002 contains a genome-scale metabolic model for Rothia
@@ -35,13 +35,13 @@ taxonomy:
   functional_role:
   - CROSS_FEEDER
 associated_datasets:
-- name: BioModels model file
+- title: BioModels model file
   dataset_type: OTHER
   repository: OTHER
   accession: MODEL2204300002.xml
   url: https://www.ebi.ac.uk/biomodels/MODEL2204300002
   description: SBML file deposited as MODEL2204300002.
-- name: Primary publication
+- title: Primary publication
   dataset_type: OTHER
   repository: OTHER
   accession: doi:10.1038/s41564-020-00816-5

--- a/data/isolates/Methylobacterium_REE_Ewaste_Platform.yaml
+++ b/data/isolates/Methylobacterium_REE_Ewaste_Platform.yaml
@@ -1,4 +1,4 @@
-id: CommunityMech:000274
+id: CommunityMech:000322
 name: Methylobacterium REE E-waste Platform
 description: 'An engineered monoculture bioplatform based on the mesophilic methylotrophic bacterium Methylobacterium extorquens
   AM1 for sustainable recovery of rare earth elements (REE) from electronic waste. This system represents a paradigm shift

--- a/docs/cross_repo_linking.md
+++ b/docs/cross_repo_linking.md
@@ -64,7 +64,7 @@ Links a community to a MediaIngredientMech ingredient through environmental or m
 
 | Repository | Pattern | Example |
 |------------|---------|---------|
-| CommunityMech | `CommunityMech:NNNNNN` | `CommunityMech:000024` |
+| CommunityMech | `CommunityMech:NNNNNN` | `CommunityMech:000319` |
 | CultureMech | `CultureMech:NNNNNN` | `CultureMech:010001` |
 | MediaIngredientMech | `MediaIngredientMech:NNNNNN` | `MediaIngredientMech:000523` |
 
@@ -87,7 +87,7 @@ related_media:
 ### Full: SPRUCE Peatland Community
 
 ```yaml
-id: CommunityMech:000024
+id: CommunityMech:000319
 name: SPRUCE Peatland Warming Microbial Community
 ecological_state: STABLE
 community_origin: NATURAL
@@ -282,7 +282,7 @@ ri = RelatedIngredient(
 
 # Add to a community
 community = MicrobialCommunity(
-    id="CommunityMech:000024",
+    id="CommunityMech:000319",
     name="SPRUCE Peatland Community",
     related_media=[rm],
     related_ingredients=[ri],

--- a/kb/communities/SPRUCE_Peatland_Warming_Community.yaml
+++ b/kb/communities/SPRUCE_Peatland_Warming_Community.yaml
@@ -1,4 +1,4 @@
-id: CommunityMech:000024
+id: CommunityMech:000319
 name: SPRUCE Peatland Warming Microbial Community
 description: 'Microbial community from the SPRUCE (Spruce and Peatland Responses Under Changing Environments) whole-ecosystem warming experiment at Marcell Experimental Forest, Minnesota. This long-term DOE-funded experiment (ORNL) provides a unique whole-ecosystem warming gradient (+0°C to +9°C) with elevated CO2 (eCO2) treatments in a northern boreal peatland. The natural microbial community has been extensively characterized through amplicon sequencing (16S rRNA for bacteria/archaea, ITS for fungi) and metatranscriptomics, revealing climate change-driven shifts in community composition and function. Key findings include: (1) warming promotes saprophytic fungi and chemoorganoheterotrophic bacteria in root-associated environments, (2) eCO2 enhances ectomycorrhizal fungal associations with vascular plants, particularly short-distance exploration strategies targeting labile soil nitrogen, (3) vascular plant fine root traits mediate climate effects on microbial communities, serving as a critical mechanism for peatland vegetation responses to global change. The community exhibits distinct niche partitioning between aquatic (waterlogged surface peat) and terrestrial (deeper peat) zones. Viral communities (4,326 vOTUs) show strong correlations with peat depth, water content, and carbon chemistry (CH4/CO2) but not temperature during initial warming phases. This represents one of the most comprehensively studied natural microbial communities under realistic climate change scenarios, with implications for carbon cycling, methane emissions, and ecosystem feedbacks in boreal peatlands. Northern peatlands store approximately one-third of global soil carbon despite covering only 3% of land area, making their responses to warming and eCO2 critical for global carbon cycle feedbacks. The comprehensive multi-omics datasets (amplicon, metagenome, metatranscriptome, virome) make this community exceptionally well-characterized for mechanistic modeling of climate-microbe-plant-carbon interactions.
 
@@ -110,6 +110,7 @@ ecological_interactions:
 
     '
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   metabolites:
   - preferred_term: carbon dioxide
     term:
@@ -165,7 +166,7 @@ ecological_interactions:
   biological_processes:
   - preferred_term: symbiont-mediated nutrient acquisition in host
     term:
-      id: GO:0052572
+      id: GO:0075136
       label: response to host
   evidence:
   - reference: PMID:38515239
@@ -183,6 +184,7 @@ ecological_interactions:
 
     '
   interaction_type: MUTUALISM
+  scope: COMMUNITY_LEVEL
   biological_processes:
   - preferred_term: response to root
     term:
@@ -209,7 +211,7 @@ ecological_interactions:
   - preferred_term: viral entry into host cell
     term:
       id: GO:0046718
-      label: viral entry into host cell
+      label: symbiont entry into host cell
   - preferred_term: host cell lysis by virus
     term:
       id: GO:0019076
@@ -298,23 +300,23 @@ environmental_factors:
 
     '
 associated_datasets:
-- name: SPRUCE 16S rRNA amplicon sequencing
+- title: SPRUCE 16S rRNA amplicon sequencing
   dataset_type: AMPLICON_16S
   accession: PMID:38515239
   description: '16S rRNA amplicon sequencing of bacterial and archaeal communities from plant fine roots, rhizospheres, and bulk peat across warming and eCO2 treatments'
-- name: SPRUCE ITS amplicon sequencing
+- title: SPRUCE ITS amplicon sequencing
   dataset_type: AMPLICON_ITS
   accession: PMID:38515239
   description: 'ITS amplicon sequencing of fungal communities from plant fine roots, rhizospheres, and bulk peat across warming and eCO2 treatments, identifying saprophytic and ectomycorrhizal functional guilds'
-- name: SPRUCE peat metagenomes
-  dataset_type: METAGENOME
+- title: SPRUCE peat metagenomes
+  dataset_type: METAGENOMICS
   accession: PMID:34836550
   description: '87 shotgun metagenomes from peat samples across depth gradients, warming treatments, and eCO2 treatments, enabling viral-host linkage prediction and taxonomic profiling'
-- name: SPRUCE peat viromes
-  dataset_type: METAGENOME
+- title: SPRUCE peat viromes
+  dataset_type: METAGENOMICS
   accession: PMID:34836550
   description: '5 viral size-fraction metagenomes (viromes) from peat samples, recovering 4,326 vOTUs with 32x higher vOTU recovery per sample than total metagenomes'
-- name: SPRUCE metatranscriptomes
-  dataset_type: METATRANSCRIPTOME
+- title: SPRUCE metatranscriptomes
+  dataset_type: METATRANSCRIPTOMICS
   accession: PMID:38515239
   description: 'Metatranscriptomic profiling of active gene expression in peat microbial communities under warming and eCO2, revealing functional responses to climate treatments'

--- a/kb/communities/SPRUCE_Peatland_Warming_Community.yaml
+++ b/kb/communities/SPRUCE_Peatland_Warming_Community.yaml
@@ -110,7 +110,17 @@ ecological_interactions:
 
     '
   interaction_type: MUTUALISM
-  scope: COMMUNITY_LEVEL
+  scope: PAIRWISE
+  source_taxon:
+    preferred_term: Fungi
+    term:
+      id: NCBITaxon:4751
+      label: Fungi
+  target_taxon:
+    preferred_term: Bacteria
+    term:
+      id: NCBITaxon:2
+      label: Bacteria
   metabolites:
   - preferred_term: carbon dioxide
     term:
@@ -166,8 +176,8 @@ ecological_interactions:
   biological_processes:
   - preferred_term: symbiont-mediated nutrient acquisition in host
     term:
-      id: GO:0075136
-      label: response to host
+      id: GO:0044002
+      label: acquisition of nutrients from host
   evidence:
   - reference: PMID:38515239
     supports: SUPPORT
@@ -183,13 +193,13 @@ ecological_interactions:
   description: 'Vascular plant fine root traits serve as critical mediators of climate change effects on microbial communities. Root trait variation (specific root length, root diameter, tissue chemistry, exudate composition) creates heterogeneous microenvironments in the rhizosphere and bulk peat, structuring microbial community composition and function. Under warming, plants shift root allocation and morphology, altering the quantity and quality of resources available to root-associated microbes. For example, increased fine root production provides fresh organic carbon substrates for decomposers, while changes in root exudate chemistry (organic acids, sugars, secondary metabolites) selectively promote or inhibit specific microbial taxa. Under eCO2, enhanced root biomass and exudation due to increased photosynthate allocation belowground fuel ectomycorrhizal fungal growth and bacterial rhizosphere communities. This plant-mediated microbial response represents a biotic feedback mechanism: climate change → plant physiological/morphological responses → altered root traits → microbial community shifts → ecosystem function changes (decomposition, nutrient cycling, carbon storage). The finding that root traits mediate climate effects suggests that plant species composition and functional diversity will strongly influence peatland microbial responses to global change, adding complexity to climate-ecosystem models.
 
     '
-  interaction_type: MUTUALISM
+  interaction_type: NICHE_PARTITIONING
   scope: COMMUNITY_LEVEL
   biological_processes:
   - preferred_term: response to root
     term:
-      id: GO:0009887
-      label: animal organ morphogenesis
+      id: GO:0075136
+      label: response to host
     notes: Microbial responses to plant root exudates and morphology
   evidence:
   - reference: PMID:38515239

--- a/tests/data/test_cross_repo_linking/spruce_with_links.yaml
+++ b/tests/data/test_cross_repo_linking/spruce_with_links.yaml
@@ -1,4 +1,4 @@
-id: CommunityMech:000024
+id: CommunityMech:000319
 name: SPRUCE Peatland Warming Microbial Community
 description: >-
   Microbial community from the SPRUCE experiment at the Marcell Experimental

--- a/tests/test_cross_repo_linking.py
+++ b/tests/test_cross_repo_linking.py
@@ -58,7 +58,7 @@ class TestSPRUCEWithLinks:
         self.data = load_yaml("spruce_with_links.yaml")
 
     def test_basic_fields(self):
-        assert self.data["id"] == "CommunityMech:000024"
+        assert self.data["id"] == "CommunityMech:000319"
         assert self.data["name"] == "SPRUCE Peatland Warming Microbial Community"
         assert self.data["ecological_state"] == "STABLE"
 

--- a/tests/test_id_uniqueness.py
+++ b/tests/test_id_uniqueness.py
@@ -25,26 +25,41 @@ REPO = Path(__file__).parent.parent
 
 # Where records may legitimately live. Anything outside these that declares an
 # id is reported too — see test_no_id_bearing_records_outside_known_dirs.
-RECORD_DIRS = ("kb/communities", "kb/taxa", "data/isolates")
+# `kb/taxa` is deliberately absent: its ids are `CommunityMech:taxon:NNNNNN`,
+# a different space from the record ids this module governs.
+RECORD_DIRS = ("kb/communities", "data/isolates")
 
 # Paths that legitimately mention ids without owning them: fixtures, caches and
 # prose. `tests/data` holds deliberate copies of real records.
 EXCLUDED = ("tests/data", "references_cache", ".git", "site", "docs", "notes")
 
-ID_RE = re.compile(r"^id:\s*(CommunityMech:\d+)\s*$", re.M)
+# Quoting is ordinary YAML, and an id in quotes must not be able to slip the
+# gate: `id: "CommunityMech:000320"` was invisible to every check here (#351).
+# Trailing comments are tolerated for the same reason.
+ID_RE = re.compile(r"""^id:[ \t]*['"]?(CommunityMech:\d+)['"]?[ \t]*(?:\#.*)?$""", re.M)
 
 
 def _declared_ids():
     """Every (id, path) pair declared anywhere in the repo."""
     found = []
-    for path in sorted(REPO.glob("**/*.yaml")):
-        rel = path.relative_to(REPO).as_posix()
-        if any(rel.startswith(skip) for skip in EXCLUDED):
+    for path in sorted([*REPO.glob("**/*.yaml"), *REPO.glob("**/*.yml")]):
+        rel = path.relative_to(REPO)
+        # Compare path *components*, not the string: `rel.startswith("notes")`
+        # also swallowed `notes_archive/`, and `data/isolates_v2/` counted as a
+        # known directory purely because the name shares a prefix (#351).
+        if _under(rel, EXCLUDED):
             continue
-        match = ID_RE.search(path.read_text())
-        if match:
-            found.append((match.group(1), rel))
+        # findall, not search: a second document in one file declares a second
+        # id, and taking only the first hid it.
+        for identifier in ID_RE.findall(path.read_text()):
+            found.append((identifier, rel.as_posix()))
     return found
+
+
+def _under(rel: Path, roots) -> bool:
+    """True if `rel` sits inside one of `roots`, matching whole path components."""
+    parts = rel.parts
+    return any(parts[: len(Path(r).parts)] == Path(r).parts for r in roots)
 
 
 @pytest.fixture(scope="module")
@@ -75,7 +90,7 @@ def test_no_id_bearing_records_outside_known_dirs(declared):
     invisible enough that nothing validated it. This makes that combination
     impossible to reach silently.
     """
-    strays = sorted(rel for _, rel in declared if not any(rel.startswith(d) for d in RECORD_DIRS))
+    strays = sorted(rel for _, rel in declared if not _under(Path(rel), RECORD_DIRS))
     assert not strays, (
         "these declare a CommunityMech id but live outside "
         f"{RECORD_DIRS}; add the directory to RECORD_DIRS and to the validation "

--- a/tests/test_id_uniqueness.py
+++ b/tests/test_id_uniqueness.py
@@ -31,12 +31,20 @@ RECORD_DIRS = ("kb/communities", "data/isolates")
 
 # Paths that legitimately mention ids without owning them: fixtures, caches and
 # prose. `tests/data` holds deliberate copies of real records.
-EXCLUDED = ("tests/data", "references_cache", ".git", "site", "docs", "notes")
+EXCLUDED = (
+    "tests/data",
+    "references_cache",
+    ".git",
+    ".venv",  # ~160 dependency YAMLs; leaving them in made the sweep machine-dependent
+    "site",
+    "docs",
+    "notes",
+)
 
 # Quoting is ordinary YAML, and an id in quotes must not be able to slip the
 # gate: `id: "CommunityMech:000320"` was invisible to every check here (#351).
 # Trailing comments are tolerated for the same reason.
-ID_RE = re.compile(r"""^id:[ \t]*['"]?(CommunityMech:\d+)['"]?[ \t]*(?:\#.*)?$""", re.M)
+ID_RE = re.compile(r"""^id:[ \t]*['"]?(CommunityMech:\d+)['"]?[ \t\r]*(?:\#[^\n]*)?$""", re.M)
 
 
 def _declared_ids():
@@ -44,16 +52,25 @@ def _declared_ids():
     found = []
     for path in sorted([*REPO.glob("**/*.yaml"), *REPO.glob("**/*.yml")]):
         rel = path.relative_to(REPO)
-        # Compare path *components*, not the string: `rel.startswith("notes")`
-        # also swallowed `notes_archive/`, and `data/isolates_v2/` counted as a
-        # known directory purely because the name shares a prefix (#351).
+        # Compare path *components*, not the string. Under `startswith`, a
+        # `notes_archive/` would be excluded outright and a `data/isolates_v2/`
+        # would count as a known directory, purely because the names share a
+        # prefix (#351). Neither exists today; this is prophylactic.
         if _under(rel, EXCLUDED):
             continue
-        # findall, not search: a second document in one file declares a second
-        # id, and taking only the first hid it.
-        for identifier in ID_RE.findall(path.read_text()):
+        for identifier in _ids_in(path):
             found.append((identifier, rel.as_posix()))
     return found
+
+
+def _ids_in(path: Path) -> list:
+    """Every record id declared in one file.
+
+    findall, not search: a second document in one file declares a second id, and
+    taking only the first hid it. Extracted so that behaviour is reachable from a
+    test — inlined, reverting it to `search` passed the whole suite (#354).
+    """
+    return ID_RE.findall(path.read_text())
 
 
 def _under(rel: Path, roots) -> bool:
@@ -147,3 +164,68 @@ def test_isolates_pass_schema_validation():
             failures.append(f"{record.name}:\n{result.stdout.strip()}")
 
     assert not failures, "schema-invalid isolate records:\n" + "\n".join(failures)
+
+
+# ---------------------------------------------------------------------------
+# The sweep internals. None of these shapes exist in the KB today, so without
+# direct tests every one of them is dead code — which is how a regression got
+# in: hardening the pattern for quotes silently dropped `\r`, and nothing
+# noticed because no record uses CRLF (#354).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "id: CommunityMech:000320",
+        'id: "CommunityMech:000320"',
+        "id: 'CommunityMech:000320'",
+        "id: CommunityMech:000320  # a trailing comment",
+        "id:\tCommunityMech:000320",
+        "id: CommunityMech:000320\r",  # CRLF
+        'id: "CommunityMech:000320"\r',
+    ],
+)
+def test_id_regex_matches_every_legitimate_spelling(line):
+    assert ID_RE.findall(line) == ["CommunityMech:000320"], f"missed: {line!r}"
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "grid: CommunityMech:000320",  # not the `id` key
+        "id: CommunityMech:taxon:000001",  # a different id space
+        "  id: CommunityMech:000320",  # nested, not a record id
+        "- id: CommunityMech:000320",  # list item, not a record id
+        "# id: CommunityMech:000320",  # commented out
+    ],
+)
+def test_id_regex_ignores_what_is_not_a_record_id(line):
+    assert ID_RE.findall(line) == [], f"false positive: {line!r}"
+
+
+def test_sweep_finds_every_document_in_a_multi_document_file(tmp_path):
+    """`search` returned only the first, so a second declaration was invisible.
+
+    Goes through `_ids_in`, the function the sweep actually calls — asserting on
+    `ID_RE` directly left the sweep free to keep using `search`.
+    """
+    record = tmp_path / "two_docs.yaml"
+    record.write_text("id: CommunityMech:000001\n---\nid: CommunityMech:000002\n")
+    assert _ids_in(record) == ["CommunityMech:000001", "CommunityMech:000002"]
+
+
+@pytest.mark.parametrize(
+    ("rel", "roots", "expected"),
+    [
+        ("kb/communities/x.yaml", ("kb/communities",), True),
+        ("data/isolates/x.yaml", ("kb/communities", "data/isolates"), True),
+        # The prefix bug: these share a name prefix but are different directories.
+        ("kb/communities_draft/x.yaml", ("kb/communities",), False),
+        ("data/isolates_v2/x.yaml", ("data/isolates",), False),
+        ("notes_archive/x.yaml", ("notes",), False),
+        ("notes/deep/x.yaml", ("notes",), True),
+    ],
+)
+def test_under_matches_whole_path_components(rel, roots, expected):
+    assert _under(Path(rel), roots) is expected

--- a/tests/test_id_uniqueness.py
+++ b/tests/test_id_uniqueness.py
@@ -1,0 +1,134 @@
+"""The CommunityMech id is a primary key, so assert it actually is one.
+
+Nothing checked this before, and it turned out not to hold: four ids were used
+twice, because `data/isolates/` carries `CommunityMech:` identifiers while
+sitting outside every gate — no workflow's `paths:` filter mentions it and
+`validate-strict` walks a glob that excludes it. New records were then minted by
+scanning only `kb/communities/`, so they reused ids the isolates already held
+(#310).
+
+Two records answering to one id means anything resolving it gets whichever the
+tool read first — silently, and differently on different machines.
+
+The sweep is directory-agnostic on purpose: it globs the repo for anything
+declaring a `CommunityMech:` id, so a *new* directory of records cannot
+reintroduce the gap the way `data/isolates/` did.
+"""
+
+import collections
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).parent.parent
+
+# Where records may legitimately live. Anything outside these that declares an
+# id is reported too — see test_no_id_bearing_records_outside_known_dirs.
+RECORD_DIRS = ("kb/communities", "kb/taxa", "data/isolates")
+
+# Paths that legitimately mention ids without owning them: fixtures, caches and
+# prose. `tests/data` holds deliberate copies of real records.
+EXCLUDED = ("tests/data", "references_cache", ".git", "site", "docs", "notes")
+
+ID_RE = re.compile(r"^id:\s*(CommunityMech:\d+)\s*$", re.M)
+
+
+def _declared_ids():
+    """Every (id, path) pair declared anywhere in the repo."""
+    found = []
+    for path in sorted(REPO.glob("**/*.yaml")):
+        rel = path.relative_to(REPO).as_posix()
+        if any(rel.startswith(skip) for skip in EXCLUDED):
+            continue
+        match = ID_RE.search(path.read_text())
+        if match:
+            found.append((match.group(1), rel))
+    return found
+
+
+@pytest.fixture(scope="module")
+def declared():
+    found = _declared_ids()
+    # A relative-path glob that matches nothing passes vacuously; make an empty
+    # sweep a failure rather than a silent success.
+    assert len(found) > 300, f"expected the full KB, swept only {len(found)} records"
+    return found
+
+
+def test_every_communitymech_id_is_used_exactly_once(declared):
+    by_id = collections.defaultdict(list)
+    for identifier, rel in declared:
+        by_id[identifier].append(rel)
+
+    collisions = {i: paths for i, paths in by_id.items() if len(paths) > 1}
+    assert not collisions, "ids used more than once:\n" + "\n".join(
+        f"  {i}\n" + "\n".join(f"      {p}" for p in paths)
+        for i, paths in sorted(collisions.items())
+    )
+
+
+def test_no_id_bearing_records_outside_known_dirs(declared):
+    """A new record directory must be added to the gates, not just created.
+
+    `data/isolates/` was real enough to hold production identifiers and
+    invisible enough that nothing validated it. This makes that combination
+    impossible to reach silently.
+    """
+    strays = sorted(rel for _, rel in declared if not any(rel.startswith(d) for d in RECORD_DIRS))
+    assert not strays, (
+        "these declare a CommunityMech id but live outside "
+        f"{RECORD_DIRS}; add the directory to RECORD_DIRS and to the validation "
+        "gates, or move the records:\n" + "\n".join(f"  {s}" for s in strays)
+    )
+
+
+def test_isolates_are_actually_single_organism(declared):
+    """`data/isolates/` is defined by its README as monocultures.
+
+    SPRUCE sat there with four taxa and a colliding id, unvalidated, because
+    nothing checked either property (#310).
+    """
+    import yaml
+
+    offenders = []
+    for path in sorted((REPO / "data/isolates").glob("*.yaml")):
+        data = yaml.safe_load(path.read_text()) or {}
+        taxa = data.get("taxonomy") or []
+        if len(taxa) != 1:
+            offenders.append(f"{path.name}: {len(taxa)} taxa")
+
+    assert not offenders, (
+        "data/isolates/ holds single-organism records by definition; these are "
+        "communities and belong in kb/communities/:\n" + "\n".join(f"  {o}" for o in offenders)
+    )
+
+
+def test_isolates_pass_schema_validation():
+    """`data/isolates/` sat outside every validation gate, and rotted there.
+
+    Two of its five records were schema-invalid on `main` — `associated_datasets`
+    entries using `name:` where the slot is `title:`, and dataset_type values
+    (`METAGENOME`, `METATRANSCRIPTOME`) that are not in the enum. Nobody knew,
+    because `validate-strict` walks a glob that excludes the directory (#310).
+    """
+    import subprocess
+
+    from linkml_runtime.utils.schemaview import SchemaView  # noqa: F401  (import cost only)
+
+    schema = REPO / "src/communitymech/schema/communitymech.yaml"
+    records = sorted((REPO / "data/isolates").glob("*.yaml"))
+    assert records, "no isolate records found"
+
+    failures = []
+    for record in records:
+        result = subprocess.run(
+            ["uv", "run", "linkml-validate", "-s", str(schema), str(record)],
+            capture_output=True,
+            text=True,
+            cwd=REPO,
+        )
+        if result.returncode != 0:
+            failures.append(f"{record.name}:\n{result.stdout.strip()}")
+
+    assert not failures, "schema-invalid isolate records:\n" + "\n".join(failures)


### PR DESCRIPTION
Closes #310.

Four `CommunityMech:` ids were used twice. Anything resolving `CommunityMech:000271` got either a chlorinated-ethene enrichment or an *Aspergillus* indium-recovery platform, depending on glob order — silently, and differently on different machines.

## Measuring first changed the plan

The issue framed this as one problem needing one decision. It is two, and the second was misdiagnosed.

**Three real isolates** (`000271/272/274`) hold one taxon each and are correctly filed. They sit outside every gate, workflow and export, and nothing resolves them but their own README — so they renumber to `000320/321/322`, and the live, exported `kb/communities` records keep their ids.

**SPRUCE was never an isolate.** `CommunityMech:000024` in `data/isolates/` has **four taxa**, was never in `kb/communities/`, and duplicated `ENIGMA_Denitrifying_SynCom`, which has held that id since 2026-02-27. It is also the worked example in `docs/cross_repo_linking.md` and its test fixture — so the collision was live in the documentation. It moves to `kb/communities/` as `000319`, doc and fixture repointed; ENIGMA keeps `000024`.

## Bringing SPRUCE under the gates found it had been rotting since March

Never validated, because nothing validates that directory:

| defect | fix |
|---|---|
| `associated_datasets` entries use `name:`; the slot is `title:` | 5 entries |
| `dataset_type: METAGENOME` / `METATRANSCRIPTOME` not in the enum | → `METAGENOMICS` / `METATRANSCRIPTOMICS` |
| `GO:0046718` label renamed upstream | → `symbiont entry into host cell` |
| `GO:0052572` ("response to host immune response") labelled "response to host" | **id** corrected to `GO:0075136` |

That last one is worth flagging: the id↔label gate cannot tell which side is wrong. The `preferred_term` is *"symbiont-mediated nutrient acquisition in host"*, so the record plainly does not mean an immune response — the curator's label was right and the id was wrong.

**The record also predates the `scope` slot entirely** (zero declarations), so all four interactions defaulted to `PAIRWISE`. The two that name no pair and assert a process across the community produced error-severity `MISSING_SOURCE` — the audit went to **2 error / 57 warning**, which would have reddened `main` the moment the file landed. Both are `COMMUNITY_LEVEL`. This is exactly the failure mode #319 predicted, arriving on schedule.

A fourth isolate (Kefir/Rothia) was **already schema-invalid on `main`** for the same `name:`/`title:` reason — verified against `main`, not assumed. Fixed here, because shipping isolate gates while knowingly leaving an isolate invalid would be incoherent.

## The gates

`tests/test_id_uniqueness.py`:

1. **Every id is used exactly once.** Sweeps the repo for anything declaring a `CommunityMech:` id rather than a fixed directory list, so a *new* records directory cannot reintroduce the gap the way `data/isolates/` did.
2. **No id-bearing record outside the known directories** — the "real enough to hold production ids, invisible enough that nothing validates it" combination is now unreachable silently.
3. **Isolates are actually single-organism**, which is how that directory's README defines itself, and which SPRUCE violated.
4. **Isolates pass schema validation.**

The sweep asserts it matched >300 records: a glob that matches nothing passes vacuously, which is how #334 nearly shipped.

`data/isolates/**` is added to `validate-strict`'s trigger paths, so editing an isolate re-runs all of it. That workflow already runs `pytest tests/`.

## Review round three — two regressions in my own fix commit

**#354 — hardening the regex for quotes silently broke CRLF.** The old pattern ended `\s*$`, which matches `\r`; my replacement ended `[ \t]*`, which does not. A record written with CRLF could declare a duplicate id, pass the uniqueness gate silently, and be invisible to the stray-directory check simultaneously. I hardened one axis and weakened another.

Nothing caught it because **every new behaviour in that commit was dead code**: the repo has no quoted ids, no trailing-comment ids, no multi-document files, no `.yml` record, no prefix-shadowed directory. There are now direct tests for each, and mutation testing confirms they bite — reverting the regex fails 2, `_under` → `startswith` fails 3, `findall` → `search` fails 1. That last needed a code change to reach: asserting on `ID_RE` directly left the *sweep* free to keep using `search`, so the call is extracted as `_ids_in()` and the test goes through it. `.venv` also joins `EXCLUDED` — the sweep was reading ~160 dependency YAMLs, making its result machine-dependent.

**#353 — #346 was only half-fixed, and the bash snippet was unsafe.** `SKILL.md` §1 was corrected, but it delegates to *"full code for every step"* in `reference/`, and those files still scanned `kb/communities/` alone. An agent following the pointer copies the stale snippet, sees 319, mints `000320`, collides with the isolate now holding it — #310 verbatim. Four snippets now take the max over both directories; the two `mint_next_id` examples carry a caution instead, since that API takes one directory by design.

The bash variant was wrong **in both directions**, and it is the procedure that actually mints, where the test is only a backstop. Canaried:

| case | old bash | hardened |
|---|---|---|
| gitignored `.bak` holding `000999` (**21 `.yaml.bak` exist**) | `000999` → 499-wide gap | `000322` |
| quoted `id: "CommunityMech:000323"` | `000322` → **collision** | `000323` |

It now agrees with the python snippet exactly.

**Filed, not fixed:** #355 (Archaea is *still* blanket-credited by interaction 3, so the #348 fix bought no auditable honesty — the real fix is interaction 4's missing `target_taxon`; and interaction 1 as PAIRWISE MUTUALISM over-claims against a co-occurrence snippet), #356 (`GO:0044002` is directionally right but contradicts its own untouched `preferred_term`, which states the inverse relation).

## Verification

Each gate **canaried** by breaking one record and confirming the right test fails:

- duplicate id injected → `test_every_communitymech_id_is_used_exactly_once` fails, naming both files
- `bogus_slot_xyz` injected into an isolate → `test_isolates_pass_schema_validation` fails

Plus: all four isolates validate; SPRUCE passes schema **and** term validation; `just validate-strict` clean (0 error rows); network audit **55 findings / 0 error — identical to `main`**; `just lint` and `mypy` clean; **950 passed, 9 skipped**.
