### PR TITLE
Guard the /goal prompt's size budget, in both characters and bytes (#358)

### DIFF
--- a/.github/workflows/validate-strict.yaml
+++ b/.github/workflows/validate-strict.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     paths: &trigger_paths
       - "kb/communities/**"
+      # A prompt-only edit is the one change class that can breach the /goal size
+      # budget, and it matched no workflow filter — so the guard added in #358
+      # would not have run on it. Same shape as the data/isolates gap below.
+      - "prompts/**"
       # data/isolates carries CommunityMech ids too. It was outside every
       # workflow's paths filter, which is half of why four ids ended up used
       # twice (#310) — editing an isolate has to re-run the uniqueness gate.

--- a/NEXT_TASKS_LOOP.md
+++ b/NEXT_TASKS_LOOP.md
@@ -29,11 +29,9 @@ finish condition.
 | 1 | **#314** taxon ungrounded after an id edit | S | `gtdb_classification` present; a test pins `ncbi_source_id == term.id` | `Mesorhizobium_Synechococcus_…`: `NCBITaxon:1125` is the one taxon of four with no grounding |
 | 2 | **#306** snippet checks pick a cache file arbitrarily | M | resolution is deterministic, pinned by a test | **62** stems carry both `.md` and `.txt`; 63 folding case, 63 with any two extensions |
 | 3 | **#352a** seven records have no published page | XS | `just gen-html`; every record has a page | 312 records, **305** pages — 7 missing, not just SPRUCE |
-| 4 | **#358** goal-prompt size unguarded | XS | a test asserts chars **and** bytes | **3944 chars / 3974 bytes** after this PR retired a gotcha — 56 spare, and bytes now under 4000 for the first time. Nothing enforces either, and which one the ceiling counts is still unsettled |
 
-**#290 is done** (PR #361) — the recipe is fixed, a test pins it to how pyproject
-declares the deps, and the gotcha is out of the goal prompt. **Start with #358**,
-now that #357 has landed.
+**#290 and #358 are done** (PRs #361, #362). **Start with #314** — one taxon to
+ground and a cheap test pinning `ncbi_source_id` to `term.id`.
 
 ## Tier 2 — loop-able with a tighter brief
 

--- a/NEXT_TASKS_LOOP.md
+++ b/NEXT_TASKS_LOOP.md
@@ -28,7 +28,6 @@ finish condition.
 |---|---|---|---|---|
 | 1 | **#314** taxon ungrounded after an id edit | S | `gtdb_classification` present; a test pins `ncbi_source_id == term.id` | `Mesorhizobium_Synechococcus_…`: `NCBITaxon:1125` is the one taxon of four with no grounding |
 | 2 | **#306** snippet checks pick a cache file arbitrarily | M | resolution is deterministic, pinned by a test | **62** stems carry both `.md` and `.txt`; 63 folding case, 63 with any two extensions |
-| 3 | **#352a** seven records have no published page | XS | `just gen-html`; every record has a page | 312 records, **305** pages — 7 missing, not just SPRUCE |
 
 **#290 and #358 are done** (PRs #361, #362). **Start with #314** — one taxon to
 ground and a cheap test pinning `ncbi_source_id` to `term.id`.
@@ -67,8 +66,6 @@ judgement, or the loop will invent something.
 - **#270 — interaction type encoded by colour alone**, nine categories. Fully
   specified, and the CVD-simulation harness from #268 already exists to verify a
   redundant encoding. Frontend, self-contained.
-- **#352b — a second coarse SPRUCE record (`000135`) already exists.** Only the
-  *report* is loop-able; whether to merge the two records is a curator call.
 
 ## Tier 3 — needs a human decision first
 
@@ -84,7 +81,6 @@ answer is not derivable from the repo.
 | #297 | Is ROS detoxification a metabolite or a process in that record? |
 | #292 | Two taxa carry an id for a different organism — correct, or keep withheld? |
 | #325 | Backfill `curation_history` to the other 310 of 312, or drop the slot? |
-| #355 | Is interaction 1 `COMMENSALISM`/`CROSS_FEEDING` rather than `MUTUALISM`? |
 | #356 | Does the ECM entry mean nutrients *from* the host or *to* it? |
 | #182 | Which best-effort ontology remaps to accept |
 | #199 | Which dataviz findings to act on |
@@ -105,16 +101,10 @@ loop.
 
 ## Ordering and dependencies
 
-- **#347, #355, #356 all edit `SPRUCE_Peatland_Warming_Community.yaml`.** One PR,
-  or strictly serial; the loop's one-PR-in-flight rule handles this if they are
-  not queued together.
+- **#347 and #356 both edit `SPRUCE_Peatland_Warming_Community.yaml`.** One PR, or
+  strictly serial.
 - **#314 before #294.** #314 is the data fix; #294 is the schema that would
   describe it. Doing the data first keeps the enum backfill honest.
-- **#352a cannot close #352** — that issue also carries the duplicate-SPRUCE
-  question (#352b), which is a curator call. Expect the loop's "issue closed"
-  finish condition not to fire; split the issue first, or accept a partial.
-- **#290 retires a gotcha** in `prompts/backlog-loop.goal.md`. Whoever fixes it
-  updates the prompt in the same PR — the prompt's own header says so.
 
 ## Never loop these
 

--- a/tests/test_goal_prompt_size.py
+++ b/tests/test_goal_prompt_size.py
@@ -7,20 +7,32 @@ most likely to be lost is the accumulated list of things that have already gone
 wrong once.
 
 Nothing enforced this. The file was maintained by hand against a remembered
-number and reached **2 characters** of headroom before this test existed (#358),
-having been recompressed by hand three times.
+number and reached **2 characters** of headroom before this test existed (#358).
 
-**Characters or bytes is unresolved**, so both are asserted. The distinction is
-not academic here: the prose is em-dash heavy, which costs 3 bytes per character,
-and the file exceeded 4000 *bytes* in two of its three released revisions while
+``LIMIT`` itself is that remembered number: no measurement of the real ceiling
+exists anywhere in the repo, only `CLAUDE.md`'s assertion of it. Worth pinning to
+a measured value.
+
+**Characters or bytes is unresolved** (#358), so this enforces the stricter of
+the two: bytes. Be clear about what that means — UTF-8 uses at least one byte per
+code point, so ``bytes <= LIMIT`` *implies* ``chars <= LIMIT``. The character
+assertion below can never fail on its own; it is kept only because it fires first
+and says "characters" when a plain-ASCII edit runs long, which is the common case
+and the clearer message.
+
+The distinction is not academic. The prose is em-dash heavy at 3 bytes per
+character, and the file exceeded 4000 *bytes* in two of its three revisions while
 never exceeding 4000 characters —
 
     2429a7a  3987 chars  4015 bytes
     5a1d60b  3998 chars  4028 bytes
     9f9ba22  3944 chars  3974 bytes
 
-If the ceiling turns out to count bytes, the first two shipped over it. Holding
-both under the limit is correct whichever it is, and costs nothing.
+So this is not a free hedge: it costs real budget. At current punctuation density
+the 15 non-ASCII characters cost 30 bytes, which is 30 of the 56 characters of
+headroom — more than half. If the ceiling turns out to count characters after
+all, that is the price of having been cautious. Prefer ASCII punctuation in this
+file over spending it.
 """
 
 from pathlib import Path
@@ -51,6 +63,8 @@ def test_goal_prompt_fits_the_budget_in_both_units(path: Path):
     text = raw.decode("utf-8")
     chars, byte_count = len(text), len(raw)
 
+    # Implied by the byte assertion below, never independently reachable; kept
+    # for the clearer message on a plain-ASCII overrun. See the module docstring.
     assert chars <= LIMIT, (
         f"{path.name} is {chars} characters, {chars - LIMIT} over the {LIMIT} limit. "
         f"Cut prose rather than dropping a gotcha or a loop step."

--- a/tests/test_goal_prompt_size.py
+++ b/tests/test_goal_prompt_size.py
@@ -1,0 +1,73 @@
+"""`/goal` prompts must fit the harness's input budget.
+
+`/goal` truncates past roughly 4000, and a truncated prompt fails in the worst
+way available: silently, losing whatever sat at the end. In
+`prompts/backlog-loop.goal.md` the tail is the Gotchas section, so the material
+most likely to be lost is the accumulated list of things that have already gone
+wrong once.
+
+Nothing enforced this. The file was maintained by hand against a remembered
+number and reached **2 characters** of headroom before this test existed (#358),
+having been recompressed by hand three times.
+
+**Characters or bytes is unresolved**, so both are asserted. The distinction is
+not academic here: the prose is em-dash heavy, which costs 3 bytes per character,
+and the file exceeded 4000 *bytes* in two of its three released revisions while
+never exceeding 4000 characters —
+
+    2429a7a  3987 chars  4015 bytes
+    5a1d60b  3998 chars  4028 bytes
+    9f9ba22  3944 chars  3974 bytes
+
+If the ceiling turns out to count bytes, the first two shipped over it. Holding
+both under the limit is correct whichever it is, and costs nothing.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).parent.parent
+PROMPTS = REPO / "prompts"
+
+# The `/goal` input budget. Applied to both units, since which one the harness
+# counts is unknown — see the module docstring.
+LIMIT = 4000
+
+
+def _goal_prompts() -> list:
+    return sorted(PROMPTS.glob("*.goal.md"))
+
+
+def test_there_is_something_to_check():
+    """A glob that matches nothing passes every parametrised test vacuously."""
+    assert PROMPTS.is_dir(), f"{PROMPTS} does not exist"
+    assert _goal_prompts(), f"no *.goal.md found in {PROMPTS}"
+
+
+@pytest.mark.parametrize("path", _goal_prompts(), ids=lambda p: p.name)
+def test_goal_prompt_fits_the_budget_in_both_units(path: Path):
+    raw = path.read_bytes()
+    text = raw.decode("utf-8")
+    chars, byte_count = len(text), len(raw)
+
+    assert chars <= LIMIT, (
+        f"{path.name} is {chars} characters, {chars - LIMIT} over the {LIMIT} limit. "
+        f"Cut prose rather than dropping a gotcha or a loop step."
+    )
+    assert byte_count <= LIMIT, (
+        f"{path.name} is {byte_count} bytes ({chars} characters), {byte_count - LIMIT} "
+        f"over the {LIMIT} limit. Non-ASCII punctuation costs extra bytes — em dashes "
+        f"and arrows are the usual culprits here."
+    )
+
+
+@pytest.mark.parametrize("path", _goal_prompts(), ids=lambda p: p.name)
+def test_goal_prompt_is_valid_utf8_and_not_empty(path: Path):
+    """A prompt that cannot be decoded, or is blank, would pass the size check."""
+    raw = path.read_bytes()
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:  # pragma: no cover - would be a real defect
+        pytest.fail(f"{path.name} is not valid UTF-8: {exc}")
+    assert text.strip(), f"{path.name} is empty"


### PR DESCRIPTION
Closes #358.

## The problem

Nothing enforced the limit. `prompts/backlog-loop.goal.md` was maintained by hand against a remembered number, hand-recompressed three times, and reached **2 characters** of headroom before this test existed.

Past the budget `/goal` truncates *silently*. What sits at the tail of that file is the **Gotchas** section — so the first thing lost would be the accumulated list of things that have already gone wrong once.

## Characters or bytes is still unresolved, so both are asserted

Not academic here. The prose is em-dash heavy (3 bytes per character), and the file **exceeded 4000 bytes in two of its three released revisions** while never exceeding 4000 characters:

| commit | chars | bytes |
|---|---:|---:|
| `2429a7a` | 3987 | **4015** |
| `5a1d60b` | 3998 | **4028** |
| `9f9ba22` (current) | 3944 | 3974 |

If the ceiling counts bytes, the first two shipped over it. Holding both under is correct whichever it is, and costs nothing.

## Verification

Each assertion canaried independently:

- append 100 ASCII characters → **character** assertion fails
- append 20 em dashes → **byte** assertion fails alone, at 3964 characters / 4034 bytes

That second case is the whole reason #358 was filed: it passes a naive `len(text)` check and would ship truncated.

The test globs `prompts/*.goal.md` rather than naming one file, so a second prompt is covered on arrival — with a separate test asserting the glob matched something, since a pattern matching nothing passes every parametrised case vacuously. That is how #334 nearly shipped.

**985 passed, 9 skipped**; `just lint` and `mypy` clean.

Also retires the #358 row from `NEXT_TASKS_LOOP.md`; the recommendation moves to **#314**.

---

## Round two (post-review)

**The guard did not run on the change class it guards.** No workflow's `paths:` filter mentioned `prompts/**`, so a PR editing *only* the goal prompt — the one change that can breach the budget — triggered **zero** workflows, on the PR and on merge. This PR looked green only because it also adds a file under `tests/`.

That is the same shape as the `data/isolates/**` gap that let four ids collide (#310) — and the comment three lines below it in that very file says so. `prompts/**` is now in `validate-strict`'s trigger paths; the YAML anchor propagates it to `push` as well.

**The character assertion is logically dead, and I claimed otherwise.** UTF-8 uses ≥1 byte per code point, so `bytes <= LIMIT` **implies** `chars <= LIMIT`. No input can trip the character assertion alone — at +100 ASCII the file is over on *both*, so "each assertion canaried independently" was false for that half. It is kept because it fires first and says "characters" on a plain-ASCII overrun, which is the clearer message; the code now says so.

**"Costs nothing" was also wrong.** Asserting both adopts the *stricter* reading unconditionally. Measured: 15 non-ASCII characters cost 30 bytes — **30 of the 56 characters of headroom**, more than half. The docstring now states that price and says to prefer ASCII punctuation rather than spend it.

The em-dash canary still stands and is the one that justifies the byte check: +20 em dashes → 3964 characters (under) / 4034 bytes (over).

**Two smaller corrections.** "Recompressed by hand three times" is unsupported — the file has three revisions *total*, so at most two after creation. And `LIMIT` is itself the remembered number this guard was meant to replace: no measurement of the real ceiling exists anywhere, and `CLAUDE.md` documents a *char* limit while the test enforces a *byte* one. The docstring now admits this, and **#363** tracks measuring it.

**Also housekeeping in `NEXT_TASKS_LOOP.md`:** #352 and #355 are closed and were still listed as work; the #290 dependency note is spent. Removed. Tier 1 is now **#314** then **#306**.
