### PR TITLE
Add NEXT_TASKS_LOOP.md: which open issues suit an autonomous /goal run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,8 @@ vocab/                            # controlled-vocabulary staging files (e.g. cu
 conf/oak_config.yaml             # OAK ontology adapter config (NCBITaxon, ENVO, CHEBI, GO)
 references_cache/                # Cached PubMed abstracts (committed for reproducibility)
 scripts/                         # Utility scripts for curation (not part of package)
-NEXT_TASKS_LOOP.md               # Which open issues suit an autonomous /goal run
+NEXT_TASKS.md                    # The deferred-work backlog (source of truth)
+NEXT_TASKS_LOOP.md               # Which of those suit an autonomous /goal run
                                  #   (and which need a human decision first)
 prompts/                         # Reusable agent prompts, pasted whole (e.g. `/goal`);
                                  #   backlog-loop.goal.md drives the issue->PR->review->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,8 @@ vocab/                            # controlled-vocabulary staging files (e.g. cu
 conf/oak_config.yaml             # OAK ontology adapter config (NCBITaxon, ENVO, CHEBI, GO)
 references_cache/                # Cached PubMed abstracts (committed for reproducibility)
 scripts/                         # Utility scripts for curation (not part of package)
+NEXT_TASKS_LOOP.md               # Which open issues suit an autonomous /goal run
+                                 #   (and which need a human decision first)
 prompts/                         # Reusable agent prompts, pasted whole (e.g. `/goal`);
                                  #   backlog-loop.goal.md drives the issue->PR->review->
                                  #   merge cycle. Kept under the 4000-char /goal limit.

--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -5,7 +5,8 @@ update this file as work is started/finished — move done items out, add new
 deferrals here. Keep the cross-Mech items in sync with the sibling repos'
 `NEXT_TASKS.md` (CultureMech / MIM / TraitMech).
 
-Last reconciled: 2026-08-03.
+Last reconciled: 2026-08-03. For which of these suit an autonomous `/goal` run,
+see [NEXT_TASKS_LOOP.md](NEXT_TASKS_LOOP.md).
 
 ## Priority menu (reconciled 2026-07-30; re-reconciled after PR #274 merged)
 

--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -5,8 +5,10 @@ update this file as work is started/finished — move done items out, add new
 deferrals here. Keep the cross-Mech items in sync with the sibling repos'
 `NEXT_TASKS.md` (CultureMech / MIM / TraitMech).
 
-Last reconciled: 2026-08-03. For which of these suit an autonomous `/goal` run,
-see [NEXT_TASKS_LOOP.md](NEXT_TASKS_LOOP.md).
+Last reconciled: 2026-08-03.
+
+For which of these suit an autonomous `/goal` run, see
+[NEXT_TASKS_LOOP.md](NEXT_TASKS_LOOP.md).
 
 ## Priority menu (reconciled 2026-07-30; re-reconciled after PR #274 merged)
 

--- a/NEXT_TASKS_LOOP.md
+++ b/NEXT_TASKS_LOOP.md
@@ -5,8 +5,8 @@ Which open issues suit an autonomous `/goal` run with
 
 `NEXT_TASKS.md` is the full backlog and stays the source of truth for *what* is
 deferred. This file answers a narrower question: *what can be handed to a loop
-that will not stop to ask?* Reconciled 2026-08-03. Every claim below was re-measured against `main`, not
-copied from the issue text — including where that contradicts the issue.
+that will not stop to ask?* Reconciled 2026-08-03. Every claim was re-measured
+against `main`, not copied from the issue — including where the two disagree.
 
 ## What makes an item loop-ready
 
@@ -30,18 +30,10 @@ finish condition.
 | 2 | **#314** taxon ungrounded after an id edit | S | `gtdb_classification` present; a test pins `ncbi_source_id == term.id` | `Mesorhizobium_Synechococcus_…`: `NCBITaxon:1125` is the one taxon of four with no grounding |
 | 3 | **#306** snippet checks pick a cache file arbitrarily | M | resolution is deterministic, pinned by a test | **62** stems carry both `.md` and `.txt`; 63 folding case, 63 with any two extensions |
 | 4 | **#352a** seven records have no published page | XS | `just gen-html`; every record has a page | 312 records, **305** pages — 7 missing, not just SPRUCE |
-| 5 | **#277** four `[[wiki-links]]` resolve to nothing | XS | no dangling links | 4 dangling: `chebi-mislabels-backlog`, `edison-auth-env-shadowing`, `ontology-term-cleanup`, `space-regolith-scouting-gap` |
 
 **Start with #290.** It is one line, it exits 0 or it doesn't, and it retires a
 gotcha the goal prompt currently has to carry. A clean first pass through the
 whole loop on a trivial item is worth more than a big first win.
-
-**Queued, not ready: #358** (guard the goal prompt's size limit). Mechanical, but
-it asserts a limit on a file [PR #357](https://github.com/CultureBotAI/CommunityMech/pull/357)
-is still changing — on `main` the prompt is 3987 chars / 4015 bytes (13 spare),
-and #357 takes it to 3995 / 4021. Note 4015 bytes is *already over* 4000, so if
-the ceiling counts bytes rather than characters the file has been over all along;
-that is the open question #358 exists to settle. Do it once #357 lands.
 
 ## Tier 2 — loop-able with a tighter brief
 
@@ -65,14 +57,29 @@ judgement, or the loop will invent something.
   `linkml-term-validator --labels`, but the failures are mostly wrong *id*, not
   wrong label (`CHEBI:30319` recorded as `dicyanoaurate(1-)`; `ENVO:00000072` as
   `mine tailing`; `GO:0055114`/`GO:0055065` obsolete). Choosing the right id per
-  term is the judgement the `id-label-correspondence` skill reserves for a
-  curator. The other branch — documenting the roots as schema-only — is
-  mechanical, so the brief must name which branch to take.
+  term is triage, not transcription — `id-label-correspondence` prescribes
+  `validate_ncbitaxon_ids.py` and `term_fix_apply.py` for it, but choosing per
+  term still needs a call. The other branch — documenting the roots as
+  schema-only — is mechanical, so the brief must name which branch to take.
+- **#277 — four dangling `[[wiki-links]]`.** Looks like doc hygiene, but the issue
+  offers three mutually exclusive remedies (inline the substance, point at a
+  committed doc, or drop the links) and the substance lives in a memory directory
+  the issue records as absent. "No dangling links" is satisfiable by deletion,
+  which throws away what the issue calls load-bearing. Brief which remedy.
 - **#270 — interaction type encoded by colour alone**, nine categories. Fully
   specified, and the CVD-simulation harness from #268 already exists to verify a
   redundant encoding. Frontend, self-contained.
 - **#352b — a second coarse SPRUCE record (`000135`) already exists.** Only the
   *report* is loop-able; whether to merge the two records is a curator call.
+
+## Queued — mechanical, but blocked
+
+**#358 — guard the goal prompt's size limit.** Mechanical, but
+it asserts a limit on a file [PR #357](https://github.com/CultureBotAI/CommunityMech/pull/357)
+is still changing — on `main` the prompt is 3987 chars / 4015 bytes (13 spare),
+and #357 takes it to 3995 / 4021. Note 4015 bytes is *already over* 4000, so if
+the ceiling counts bytes rather than characters the file has been over all along;
+that is the open question #358 exists to settle. Do it once #357 lands.
 
 ## Tier 3 — needs a human decision first
 
@@ -97,11 +104,15 @@ answer is not derivable from the repo.
 `NCBITaxon:2` aggregate placeholders lose their participant slot instead. The
 decision is [recorded on the issue](https://github.com/CultureBotAI/CommunityMech/issues/319#issuecomment-5173848793)
 — the issue body still reads "unresolved", so cite the comment, not the body.
-Re-measured on `main`: **13 host/antagonist slots across 9 records** and **14
-placeholder slots across 9 records**. (These differ from the 23-across-17 in the
-issue body, which predates #345 and used a broader criterion.) The 14 are
-mechanical; the 13 each need a grounded term and a snippet, so this belongs in a
-focused session, not an unattended loop.
+
+Measured over all 1127 participant slots, counting a participant as absent only
+when its id appears nowhere in that record's `taxonomy`: **10 host/antagonist
+slots across 8 records** to add, **13 placeholder slots across 8 records** to
+drop, and **4 name variants** of existing members to reconcile. That reproduces
+the 23 in the issue body; an earlier draft here said 13 and 14, which came from
+the *auditor's* looser rule and counted members whose name merely differs. The 10
+each need a grounded term and a snippet, so this is a focused session, not a
+loop.
 
 ## Ordering and dependencies
 
@@ -124,4 +135,3 @@ focused session, not an unattended loop.
   half of **#259**).
 - Anything editing sibling repos (**#30** touches cross-Mech linking; the loop is
   scoped to this repo and must only report divergence).
-- **#359** is a note, not a task.

--- a/NEXT_TASKS_LOOP.md
+++ b/NEXT_TASKS_LOOP.md
@@ -1,0 +1,103 @@
+# Loop-ready backlog
+
+Which open issues suit an autonomous `/goal` run with
+[`prompts/backlog-loop.goal.md`](prompts/backlog-loop.goal.md), and which do not.
+
+`NEXT_TASKS.md` is the full backlog and stays the source of truth for *what* is
+deferred. This file answers a narrower question: *what can be handed to a loop
+that will not stop to ask?* Reconciled 2026-08-04. Every claim below was
+re-measured against `main` on that date, not copied from the issue text.
+
+## What makes an item loop-ready
+
+1. **A machine-checkable definition of done** — a test, a gate, a command exit
+   code. Not "reads better".
+2. **No curation or schema decision.** The loop pauses for those by design, and
+   an item that pauses on its first step wastes the run.
+3. **Bounded blast radius**, so an adversarial review can actually cover it.
+4. **A premise that survives measurement.** Half the issues in this repo have
+   been wrong on inspection (#273, #276, #310, #346); the loop re-measures
+   first, but an item whose premise is already verified starts a step ahead.
+
+## Tier 1 — ready now
+
+Ranked by value per unit of risk. Each has a verified premise and a green/red
+finish condition.
+
+| # | Item | Size | Done when | Verified 2026-08-04 |
+|---|---|---|---|---|
+| 1 | **#290** `just install` fails | XS | `just install` exits 0 | `uv sync --group dev` → *"Group `dev` is not defined"*; deps are under `[project.optional-dependencies]` |
+| 2 | **#295** one snippet cited at two supports levels | S | the pair agrees, or the difference is explained | `Geobacter_Clostridium_…` cites the DIET snippet as both `PARTIAL` and `SUPPORT` |
+| 3 | **#314** taxon ungrounded after an id edit | S | `gtdb_classification` present; a test pins `ncbi_source_id == term.id` | `Mesorhizobium_Synechococcus_…`: `NCBITaxon:1125` is the one taxon of four with no grounding |
+| 4 | **#358** goal-prompt size unguarded | XS | a test asserts chars **and** bytes | 3995 chars / 4021 bytes, 5 chars of headroom, nothing guards it |
+| 5 | **#350** isolates are gated for schema only | M | isolates pass term validation, or the roots are documented as schema-only | **4 of 4** isolates fail `linkml-term-validator --labels` today |
+| 6 | **#306** snippet checks pick a cache file arbitrarily | M | resolution is deterministic, pinned by a test | **63** references have both `.md` and `.txt` in `references_cache/` |
+| 7 | **#352a** SPRUCE has no published page | XS | `just gen-html`, page committed | 312 records, **305** pages |
+| 8 | **#277** four `[[wiki-links]]` resolve to nothing | XS | no dangling links | 4 dangling: `chebi-mislabels-backlog`, `edison-auth-env-shadowing`, `ontology-term-cleanup`, `space-regolith-scouting-gap` |
+
+**Start with #290.** It is one line, it exits 0 or it doesn't, and it retires a
+gotcha the goal prompt currently has to carry. A clean first pass through the
+whole loop on a trivial item is worth more than a big first win.
+
+## Tier 2 — loop-able with a tighter brief
+
+Mechanical enough to automate, but each needs an instruction that constrains
+judgement, or the loop will invent something.
+
+- **#347 — SPRUCE's 17 snippets are paraphrases, not quotes.** Both abstracts are
+  cached, and "is this a verbatim substring" is machine-checkable, so the loop
+  can do it. Brief it to *only* use exact substrings and to **delete** a claim it
+  cannot source rather than reword one. Without that, the failure mode is
+  fabricating support. Note `just validate-references-all` already fails on
+  `main` (e.g. `Aalborg_East_…`), so this improves a red gate rather than
+  greening it.
+- **#270 — interaction type encoded by colour alone**, nine categories. Fully
+  specified, and the CVD-simulation harness from #268 already exists to verify a
+  redundant encoding. Frontend, self-contained.
+- **#352b — a second coarse SPRUCE record (`000135`) already exists.** Only the
+  *report* is loop-able; whether to merge the two records is a curator call.
+
+## Tier 3 — needs a human decision first
+
+Do not queue these. Each stops on the loop's first substantive step, and the
+answer is not derivable from the repo.
+
+| # | The decision that is actually needed |
+|---|---|
+| #294 | Approve or reject the `gtdb_grounding_status` enum (proposal §4.1) |
+| #307 | Approve or reject the counter-selection block (§4.3) — design **with** #312 |
+| #312 | Should a `COMMUNITY_LEVEL` interaction be able to name *which* members it concerns? |
+| #301 | Mint METPO terms for biocontrol/antagonist and N-fixing symbiont, or reuse? |
+| #297 | Is ROS detoxification a metabolite or a process in that record? |
+| #292 | Two taxa carry an id for a different organism — correct, or keep withheld? |
+| #325 | Backfill `curation_history` to 311 records, or drop the slot? |
+| #355 | Is interaction 1 `COMMENSALISM`/`CROSS_FEEDING` rather than `MUTUALISM`? |
+| #356 | Does the ECM entry mean nutrients *from* the host or *to* it? |
+| #182 | Which best-effort ontology remaps to accept |
+| #199 | Which dataviz findings to act on |
+
+**#319 is decided but heavy.** Hosts and antagonists become taxonomy members (13
+instances, 12 records) and the 14 `NCBITaxon:2` aggregate placeholders lose their
+participant slot. The decision is made; the work is per-record evidence curation,
+so it belongs in a focused session rather than an unattended loop.
+
+## Ordering and dependencies
+
+- **#358 waits for [#357](https://github.com/CultureBotAI/CommunityMech/pull/357)
+  to merge** — it asserts a limit on the file that PR is still changing.
+- **#347, #355, #356 all edit `SPRUCE_Peatland_Warming_Community.yaml`.** One PR,
+  or strictly serial; the loop's one-PR-in-flight rule handles this if they are
+  not queued together.
+- **#314 before #294.** #314 is the data fix; #294 is the schema that would
+  describe it. Doing the data first keeps the enum backfill honest.
+- **#350 and #352a** both touch isolate/site generation but do not overlap.
+- **#290 retires a gotcha** in `prompts/backlog-loop.goal.md`. Whoever fixes it
+  updates the prompt in the same PR — the prompt's own header says so.
+
+## Never loop these
+
+- Anything needing full text the repo cannot fetch (**#183**, and the blocked
+  half of **#259**).
+- Anything editing sibling repos (**#30** touches cross-Mech linking; the loop is
+  scoped to this repo and must only report divergence).
+- **#359** is a note, not a task.

--- a/NEXT_TASKS_LOOP.md
+++ b/NEXT_TASKS_LOOP.md
@@ -30,6 +30,7 @@ finish condition.
 | 2 | **#314** taxon ungrounded after an id edit | S | `gtdb_classification` present; a test pins `ncbi_source_id == term.id` | `Mesorhizobium_Synechococcus_…`: `NCBITaxon:1125` is the one taxon of four with no grounding |
 | 3 | **#306** snippet checks pick a cache file arbitrarily | M | resolution is deterministic, pinned by a test | **62** stems carry both `.md` and `.txt`; 63 folding case, 63 with any two extensions |
 | 4 | **#352a** seven records have no published page | XS | `just gen-html`; every record has a page | 312 records, **305** pages — 7 missing, not just SPRUCE |
+| 5 | **#358** goal-prompt size unguarded | XS | a test asserts chars **and** bytes | 3998 chars / **4028 bytes** on `main`, 2 chars spare. Unblocked: #357 merged as `5a1d60b`. Note bytes already exceed 4000, which is the question #358 settles |
 
 **Start with #290.** It is one line, it exits 0 or it doesn't, and it retires a
 gotcha the goal prompt currently has to carry. A clean first pass through the
@@ -72,15 +73,6 @@ judgement, or the loop will invent something.
 - **#352b — a second coarse SPRUCE record (`000135`) already exists.** Only the
   *report* is loop-able; whether to merge the two records is a curator call.
 
-## Queued — mechanical, but blocked
-
-**#358 — guard the goal prompt's size limit.** Mechanical, but
-it asserts a limit on a file [PR #357](https://github.com/CultureBotAI/CommunityMech/pull/357)
-is still changing — on `main` the prompt is 3987 chars / 4015 bytes (13 spare),
-and #357 takes it to 3995 / 4021. Note 4015 bytes is *already over* 4000, so if
-the ceiling counts bytes rather than characters the file has been over all along;
-that is the open question #358 exists to settle. Do it once #357 lands.
-
 ## Tier 3 — needs a human decision first
 
 Do not queue these. Each stops on the loop's first substantive step, and the
@@ -116,8 +108,6 @@ loop.
 
 ## Ordering and dependencies
 
-- **#358 waits for [#357](https://github.com/CultureBotAI/CommunityMech/pull/357)
-  to merge** — it asserts a limit on the file that PR is still changing.
 - **#347, #355, #356 all edit `SPRUCE_Peatland_Warming_Community.yaml`.** One PR,
   or strictly serial; the loop's one-PR-in-flight rule handles this if they are
   not queued together.

--- a/NEXT_TASKS_LOOP.md
+++ b/NEXT_TASKS_LOOP.md
@@ -5,8 +5,8 @@ Which open issues suit an autonomous `/goal` run with
 
 `NEXT_TASKS.md` is the full backlog and stays the source of truth for *what* is
 deferred. This file answers a narrower question: *what can be handed to a loop
-that will not stop to ask?* Reconciled 2026-08-04. Every claim below was
-re-measured against `main` on that date, not copied from the issue text.
+that will not stop to ask?* Reconciled 2026-08-03. Every claim below was re-measured against `main`, not
+copied from the issue text — including where that contradicts the issue.
 
 ## What makes an item loop-ready
 
@@ -24,20 +24,24 @@ re-measured against `main` on that date, not copied from the issue text.
 Ranked by value per unit of risk. Each has a verified premise and a green/red
 finish condition.
 
-| # | Item | Size | Done when | Verified 2026-08-04 |
+| # | Item | Size | Done when | Verified against `main` |
 |---|---|---|---|---|
 | 1 | **#290** `just install` fails | XS | `just install` exits 0 | `uv sync --group dev` → *"Group `dev` is not defined"*; deps are under `[project.optional-dependencies]` |
-| 2 | **#295** one snippet cited at two supports levels | S | the pair agrees, or the difference is explained | `Geobacter_Clostridium_…` cites the DIET snippet as both `PARTIAL` and `SUPPORT` |
-| 3 | **#314** taxon ungrounded after an id edit | S | `gtdb_classification` present; a test pins `ncbi_source_id == term.id` | `Mesorhizobium_Synechococcus_…`: `NCBITaxon:1125` is the one taxon of four with no grounding |
-| 4 | **#358** goal-prompt size unguarded | XS | a test asserts chars **and** bytes | on `main` 3987 chars / 4015 bytes (13 spare); PR #357 takes it to 3995 / 4021. Nothing guards either |
-| 5 | **#350** isolates are gated for schema only | M | isolates pass term validation, or the roots are documented as schema-only | **4 of 4** isolates fail `linkml-term-validator --labels` today |
-| 6 | **#306** snippet checks pick a cache file arbitrarily | M | resolution is deterministic, pinned by a test | **63** references have both `.md` and `.txt` in `references_cache/` |
-| 7 | **#352a** SPRUCE has no published page | XS | `just gen-html`, page committed | 312 records, **305** pages |
-| 8 | **#277** four `[[wiki-links]]` resolve to nothing | XS | no dangling links | 4 dangling: `chebi-mislabels-backlog`, `edison-auth-env-shadowing`, `ontology-term-cleanup`, `space-regolith-scouting-gap` |
+| 2 | **#314** taxon ungrounded after an id edit | S | `gtdb_classification` present; a test pins `ncbi_source_id == term.id` | `Mesorhizobium_Synechococcus_…`: `NCBITaxon:1125` is the one taxon of four with no grounding |
+| 3 | **#306** snippet checks pick a cache file arbitrarily | M | resolution is deterministic, pinned by a test | **62** stems carry both `.md` and `.txt`; 63 folding case, 63 with any two extensions |
+| 4 | **#352a** seven records have no published page | XS | `just gen-html`; every record has a page | 312 records, **305** pages — 7 missing, not just SPRUCE |
+| 5 | **#277** four `[[wiki-links]]` resolve to nothing | XS | no dangling links | 4 dangling: `chebi-mislabels-backlog`, `edison-auth-env-shadowing`, `ontology-term-cleanup`, `space-regolith-scouting-gap` |
 
 **Start with #290.** It is one line, it exits 0 or it doesn't, and it retires a
 gotcha the goal prompt currently has to carry. A clean first pass through the
 whole loop on a trivial item is worth more than a big first win.
+
+**Queued, not ready: #358** (guard the goal prompt's size limit). Mechanical, but
+it asserts a limit on a file [PR #357](https://github.com/CultureBotAI/CommunityMech/pull/357)
+is still changing — on `main` the prompt is 3987 chars / 4015 bytes (13 spare),
+and #357 takes it to 3995 / 4021. Note 4015 bytes is *already over* 4000, so if
+the ceiling counts bytes rather than characters the file has been over all along;
+that is the open question #358 exists to settle. Do it once #357 lands.
 
 ## Tier 2 — loop-able with a tighter brief
 
@@ -51,6 +55,19 @@ judgement, or the loop will invent something.
   fabricating support. Note `just validate-references-all` already fails on
   `main` (e.g. `Aalborg_East_…`), so this improves a red gate rather than
   greening it.
+- **#295 — one snippet cited at two supports levels.** Looks mechanical and is
+  not: the issue asks for `PARTIAL` *or* dropping the citation, and names the
+  curator who made #262's call as the decider. Brief it to reuse that reasoning.
+  It is also not a clean pair — the `SUPPORT` occurrence is 150 chars and
+  truncated mid-word against the other two at 188, so the fix has to repair a
+  truncation as well as reconcile the level.
+- **#350 — isolates are gated for schema only.** All **4 of 4** fail
+  `linkml-term-validator --labels`, but the failures are mostly wrong *id*, not
+  wrong label (`CHEBI:30319` recorded as `dicyanoaurate(1-)`; `ENVO:00000072` as
+  `mine tailing`; `GO:0055114`/`GO:0055065` obsolete). Choosing the right id per
+  term is the judgement the `id-label-correspondence` skill reserves for a
+  curator. The other branch — documenting the roots as schema-only — is
+  mechanical, so the brief must name which branch to take.
 - **#270 — interaction type encoded by colour alone**, nine categories. Fully
   specified, and the CVD-simulation harness from #268 already exists to verify a
   redundant encoding. Frontend, self-contained.
@@ -70,16 +87,21 @@ answer is not derivable from the repo.
 | #301 | Mint METPO terms for biocontrol/antagonist and N-fixing symbiont, or reuse? |
 | #297 | Is ROS detoxification a metabolite or a process in that record? |
 | #292 | Two taxa carry an id for a different organism — correct, or keep withheld? |
-| #325 | Backfill `curation_history` to 311 records, or drop the slot? |
+| #325 | Backfill `curation_history` to the other 310 of 312, or drop the slot? |
 | #355 | Is interaction 1 `COMMENSALISM`/`CROSS_FEEDING` rather than `MUTUALISM`? |
 | #356 | Does the ECM entry mean nutrients *from* the host or *to* it? |
 | #182 | Which best-effort ontology remaps to accept |
 | #199 | Which dataviz findings to act on |
 
-**#319 is decided but heavy.** Hosts and antagonists become taxonomy members (13
-instances, 12 records) and the 14 `NCBITaxon:2` aggregate placeholders lose their
-participant slot. The decision is made; the work is per-record evidence curation,
-so it belongs in a focused session rather than an unattended loop.
+**#319 is decided but heavy.** Hosts and antagonists become taxonomy members; the
+`NCBITaxon:2` aggregate placeholders lose their participant slot instead. The
+decision is [recorded on the issue](https://github.com/CultureBotAI/CommunityMech/issues/319#issuecomment-5173848793)
+— the issue body still reads "unresolved", so cite the comment, not the body.
+Re-measured on `main`: **13 host/antagonist slots across 9 records** and **14
+placeholder slots across 9 records**. (These differ from the 23-across-17 in the
+issue body, which predates #345 and used a broader criterion.) The 14 are
+mechanical; the 13 each need a grounded term and a snippet, so this belongs in a
+focused session, not an unattended loop.
 
 ## Ordering and dependencies
 
@@ -90,7 +112,9 @@ so it belongs in a focused session rather than an unattended loop.
   not queued together.
 - **#314 before #294.** #314 is the data fix; #294 is the schema that would
   describe it. Doing the data first keeps the enum backfill honest.
-- **#350 and #352a** both touch isolate/site generation but do not overlap.
+- **#352a cannot close #352** — that issue also carries the duplicate-SPRUCE
+  question (#352b), which is a curator call. Expect the loop's "issue closed"
+  finish condition not to fire; split the issue first, or accept a partial.
 - **#290 retires a gotcha** in `prompts/backlog-loop.goal.md`. Whoever fixes it
   updates the prompt in the same PR — the prompt's own header says so.
 

--- a/NEXT_TASKS_LOOP.md
+++ b/NEXT_TASKS_LOOP.md
@@ -29,7 +29,7 @@ finish condition.
 | 1 | **#290** `just install` fails | XS | `just install` exits 0 | `uv sync --group dev` → *"Group `dev` is not defined"*; deps are under `[project.optional-dependencies]` |
 | 2 | **#295** one snippet cited at two supports levels | S | the pair agrees, or the difference is explained | `Geobacter_Clostridium_…` cites the DIET snippet as both `PARTIAL` and `SUPPORT` |
 | 3 | **#314** taxon ungrounded after an id edit | S | `gtdb_classification` present; a test pins `ncbi_source_id == term.id` | `Mesorhizobium_Synechococcus_…`: `NCBITaxon:1125` is the one taxon of four with no grounding |
-| 4 | **#358** goal-prompt size unguarded | XS | a test asserts chars **and** bytes | 3995 chars / 4021 bytes, 5 chars of headroom, nothing guards it |
+| 4 | **#358** goal-prompt size unguarded | XS | a test asserts chars **and** bytes | on `main` 3987 chars / 4015 bytes (13 spare); PR #357 takes it to 3995 / 4021. Nothing guards either |
 | 5 | **#350** isolates are gated for schema only | M | isolates pass term validation, or the roots are documented as schema-only | **4 of 4** isolates fail `linkml-term-validator --labels` today |
 | 6 | **#306** snippet checks pick a cache file arbitrarily | M | resolution is deterministic, pinned by a test | **63** references have both `.md` and `.txt` in `references_cache/` |
 | 7 | **#352a** SPRUCE has no published page | XS | `just gen-html`, page committed | 312 records, **305** pages |


### PR DESCRIPTION
Adds `NEXT_TASKS_LOOP.md`, plus pointers from `CLAUDE.md` and `NEXT_TASKS.md`.

## Why a second backlog file

`NEXT_TASKS.md` answers *what is deferred*. It does not answer *what can be handed to a loop that will not stop to ask* — and that is a different question. An item needing a curation or schema decision stops on the loop’s first substantive step, so queueing it wastes the run. #319 is the worked example: fully specified, genuinely valuable, and it halted the first loop run inside two minutes pending a decision only you could make.

All **26** open issues are classified: three tiers plus a never-loop set.

## Everything was re-measured, not copied

Half the issues in this repo have turned out wrong on inspection (#273, #276, #310, #346), so the file states its evidence per row. Verified against `main` today:

| claim | measured |
|---|---|
| #290 `just install` fails | `uv sync --group dev` → *"Group `dev` is not defined"* |
| #295 one snippet, two supports levels | DIET snippet cited as both `PARTIAL` and `SUPPORT` |
| #314 taxon ungrounded after id edit | `NCBITaxon:1125` is the one of four with no `gtdb_classification` |
| #350 isolates gated for schema only | **4 of 4** fail `linkml-term-validator --labels` |
| #306 arbitrary cache-file choice | **63** references have both `.md` and `.txt` |
| #352a no published page | 312 records, **305** pages |
| #277 dangling wiki-links | 4, named |
| #358 size unguarded | 3995 chars / 4021 bytes, 5 chars headroom |

## The tiers

**Tier 1 (8 items)** — ready now, each with a green/red finish condition. Recommends **#290 first**: one line, exits 0 or it doesn’t, and it retires a gotcha `prompts/backlog-loop.goal.md` currently has to carry. A clean first pass through the whole loop on a trivial item is worth more than a big first win.

**Tier 2 (3 items)** — automatable only with a brief that constrains judgement. **#347** is the sharp one: the abstracts are cached and "is this a verbatim substring" is machine-checkable, so a loop *can* do it — but it must be told to use exact substrings and **delete** what it cannot source, or the failure mode is fabricating support.

**Tier 3 (11 items)** — the decision needed is named per issue, so you can answer them in one pass rather than rediscovering each. #319 is called out separately: decided, but per-record evidence curation, so it belongs in a focused session rather than an unattended loop.

## Ordering constraints recorded

- **#358 waits on #357** — it asserts a limit on the file that PR is still changing.
- **#347, #355, #356 all edit the same SPRUCE record** — one PR or strictly serial.
- **#314 before #294**, so the enum backfill has correct data under it.

## Note

This is the **second** open PR (#357 is still awaiting your merge decision), which is a deliberate exception to the loop’s one-PR-in-flight rule — this file is independent of the prompt change and you asked for it directly. If you would rather keep strictly one in flight, I can hold this until #357 lands.

Docs-only, so only `vendored-sync` runs; the other workflows are path-filtered.

---

## Round two (post-review) — the headline fix was itself wrong

The review caught a P1, and it is the worst kind of error for this file: **the counts I published contradicted the criterion published beside them.**

My comment on #319 said the figures were "restricted to participants that resolve to no taxonomy entry", then gave 13 and 14 — which came from the *auditor's* rule (no name match **and** the id is not unique), not that one. Re-measured over all **1127** participant slots in 312 records:

| criterion | non-placeholder | `NCBITaxon:2` | total |
|---|---|---|---|
| **id appears nowhere in that record's `taxonomy`** | **10 / 8 rec** | **13 / 8 rec** | 23 / 16 |
| unresolved by the auditor | 13 / 9 rec | 14 / 9 rec | 27 / 18 |

The first is the right criterion here, and it reproduces the **23** in the issue body exactly — only the record count moved, 17 → 16, after #345. So my aside that the issue "used a broader criterion" was backwards: the issue's was tighter, mine was looser.

The four extra slots are **name variants of members already in `taxonomy`** — "Olsenella (Actinobacteriota)" against an id listed twice, "Variovorax" against one listed six times, "Bacillus SynCom" against one listed four times, plus Saanich Inlet's aggregate. They need a rename, not a new entry — so "the 13 each need a grounded term and a snippet" was false for at least three, and calling them host/antagonist was wrong.

**The GitHub comment is corrected too**, since this file tells readers to cite it in preference to the issue body; fixing only the file would have left the citable record wrong.

## Other changes

- **#277 demoted to Tier 2** — it fails the same test that demoted #295 and #350: three mutually exclusive remedies in the issue, substance living in a memory directory the issue records as absent, and "no dangling links" satisfiable by deletion.
- **#358 was promoted back to Tier 1** after PR #357 merged as `5a1d60b`, with figures re-measured against the new `main`: **3998 chars / 4028 bytes, 2 spare.** The bytes now exceed 4000 by 28, which sharpens the char-or-byte question #358 exists to settle.
- The `id-label-correspondence` claim was overstated — the skill never reserves that call for a curator; it prescribes `validate_ncbitaxon_ids.py` and `term_fix_apply.py`. The #350 demotion stands on its other ground.
- **#359 dropped** from "Never loop these", having been closed as filed-on-a-false-premise.

Tier 1 is now **5 items**, Tier 2 **5**, Tier 3 **11**.
