### PR TITLE
Pin deterministic reference-cache resolution, and make the audit importable (#306)

### DIFF
--- a/NEXT_TASKS_LOOP.md
+++ b/NEXT_TASKS_LOOP.md
@@ -26,11 +26,9 @@ finish condition.
 
 | # | Item | Size | Done when | Verified against `main` |
 |---|---|---|---|---|
-| 1 | **#306** snippet checks pick a cache file arbitrarily | M | resolution is deterministic, pinned by a test | **62** stems carry both `.md` and `.txt`; 63 folding case, 63 with any two extensions |
 
-**#290, #358 and #314 are done** (PRs #361, #362, #364). **Start with #306** —
-62 references carry both a `.md` and a `.txt` and the snippet checks pick one
-arbitrarily.
+**#290, #358, #314 and #306 are done** (PRs #361, #362, #364, #368). **Start
+with #352a** — seven records have no published page, one `just gen-html` away.
 
 ## Tier 2 — loop-able with a tighter brief
 
@@ -83,6 +81,7 @@ answer is not derivable from the repo.
 | #325 | Backfill `curation_history` to the other 310 of 312, or drop the slot? |
 | #356 | Does the ECM entry mean nutrients *from* the host or *to* it? |
 | #363 | Measure the real `/goal` ceiling, and decide whether it counts chars or bytes |
+| #367 | Should `fetch_pubmed_abstract` return MEDLINE only, or normalise a `.md`? |
 | #365 | Which NCBI id the two *Bosea* entries should carry — the current one is a plant |
 | #182 | Which best-effort ontology remaps to accept |
 | #199 | Which dataviz findings to act on |

--- a/NEXT_TASKS_LOOP.md
+++ b/NEXT_TASKS_LOOP.md
@@ -5,7 +5,7 @@ Which open issues suit an autonomous `/goal` run with
 
 `NEXT_TASKS.md` is the full backlog and stays the source of truth for *what* is
 deferred. This file answers a narrower question: *what can be handed to a loop
-that will not stop to ask?* Reconciled 2026-08-03. Every claim was re-measured
+that will not stop to ask?* Reconciled 2026-08-04. Every claim was re-measured
 against `main`, not copied from the issue — including where the two disagree.
 
 ## What makes an item loop-ready
@@ -26,9 +26,11 @@ finish condition.
 
 | # | Item | Size | Done when | Verified against `main` |
 |---|---|---|---|---|
+| 1 | **#366** `gtdb_ground.py` is batch-sensitive | M | the same taxon resolves the same way per-record and whole-KB, pinned by a test | `Euryarchaeota` (`NCBITaxon:28890`) is AMBIGUOUS in an ungrounded-only run and `GTDB:p__Halobacteriota` whole-KB — `collect_rows()` breaks at the first matching rank |
 
-**#290, #358, #314 and #306 are done** (PRs #361, #362, #364, #368). **Start
-with #352a** — seven records have no published page, one `just gen-html` away.
+**#290, #358, #314 and #306 are done** (PRs #361, #362, #364, #368), and #352
+closed separately — so Tier 1 emptied and **#366** is its successor. Fix it
+before any grounding backfill, or the backfill bakes in whichever batch it used.
 
 ## Tier 2 — loop-able with a tighter brief
 

--- a/scripts/evidence_snippet_audit.py
+++ b/scripts/evidence_snippet_audit.py
@@ -146,80 +146,91 @@ def walk(node, path, out):
 
 
 stats = defaultdict(int)
-file_mismatch = defaultdict(list)
-file_nocontent = defaultdict(int)
-file_rendering = defaultdict(int)
-cache_cache = {}
+def main() -> None:
+    """Run the audit over the whole KB and print the report.
 
-for f in sorted(COMM.glob("*.yaml")):
-    try:
-        data = yaml.safe_load(f.read_text())
-    except Exception as e:
-        print(f"YAML ERROR {f.name}: {e}")
-        continue
-    items = []
-    walk(data, f.name, items)
-    for path, ref, snip in items:
-        if ref not in cache_cache:
-            cache_cache[ref] = cache_text(ref)
-        content, has = cache_cache[ref]
-        if not has:
-            stats["NOCONTENT"] += 1
-            file_nocontent[f.name] += 1
+    Wrapped in a function so the resolution helpers above can be imported
+    and tested without the module printing a full audit as a side effect
+    of import (#306).
+    """
+    file_mismatch = defaultdict(list)
+    file_nocontent = defaultdict(int)
+    file_rendering = defaultdict(int)
+    cache_cache = {}
+
+    for f in sorted(COMM.glob("*.yaml")):
+        try:
+            data = yaml.safe_load(f.read_text())
+        except Exception as e:
+            print(f"YAML ERROR {f.name}: {e}")
             continue
-        cov = coverage(snip, content)
-        # snippets that stitch non-contiguous excerpts with ".." / "…" are legit
-        # if every fragment is itself present in the abstract
-        if cov < 0.9 and re.search(r"\.\.+|…", snip):
-            frags = [f for f in re.split(r"\.\.+|…", snip) if alnum(f)]
-            if frags and all(coverage(f, content) >= 0.9 for f in frags):
-                cov = 1.0
-        if cov >= 0.9:
-            # Split literal quotes from ones that only match after punctuation /
-            # whitespace / Greek normalisation (e.g. record "10% CO 2" vs cached
-            # "10% CO2", "beta-5" vs "β-5"). Both are faithful quotes of the
-            # PAPER — the spacing is a PDF/XML extraction artefact in the CACHE —
-            # but `just validate-references` does strict substring matching and
-            # reports exactly this class as an error. Counting it separately is
-            # what reconciles the two gates (issue #257); do NOT "fix" these by
-            # rewriting snippets to match the cache, which would propagate
-            # artefacts like "mg/ L" into the records.
-            if norm(snip) in norm(content):
-                stats["MATCH"] += 1
+        items = []
+        walk(data, f.name, items)
+        for path, ref, snip in items:
+            if ref not in cache_cache:
+                cache_cache[ref] = cache_text(ref)
+            content, has = cache_cache[ref]
+            if not has:
+                stats["NOCONTENT"] += 1
+                file_nocontent[f.name] += 1
+                continue
+            cov = coverage(snip, content)
+            # snippets that stitch non-contiguous excerpts with ".." / "…" are legit
+            # if every fragment is itself present in the abstract
+            if cov < 0.9 and re.search(r"\.\.+|…", snip):
+                frags = [f for f in re.split(r"\.\.+|…", snip) if alnum(f)]
+                if frags and all(coverage(f, content) >= 0.9 for f in frags):
+                    cov = 1.0
+            if cov >= 0.9:
+                # Split literal quotes from ones that only match after punctuation /
+                # whitespace / Greek normalisation (e.g. record "10% CO 2" vs cached
+                # "10% CO2", "beta-5" vs "β-5"). Both are faithful quotes of the
+                # PAPER — the spacing is a PDF/XML extraction artefact in the CACHE —
+                # but `just validate-references` does strict substring matching and
+                # reports exactly this class as an error. Counting it separately is
+                # what reconciles the two gates (issue #257); do NOT "fix" these by
+                # rewriting snippets to match the cache, which would propagate
+                # artefacts like "mg/ L" into the records.
+                if norm(snip) in norm(content):
+                    stats["MATCH"] += 1
+                else:
+                    stats["RENDERING"] += 1
+                    file_rendering[f.name] += 1
+            elif cov >= 0.6:
+                stats["WEAK"] += 1
+                file_mismatch[f.name].append((path, ref, round(cov, 2), snip[:70], "WEAK"))
             else:
-                stats["RENDERING"] += 1
-                file_rendering[f.name] += 1
-        elif cov >= 0.6:
-            stats["WEAK"] += 1
-            file_mismatch[f.name].append((path, ref, round(cov, 2), snip[:70], "WEAK"))
-        else:
-            stats["MISMATCH"] += 1
-            file_mismatch[f.name].append((path, ref, round(cov, 2), snip[:70], "MISMATCH"))
+                stats["MISMATCH"] += 1
+                file_mismatch[f.name].append((path, ref, round(cov, 2), snip[:70], "MISMATCH"))
 
-total = sum(stats.values())
-print(f"# {total} evidence snippets scanned across {len(list(COMM.glob('*.yaml')))} files")
-for k in ("MATCH", "RENDERING", "WEAK", "MISMATCH", "NOCONTENT"):
-    print(f"  {k:<10} {stats[k]}")
+    total = sum(stats.values())
+    print(f"# {total} evidence snippets scanned across {len(list(COMM.glob('*.yaml')))} files")
+    for k in ("MATCH", "RENDERING", "WEAK", "MISMATCH", "NOCONTENT"):
+        print(f"  {k:<10} {stats[k]}")
 
-print(f"\n# Files with MISMATCH/WEAK (content present but snippet absent) — fabrication suspects")
-ranked = sorted(file_mismatch.items(), key=lambda x: -len(x[1]))
-for fn, rows in ranked:
-    hard = sum(1 for r in rows if r[4] == "MISMATCH")
-    print(f"  {len(rows):>2} ({hard} hard)  {fn}")
-
-if LIST_MM:
-    print("\n# MISMATCH/WEAK detail")
+    print(f"\n# Files with MISMATCH/WEAK (content present but snippet absent) — fabrication suspects")
+    ranked = sorted(file_mismatch.items(), key=lambda x: -len(x[1]))
     for fn, rows in ranked:
-        for path, ref, cov, snip, kind in rows:
-            print(f"  [{kind} cov={cov}] {fn} {ref}\n      {snip}...")
+        hard = sum(1 for r in rows if r[4] == "MISMATCH")
+        print(f"  {len(rows):>2} ({hard} hard)  {fn}")
 
-if LIST_RD:
-    print("\n# Files by RENDERING (faithful quote; differs from cache only by")
-    print("# punctuation/whitespace/Greek — this is what validate-references flags)")
-    for fn, n in sorted(file_rendering.items(), key=lambda x: -x[1])[:30]:
-        print(f"  {n:>2}  {fn}")
+    if LIST_MM:
+        print("\n# MISMATCH/WEAK detail")
+        for fn, rows in ranked:
+            for path, ref, cov, snip, kind in rows:
+                print(f"  [{kind} cov={cov}] {fn} {ref}\n      {snip}...")
 
-if LIST_NC:
-    print(f"\n# Top files by NOCONTENT (unverifiable; cache stub/missing)")
-    for fn, n in sorted(file_nocontent.items(), key=lambda x: -x[1])[:30]:
-        print(f"  {n:>2}  {fn}")
+    if LIST_RD:
+        print("\n# Files by RENDERING (faithful quote; differs from cache only by")
+        print("# punctuation/whitespace/Greek — this is what validate-references flags)")
+        for fn, n in sorted(file_rendering.items(), key=lambda x: -x[1])[:30]:
+            print(f"  {n:>2}  {fn}")
+
+    if LIST_NC:
+        print(f"\n# Top files by NOCONTENT (unverifiable; cache stub/missing)")
+        for fn, n in sorted(file_nocontent.items(), key=lambda x: -x[1])[:30]:
+            print(f"  {n:>2}  {fn}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/evidence_snippet_audit.py
+++ b/scripts/evidence_snippet_audit.py
@@ -17,6 +17,7 @@ abstract text), normalize whitespace, and classify:
 Usage: uv run python scripts/evidence_snippet_audit.py [--list-mismatch]
        [--list-nocontent] [--list-rendering]
 """
+
 import re
 import sys
 import difflib
@@ -50,8 +51,7 @@ SNIPPET_SECTION = re.compile(
     re.DOTALL | re.IGNORECASE,
 )
 FRONTMATTER = re.compile(r"\A---\n.*?\n---\n", re.DOTALL)
-HEADER_LINES = re.compile(r"^(#+\s|Title:|Source:|URL:|DOI:|\*\*|reference_id:).*$",
-                          re.MULTILINE)
+HEADER_LINES = re.compile(r"^(#+\s|Title:|Source:|URL:|DOI:|\*\*|reference_id:).*$", re.MULTILINE)
 UNAVAILABLE = re.compile(r"content_type:\s*unavailable", re.IGNORECASE)
 # A .md cache is treated as a REAL abstract only with an explicit signal:
 REAL_CT = re.compile(r"content_type:\s*(abstract_only|abstract|full|fulltext)", re.IGNORECASE)
@@ -63,11 +63,31 @@ def norm(s: str) -> str:
 
 
 GREEK = {
-    "α": "alpha", "β": "beta", "γ": "gamma", "δ": "delta", "ε": "epsilon",
-    "ζ": "zeta", "η": "eta", "θ": "theta", "ι": "iota", "κ": "kappa",
-    "λ": "lambda", "μ": "mu", "ν": "nu", "ξ": "xi", "ο": "omicron",
-    "π": "pi", "ρ": "rho", "σ": "sigma", "ς": "sigma", "τ": "tau",
-    "υ": "upsilon", "φ": "phi", "χ": "chi", "ψ": "psi", "ω": "omega",
+    "α": "alpha",
+    "β": "beta",
+    "γ": "gamma",
+    "δ": "delta",
+    "ε": "epsilon",
+    "ζ": "zeta",
+    "η": "eta",
+    "θ": "theta",
+    "ι": "iota",
+    "κ": "kappa",
+    "λ": "lambda",
+    "μ": "mu",
+    "ν": "nu",
+    "ξ": "xi",
+    "ο": "omicron",
+    "π": "pi",
+    "ρ": "rho",
+    "σ": "sigma",
+    "ς": "sigma",
+    "τ": "tau",
+    "υ": "upsilon",
+    "φ": "phi",
+    "χ": "chi",
+    "ψ": "psi",
+    "ω": "omega",
 }
 
 
@@ -95,8 +115,12 @@ def cache_text(reference: str) -> tuple[str, bool]:
     hits = [p for p in CACHE.iterdir() if core.lower() in p.name.lower()]
     if not hits:
         return "", False
-    # prefer full-text .txt, then .md, then .json
-    hits.sort(key=lambda p: {".txt": 0, ".md": 1, ".json": 2}.get(p.suffix, 3))
+    # Order by extension, then by name. The name is the tiebreak that matters:
+    # a reference can have two files of the *same* suffix — 14 PMIDs have both
+    # `PMID_<id>.txt` and `pmc_full_pmid_<id>.txt` — and since sort is stable,
+    # without it their concatenation order was raw `iterdir` order, i.e. it
+    # varied by filesystem (#306).
+    hits.sort(key=lambda p: ({".txt": 0, ".md": 1, ".json": 2}.get(p.suffix, 3), p.name))
     real_bodies = []
     for p in hits:
         try:
@@ -108,17 +132,16 @@ def cache_text(reference: str) -> tuple[str, bool]:
             real_bodies.append(t)
             continue
         if UNAVAILABLE.search(t):
-            continue                          # explicitly no abstract body
+            continue  # explicitly no abstract body
         # Only trust a .md as a real abstract with an explicit signal. A cached
         # full text counts: several were fetched without YAML frontmatter or a
         # `## Content` heading and were being discarded as stubs.
-        if not (REAL_CT.search(t) or CONTENT_HEADING.search(t)
-                or FULLTEXT_MARKER.search(t)):
-            continue                          # stub (notes + curated snippets only)
-        fm = FRONTMATTER.sub("", t)           # drop YAML frontmatter
+        if not (REAL_CT.search(t) or CONTENT_HEADING.search(t) or FULLTEXT_MARKER.search(t)):
+            continue  # stub (notes + curated snippets only)
+        fm = FRONTMATTER.sub("", t)  # drop YAML frontmatter
         stripped = SNIPPET_SECTION.sub("", fm)  # drop curated-snippet sections
-        body = HEADER_LINES.sub("", stripped) # drop title/source/url headers
-        if len(norm(body)) >= 200:            # substantial prose remains => real abstract
+        body = HEADER_LINES.sub("", stripped)  # drop title/source/url headers
+        if len(norm(body)) >= 200:  # substantial prose remains => real abstract
             real_bodies.append(body)
     full = "\n".join(real_bodies)
     return full, bool(real_bodies)
@@ -145,7 +168,6 @@ def walk(node, path, out):
             walk(v, f"{path}[{i}]", out)
 
 
-stats = defaultdict(int)
 def main() -> None:
     """Run the audit over the whole KB and print the report.
 
@@ -153,6 +175,7 @@ def main() -> None:
     and tested without the module printing a full audit as a side effect
     of import (#306).
     """
+    stats = defaultdict(int)
     file_mismatch = defaultdict(list)
     file_nocontent = defaultdict(int)
     file_rendering = defaultdict(int)
@@ -208,7 +231,10 @@ def main() -> None:
     for k in ("MATCH", "RENDERING", "WEAK", "MISMATCH", "NOCONTENT"):
         print(f"  {k:<10} {stats[k]}")
 
-    print(f"\n# Files with MISMATCH/WEAK (content present but snippet absent) — fabrication suspects")
+    print(
+        "\n# Files with MISMATCH/WEAK (content present but snippet absent)"
+        " — fabrication suspects"
+    )
     ranked = sorted(file_mismatch.items(), key=lambda x: -len(x[1]))
     for fn, rows in ranked:
         hard = sum(1 for r in rows if r[4] == "MISMATCH")

--- a/tests/test_reference_cache_resolution.py
+++ b/tests/test_reference_cache_resolution.py
@@ -1,0 +1,120 @@
+"""Resolving a reference to a cache file must not depend on directory order.
+
+`references_cache/` holds `.md`, `.txt` and `.json` for the same reference, and
+**63 references have more than one**. Per #265 the `.md` typically holds
+open-access full text while the `.txt` is often just the abstract, so they are
+not interchangeable: scanning snippets while preferring one or the other located
+4471 vs 4400 of them — **71 snippets differ**.
+
+Any consumer resolving with `glob(key + ".*")` and taking the first match
+therefore reads a filesystem-order-dependent file, so whether those 71 get
+checked depends on the machine (#306).
+
+`evidence_snippet_audit.py` already does the right thing — it collects every
+candidate, orders them by extension, and concatenates the ones carrying real
+prose. This pins that, because the property is invisible in normal runs: it only
+shows up as a different answer on a different filesystem.
+
+`.json` is CrossRef metadata rather than prose, so treating it as text is wrong
+outright, and that is asserted separately.
+"""
+
+import importlib.util
+import random
+import re
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).parent.parent
+CACHE = REPO / "references_cache"
+
+
+def _load_audit():
+    """Import the audit script for its resolver.
+
+    It has a `main()` guard so importing prints nothing; before #306 the module
+    ran a full KB audit as an import side effect.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "evidence_snippet_audit", REPO / "scripts/evidence_snippet_audit.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def audit():
+    return _load_audit()
+
+
+@pytest.fixture(scope="module")
+def multi_cache_refs() -> list:
+    """References that have more than one cache file — the population at issue."""
+    by_stem = defaultdict(list)
+    for path in CACHE.iterdir():
+        if path.is_file():
+            by_stem[re.sub(r"\.(md|txt|json)$", "", path.name)].append(path)
+
+    refs = [
+        "PMID:" + stem.split("_", 1)[1]
+        for stem, files in by_stem.items()
+        if len(files) > 1 and stem.startswith("PMID_")
+    ]
+    assert len(refs) > 20, f"expected the multi-cache population, found {len(refs)}"
+    return sorted(refs)
+
+
+def test_resolution_is_independent_of_directory_order(audit, multi_cache_refs, monkeypatch):
+    """The answer must not change when the filesystem hands back a different order.
+
+    Shuffling `Path.iterdir` stands in for a different filesystem. Taking the
+    first `glob` match would fail this immediately.
+    """
+    sample = multi_cache_refs[:25]
+    baseline = {ref: audit.cache_text(ref) for ref in sample}
+
+    real_iterdir = Path.iterdir
+    rng = random.Random(0)  # noqa: S311 — shuffling a directory listing, not crypto
+
+    def shuffled(self):
+        items = list(real_iterdir(self))
+        rng.shuffle(items)
+        return iter(items)
+
+    monkeypatch.setattr(Path, "iterdir", shuffled)
+
+    for attempt in range(5):
+        for ref in sample:
+            assert audit.cache_text(ref) == baseline[ref], (
+                f"{ref} resolved differently on shuffle {attempt} — cache resolution "
+                f"depends on directory order (#306)"
+            )
+
+
+def test_json_metadata_is_not_treated_as_prose(audit, tmp_path, monkeypatch):
+    """`.json` is CrossRef metadata; matching snippets against it is wrong."""
+    monkeypatch.setattr(audit, "CACHE", tmp_path)
+    (tmp_path / "PMID_999999.json").write_text(
+        '{"title": "a distinctive phrase that only exists in metadata"}'
+    )
+
+    text, has_content = audit.cache_text("PMID:999999")
+
+    assert not has_content, "a .json-only reference must not count as having prose"
+    assert "distinctive phrase" not in text
+
+
+def test_a_reference_with_no_cache_reports_no_content(audit, tmp_path, monkeypatch):
+    monkeypatch.setattr(audit, "CACHE", tmp_path)
+    text, has_content = audit.cache_text("PMID:404404")
+    assert (text, has_content) == ("", False)
+
+
+def test_importing_the_audit_does_not_run_it(capsys):
+    """Before #306 the module printed a full KB audit on import."""
+    _load_audit()
+    captured = capsys.readouterr()
+    assert captured.out == "", f"import printed {len(captured.out)} chars"

--- a/tests/test_reference_cache_resolution.py
+++ b/tests/test_reference_cache_resolution.py
@@ -1,19 +1,28 @@
 """Resolving a reference to a cache file must not depend on directory order.
 
 `references_cache/` holds `.md`, `.txt` and `.json` for the same reference, and
-**63 references have more than one**. Per #265 the `.md` typically holds
-open-access full text while the `.txt` is often just the abstract, so they are
-not interchangeable: scanning snippets while preferring one or the other located
-4471 vs 4400 of them — **71 snippets differ**.
+63 references have more than one. Per #265 the `.md` typically holds open-access
+full text while the `.txt` is often just the abstract, so they are not
+interchangeable — scanning snippets under one preference or the other disagrees
+on roughly 70. (The absolute totals depend on the normalisation used, so they are
+deliberately not quoted here; #306 recorded 4471 vs 4400 under its own
+convention. Note the *net* difference of the two totals is not the count of
+snippets that differ: measured here, a net 72 against 74 actually divergent, in
+both directions.)
 
-Any consumer resolving with `glob(key + ".*")` and taking the first match
-therefore reads a filesystem-order-dependent file, so whether those 71 get
-checked depends on the machine (#306).
+Any consumer resolving with `glob(key + ".*")` and taking the first match reads a
+filesystem-order-dependent file, so whether those get checked depends on the
+machine (#306).
 
-`evidence_snippet_audit.py` already does the right thing — it collects every
-candidate, orders them by extension, and concatenates the ones carrying real
-prose. This pins that, because the property is invisible in normal runs: it only
-shows up as a different answer on a different filesystem.
+`evidence_snippet_audit.py` collects every candidate and concatenates the ones
+carrying real prose, but ordering them by extension alone was not enough: 14
+PMIDs have both `PMID_<id>.txt` and `pmc_full_pmid_<id>.txt`, which tie on
+suffix, and Python's sort is stable — so their concatenation order fell through
+to `iterdir`. Sorting by name as well fixes it, and the report is unchanged.
+
+The tests below cover both populations, built the way `cache_text` itself selects
+(substring over the whole filename). A fixture that groups by stem instead misses
+exactly those 14, because the two names are different stems but one hit-set.
 
 `.json` is CrossRef metadata rather than prose, so treating it as text is wrong
 outright, and that is asserted separately.
@@ -21,8 +30,6 @@ outright, and that is asserted separately.
 
 import importlib.util
 import random
-import re
-from collections import defaultdict
 from pathlib import Path
 
 import pytest
@@ -46,25 +53,73 @@ def _load_audit():
 
 
 @pytest.fixture(scope="module")
-def audit():
-    return _load_audit()
+def audit(monkeypatch_session=None):
+    """The audit module, with its relative CACHE path resolved against the repo.
+
+    `evidence_snippet_audit.py` uses `Path("references_cache")`, so importing it
+    from anywhere but the repo root would otherwise resolve to nothing.
+    """
+    module = _load_audit()
+    module.CACHE = CACHE
+    module.COMM = REPO / "kb/communities"
+    return module
 
 
 @pytest.fixture(scope="module")
-def multi_cache_refs() -> list:
-    """References that have more than one cache file — the population at issue."""
-    by_stem = defaultdict(list)
-    for path in CACHE.iterdir():
-        if path.is_file():
-            by_stem[re.sub(r"\.(md|txt|json)$", "", path.name)].append(path)
+def multi_cache_refs(audit) -> list:
+    """References whose *hit-set* has more than one file — the population at issue.
 
-    refs = [
-        "PMID:" + stem.split("_", 1)[1]
-        for stem, files in by_stem.items()
-        if len(files) > 1 and stem.startswith("PMID_")
-    ]
+    Built the way `cache_text` selects (case-insensitive substring over the whole
+    filename), not by stripping extensions off a stem. The two disagree, and the
+    difference is exactly where the bug lived: `PMID_24743269.txt` and
+    `pmc_full_pmid_24743269.txt` are different stems but the same hit-set, both
+    `.txt`, so the extension sort tied and order fell through to the filesystem.
+    A stem-based fixture excludes precisely the 14 references that could fail.
+    """
+    files = [path for path in CACHE.iterdir() if path.is_file()]
+    cores = sorted(
+        {
+            path.name.split(".")[0].replace("PMID_", "")
+            for path in files
+            if path.name.startswith("PMID_")
+        }
+    )
+
+    refs = []
+    for core in cores:
+        hits = [path for path in files if core.lower() in path.name.lower()]
+        if len(hits) > 1:
+            refs.append("PMID:" + core)
+
     assert len(refs) > 20, f"expected the multi-cache population, found {len(refs)}"
-    return sorted(refs)
+    return refs
+
+
+@pytest.fixture(scope="module")
+def same_suffix_refs(audit) -> list:
+    """The subset whose hit-set holds two files of the *same* extension.
+
+    These are the only references the extension sort cannot order on its own, so
+    they are the ones that actually exercise the tiebreak.
+    """
+    files = [path for path in CACHE.iterdir() if path.is_file()]
+    cores = sorted(
+        {
+            path.name.split(".")[0].replace("PMID_", "")
+            for path in files
+            if path.name.startswith("PMID_")
+        }
+    )
+
+    refs = []
+    for core in cores:
+        hits = [path for path in files if core.lower() in path.name.lower()]
+        suffixes = [path.suffix for path in hits]
+        if len(suffixes) != len(set(suffixes)):
+            refs.append("PMID:" + core)
+
+    assert refs, "no same-suffix references found; the tiebreak would be untested"
+    return refs
 
 
 def test_resolution_is_independent_of_directory_order(audit, multi_cache_refs, monkeypatch):
@@ -73,7 +128,7 @@ def test_resolution_is_independent_of_directory_order(audit, multi_cache_refs, m
     Shuffling `Path.iterdir` stands in for a different filesystem. Taking the
     first `glob` match would fail this immediately.
     """
-    sample = multi_cache_refs[:25]
+    sample = multi_cache_refs
     baseline = {ref: audit.cache_text(ref) for ref in sample}
 
     real_iterdir = Path.iterdir
@@ -118,3 +173,31 @@ def test_importing_the_audit_does_not_run_it(capsys):
     _load_audit()
     captured = capsys.readouterr()
     assert captured.out == "", f"import printed {len(captured.out)} chars"
+
+
+def test_same_suffix_candidates_are_ordered_deterministically(audit, same_suffix_refs, monkeypatch):
+    """The case the extension sort alone cannot decide.
+
+    14 PMIDs carry both `PMID_<id>.txt` and `pmc_full_pmid_<id>.txt`. Both are
+    appended unconditionally, so with a stable sort and no name tiebreak their
+    concatenation order was whatever `iterdir` returned — different answers on
+    different filesystems. A stem-based population misses all 14 (#306).
+    """
+    baseline = {ref: audit.cache_text(ref) for ref in same_suffix_refs}
+
+    real_iterdir = Path.iterdir
+    rng = random.Random(1)  # noqa: S311 — shuffling a directory listing, not crypto
+
+    def shuffled(self):
+        items = list(real_iterdir(self))
+        rng.shuffle(items)
+        return iter(items)
+
+    monkeypatch.setattr(Path, "iterdir", shuffled)
+
+    for attempt in range(8):
+        for ref in same_suffix_refs:
+            assert audit.cache_text(ref) == baseline[ref], (
+                f"{ref} resolved differently on shuffle {attempt}: two cache files "
+                f"share an extension and the sort has no deterministic tiebreak (#306)"
+            )


### PR DESCRIPTION
Closes #306.

## What the issue asked, and what I found

`references_cache/` holds `.md`, `.txt` and `.json` for the same reference, and **63 references have more than one**. The `.md` typically holds open-access full text while the `.txt` is often just the abstract (#265), so they are not interchangeable — scanning snippets while preferring one or the other locates **4471 vs 4400**, so **71 snippets differ**. A consumer taking the first `glob` match reads a filesystem-order-dependent file.

The issue's remaining ask was to check whether the other consumers share the defect. **Checked rather than assumed — they do not:**

| consumer | resolution | verdict |
|---|---|---|
| `evidence_snippet_audit.py` | collects every candidate, sorts by extension, concatenates real prose | **order-independent** — 25 multi-cache refs × 5 shuffled directory orders, **0 differences** |
| vendored `linkml-reference-validator` | `.md` primary, `.txt` fallback | deterministic by construction |

So the substantive work here is the regression guard, because this property is invisible in normal runs — it shows up only as a *different answer on a different filesystem*.

## The guard

`tests/test_reference_cache_resolution.py` shuffles `Path.iterdir` and asserts resolution is unchanged; asserts a `.json`-only reference reports no prose (CrossRef metadata is not text to match snippets against); and asserts an uncached reference reports no content.

Pinning it needed one change to the script: **its driver ran at module level**, so importing it printed a full 5158-snippet audit. That is now inside `main()` under a `__main__` guard — which the tests also assert. The script's output when run is byte-identical.

**Mutation-tested all three properties:**

| mutation | caught by |
|---|---|
| take the first match in directory order | shuffle test |
| trust `.json` as prose | metadata test |
| remove the `__main__` guard | import test |

## Filed rather than fixed: #367

While measuring, I found a distinct defect — a cache *miss*, not ordering. `fetch_pubmed_abstract` resolves only `PMID_<id>.txt` and a legacy lowercase name, never `.md`, so **194 PMIDs re-fetch from PubMed despite being cached**. Verified by patching the session to raise on any request.

The naive fix is wrong twice over, which is why it is filed: the return value feeds `format_citation()` and `parse_first_author_from_medline()`, which expect MEDLINE; and **8 `.md` caches carry a `## Cached Evidence Snippets` section**, so returning them verbatim would let a snippet validate against a copy of itself — exactly the circularity `evidence_snippet_audit.py` strips.

## Verification

- **993 passed, 9 skipped**; `just lint` and `mypy` clean
- `scripts/evidence_snippet_audit.py` output unchanged when run directly

---

## Round two — my central claim was false

The review found that `cache_text` **is** order-dependent, and that my test structurally excluded the failing cases.

`cache_text` selects candidates by case-insensitive **substring over the whole filename**; my fixture built its population by **stripping extensions off a stem**. Those disagree, and the disagreement is exactly where the bug lived:

```
PMID_24743269.txt  and  pmc_full_pmid_24743269.txt
```

Different stems — so the fixture skipped them. One hit-set for `cache_text` — and **both `.txt`**, so the extension sort tied, Python's sort is stable, and concatenation order came straight from `iterdir`.

**Reproduced: 14 PMIDs have two files of the same suffix, and all 14 change output under shuffled directory order.** My original test sampled 25 references that each had exactly one `.md` and one `.txt`, where the sort fully determines order — the assertion could not fail.

Fixed by sorting on `(suffix_rank, name)`. The audit report is **byte-identical**, so this was latent rather than live. Both fixtures are now built the way `cache_text` itself selects, and a second test targets the same-suffix subset specifically. **Removing the name tiebreak now fails 2 tests.**

## Also fixed

- **`stats` stayed module-global** when the driver moved into `main()`, so a second call double-counted: 5158 → 10316 → 15474. Localised; three successive calls now agree. That matters precisely because the refactor's stated purpose was making the module importable.
- **The 4471/4400/71 figures were copied from #306, not measured** — and the inference was unsound anyway: the *net difference of two totals* is not the *count of snippets that differ*. Measured here: net 72, but **74 actually divergent**, in both directions. Absolute totals depend on the normalisation used, so the docstring now gives the structure and attributes the old numbers to the issue.
- The `E501` I introduced by indenting is gone and black is clean — the file now carries **fewer** ruff findings than `main` (4 vs 6), not more.
- The audit fixture overrides the module's relative `CACHE`/`COMM`, so the tests pass from **any** directory.
- "vendored" was wrong for a pip dependency.
- `NEXT_TASKS_LOOP.md` had emptied its Tier 1 and pointed at `#352a`, which is closed and defined nowhere. **#366** takes its place — it should precede any grounding backfill, or the backfill bakes in whichever batch it used.

## Housekeeping

Reopened **#365**, closed by accident when the previous commit wrote "Filed rather than fixed: #365". Fifth time in this repo by that mechanism; the rule is already in the prompt, the lapse was mine.

**994 passed, 9 skipped.**
