### PR TITLE
Ground the taxon left stale by an id edit, and pin grounding to its source id (#314)

### DIFF
--- a/NEXT_TASKS_LOOP.md
+++ b/NEXT_TASKS_LOOP.md
@@ -26,11 +26,11 @@ finish condition.
 
 | # | Item | Size | Done when | Verified against `main` |
 |---|---|---|---|---|
-| 1 | **#314** taxon ungrounded after an id edit | S | `gtdb_classification` present; a test pins `ncbi_source_id == term.id` | `Mesorhizobium_Synechococcus_…`: `NCBITaxon:1125` is the one taxon of four with no grounding |
-| 2 | **#306** snippet checks pick a cache file arbitrarily | M | resolution is deterministic, pinned by a test | **62** stems carry both `.md` and `.txt`; 63 folding case, 63 with any two extensions |
+| 1 | **#306** snippet checks pick a cache file arbitrarily | M | resolution is deterministic, pinned by a test | **62** stems carry both `.md` and `.txt`; 63 folding case, 63 with any two extensions |
 
-**#290 and #358 are done** (PRs #361, #362). **Start with #314** — one taxon to
-ground and a cheap test pinning `ncbi_source_id` to `term.id`.
+**#290, #358 and #314 are done** (PRs #361, #362, #364). **Start with #306** —
+63 references carry both a `.md` and a `.txt` and the snippet checks pick one
+arbitrarily.
 
 ## Tier 2 — loop-able with a tighter brief
 
@@ -103,8 +103,7 @@ loop.
 
 - **#347 and #356 both edit `SPRUCE_Peatland_Warming_Community.yaml`.** One PR, or
   strictly serial.
-- **#314 before #294.** #314 is the data fix; #294 is the schema that would
-  describe it. Doing the data first keeps the enum backfill honest.
+- **#314 is done, so #294's backfill has correct data under it.**
 
 ## Never loop these
 

--- a/NEXT_TASKS_LOOP.md
+++ b/NEXT_TASKS_LOOP.md
@@ -29,7 +29,7 @@ finish condition.
 | 1 | **#306** snippet checks pick a cache file arbitrarily | M | resolution is deterministic, pinned by a test | **62** stems carry both `.md` and `.txt`; 63 folding case, 63 with any two extensions |
 
 **#290, #358 and #314 are done** (PRs #361, #362, #364). **Start with #306** —
-63 references carry both a `.md` and a `.txt` and the snippet checks pick one
+62 references carry both a `.md` and a `.txt` and the snippet checks pick one
 arbitrarily.
 
 ## Tier 2 — loop-able with a tighter brief
@@ -82,6 +82,8 @@ answer is not derivable from the repo.
 | #292 | Two taxa carry an id for a different organism — correct, or keep withheld? |
 | #325 | Backfill `curation_history` to the other 310 of 312, or drop the slot? |
 | #356 | Does the ECM entry mean nutrients *from* the host or *to* it? |
+| #363 | Measure the real `/goal` ceiling, and decide whether it counts chars or bytes |
+| #365 | Which NCBI id the two *Bosea* entries should carry — the current one is a plant |
 | #182 | Which best-effort ontology remaps to accept |
 | #199 | Which dataviz findings to act on |
 
@@ -103,6 +105,9 @@ loop.
 
 - **#347 and #356 both edit `SPRUCE_Peatland_Warming_Community.yaml`.** One PR, or
   strictly serial.
+- **#366 before any grounding backfill.** `gtdb_ground.py` is batch-sensitive —
+  the same taxon can resolve differently per-record versus whole-KB — so a
+  backfill run now would bake in whichever batch it happened to use.
 - **#314 is done, so #294's backfill has correct data under it.**
 
 ## Never loop these

--- a/kb/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.yaml
+++ b/kb/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.yaml
@@ -127,6 +127,14 @@ taxonomy:
     term:
       id: NCBITaxon:1125
       label: Microcystis <cyanobacteria>
+    gtdb_classification:
+      gtdb_id: GTDB:g__Microcystis
+      gtdb_taxon: Microcystis
+      gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Cyanobacteriales;f__Microcystaceae;g__Microcystis
+      ncbi_source_id: NCBITaxon:1125
+      majority_fraction: 0.991
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: The bloom-forming community co-cultured with Syn7002 to seed the consortium. Grounded at
       genus, which is exactly the rank the paper uses — an earlier draft grounded this to
       Microcystis aeruginosa on the grounds that it dominates Lake Taihu blooms, but the source

--- a/tests/test_gtdb_grounding_freshness.py
+++ b/tests/test_gtdb_grounding_freshness.py
@@ -1,0 +1,113 @@
+"""A `gtdb_classification` must still describe the `term.id` it was derived from.
+
+The block is derived data: `gtdb_ground.py` reads `taxon_term.term.id` and writes
+the result, recording the input in `ncbi_source_id`. Nothing tied the two
+together afterwards, so editing the id left the derived block describing a
+different organism, with no gate objecting (#314).
+
+That is exactly what happened to `Mesorhizobium_Synechococcus_B12_Synthetic_Consortium`:
+grounding ran against `NCBITaxon:1126` (*Microcystis aeruginosa*), review then
+established the paper names only a genus and changed the id to `NCBITaxon:1125`,
+and grounding was never re-run.
+
+The resulting blank is worse than wrong, it is *ambiguous*: of 382 ungrounded
+taxa, 288 have no GTDB equivalent, 87 are ambiguous, and a handful are withheld
+on purpose (#292, pinned by `tests/test_gtdb_withheld_groundings.py`). Telling an
+accidental gap from a deliberate one took re-running the grounding tool over the
+whole KB. `#294`'s status enum is the real fix; this is the cheap half that works
+today and needs no schema change.
+
+`ncbi_source_id` is the only self-check the block carries, so it is worth
+asserting even though it holds for all 647 grounded taxa right now — it is a
+guard against the next id edit, not a report on this one.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).parent.parent
+COMMUNITIES = REPO / "kb/communities"
+
+
+def _grounded_taxa():
+    """(record, preferred_term, term_id, gtdb_classification) for every grounded taxon."""
+    found = []
+    for path in sorted(COMMUNITIES.glob("*.yaml")):
+        data = yaml.safe_load(path.read_text()) or {}
+        for taxon in data.get("taxonomy") or []:
+            if not isinstance(taxon, dict):
+                continue
+            term_block = taxon.get("taxon_term") or {}
+            grounding = term_block.get("gtdb_classification")
+            if not grounding:
+                continue
+            found.append(
+                (
+                    path.name,
+                    term_block.get("preferred_term"),
+                    (term_block.get("term") or {}).get("id"),
+                    grounding,
+                )
+            )
+    return found
+
+
+@pytest.fixture(scope="module")
+def grounded():
+    found = _grounded_taxa()
+    # A relative path or an empty glob would pass every assertion below vacuously.
+    assert len(found) > 500, f"expected the grounded KB, swept only {len(found)} taxa"
+    return found
+
+
+def test_grounding_records_the_id_it_was_derived_from(grounded):
+    """`ncbi_source_id` must be present — it is the block's only provenance."""
+    missing = [
+        f"{record}: {name}"
+        for record, name, _, grounding in grounded
+        if not grounding.get("ncbi_source_id")
+    ]
+    assert not missing, "gtdb_classification without ncbi_source_id:\n" + "\n".join(
+        f"  {m}" for m in missing
+    )
+
+
+def test_grounding_is_not_stale_against_its_taxon_id(grounded):
+    """The derived block must describe the taxon it is attached to.
+
+    Editing `term.id` after grounding leaves the block describing the *previous*
+    organism. Nothing else in the pipeline notices (#314).
+    """
+    stale = [
+        f"{record}: {name}\n"
+        f"      term.id        = {term_id}\n"
+        f"      ncbi_source_id = {grounding.get('ncbi_source_id')}"
+        for record, name, term_id, grounding in grounded
+        if term_id and grounding.get("ncbi_source_id") != term_id
+    ]
+    assert not stale, (
+        "gtdb_classification derived from a different id than the taxon now carries — "
+        "re-run `gtdb_ground.py --apply` on these records:\n" + "\n".join(f"  {s}" for s in stale)
+    )
+
+
+def test_the_known_stale_entry_is_now_grounded():
+    """The instance that prompted #314, pinned so it cannot silently regress."""
+    record = COMMUNITIES / "Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.yaml"
+    data = yaml.safe_load(record.read_text())
+
+    by_id = {
+        (t["taxon_term"].get("term") or {}).get("id"): t["taxon_term"] for t in data["taxonomy"]
+    }
+    microcystis = by_id.get("NCBITaxon:1125")
+    assert microcystis, "NCBITaxon:1125 is no longer in this record"
+
+    grounding = microcystis.get("gtdb_classification")
+    assert grounding, "NCBITaxon:1125 is ungrounded again (#314)"
+    assert grounding["ncbi_source_id"] == "NCBITaxon:1125"
+    assert grounding["gtdb_id"] == "GTDB:g__Microcystis", (
+        "the paper names only a genus, so this must stay at g__ rank — an earlier "
+        "draft grounded it to Microcystis aeruginosa, which the source never names"
+    )

--- a/tests/test_gtdb_grounding_freshness.py
+++ b/tests/test_gtdb_grounding_freshness.py
@@ -5,21 +5,24 @@ the result, recording the input in `ncbi_source_id`. Nothing tied the two
 together afterwards, so editing the id left the derived block describing a
 different organism, with no gate objecting (#314).
 
-That is exactly what happened to `Mesorhizobium_Synechococcus_B12_Synthetic_Consortium`:
-grounding ran against `NCBITaxon:1126` (*Microcystis aeruginosa*), review then
-established the paper names only a genus and changed the id to `NCBITaxon:1125`,
-and grounding was never re-run.
+**Be precise about what this does and does not catch.** In the #314 instance the
+id was corrected *before* the record was ever committed, so `main` held an
+**absent** block, never a stale one — `git log --follow` shows the entry reading
+`NCBITaxon:1125` with no grounding from its first commit. The two general
+assertions below inspect only taxa that *have* a block, so neither would have
+caught #314. Test 3 pins that instance directly; the general pair guards the
+sibling failure mode, where the block survives an id edit and quietly describes
+the previous organism.
 
-The resulting blank is worse than wrong, it is *ambiguous*: of 382 ungrounded
-taxa, 288 have no GTDB equivalent, 87 are ambiguous, and a handful are withheld
-on purpose (#292, pinned by `tests/test_gtdb_withheld_groundings.py`). Telling an
-accidental gap from a deliberate one took re-running the grounding tool over the
-whole KB. `#294`'s status enum is the real fix; this is the cheap half that works
-today and needs no schema change.
+The resulting blank is also *ambiguous*, which is the deeper problem: of the 381
+ungrounded taxa here, 292 have no GTDB equivalent, 87 are ambiguous, and 2 are
+withheld on purpose (#292, pinned by `tests/test_gtdb_withheld_groundings.py`) —
+292 + 87 + 2 = 381. Telling an accidental gap from a deliberate one took
+re-running the grounding tool over the whole KB. #294's status enum is the real
+fix; this is the cheap half that works today and needs no schema change.
 
-`ncbi_source_id` is the only self-check the block carries, so it is worth
-asserting even though it holds for all 647 grounded taxa right now — it is a
-guard against the next id edit, not a report on this one.
+`ncbi_source_id` holds for all 647 grounded taxa right now, so this is a guard
+against the next id edit, not a report on this one.
 """
 
 from pathlib import Path
@@ -28,13 +31,17 @@ import pytest
 import yaml
 
 REPO = Path(__file__).parent.parent
-COMMUNITIES = REPO / "kb/communities"
+# `data/isolates/` uses the same `taxonomy[].taxon_term` shape and carries no
+# grounding today, but a grounded isolate would otherwise slip past unseen — the
+# directory has been outside a gate's scope once already (#310).
+RECORD_DIRS = ("kb/communities", "data/isolates")
 
 
 def _grounded_taxa():
     """(record, preferred_term, term_id, gtdb_classification) for every grounded taxon."""
     found = []
-    for path in sorted(COMMUNITIES.glob("*.yaml")):
+    paths = [p for d in RECORD_DIRS for p in sorted((REPO / d).glob("*.yaml"))]
+    for path in paths:
         data = yaml.safe_load(path.read_text()) or {}
         for taxon in data.get("taxonomy") or []:
             if not isinstance(taxon, dict):
@@ -85,7 +92,7 @@ def test_grounding_is_not_stale_against_its_taxon_id(grounded):
         f"      term.id        = {term_id}\n"
         f"      ncbi_source_id = {grounding.get('ncbi_source_id')}"
         for record, name, term_id, grounding in grounded
-        if term_id and grounding.get("ncbi_source_id") != term_id
+        if grounding.get("ncbi_source_id") != term_id
     ]
     assert not stale, (
         "gtdb_classification derived from a different id than the taxon now carries — "
@@ -95,7 +102,7 @@ def test_grounding_is_not_stale_against_its_taxon_id(grounded):
 
 def test_the_known_stale_entry_is_now_grounded():
     """The instance that prompted #314, pinned so it cannot silently regress."""
-    record = COMMUNITIES / "Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.yaml"
+    record = REPO / "kb/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.yaml"
     data = yaml.safe_load(record.read_text())
 
     by_id = {
@@ -110,4 +117,40 @@ def test_the_known_stale_entry_is_now_grounded():
     assert grounding["gtdb_id"] == "GTDB:g__Microcystis", (
         "the paper names only a genus, so this must stay at g__ rank — an earlier "
         "draft grounded it to Microcystis aeruginosa, which the source never names"
+    )
+
+
+def test_grounding_is_internally_coherent(grounded):
+    """A block whose fields contradict each other passed every check above.
+
+    `gtdb_id`, `gtdb_taxon` and the tail of `gtdb_lineage` are three spellings of
+    one answer, and `majority_fraction` is a share of genomes, so it cannot
+    exceed 1 — nor fall at or below 0.5, since the tool grounds on a majority.
+    `linkml-validate` accepts `majority_fraction: 7.5` today.
+    """
+    problems = []
+    for record, name, _, g in grounded:
+        gtdb_id, taxon, lineage = (
+            g.get("gtdb_id", ""),
+            g.get("gtdb_taxon"),
+            g.get("gtdb_lineage", ""),
+        )
+        where = f"{record}: {name}"
+
+        # GTDB:g__Foo -> the lineage must end in that same g__Foo
+        rank_token = gtdb_id.split(":", 1)[-1]
+        if lineage and rank_token and lineage.split(";")[-1].replace(" ", "_") != rank_token:
+            problems.append(
+                f"{where}\n      gtdb_id={gtdb_id} but lineage ends {lineage.split(';')[-1]!r}"
+            )
+
+        if taxon and rank_token and taxon.replace(" ", "_") != rank_token.split("__", 1)[-1]:
+            problems.append(f"{where}\n      gtdb_id={gtdb_id} but gtdb_taxon={taxon!r}")
+
+        fraction = g.get("majority_fraction")
+        if fraction is not None and not (0.5 <= fraction <= 1.0):
+            problems.append(f"{where}\n      majority_fraction={fraction} outside (0.5, 1]")
+
+    assert not problems, "internally inconsistent gtdb_classification:\n" + "\n".join(
+        f"  {p}" for p in problems
     )


### PR DESCRIPTION
Closes #314.

## The instance

`Mesorhizobium_Synechococcus_B12_Synthetic_Consortium` carried one ungrounded taxon of four. Grounding had run against `NCBITaxon:1126` (*Microcystis aeruginosa*); review then established the paper names only a genus and changed the id to `NCBITaxon:1125` — and grounding was never re-run. The entry read as ungrounded when it was simply out of date.

**The premise needed checking rather than taking.** The issue says `NCBITaxon:1125` "**is** groundable". Run directly, it looks like it is not:

```
$ gtdb_ground.py --ncbi-id NCBITaxon:1125
  no GTDB mapping (rank absent from the NCBI2GTDB table, or eukaryote).
```

It *is* groundable — the rank-aware aggregation only runs in `--community` mode, where the label supplies the rank. There it lands on `GTDB:g__Microcystis`, **0.991 majority** over 2 GTDB taxa. Applied: **8 lines added, nothing else in the record touched**; 646 grounded taxa become 647.

Genus rank is the whole point, so the test pins it: an earlier draft grounded this to *M. aeruginosa* because it dominates Lake Taihu blooms, the source never names a species, and that inference was removed once already.

## The durable half

A `gtdb_classification` is derived from `term.id` and records its input in `ncbi_source_id` — but nothing tied the two together. Edit the id and the block silently describes a different organism. `tests/test_gtdb_withheld_groundings.py` pins *deliberate* absence for the #292 entries; accidental staleness had nothing.

`tests/test_gtdb_grounding_freshness.py` asserts:

1. every grounded taxon records an `ncbi_source_id` — the block's only provenance
2. that id still matches the taxon's `term.id`
3. the #314 instance specifically, at `g__` rank

**Measured before writing it: 0 of 647 grounded taxa currently mismatch.** So this guards the *next* id edit rather than reporting on this one — which is why the third test pins the instance separately, and why the fixture requires >500 taxa so an empty sweep cannot pass vacuously.

Canaried all three: a stale `ncbi_source_id` fails 2, removing the provenance field fails 3, removing the whole block fails 1.

## What this does not do

It does not close the ambiguity #294 exists for. An accidental blank still looks identical to a deliberate one — of 382 ungrounded taxa, 288 have no GTDB equivalent, 87 are ambiguous, and a handful are withheld on purpose. This closes only the case where the block's own provenance field can settle it today, with no schema change.

## Verification

- `just validate` and `just validate-terms` on the record: clean
- Network audit unchanged: 55 findings, 0 error
- `just lint`, `mypy` clean; **988 passed, 9 skipped**

---

## Round two (post-review)

**The causal story I wrote was wrong, and it mattered.** I said grounding ran against `NCBITaxon:1126` and was left stale by the id edit. `git log --follow` shows otherwise: the record's *first* commit already reads `NCBITaxon:1125` with no grounding. The 1126 → 1125 edit happened pre-commit, so `main` never held a stale block — only an absent one.

That is not a wording nit. Both general assertions inspect only taxa that **have** a block, so **neither would have caught #314**. Only test 3, the instance pin, covers it; the general pair guards the *sibling* failure mode, where a block survives an id edit and quietly describes the previous organism. The docstring now says that plainly.

**My canary claims were also wrong on all three counts.** Re-measured:

| mutation | I claimed | actually fails |
|---|---|---|
| stale `ncbi_source_id` | test 2 | tests 2 **and 3** |
| delete `ncbi_source_id` | test 3 | tests **1, 2 and 3** |
| delete the whole block | test 1 | **only test 3** |

The last is structural: test 1 iterates over taxa that have a block, so a removed block makes the taxon vanish from the fixture — it can never fail that way.

**Two silent holes, found by mutation, now failing loudly:**

- a block whose taxon has **no `term.id`** was skipped by an `if term_id and …` guard — deleting the id passed everything
- an **internally incoherent** block passed too: `gtdb_taxon: Nostoc` against `gtdb_id: GTDB:g__Microcystis`, or `majority_fraction: 7.5`, which `linkml-validate` also accepts

A fourth test cross-checks `gtdb_id`, `gtdb_taxon` and the lineage tail against one another and bounds the fraction to the (0.5, 1] the majority rule implies. Scope also widened to `data/isolates/` — no grounding there today, but it uses the same shape, and that directory has been outside a gate's scope once already (#310).

**Numbers corrected.** "288 have no GTDB equivalent" was inherited from #314's body via #309 and did not close against the total. It is **292**: 292 + 87 ambiguous + 2 withheld = **381**, the ungrounded count after this PR. `NEXT_TASKS_LOOP.md` prose also said 63 references carry both a `.md` and a `.txt` where its own table says 62.

## Filed, not fixed

- **#365** — two records carry a GTDB block on `NCBITaxon:169215`, which is the **plant** genus *Bosea* (Amaranthaceae). The tool's higher-rank path matches on **label, not id**, so a bacterial lineage got attached to a plant taxon, and every gate passes: `ncbi_source_id == term.id`, and "Bosea" really is that id's label. Choosing the right id is a curation call.
- **#366** — `gtdb_ground.py` is **batch-sensitive**: `Euryarchaeota` resolves AMBIGUOUS in an ungrounded-only run but grounds to `GTDB:p__Halobacteriota` whole-KB. That makes this test's own failure message ("re-run `--apply` on these records") not reproducible.

Both, plus #363, are now classified in `NEXT_TASKS_LOOP.md`; no open issue is unclassified.

**989 passed, 9 skipped.** All checks green including `label-correspondence`.
