### PR TITLE
Fix `just install`, and pin the recipe to how pyproject declares dev deps (#290)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Adapted from Monarch Initiative's dismech: YAML is the source of truth, with los
 ## Commands
 
 ```bash
-just install              # Install deps (uv sync --group dev)
+just install              # Install deps (uv sync --extra dev)
 just test                 # Run pytest
 just validate FILE        # Validate one YAML against schema
 just validate-all         # Validate all community YAMLs

--- a/NEXT_TASKS_LOOP.md
+++ b/NEXT_TASKS_LOOP.md
@@ -26,15 +26,14 @@ finish condition.
 
 | # | Item | Size | Done when | Verified against `main` |
 |---|---|---|---|---|
-| 1 | **#290** `just install` fails | XS | `just install` exits 0 | `uv sync --group dev` → *"Group `dev` is not defined"*; deps are under `[project.optional-dependencies]` |
-| 2 | **#314** taxon ungrounded after an id edit | S | `gtdb_classification` present; a test pins `ncbi_source_id == term.id` | `Mesorhizobium_Synechococcus_…`: `NCBITaxon:1125` is the one taxon of four with no grounding |
-| 3 | **#306** snippet checks pick a cache file arbitrarily | M | resolution is deterministic, pinned by a test | **62** stems carry both `.md` and `.txt`; 63 folding case, 63 with any two extensions |
-| 4 | **#352a** seven records have no published page | XS | `just gen-html`; every record has a page | 312 records, **305** pages — 7 missing, not just SPRUCE |
-| 5 | **#358** goal-prompt size unguarded | XS | a test asserts chars **and** bytes | 3998 chars / **4028 bytes** on `main`, 2 chars spare. Unblocked: #357 merged as `5a1d60b`. Note bytes already exceed 4000, which is the question #358 settles |
+| 1 | **#314** taxon ungrounded after an id edit | S | `gtdb_classification` present; a test pins `ncbi_source_id == term.id` | `Mesorhizobium_Synechococcus_…`: `NCBITaxon:1125` is the one taxon of four with no grounding |
+| 2 | **#306** snippet checks pick a cache file arbitrarily | M | resolution is deterministic, pinned by a test | **62** stems carry both `.md` and `.txt`; 63 folding case, 63 with any two extensions |
+| 3 | **#352a** seven records have no published page | XS | `just gen-html`; every record has a page | 312 records, **305** pages — 7 missing, not just SPRUCE |
+| 4 | **#358** goal-prompt size unguarded | XS | a test asserts chars **and** bytes | 3998 chars / **4028 bytes** on `main`, 2 chars spare. Unblocked: #357 merged as `5a1d60b`. Note bytes already exceed 4000, which is the question #358 settles |
 
-**Start with #290.** It is one line, it exits 0 or it doesn't, and it retires a
-gotcha the goal prompt currently has to carry. A clean first pass through the
-whole loop on a trivial item is worth more than a big first win.
+**#290 is done** (PR #361) — the recipe is fixed, a test pins it to how pyproject
+declares the deps, and the gotcha is out of the goal prompt. **Start with #358**,
+now that #357 has landed.
 
 ## Tier 2 — loop-able with a tighter brief
 

--- a/NEXT_TASKS_LOOP.md
+++ b/NEXT_TASKS_LOOP.md
@@ -29,7 +29,7 @@ finish condition.
 | 1 | **#314** taxon ungrounded after an id edit | S | `gtdb_classification` present; a test pins `ncbi_source_id == term.id` | `Mesorhizobium_Synechococcus_…`: `NCBITaxon:1125` is the one taxon of four with no grounding |
 | 2 | **#306** snippet checks pick a cache file arbitrarily | M | resolution is deterministic, pinned by a test | **62** stems carry both `.md` and `.txt`; 63 folding case, 63 with any two extensions |
 | 3 | **#352a** seven records have no published page | XS | `just gen-html`; every record has a page | 312 records, **305** pages — 7 missing, not just SPRUCE |
-| 4 | **#358** goal-prompt size unguarded | XS | a test asserts chars **and** bytes | 3998 chars / **4028 bytes** on `main`, 2 chars spare. Unblocked: #357 merged as `5a1d60b`. Note bytes already exceed 4000, which is the question #358 settles |
+| 4 | **#358** goal-prompt size unguarded | XS | a test asserts chars **and** bytes | **3944 chars / 3974 bytes** after this PR retired a gotcha — 56 spare, and bytes now under 4000 for the first time. Nothing enforces either, and which one the ceiling counts is still unsettled |
 
 **#290 is done** (PR #361) — the recipe is fixed, a test pins it to how pyproject
 declares the deps, and the gotcha is out of the goal prompt. **Start with #358**,

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Rich YAML Source
 git clone https://github.com/CultureBotAI/CommunityMech.git
 cd CommunityMech
 
-# Install dependencies (once implemented)
+# Install dependencies
 just install
 
-# Or with uv
-uv sync --group dev
+# Or with uv directly
+uv sync --extra dev
 ```
 
 ### Validate a Community

--- a/docs/NETWORK_REPAIR_USER_GUIDE.md
+++ b/docs/NETWORK_REPAIR_USER_GUIDE.md
@@ -663,8 +663,8 @@ limits:
 # Install with LLM dependencies
 uv sync --all-extras
 
-# Or specific group
-uv sync --group llm
+# Or just the LLM extra
+uv sync --extra llm
 ```
 
 ### Issue: Slow Batch Processing

--- a/justfile
+++ b/justfile
@@ -33,7 +33,7 @@ default:
 
 # Install dependencies
 install:
-    uv sync --group dev
+    uv sync --extra dev
 
 # Validate a single community YAML file against schema
 validate FILE:

--- a/prompts/backlog-loop.goal.md
+++ b/prompts/backlog-loop.goal.md
@@ -66,7 +66,6 @@ recommendation.
   #1, #2` closes only #1; prose closes nothing. Repeat `Closes #N.` per issue in the PR
   body; accidental closes here came via commit messages.
 - `git add` explicit paths only; `git add -A` has swept unrelated work into a PR.
-- `just install` fails (#290): `uv sync --extra dev`.
 - Duplicate YAML keys and `preferred_term`s are invisible to `linkml-validate` — see
   `test_no_duplicate_yaml_keys.py` and `DUPLICATE_TAXON_NAME`. Run the tests too.
 - Report honestly: failing test, show it; skipped step, say so.

--- a/tests/test_install_recipe.py
+++ b/tests/test_install_recipe.py
@@ -1,0 +1,121 @@
+"""`just install` must agree with how pyproject declares its dev dependencies.
+
+uv has two separate mechanisms, and the flags are not interchangeable:
+
+* ``[project.optional-dependencies]`` — installed with ``--extra NAME``
+* ``[dependency-groups]``            — installed with ``--group NAME``
+
+The recipe passed ``--group dev`` while the deps were declared as an extra, so
+``just install`` — the setup command CLAUDE.md and the README both point new
+contributors at — failed outright with *"Group `dev` is not defined in the
+project's dependency-groups table"* (#290). Nothing caught it because no CI
+workflow runs ``just install``; they all call ``uv sync`` directly.
+
+This pins the *pairing* rather than the flag, so moving the deps to a
+``[dependency-groups]`` table later is fine — the test then requires ``--group``.
+
+`tomllib` is 3.11+ and CI runs 3.10, with no `tomli` in the tree, so the little
+parser below stands in. Where `tomllib` does exist it is used to check the parser
+agrees, so the shortcut cannot drift unnoticed.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).parent.parent
+JUSTFILE = REPO / "justfile"
+PYPROJECT = REPO / "pyproject.toml"
+
+
+def _array_keys(text: str, section: str) -> set:
+    """Names of the array-valued keys declared directly under ``[section]``."""
+    match = re.search(rf"^\[{re.escape(section)}\]\n(.*?)(?=^\[|\Z)", text, re.M | re.S)
+    if not match:
+        return set()
+    return set(re.findall(r"^([A-Za-z0-9_.-]+)\s*=\s*\[", match.group(1), re.M))
+
+
+def _array_values(text: str, section: str, key: str) -> list:
+    """The string entries of ``[section] key = [...]``."""
+    match = re.search(rf"^\[{re.escape(section)}\]\n(.*?)(?=^\[|\Z)", text, re.M | re.S)
+    if not match:
+        return []
+    body = re.search(rf"^{re.escape(key)}\s*=\s*\[(.*?)^\]", match.group(1), re.M | re.S)
+    if not body:
+        return []
+    # Match on the outer delimiter only. A naive [\"'] character class split
+    # `"deep-research-client[cyberian]>=0.2.4; python_version >= '3.12'"` at its
+    # inner quotes — caught by the tomllib cross-check below.
+    entries = re.findall(r'"((?:[^"\\]|\\.)*)"', body.group(1))
+    return entries or re.findall(r"'((?:[^'\\]|\\.)*)'", body.group(1))
+
+
+@pytest.fixture(scope="module")
+def pyproject_text() -> str:
+    return PYPROJECT.read_text()
+
+
+@pytest.fixture(scope="module")
+def install_recipe() -> str:
+    """The body of the `install` recipe."""
+    match = re.search(r"^install:\n((?:[ \t]+.*\n)+)", JUSTFILE.read_text(), re.M)
+    assert match, "no `install:` recipe found in the justfile"
+    return match.group(1)
+
+
+def test_install_uses_the_flag_matching_how_dev_deps_are_declared(pyproject_text, install_recipe):
+    extras = _array_keys(pyproject_text, "project.optional-dependencies")
+    groups = _array_keys(pyproject_text, "dependency-groups")
+
+    assert "dev" in extras or "dev" in groups, "pyproject declares no dev dependencies at all"
+    assert not ("dev" in extras and "dev" in groups), (
+        "dev is declared both as an extra and as a dependency group; "
+        "the install recipe cannot be right for both"
+    )
+
+    if "dev" in extras:
+        assert "--extra dev" in install_recipe, (
+            "pyproject declares dev under [project.optional-dependencies], so the "
+            f"install recipe must use `--extra dev`, not:\n{install_recipe}"
+        )
+        assert "--group dev" not in install_recipe, "`--group dev` cannot install an extra"
+    else:
+        assert "--group dev" in install_recipe, (
+            "pyproject declares dev under [dependency-groups], so the install "
+            f"recipe must use `--group dev`, not:\n{install_recipe}"
+        )
+        assert "--extra dev" not in install_recipe, "`--extra dev` cannot install a group"
+
+
+def test_install_actually_installs_the_dev_tools(pyproject_text):
+    """The recipe is only useful if `dev` carries what the docs then tell you to run.
+
+    CLAUDE.md points a new contributor at `just install` and then `just qc`,
+    which runs black, ruff, mypy and pytest.
+    """
+    declared = _array_values(
+        pyproject_text, "project.optional-dependencies", "dev"
+    ) or _array_values(pyproject_text, "dependency-groups", "dev")
+    names = {re.split(r"[><=\[;]", spec, maxsplit=1)[0].strip() for spec in declared}
+
+    for tool in ("pytest", "black", "ruff", "mypy"):
+        assert tool in names, f"`just qc` runs {tool}, but dev does not declare it"
+
+
+def test_the_shortcut_parser_agrees_with_a_real_toml_parser(pyproject_text):
+    """Guard the stand-in. Runs only where `tomllib` exists (3.11+), skips on CI's 3.10."""
+    tomllib = pytest.importorskip("tomllib")
+    parsed = tomllib.loads(pyproject_text)
+
+    assert _array_keys(pyproject_text, "project.optional-dependencies") == set(
+        parsed.get("project", {}).get("optional-dependencies", {})
+    )
+    assert _array_keys(pyproject_text, "dependency-groups") == set(
+        parsed.get("dependency-groups", {})
+    )
+    assert (
+        _array_values(pyproject_text, "project.optional-dependencies", "dev")
+        == parsed["project"]["optional-dependencies"]["dev"]
+    )

--- a/tests/test_install_recipe.py
+++ b/tests/test_install_recipe.py
@@ -29,27 +29,70 @@ JUSTFILE = REPO / "justfile"
 PYPROJECT = REPO / "pyproject.toml"
 
 
+def _strip_comments(text: str) -> str:
+    """Drop ``#`` comments that start outside a string.
+
+    A comment containing a quoted word — ``# see "PEP 508" markers`` — otherwise
+    reads as a dependency entry, silently.
+    """
+    out = []
+    for line in text.splitlines():
+        quote, cut = None, len(line)
+        for i, ch in enumerate(line):
+            if quote:
+                if ch == quote:
+                    quote = None
+            elif ch in "\"'":
+                quote = ch
+            elif ch == "#":
+                cut = i
+                break
+        out.append(line[:cut].rstrip())
+    return "\n".join(out) + "\n"
+
+
+def _section(text: str, section: str) -> str:
+    match = re.search(rf"^\[{re.escape(section)}\][ \t]*$\n(.*?)(?=^\[|\Z)", text, re.M | re.S)
+    return match.group(1) if match else ""
+
+
 def _array_keys(text: str, section: str) -> set:
     """Names of the array-valued keys declared directly under ``[section]``."""
-    match = re.search(rf"^\[{re.escape(section)}\]\n(.*?)(?=^\[|\Z)", text, re.M | re.S)
-    if not match:
-        return set()
-    return set(re.findall(r"^([A-Za-z0-9_.-]+)\s*=\s*\[", match.group(1), re.M))
+    body = _section(_strip_comments(text), section)
+    return set(re.findall(r"""^["']?([A-Za-z0-9_.-]+)["']?\s*=\s*\[""", body, re.M))
 
 
 def _array_values(text: str, section: str, key: str) -> list:
-    """The string entries of ``[section] key = [...]``."""
-    match = re.search(rf"^\[{re.escape(section)}\]\n(.*?)(?=^\[|\Z)", text, re.M | re.S)
-    if not match:
+    """The string entries of ``[section] key = [...]``, on one line or many.
+
+    Scans for the matching close bracket rather than regexing to the first one:
+    a dependency may carry its own brackets, as
+    ``deep-research-client[cyberian]>=0.2.4`` does, and a non-greedy ``\[(.*?)\]``
+    stops inside it.
+    """
+    body = _section(_strip_comments(text), section)
+    opener = re.search(rf"""^["']?{re.escape(key)}["']?\s*=\s*\[""", body, re.M)
+    if not opener:
         return []
-    body = re.search(rf"^{re.escape(key)}\s*=\s*\[(.*?)^\]", match.group(1), re.M | re.S)
-    if not body:
-        return []
-    # Match on the outer delimiter only. A naive [\"'] character class split
-    # `"deep-research-client[cyberian]>=0.2.4; python_version >= '3.12'"` at its
-    # inner quotes — caught by the tomllib cross-check below.
-    entries = re.findall(r'"((?:[^"\\]|\\.)*)"', body.group(1))
-    return entries or re.findall(r"'((?:[^'\\]|\\.)*)'", body.group(1))
+
+    depth, quote, entries, buf = 1, None, [], []
+    for ch in body[opener.end() :]:
+        if quote:
+            if ch == quote:
+                entries.append("".join(buf))
+                buf, quote = [], None
+            else:
+                buf.append(ch)
+            continue
+        if ch in "\"'":
+            quote, buf = ch, []
+        elif ch == "[":
+            depth += 1
+        elif ch == "]":
+            depth -= 1
+            if depth == 0:
+                break
+    return entries
 
 
 @pytest.fixture(scope="module")
@@ -76,9 +119,11 @@ def test_install_uses_the_flag_matching_how_dev_deps_are_declared(pyproject_text
     )
 
     if "dev" in extras:
-        assert "--extra dev" in install_recipe, (
+        # --all-extras installs every extra, dev included, and is what four of the
+        # five CI workflows use — so it satisfies the pairing just as well.
+        assert "--extra dev" in install_recipe or "--all-extras" in install_recipe, (
             "pyproject declares dev under [project.optional-dependencies], so the "
-            f"install recipe must use `--extra dev`, not:\n{install_recipe}"
+            f"install recipe must use `--extra dev` (or --all-extras), not:\n{install_recipe}"
         )
         assert "--group dev" not in install_recipe, "`--group dev` cannot install an extra"
     else:
@@ -119,3 +164,72 @@ def test_the_shortcut_parser_agrees_with_a_real_toml_parser(pyproject_text):
         _array_values(pyproject_text, "project.optional-dependencies", "dev")
         == parsed["project"]["optional-dependencies"]["dev"]
     )
+
+
+# ---------------------------------------------------------------------------
+# The parser, on TOML shapes this pyproject does not currently use. The tomllib
+# cross-check above skips on CI's 3.10, so without these the parser is only ever
+# exercised against one file, in one shape (#290 review).
+# ---------------------------------------------------------------------------
+
+
+SECTION = "project.optional-dependencies"
+
+
+@pytest.mark.parametrize(
+    ("label", "toml", "expected"),
+    [
+        (
+            "multi-line",
+            '[project.optional-dependencies]\ndev = [\n  "pytest",\n  "black",\n]\n',
+            ["pytest", "black"],
+        ),
+        (
+            "single-line",
+            '[project.optional-dependencies]\ndev = ["pytest", "black"]\n',
+            ["pytest", "black"],
+        ),
+        (
+            "bracket inside an entry",
+            '[project.optional-dependencies]\ndev = [\n  "drc[cyberian]>=0.2",\n  "black",\n]\n',
+            ["drc[cyberian]>=0.2", "black"],
+        ),
+        (
+            "quote inside an entry",
+            "[project.optional-dependencies]\ndev = [\n  \"x; python_version >= '3.12'\",\n]\n",
+            ["x; python_version >= '3.12'"],
+        ),
+        (
+            "comment containing a quoted word",
+            '[project.optional-dependencies]\ndev = [\n  "pytest",  # see "PEP 508"\n'
+            '  "black",\n]\n',
+            ["pytest", "black"],
+        ),
+        (
+            "comment containing an apostrophe",
+            '[project.optional-dependencies]\ndev = [\n  # don\'t pin "black" yet\n'
+            '  "pytest",\n]\n',
+            ["pytest"],
+        ),
+        (
+            "literal (single-quoted) strings",
+            "[project.optional-dependencies]\ndev = [\n  'pytest',\n  'black',\n]\n",
+            ["pytest", "black"],
+        ),
+        ("quoted key", '[project.optional-dependencies]\n"dev" = [\n  "pytest",\n]\n', ["pytest"]),
+        (
+            "another section is not consulted",
+            '[tool.other]\ndev = [\n  "nope",\n]\n\n'
+            '[project.optional-dependencies]\ndev = [\n  "pytest",\n]\n',
+            ["pytest"],
+        ),
+    ],
+)
+def test_parser_handles_the_toml_shapes_that_could_appear(label, toml, expected):
+    assert _array_values(toml, SECTION, "dev") == expected, label
+    assert "dev" in _array_keys(toml, SECTION), label
+
+
+def test_parser_reports_absence_rather_than_guessing():
+    assert _array_values('[project.optional-dependencies]\nother = ["x"]\n', SECTION, "dev") == []
+    assert _array_keys("[tool.black]\nline-length = 100\n", SECTION) == set()


### PR DESCRIPTION
Closes #290.

## The defect

```
$ just install
uv sync --group dev
error: Group `dev` is not defined in the project's `dependency-groups` table
```

uv has two mechanisms and the flags are not interchangeable — `[project.optional-dependencies]` takes `--extra`, `[dependency-groups]` takes `--group`. The recipe used `--group` against deps declared as an extra.

This is the setup command **CLAUDE.md and README.md both point a new contributor at**, so it was the first thing they would run. Every other `uv` invocation in the justfile already used `--extra dev`; `install` was the lone holdout.

**Why nothing caught it:** no workflow runs `just install`. CI calls `uv sync` directly, mostly `--all-extras`. The one command a human runs and CI never does was the one that was broken.

`--extra dev` rather than `--all-extras` because the linkml tooling `just qc` needs is already a **core** dependency, so `dev` alone covers the documented next step.

## The guard

`tests/test_install_recipe.py` pins the **pairing**, not the flag — move the deps to a `[dependency-groups]` table later and the test then requires `--group`. It also checks `dev` still declares the four tools `just qc` runs, since a recipe that succeeds while installing the wrong thing is no better.

**It nearly reddened `main` itself.** `tomllib` is 3.11+ and CI runs **3.10**, with no `tomli` in the tree — the test would have failed at import. It uses a small parser instead, with a cross-check against `tomllib` where that exists.

That cross-check immediately earned its keep: my first value regex split

```
"deep-research-client[cyberian]>=0.2.4; python_version >= 3.12"
```

at its *inner* quotes, producing a truncated entry and a stray `,\n    `. Nothing else would have noticed — the two functional tests passed throughout.

## Verification

- `just install` → **exit 0**
- Canaried: reverting the recipe to `--group dev` fails the guard
- Simulated CI's 3.10 (blocking the `tomllib` import): the cross-check skips, the two functional tests still pass
- `just lint`, `mypy` clean; **972 passed, 9 skipped**

## Also

Retires the `just install` gotcha from `prompts/backlog-loop.goal.md` — its header says to fix these there when they stop being true. That frees 54 characters of a budget that had **2** left, which is relevant to #358 (next).

---

## Round two (post-review)

**This PR falsified a row in a file it edits.** Removing the gotcha shrank the goal prompt from 3998/4028 to **3944 chars / 3974 bytes**, so #358's row — which this PR renumbered, and whose item its own body recommends next — still claimed "bytes already exceed 4000". That was the premise making the finding interesting; bytes are now *under* 4000 for the first time. Re-measured in place.

**The same defect survived one extra over.** `docs/NETWORK_REPAIR_USER_GUIDE.md:667` said `uv sync --group llm`, and `llm` is also an optional-dependency, so it fails identically. The new guard covers only `dev` + the justfile, so nothing caught it. Fixed — **no wrong `--group` remains anywhere in the repo**.

**The guard rejected a correct alternative.** Its docstring claimed to pin the *pairing*, but `assert "--extra dev" in recipe` is a literal substring test: switching to `--all-extras` — which installs dev correctly and is what four of five CI workflows use — would have reddened the build. Now accepted, canaried both ways.

**The parser guessed on TOML it had never seen.** Probed against `tomllib`, it mis-handled:

| form | old behaviour |
|---|---|
| `# see "PEP 508" markers` | **silent**: parsed the comment as a dependency |
| `# don't pin "black" yet` | **silent**: duplicated an entry |
| mixed quotes `["a", 'b']` | dropped the single-quoted entry |
| `dev = ["a", "b"]` on one line | returned `[]` |
| inline tables, quoted keys, sub-tables | returned `set()` |

It now strips comments outside strings, accepts either quote style and quoted keys, and **scans for the matching close bracket** rather than regexing to the first one — which the cross-check demanded immediately, since `deep-research-client[cyberian]` closes a bracket *inside* an entry.

**And the cross-check never runs in CI.** `pytest.importorskip("tomllib")` skips on 3.10, so the parser was verified only on a contributor's 3.11+ machine, against one file in one shape. Nine synthetic cases now cover it directly: **12 of 13 tests run on 3.10**, where the parser previously had no coverage at all.

**982 passed, 9 skipped.** `lint`, `validate-strict`, `vendored-sync` all green.
