### PR TITLE
Make GTDB grounding independent of batch composition, and correct the block it got wrong (#366)

### DIFF
--- a/NEXT_TASKS_LOOP.md
+++ b/NEXT_TASKS_LOOP.md
@@ -26,11 +26,12 @@ finish condition.
 
 | # | Item | Size | Done when | Verified against `main` |
 |---|---|---|---|---|
-| 1 | **#366** `gtdb_ground.py` is batch-sensitive | M | the same taxon resolves the same way per-record and whole-KB, pinned by a test | `Euryarchaeota` (`NCBITaxon:28890`) is AMBIGUOUS in an ungrounded-only run and `GTDB:p__Halobacteriota` whole-KB — `collect_rows()` breaks at the first matching rank |
 
-**#290, #358, #314 and #306 are done** (PRs #361, #362, #364, #368), and #352
-closed separately — so Tier 1 emptied and **#366** is its successor. Fix it
-before any grounding backfill, or the backfill bakes in whichever batch it used.
+**#290, #358, #314, #306 and #366 are done** (PRs #361, #362, #364, #368, #370).
+Tier 1 is empty again: every mechanical, decision-free item in the backlog has
+shipped. What remains needs either a constraining brief (Tier 2) or a decision
+from you (Tier 3) — so the next pass should start by answering a Tier 3 row
+rather than by running the loop.
 
 ## Tier 2 — loop-able with a tighter brief
 
@@ -83,6 +84,7 @@ answer is not derivable from the repo.
 | #325 | Backfill `curation_history` to the other 310 of 312, or drop the slot? |
 | #356 | Does the ECM entry mean nutrients *from* the host or *to* it? |
 | #363 | Measure the real `/goal` ceiling, and decide whether it counts chars or bytes |
+| #369 | Two stored GTDB blocks disagree with the current tool — re-ground, or keep? |
 | #367 | Should `fetch_pubmed_abstract` return MEDLINE only, or normalise a `.md`? |
 | #365 | Which NCBI id the two *Bosea* entries should carry — the current one is a plant |
 | #182 | Which best-effort ontology remaps to accept |

--- a/NEXT_TASKS_LOOP.md
+++ b/NEXT_TASKS_LOOP.md
@@ -85,6 +85,7 @@ answer is not derivable from the repo.
 | #356 | Does the ECM entry mean nutrients *from* the host or *to* it? |
 | #363 | Measure the real `/goal` ceiling, and decide whether it counts chars or bytes |
 | #369 | Two stored GTDB blocks disagree with the current tool — re-ground, or keep? |
+| #371 | What should the GTDB majority denominator be? Nested rows are double-counted |
 | #367 | Should `fetch_pubmed_abstract` return MEDLINE only, or normalise a `.md`? |
 | #365 | Which NCBI id the two *Bosea* entries should carry — the current one is a plant |
 | #182 | Which best-effort ontology remaps to accept |

--- a/kb/communities/ANME_SRB_Anaerobic_Methanotrophic_Syntrophic_Consortia.yaml
+++ b/kb/communities/ANME_SRB_Anaerobic_Methanotrophic_Syntrophic_Consortia.yaml
@@ -126,9 +126,9 @@ taxonomy:
       gtdb_taxon: Desulfobacterales
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfobacteria;o__Desulfobacterales
       ncbi_source_id: NCBITaxon:213118
-      majority_fraction: 0.896
+      majority_fraction: 0.81
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at o__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 5 GTDB taxa under the NCBI taxon]
     notes: Seep-SRB2 is an informal deltaproteobacterial SRB clade of uncertain family; grounded
       conservatively at the OAK-confirmed order Desulfobacterales as there is no NCBITaxon for
       "Seep-SRB2".

--- a/kb/communities/ANME_SRB_Marine_Methane_Seep_Consortium.yaml
+++ b/kb/communities/ANME_SRB_Marine_Methane_Seep_Consortium.yaml
@@ -49,7 +49,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:213118
       majority_fraction: 0.81
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at o__ rank; 5 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 5 GTDB taxa under the NCBI taxon]
     notes: Desulfobacterales is used as a conservative NCBI-grounded representation for common marine
       sulfate-reducing bacterial partners of ANME aggregates.
   functional_role:

--- a/kb/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.yaml
+++ b/kb/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.yaml
@@ -41,9 +41,9 @@ taxonomy:
       gtdb_taxon: Bacillota_A
       gtdb_lineage: d__Bacteria;p__Bacillota_A
       ncbi_source_id: NCBITaxon:1239
-      majority_fraction: 0.556
+      majority_fraction: 0.55
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 21 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 21 GTDB taxa under the NCBI taxon]
     notes: Represents ASF356 Clostridium sp., ASF492 Eubacterium plexicaudatum, ASF500 Firmicutes bacterium,
       and ASF502 Clostridium sp. as a grouped firmicute guild.
   functional_role:

--- a/kb/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.yaml
+++ b/kb/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.yaml
@@ -79,7 +79,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1239
       majority_fraction: 0.55
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 21 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 21 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_DEGRADER
   evidence:

--- a/kb/communities/Dangl_SynComm_35.yaml
+++ b/kb/communities/Dangl_SynComm_35.yaml
@@ -92,7 +92,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:135614
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at o__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 4 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml
+++ b/kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml
@@ -82,13 +82,13 @@ taxonomy:
       id: NCBITaxon:403
       label: Methylococcaceae
     gtdb_classification:
-      gtdb_id: GTDB:f__Methylococcaceae
-      gtdb_taxon: Methylococcaceae
-      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylococcaceae
+      gtdb_id: GTDB:f__Methylomonadaceae
+      gtdb_taxon: Methylomonadaceae
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylomonadaceae
       ncbi_source_id: NCBITaxon:403
-      majority_fraction: 0.505
-      is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at f__ rank; 6 GTDB taxa under the NCBI taxon]
+      majority_fraction: 0.64
+      is_reclassified: true
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at f__ rank; 7 GTDB taxa under the NCBI taxon]
     notes: >
       Type I methanotroph family represented in methane-consuming Lake
       Washington sediment microcosms; includes oxygen-dependent genera such as

--- a/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
+++ b/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
@@ -164,7 +164,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1239
       majority_fraction: 0.55
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 21 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 21 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive bacteria detected in Naica subsurface waters, likely representing thermophilic
       spore-forming genera adapted to oligotrophic deep biosphere conditions. Firmicutes in analogous
       geothermal subsurface systems include thermophilic fermenters (Thermoanaerobacter, Moorella) and

--- a/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
+++ b/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
@@ -166,7 +166,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1239
       majority_fraction: 0.55
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 21 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 21 GTDB taxa under the NCBI taxon]
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:

--- a/kb/communities/Rifle_Uranium_Reducing_Community.yaml
+++ b/kb/communities/Rifle_Uranium_Reducing_Community.yaml
@@ -192,7 +192,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:213118
       majority_fraction: 0.81
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at o__ rank; 5 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 5 GTDB taxa under the NCBI taxon]
     notes: 'Family of sulfate-reducing bacteria that becomes dominant during Phase II of uranium biostimulation
       at Rifle (>50 days). By day 80, Desulfobacteraceae comprise 45% of the groundwater microbial community,
       replacing Geobacter as Fe(III) is depleted. This family includes diverse sulfate reducers that oxidize

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -139,9 +139,15 @@ def collect_rows(mapping_path: Path, want_ids, want_species_lc, want_higher_lc):
                 # so a taxon's row set depended on which *other* taxa shared the
                 # run. Grounding the same id per-record and whole-KB could then
                 # disagree (#366).
+                seen = set()
                 for ncbi_col, _, _ in HIGHER_RANKS:
                     v = cells[ncbi_col].strip().lower()
-                    if v and v in want_higher_lc:
+                    # `seen` guards the other direction: one row carrying the same
+                    # name in two rank columns would otherwise be appended twice
+                    # and double-weighted. No row does today, but that is a
+                    # property of the data, not of the code.
+                    if v and v in want_higher_lc and v not in seen:
+                        seen.add(v)
                         by_higher.setdefault(v, []).append(cells)
     return by_id, by_name, by_higher
 

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -132,11 +132,17 @@ def collect_rows(mapping_path: Path, want_ids, want_species_lc, want_higher_lc):
             if sp and sp in want_species_lc:
                 by_name.setdefault(sp, []).append(cells)
             if want_higher_lc:
+                # Index under *every* wanted rank this row matches, not just the
+                # first. With a `break` here, a row carrying two wanted names —
+                # say genus Methanosarcina inside phylum Methanobacteriota —
+                # counted only toward whichever rank HIGHER_RANKS reached first,
+                # so a taxon's row set depended on which *other* taxa shared the
+                # run. Grounding the same id per-record and whole-KB could then
+                # disagree (#366).
                 for ncbi_col, _, _ in HIGHER_RANKS:
                     v = cells[ncbi_col].strip().lower()
                     if v and v in want_higher_lc:
                         by_higher.setdefault(v, []).append(cells)
-                        break
     return by_id, by_name, by_higher
 
 

--- a/tests/test_gtdb_batch_independence.py
+++ b/tests/test_gtdb_batch_independence.py
@@ -16,8 +16,12 @@ That is not academic. It changed three whole-KB outcomes, one of which was live
 in the KB: `NCBITaxon:403` (*Methylococcaceae*) had been grounded to
 `GTDB:f__Methylococcaceae` on a bare 0.505 majority computed from a starved row
 set. With the full set it resolves to `GTDB:f__Methylomonadaceae` at 0.64, and
-`is_reclassified` flips to true — GTDB renamed the family, which the stored block
-denied. The record is re-grounded alongside this test.
+`is_reclassified` flips to true. GTDB did not *rename* Methylococcaceae —
+`f__Methylococcaceae` still exists and holds 31% of the NCBI family, including
+the type genus *Methylococcus*. It **split** it, and the majority moved. The
+record's own notes name *Methylobacter*, *Methylomonas* and *Methylosarcina*,
+all of which are `f__Methylomonadaceae` with zero genomes in the retained family,
+so the grounding matches this record's organisms and not merely the majority.
 
 These tests are deliberately structural: they compare row sets rather than
 grounding outcomes, so they hold regardless of which `NCBI2GTDB` release is
@@ -66,6 +70,10 @@ def test_row_set_is_unchanged_by_unrelated_taxa_in_the_batch(gtdb, mapping):
     both were stolen by the genus and never counted toward the phylum.
     """
     alone = gtdb.collect_rows(mapping, set(), set(), {"methanobacteriota"})[2]
+    assert alone.get("methanobacteriota"), (
+        "no rows for this taxon — the mapping no longer carries the name, so this "
+        "test would pass by comparing None to None"
+    )
     with_company = gtdb.collect_rows(
         mapping, set(), set(), {"methanobacteriota", "methanosarcina", "clostridia", "bacilli"}
     )[2]
@@ -103,6 +111,7 @@ def test_higher_ranks_are_not_starved_by_their_own_members(gtdb, mapping, name):
     majority computed from the old set was drawn from under 1% of the evidence.
     """
     alone = gtdb.collect_rows(mapping, set(), set(), {name})[2].get(name, [])
+    assert alone, f"no rows for {name} — the comparison below would be 0 == 0"
     crowded = gtdb.collect_rows(
         mapping,
         set(),
@@ -110,7 +119,7 @@ def test_higher_ranks_are_not_starved_by_their_own_members(gtdb, mapping, name):
         {name, "escherichia", "bacillus", "staphylococcus", "streptomyces", "pseudomonas"},
     )[2].get(name, [])
 
-    assert len(alone) == len(crowded), (
+    assert alone == crowded, (
         f"{name} collected {len(alone)} rows alone but {len(crowded)} alongside "
         f"five common genera — its row set depends on the batch (#366)"
     )
@@ -137,4 +146,10 @@ def test_the_regrounded_record_matches_the_tool(gtdb, mapping):
     fresh = gtdb.resolve_target("403", "Methylococcaceae", by_id, by_name, by_higher)
 
     assert fresh["gtdb_id"] == stored["gtdb_id"] == "GTDB:f__Methylomonadaceae"
-    assert stored["is_reclassified"] is True, "GTDB renamed this family; the block must say so"
+    # Pin the tool's own values too. Asserting only on the stored YAML let two
+    # mutants through: destroying the genome weighting, and hard-wiring
+    # is_reclassified False in resolve_higher.
+    assert fresh["majority_fraction"] == stored["majority_fraction"] == 0.64
+    assert (
+        fresh["is_reclassified"] is stored["is_reclassified"] is True
+    ), "GTDB's name for this family differs from NCBI's, so both must say so"

--- a/tests/test_gtdb_batch_independence.py
+++ b/tests/test_gtdb_batch_independence.py
@@ -1,0 +1,140 @@
+"""Grounding a taxon must not depend on which other taxa share the run.
+
+`collect_rows()` indexes each mapping row under the NCBI names it carries. It
+used to `break` after the first rank that matched something the caller wanted, so
+a row naming two wanted taxa — genus *Methanosarcina* inside phylum
+*Methanobacteriota*, say — counted only toward whichever rank `HIGHER_RANKS`
+reached first. A taxon's row set therefore depended on the *batch*: grounding one
+record alone and grounding the whole KB could disagree for the same id.
+
+Measured before the fix: asking for `methanobacteriota` alone collected 1534
+rows; asking for it alongside three unrelated taxa collected 1456. Higher ranks
+were starved worst — over the whole KB, `pseudomonadota` went from 238 rows to
+35874 once the `break` was removed.
+
+That is not academic. It changed three whole-KB outcomes, one of which was live
+in the KB: `NCBITaxon:403` (*Methylococcaceae*) had been grounded to
+`GTDB:f__Methylococcaceae` on a bare 0.505 majority computed from a starved row
+set. With the full set it resolves to `GTDB:f__Methylomonadaceae` at 0.64, and
+`is_reclassified` flips to true — GTDB renamed the family, which the stored block
+denied. The record is re-grounded alongside this test.
+
+These tests are deliberately structural: they compare row sets rather than
+grounding outcomes, so they hold regardless of which `NCBI2GTDB` release is
+present. Outcome-level drift against a newer release is a different problem
+(#369).
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).parent.parent
+
+
+@pytest.fixture(scope="module")
+def gtdb():
+    spec = importlib.util.spec_from_file_location("gtdb_ground", REPO / "scripts/gtdb_ground.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def mapping(gtdb):
+    """The kg-microbe NCBI2GTDB table, or skip.
+
+    CI has no kg-microbe checkout. `resolve_kg_microbe_dir` calls `sys.exit()`
+    when it finds none, which pytest reports as an *error*, not a skip — so
+    catching SystemExit is what keeps this from reddening a build that simply
+    lacks an optional local dependency.
+    """
+    try:
+        path = gtdb.resolve_kg_microbe_dir(None) / "data/raw/NCBI2GTDB.tsv.gz"
+    except SystemExit as exc:
+        pytest.skip(f"kg-microbe mapping unavailable: {str(exc).splitlines()[0]}")
+    if not path.exists():
+        pytest.skip(f"kg-microbe NCBI2GTDB mapping not available at {path}")
+    return path
+
+
+def test_row_set_is_unchanged_by_unrelated_taxa_in_the_batch(gtdb, mapping):
+    """The defect, at its smallest: one taxon, with and without company.
+
+    *Methanosarcina* is a genus inside phylum *Methanobacteriota*, so rows naming
+    both were stolen by the genus and never counted toward the phylum.
+    """
+    alone = gtdb.collect_rows(mapping, set(), set(), {"methanobacteriota"})[2]
+    with_company = gtdb.collect_rows(
+        mapping, set(), set(), {"methanobacteriota", "methanosarcina", "clostridia", "bacilli"}
+    )[2]
+
+    assert alone.get("methanobacteriota") == with_company.get("methanobacteriota"), (
+        "asking for extra taxa changed this taxon's row set — a row matching two "
+        "wanted ranks is being counted toward only one of them (#366)"
+    )
+
+
+def test_a_nested_pair_lands_in_both_row_sets(gtdb, mapping):
+    """A row naming both a wanted genus and its wanted phylum belongs to each."""
+    both = gtdb.collect_rows(mapping, set(), set(), {"methanobacteriota", "methanosarcina"})[2]
+
+    assert both.get("methanosarcina"), "expected rows for the genus"
+    assert both.get("methanobacteriota"), "expected rows for the phylum"
+
+    genus_rows = {tuple(row) for row in both["methanosarcina"]}
+    phylum_rows = {tuple(row) for row in both["methanobacteriota"]}
+    shared = genus_rows & phylum_rows
+    assert shared, (
+        "no row was indexed under both the genus and its parent phylum, so one "
+        "rank is still shadowing the other (#366)"
+    )
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["pseudomonadota", "bacillota", "gammaproteobacteria", "actinomycetota", "bacilli"],
+)
+def test_higher_ranks_are_not_starved_by_their_own_members(gtdb, mapping, name):
+    """Each of these lost most of its rows to a nested genus or family.
+
+    `pseudomonadota` collected 238 rows before the fix and 35874 after, so a
+    majority computed from the old set was drawn from under 1% of the evidence.
+    """
+    alone = gtdb.collect_rows(mapping, set(), set(), {name})[2].get(name, [])
+    crowded = gtdb.collect_rows(
+        mapping,
+        set(),
+        set(),
+        {name, "escherichia", "bacillus", "staphylococcus", "streptomyces", "pseudomonas"},
+    )[2].get(name, [])
+
+    assert len(alone) == len(crowded), (
+        f"{name} collected {len(alone)} rows alone but {len(crowded)} alongside "
+        f"five common genera — its row set depends on the batch (#366)"
+    )
+
+
+def test_the_regrounded_record_matches_the_tool(gtdb, mapping):
+    """`NCBITaxon:403` is the live outcome the fix changed, pinned to the tool.
+
+    The stored block claimed `GTDB:f__Methylococcaceae` at a 0.505 majority and
+    `is_reclassified: false`; the full row set gives `Methylomonadaceae` at 0.64,
+    reclassified. If these drift apart again, one of them is stale.
+    """
+    import yaml
+
+    record = REPO / "kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml"
+    data = yaml.safe_load(record.read_text())
+    stored = next(
+        t["taxon_term"]["gtdb_classification"]
+        for t in data["taxonomy"]
+        if (t["taxon_term"].get("term") or {}).get("id") == "NCBITaxon:403"
+    )
+
+    by_id, by_name, by_higher = gtdb.collect_rows(mapping, {"403"}, set(), {"methylococcaceae"})
+    fresh = gtdb.resolve_target("403", "Methylococcaceae", by_id, by_name, by_higher)
+
+    assert fresh["gtdb_id"] == stored["gtdb_id"] == "GTDB:f__Methylomonadaceae"
+    assert stored["is_reclassified"] is True, "GTDB renamed this family; the block must say so"


### PR DESCRIPTION
Closes #366.

## The defect

`collect_rows()` indexes each mapping row under the NCBI names it carries — but `break`s after the first rank matching something the caller wanted. A row naming two wanted taxa, say genus *Methanosarcina* inside phylum *Methanobacteriota*, counted only toward whichever rank `HIGHER_RANKS` reached first. **A taxon's row set therefore depended on which other taxa shared the run.**

Measured at its smallest:

```
methanobacteriota alone                     -> 1534 rows
methanobacteriota + 3 unrelated taxa        -> 1456 rows
```

Higher ranks were starved worst. Over the whole KB, removing the `break` takes `pseudomonadota` from **238 rows to 35874** — any majority computed for it came from under 1% of the evidence.

## One live block was wrong because of it

Comparing whole-KB outcomes before and after, exactly **3 change**, and one is in the KB:

| taxon | before | after | in KB? |
|---|---|---|---|
| **`NCBITaxon:403`** *Methylococcaceae* | `f__Methylococcaceae` @ **0.505** | `f__Methylomonadaceae` @ **0.64** | **yes — corrected here** |
| `NCBITaxon:28890` | `p__Halobacteriota` | *ambiguous* | no |
| `NCBITaxon:1239` | *ambiguous* | `p__Bacillota_A` | no (already correct in KB) |

`NCBITaxon:403` was grounded on a **bare 0.505 majority** from a starved row set, and carried `is_reclassified: false`. With the full set it is `Methylomonadaceae` at 0.64 and **reclassified** — GTDB renamed the family, which the stored block denied. Re-grounded.

The other two are both improvements: `28890` stops grounding to one of the **fourteen** phyla GTDB splits it into, and `1239` starts reproducing what the KB already records but the whole-KB run previously could not.

## Audited the rest rather than assuming

All **366 distinct grounded ids** checked against the corrected tool: 3 disagreements. Only `NCBITaxon:403` is caused by this fix — the other two disagree under the *old* code as well, so they are mapping-release drift, filed as **#369** rather than silently changed here.

## The tests

Deliberately **structural** — they compare row sets, not grounding outcomes, so they hold whatever `NCBI2GTDB` release is present. Restoring the `break` fails **7 of the 8**.

One trap worth recording: `resolve_kg_microbe_dir` calls `sys.exit()` when it finds no checkout, and pytest reports `SystemExit` as an **error, not a skip**. CI has no kg-microbe, so without catching it these tests would have reddened every build. The fixture catches it and skips.

## Verification

- `just validate` / `just validate-terms` on the changed record: clean
- Network audit unchanged: 55 findings, 0 error
- `just lint`, `mypy` clean; **1002 passed, 9 skipped**

---

## Round two — my audit was narrower than my claim

I reported "3 disagreements, one in the KB". That holds only if a *disagreement* means a different CURIE. Comparing **every emitted field**, this fix also made two more stored blocks stale, and I left them:

| taxon | file(s) | stored | corrected |
|---|---|---|---|
| `NCBITaxon:213118` | ANME_SRB_Anaerobic_Methanotrophic | `0.896`, 3 GTDB taxa | `0.81`, 5 |
| `NCBITaxon:135614` | Dangl_SynComm_35 | 3 GTDB taxa | 4 |

The live footprint was **3 blocks across 8 files**, not 1.

`213118` is the sharper case, because **the KB already contained the contradiction**: two files said `0.81`/5 while a third said `0.896`/3 — same id, same mapping release, two answers, one from a starved batch. That is #366's signature sitting in the data. All three now agree.

**Re-grounding took three attempts and two reverts**, which is worth recording. My first strip bounded the block with a 4-space-indent regex, which does not match a 2-space sibling key — it deleted `functional_role`, `evidence` and a PMID reference. My second dropped a newline while rewriting `mapping_source`, joining two lines. Both were caught by checking the diff was balanced, and reverted immediately. The third strips only lines indented deeper than the block key, hands the rewrite to the tool's own `--apply`, and is **verified structurally**: parsing before and after, with `gtdb_classification` removed, shows no difference anywhere else.

## Three test defects, all found by mutation

- **Six of eight passed vacuously** if the mapping stopped carrying the hard-coded names — comparing `None == None`, or `0 == 0`. Each now asserts it found rows first; substituting absent names fails 3.
- **The regrounded-record test asserted only on the stored YAML**, so hard-wiring `is_reclassified: False` in `resolve_higher`, or destroying the genome weighting, both passed. It now pins the *tool's* `majority_fraction` and `is_reclassified`; each mutation fails it.
- `test_higher_ranks` compared **lengths** where its sibling compares contents — a content-changing, count-preserving bug would have slipped. Now compares contents.

## "GTDB renamed the family" was wrong

GTDB **split** Methylococcaceae. `f__Methylococcaceae` still exists and holds **31%** of the NCBI family, including the type genus *Methylococcus*. `is_reclassified: true` remains correct by the schema's definition, but the justification was not.

The stronger argument, added instead: the record's own notes name *Methylobacter*, *Methylomonas* and *Methylosarcina* — all `f__Methylomonadaceae`, **zero** genomes in the retained family. The grounding matches this record's organisms, not merely a majority.

## Filed: #371

`resolve_higher`'s denominator **double-counts nested species and strain rows** (2827 species have both). Pre-existing — but this fix promotes it to the dominant remaining error source by removing the starving that masked it. Under a crude dedup, 11 of 207 higher-rank targets flip, and not all in the same direction, so it needs a decision rather than a patch.

**1002 passed, 9 skipped.** All checks green including `label-correspondence`.
