### PR TITLE
Compare the two GTDB denominators, and make the named-species filter the default (#371, #375)

### DIFF
--- a/.claude/skills/ground-taxa-gtdb/SKILL.md
+++ b/.claude/skills/ground-taxa-gtdb/SKILL.md
@@ -106,17 +106,40 @@ Grounding happens at the **rank of the input**:
   species-name fallback (the mapping is strain/genome-keyed, so species ids often
   miss on id alone). GTDB species split → AMBIGUOUS.
 - **Genus / family / order / …** (single-name label) → `GTDB:g__...` (or
-  `f__`/`o__`/…): the script aggregates the GTDB rank column over all genomes
+  `f__`/`o__`/…): the script aggregates the GTDB rank column over the genomes
   under the NCBI taxon and grounds to the GTDB taxon holding a **majority (≥50%)**
-  of genomes; otherwise AMBIGUOUS. `mapping_source` records the rank and how many
-  GTDB taxa fall under the NCBI taxon (e.g. NCBI genus *Bacillus* → `g__Bacillus`
-  at 51%, noted as 102 GTDB genera).
+  of them; otherwise AMBIGUOUS. `mapping_source` records the rank and how many
+  GTDB taxa fall under the NCBI taxon (NCBI genus *Bacillus* → `g__Bacillus` at
+  0.57, noted as 44 GTDB genera).
+
+  **Since #372 this counts only rows naming an actual binomial.** Rows whose NCBI
+  species is `sp.`, `uncultured`, or informal (`Firmicutes bacterium CAG:176`,
+  `gamma proteobacterium HTCC2080`) are excluded before the majority is computed
+  — `exclude_unnamed`, on by default (#375). `Candidatus` names are kept: those
+  are provisional *species* names, not placeholders. Pass `exclude_unnamed=False`
+  for the pre-#372 behaviour; *Bacillus* was `g__Bacillus` at 0.508 across 102
+  GTDB genera under that rule.
 
 ## Interpreting the output
 
 - **`majority_fraction`** — for species, the mapping's majority fraction; for
-  genus/higher, the share of the NCBI taxon's genomes that land on the chosen
-  GTDB taxon. Lower values (e.g. *Bacillus* 0.51) warrant a curator glance.
+  genus/higher, the share of the NCBI taxon's **named-binomial** genomes that land
+  on the chosen GTDB taxon. Lower values (e.g. *Bacillus* 0.57) warrant a curator
+  glance.
+
+  **It does not tell you how much evidence is behind it**, and the filter above
+  shrinks that evidence: 0.571 can mean 4 genomes and 1.0 can mean 7. 19 of the
+  KB's 158 higher-rank groundings now rest on fewer than 10 genomes. Before
+  trusting a genus/higher grounding, re-run the tool on that taxon and read the
+  row counts. Adding the denominator to the block is #383.
+
+  A fraction of exactly **0.5** is a two-way tie, not a majority — it is broken by
+  name so the answer is reproducible, but it is still a coin flip (#382).
+
+  A grounding the majority vote gets *wrong* can be pinned in `CURATED` in
+  `tests/test_gtdb_withheld_groundings.py`; the tool has no memory of such a
+  decision and `--refresh` will otherwise re-break it (#384). `NCBITaxon:18`
+  (*Pelobacter* SFB93 → `g__Syntrophotalea`) is the worked example.
 - **`is_reclassified: true`** — GTDB uses a different name than NCBI at that rank
   (e.g. *A. deltae* → *A. leguminum*, *Enterococcus* → *Enterococcus_B*). Keep
   both groundings; the disagreement is the point.

--- a/justfile
+++ b/justfile
@@ -383,6 +383,11 @@ enrich-edison-response *args="":
 scout-communities *args="":
     uv run python scripts/scout_communities.py {{args}}
 
+# Compare the two GTDB majority denominators over the KB (issue #371).
+# Writes reports/gtdb_denominators.tsv; changes nothing.
+gtdb-compare-denominators *args:
+    uv run python scripts/gtdb_denominator_compare.py {{args}}
+
 # Ground taxa in GTDB via the local kg-microbe NCBI<->GTDB mapping (no network).
 #   just ground-taxa-gtdb --community kb/communities/Foo.yaml --emit-yaml
 #   just ground-taxa-gtdb --ncbi-id NCBITaxon:492670 --emit-yaml

--- a/kb/communities/AMD_Acidophile_Heterotroph_Network.yaml
+++ b/kb/communities/AMD_Acidophile_Heterotroph_Network.yaml
@@ -49,7 +49,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:62140
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Facultative anaerobic acidophilic heterotroph isolated from pyritic acid mine drainage. This
       α-proteobacterium couples Fe(III) reduction to organic carbon oxidation under anaerobic conditions
       and performs aerobic heterotrophy when oxygen is available. It completely oxidizes sugars (glucose,
@@ -93,7 +93,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:121039
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Obligately heterotrophic iron-oxidizing actinobacterium from the subclass Acidimicrobidae.
       Unlike most heterotrophs, F. acidiphilum catalyzes both dissimilatory oxidation and reduction of
       soluble iron while requiring organic carbon for growth. This dual capability makes it unique among
@@ -136,7 +136,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:524
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Facultative anaerobic acidophile capable of coupling complete oxidation of organic substrates
       to Fe(III) reduction at pH 3-5. This organism demonstrates metabolic versatility by performing aerobic
       respiration with oxygen, anaerobic respiration with ferric iron, or fermentation. It oxidizes a
@@ -178,7 +178,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:525
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Obligately aerobic heterotrophic α-proteobacterium with strict respiratory metabolism. Unlike
       facultative anaerobes in the genus Acidiphilium, A. facilis requires oxygen as terminal electron
       acceptor and cannot perform Fe(III) reduction. It degrades organic compounds using dissolved oxygen
@@ -217,7 +217,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:50715
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Aerobic photoheterotrophic α-proteobacterium that produces bacteriochlorophyll a and carotenoids
       under aerobic conditions. This unique organism combines heterotrophic carbon metabolism with light-harvesting
       capability, allowing it to supplement energy from organic carbon oxidation with photosynthetic light

--- a/kb/communities/AMD_Nitrososphaerota_Archaeal.yaml
+++ b/kb/communities/AMD_Nitrososphaerota_Archaeal.yaml
@@ -52,7 +52,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1078905
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Obligately acidophilic ammonia-oxidizing archaeon from the phylum Nitrososphaerota, class
       Nitrososphaeria. This chemolithoautotrophic organism represents the first cultivated acidophilic
       AOA, isolated from acidic agricultural soil (pH 4.5). Grows optimally at pH 4.0-5.5 with extraordinary
@@ -107,9 +107,9 @@ taxonomy:
       gtdb_taxon: Nitrososphaera
       gtdb_lineage: d__Archaea;p__Thermoproteota;c__Nitrososphaeria;o__Nitrososphaerales;f__Nitrososphaeraceae;g__Nitrososphaera
       ncbi_source_id: NCBITaxon:497726
-      majority_fraction: 0.833
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Mesophilic ammonia-oxidizing archaea related to Nitrososphaera viennensis but adapted to acidic
       conditions (pH 3.5-5.0). Detected in AMD-impacted sediments through 16S rRNA and amoA gene sequencing,
       with OTUs clustering with acidic soil- associated Nitrososphaera lineages. These archaea possess
@@ -154,7 +154,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:74969
       majority_fraction: 0.91
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Cell wall-lacking archaeon (Thermoplasmatales, Thermoplasmata) found in acid mine drainage
       alongside Nitrososphaerota AOA. Grows chemomixotrophically, oxidizing ferrous iron for energy while
       consuming organic matter. In the context of the archaeal nitrifying community, Ferroplasma plays

--- a/kb/communities/ANME_SRB_Anaerobic_Methanotrophic_Syntrophic_Consortia.yaml
+++ b/kb/communities/ANME_SRB_Anaerobic_Methanotrophic_Syntrophic_Consortia.yaml
@@ -126,9 +126,9 @@ taxonomy:
       gtdb_taxon: Desulfobacterales
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfobacteria;o__Desulfobacterales
       ncbi_source_id: NCBITaxon:213118
-      majority_fraction: 0.81
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 5 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Seep-SRB2 is an informal deltaproteobacterial SRB clade of uncertain family; grounded
       conservatively at the OAK-confirmed order Desulfobacterales as there is no NCBITaxon for
       "Seep-SRB2".

--- a/kb/communities/ANME_SRB_Marine_Methane_Seep_Consortium.yaml
+++ b/kb/communities/ANME_SRB_Marine_Methane_Seep_Consortium.yaml
@@ -47,9 +47,9 @@ taxonomy:
       gtdb_taxon: Desulfobacterales
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfobacteria;o__Desulfobacterales
       ncbi_source_id: NCBITaxon:213118
-      majority_fraction: 0.81
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 5 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Desulfobacterales is used as a conservative NCBI-grounded representation for common marine
       sulfate-reducing bacterial partners of ANME aggregates.
   functional_role:

--- a/kb/communities/Aalborg_East_Full_Scale_EBPR_Community.yaml
+++ b/kb/communities/Aalborg_East_Full_Scale_EBPR_Community.yaml
@@ -46,7 +46,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:28216
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at c__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Accumulibacter is represented with the validated Betaproteobacteria class term because the record
       captures the full-scale community and clade-level microdiversity rather than a cultured isolate.
   functional_role:
@@ -81,7 +81,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:201174
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 6 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Tetrasphaera-related Actinobacteria were abundant by qFISH but underrepresented in the metagenome,
       likely because of DNA extraction bias against gram-positive bacteria.
   functional_role:
@@ -115,7 +115,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:976
       majority_fraction: 0.999
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 8 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 5 GTDB taxa under the NCBI taxon]
     notes: Bacteroidetes-related Saprospiraceae and other flanking bacteria contribute to biomass processing
       and were prominent in metagenomic assignments.
   functional_role:

--- a/kb/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.yaml
+++ b/kb/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.yaml
@@ -55,7 +55,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:33952
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Recombinant lactate-producing A. woodii mutant used as the acetogenic CO2/H2-converting
       partner.
   abundance_level: ABUNDANT
@@ -85,7 +85,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:332101
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Wild-type chain-elongating partner that converts lactate-derived intermediates toward
       caproic acid.
   abundance_level: ABUNDANT

--- a/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
+++ b/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
@@ -60,7 +60,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:201174
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 6 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: A novel anaerobic acetylenotroph in the phylum Actinobacteria was
       identified by metagenomic analysis of the stable enrichment.
   functional_role:

--- a/kb/communities/Aerobic_Denitrification_Disturbance_SynCom.yaml
+++ b/kb/communities/Aerobic_Denitrification_Disturbance_SynCom.yaml
@@ -44,7 +44,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:287
       majority_fraction: 0.99
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -61,7 +61,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:470
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -78,7 +78,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:644
       majority_fraction: 0.96
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Aerobic_Denitrification_QQ_SynCom.yaml
+++ b/kb/communities/Aerobic_Denitrification_QQ_SynCom.yaml
@@ -43,7 +43,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:470
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -60,7 +60,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:287
       majority_fraction: 0.99
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -77,7 +77,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:644
       majority_fraction: 0.96
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Alaska_Tundra_Permafrost_Iron_Redox_Community.yaml
+++ b/kb/communities/Alaska_Tundra_Permafrost_Iron_Redox_Community.yaml
@@ -36,9 +36,9 @@ taxonomy:
       gtdb_taxon: Rhodoferax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Rhodoferax
       ncbi_source_id: NCBITaxon:28065
-      majority_fraction: 0.718
+      majority_fraction: 0.706
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Iron-cycling Gammaproteobacteria-lineage Rhodoferax sp. that
       becomes numerically dominant in transition-zone and permafrost
       microbiomes following extended anaerobic thaw.
@@ -68,7 +68,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:96
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Iron-cycling Gammaproteobacteria-lineage Gallionella sp. that, with
       Rhodoferax sp., accounts for 65% of community abundance in the
       transition-zone and permafrost depths after extended thaw.
@@ -94,9 +94,9 @@ taxonomy:
       gtdb_taxon: Methanosarcinia
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanosarcinia
       ncbi_source_id: NCBITaxon:224756
-      majority_fraction: 0.617
+      majority_fraction: 0.709
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at c__ rank; 9 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Co-resident acetoclastic methanogenic archaea whose CH4-metabolism
       gene abundance decreased during extended thaw, consistent with competitive
       suppression by Fe(III) reduction. Methanomicrobia is used as the closest

--- a/kb/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.yaml
+++ b/kb/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.yaml
@@ -41,9 +41,9 @@ taxonomy:
       gtdb_taxon: Bacillota_A
       gtdb_lineage: d__Bacteria;p__Bacillota_A
       ncbi_source_id: NCBITaxon:1239
-      majority_fraction: 0.55
+      majority_fraction: 0.501
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 21 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 12 GTDB taxa under the NCBI taxon]
     notes: Represents ASF356 Clostridium sp., ASF492 Eubacterium plexicaudatum, ASF500 Firmicutes bacterium,
       and ASF502 Clostridium sp. as a grouped firmicute guild.
   functional_role:
@@ -71,9 +71,9 @@ taxonomy:
       gtdb_taxon: Lactobacillus
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactobacillus
       ncbi_source_id: NCBITaxon:1578
-      majority_fraction: 0.971
+      majority_fraction: 0.998
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 16 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Represents ASF360 Lactobacillus sp. and ASF361 Lactobacillus murinus.
   functional_role:
   - PRIMARY_DEGRADER
@@ -101,7 +101,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1379858
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Spiral, mucus-associated member of the ASF.
   functional_role:
   - SECONDARY_FERMENTER
@@ -122,9 +122,9 @@ taxonomy:
       gtdb_taxon: Parabacteroides
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Tannerellaceae;g__Parabacteroides
       ncbi_source_id: NCBITaxon:375288
-      majority_fraction: 0.997
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 9 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Bacteroidetes/Tannerellaceae member of the ASF, represented at genus level because the genome
       paper table identifies it as Parabacteroides sp.
   functional_role:

--- a/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
+++ b/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
@@ -58,9 +58,9 @@ taxonomy:
       gtdb_taxon: Planctomycetota
       gtdb_lineage: d__Bacteria;p__Planctomycetota
       ncbi_source_id: NCBITaxon:203682
-      majority_fraction: 0.995
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Anaerobic ammonium-oxidizing bacterium that drives nitrogen removal
       in the bioreactor; outcompeted during destabilization.
   abundance_level: DOMINANT

--- a/kb/communities/Anammox_Granule_Metabolic_Interaction_Community.yaml
+++ b/kb/communities/Anammox_Granule_Metabolic_Interaction_Community.yaml
@@ -46,7 +46,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:795830
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: AMX1 was reported as a Brocadia-affiliated anammox MAG closely related to named Brocadia species.
       The NCBI term is used as the closest named representative for the Brocadia-like anammox population.
   functional_role:
@@ -74,9 +74,9 @@ taxonomy:
       gtdb_taxon: Bacteroidota
       gtdb_lineage: d__Bacteria;p__Bacteroidota
       ncbi_source_id: NCBITaxon:1090
-      majority_fraction: 0.989
+      majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Chlorobi-affiliated MAGs, especially CHB1 and CHB2, were inferred as active protein and peptide
       degraders in the EPS matrix.
   functional_role:

--- a/kb/communities/Angelarchaeales_Thermoplasmata_CuMMO_Soil_Sediment_Community.yaml
+++ b/kb/communities/Angelarchaeales_Thermoplasmata_CuMMO_Soil_Sediment_Community.yaml
@@ -36,7 +36,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:2283796
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Newly defined Thermoplasmatota archaeal order encoding divergent
       CuMMO sequences across 20 species-level genomes.
   abundance_level: ABUNDANT

--- a/kb/communities/At_RSPHERE_SynCom.yaml
+++ b/kb/communities/At_RSPHERE_SynCom.yaml
@@ -94,9 +94,9 @@ taxonomy:
       gtdb_taxon: Rhodococcus
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Rhodococcus
       ncbi_source_id: NCBITaxon:1827
-      majority_fraction: 0.996
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Australian_Lead_Zinc_Polymetallic.yaml
+++ b/kb/communities/Australian_Lead_Zinc_Polymetallic.yaml
@@ -57,7 +57,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Metabolically versatile chemolithoautotrophic γ-proteobacterium that dominates the upper oxidized
       layer of the tailings, capable of oxidizing both ferrous iron (Fe²⁺ → Fe³⁺) and reduced sulfur compounds
       (sulfide, elemental sulfur, thiosulfate) to sulfuric acid. At. ferrooxidans thrives at pH 1.5-2.5
@@ -110,7 +110,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Highly specialized chemolithoautotrophic iron-oxidizing bacterium (phylum Nitrospirae) that
       thrives in extremely acidic environments (pH 1.3-2.5) within the oxidized tailings layer. Unlike
       At. ferrooxidans, L. ferriphilum oxidizes only ferrous iron and does not utilize reduced sulfur
@@ -157,7 +157,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:97393
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Extremely acidophilic archaeon (order Thermoplasmatales) that dominates the most acidic microhabitats
       within the tailings (pH 0-2.0), filling ecological niches too extreme for bacterial acidophiles.
       Ferroplasma is a pleomorphic, cell wall-lacking organism adapted to extraordinarily low pH while
@@ -207,7 +207,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Obligately anaerobic δ-proteobacterium specialized for dissimilatory metal reduction, inhabiting
       the deeper sediment layers (>3m depth) of the stratified tailings where anoxic conditions prevail.
       Geobacter reduces ferric iron [Fe(III)] to ferrous iron [Fe(II)] using organic carbon as electron
@@ -256,7 +256,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:28034
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Moderately thermophilic facultatively chemolithoautotrophic bacterium (Firmicutes) present
       in warmer microniches within the tailings that experience solar heating in the arid Australian climate.
       Sulfobacillus can oxidize both iron and reduced sulfur compounds and exhibits mixotrophic metabolism,
@@ -302,7 +302,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:524
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Heterotrophic acidophilic α-proteobacterium that scavenges organic carbon in the acidic tailings
       environment, occupying a distinct trophic niche from chemolithoautotrophic iron and sulfur oxidizers.
       Acidiphilium thrives at pH 2-6, bridging highly acidic surface layers and less acidic deeper zones.

--- a/kb/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.yaml
+++ b/kb/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.yaml
@@ -83,7 +83,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:80840
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at o__ rank; 7 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -104,7 +104,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:414878
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_DEGRADER
   evidence:

--- a/kb/communities/BSFL_Gut_SynCom_Bacillus_Lactobacillus_Issatchenkia.yaml
+++ b/kb/communities/BSFL_Gut_SynCom_Bacillus_Lactobacillus_Issatchenkia.yaml
@@ -30,9 +30,9 @@ taxonomy:
       gtdb_taxon: Bacillus
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
-      majority_fraction: 0.508
+      majority_fraction: 0.57
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the source paper names the functionally relevant taxon only as
       "Bacillus". Canonical NCBITaxon label carries the "<firmicutes>" homonym disambiguation.
   functional_role:
@@ -56,9 +56,9 @@ taxonomy:
       gtdb_taxon: Lactobacillus
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactobacillus
       ncbi_source_id: NCBITaxon:1578
-      majority_fraction: 0.971
+      majority_fraction: 0.998
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 16 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the source paper names the functionally relevant taxon only as
       "Lactobacillus".
   functional_role:

--- a/kb/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.yaml
+++ b/kb/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.yaml
@@ -44,7 +44,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:659243
       majority_fraction: 0.85
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - PRIMARY_DEGRADER
   evidence:

--- a/kb/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.yaml
+++ b/kb/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.yaml
@@ -49,7 +49,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:226186
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Human gut Bacteroidetes member used as the polysaccharide-foraging partner.
   strain_designation:
     strain_name: VPI-5482
@@ -86,7 +86,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:515619
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Literature name retained in preferred_term; NCBI currently labels the strain as Agathobacter
       rectalis ATCC 33656 and lists Eubacterium rectale ATCC 33656 as an equivalent name.
   strain_designation:

--- a/kb/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.yaml
+++ b/kb/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.yaml
@@ -46,7 +46,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:818
       majority_fraction: 0.99
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Saccharolytic bacterial forager in the defined gnotobiotic community.
   functional_role:
   - PRIMARY_DEGRADER
@@ -89,7 +89,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:901
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Sulfate-reducing comparator organism used to distinguish M. smithii-specific effects.
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Banana_Fusarium_Biocontrol_SynCom12.yaml
+++ b/kb/communities/Banana_Fusarium_Biocontrol_SynCom12.yaml
@@ -52,7 +52,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:492670
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Bayan_Obo_REE_Tailings_Consortium.yaml
+++ b/kb/communities/Bayan_Obo_REE_Tailings_Consortium.yaml
@@ -69,7 +69,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Autotrophic chemolithotrophic acidophile that oxidizes ferrous iron and reduced sulfur compounds
       to generate sulfuric acid. In the Bayan Obo REE bioleaching consortium, At. ferrooxidans plays a
       primary role in acidification of the tailings slurry, lowering pH to facilitate REE dissolution
@@ -117,7 +117,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:524
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Heterotrophic acidophilic bacterium that produces high concentrations of organic acids critical
       for REE complexation and mobilization. Acidiphilium cryptum achieves maximum organic acid production
       (13.8 mM) when cultured in advance and then co-cultured with Acidithiobacillus ferrooxidans in a
@@ -144,9 +144,9 @@ taxonomy:
       gtdb_taxon: Streptomyces
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Streptomycetales;f__Streptomycetaceae;g__Streptomyces
       ncbi_source_id: NCBITaxon:1883
-      majority_fraction: 0.973
+      majority_fraction: 0.99
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 14 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
     notes: 'Actinobacterial genus capable of bioleaching rare earth elements from bastnaesite-bearing
       rock through secretion of organic acids (lactic, oxalic, pyruvic), siderophores, and complexing
       ligands. A Streptomyces sp. strain demonstrated growth in oligotrophic medium in the presence of

--- a/kb/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.yaml
+++ b/kb/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.yaml
@@ -60,7 +60,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1685
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: ABUNDANT
   functional_role:
   - CROSS_FEEDER
@@ -83,7 +83,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:33038
       majority_fraction: 0.99
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: ABUNDANT
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
+++ b/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
@@ -44,7 +44,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:267818
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - PRIMARY_DEGRADER
   abundance_level: DOMINANT
@@ -66,7 +66,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1358
       majority_fraction: 0.92
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -89,7 +89,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1245
       majority_fraction: 0.99
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - SECONDARY_FERMENTER
   evidence:
@@ -112,7 +112,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:33962
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - SECONDARY_FERMENTER
   evidence:
@@ -135,7 +135,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:483199
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/BioModels_MODEL2209060002_DPigrum_SAureus_Community.yaml
+++ b/kb/communities/BioModels_MODEL2209060002_DPigrum_SAureus_Community.yaml
@@ -39,7 +39,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:29394
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - CROSS_FEEDER
 - taxon_term:
@@ -54,7 +54,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1280
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - CROSS_FEEDER
 ecological_interactions:

--- a/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
+++ b/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
@@ -44,7 +44,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1682
       majority_fraction: 0.94
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: ATCC15697
   functional_role:
@@ -68,7 +68,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1681
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: JCM1254
   functional_role:
@@ -91,7 +91,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1685
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:
     strain_name: ATCC15700
   functional_role:
@@ -117,7 +117,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:821
       majority_fraction: 0.86
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: ATCC8482
   functional_role:
@@ -143,7 +143,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:29466
       majority_fraction: 0.95
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: ATCC10790
   functional_role:
@@ -160,7 +160,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:33038
       majority_fraction: 0.99
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: ATCC29149
   functional_role:
@@ -177,7 +177,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:83333
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: MG1655
   functional_role:
@@ -194,7 +194,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:47715
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: GG
   functional_role:
@@ -211,7 +211,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1351
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: ATCC19433
   functional_role:
@@ -228,7 +228,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1308
       majority_fraction: 0.99
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: ATCC19258
   functional_role:
@@ -245,7 +245,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:33035
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:
     strain_name: JCM1471
   functional_role:

--- a/kb/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.yaml
+++ b/kb/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.yaml
@@ -36,7 +36,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:201174
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 6 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -58,7 +58,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:976
       majority_fraction: 0.999
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 8 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 5 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -77,9 +77,9 @@ taxonomy:
       gtdb_taxon: Bacillota_A
       gtdb_lineage: d__Bacteria;p__Bacillota_A
       ncbi_source_id: NCBITaxon:1239
-      majority_fraction: 0.55
+      majority_fraction: 0.501
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 21 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 12 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -100,7 +100,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1224
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 14 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_DEGRADER
   evidence:

--- a/kb/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.yaml
+++ b/kb/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.yaml
@@ -100,7 +100,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1224
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_DEGRADER
   evidence:

--- a/kb/communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.yaml
+++ b/kb/communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.yaml
@@ -29,7 +29,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:372461
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Reduced-genome primary aphid endosymbiont from Cinara cedri.
   functional_role:
   - CROSS_FEEDER

--- a/kb/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.yaml
+++ b/kb/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.yaml
@@ -26,9 +26,9 @@ taxonomy:
       gtdb_taxon: Desulfobulbaceae
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfobulbia;o__Desulfobulbales;f__Desulfobulbaceae
       ncbi_source_id: NCBITaxon:213121
-      majority_fraction: 0.529
+      majority_fraction: 0.852
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at f__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at f__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Long multicellular filamentous bacteria mediating electrogenic sulfur oxidation in sediment.
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.yaml
+++ b/kb/communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.yaml
@@ -57,7 +57,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1515
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Cellulolytic anaerobic partner in the designed coculture.
   functional_role:
   - PRIMARY_DEGRADER
@@ -80,7 +80,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:301148
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Noncellulolytic facultative anaerobe isolated from the air-tolerant cellulolytic enrichment
       and used as the respiratory-protection partner.
   strain_designation:

--- a/kb/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.yaml
+++ b/kb/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.yaml
@@ -59,7 +59,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:351627
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Extreme thermophilic anaerobe used as one hydrogen-producing member of the defined coculture.
   strain_designation:
     strain_name: DSM 8903
@@ -91,7 +91,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:632335
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
       The primary paper reports this member as C. kristjanssonii DSM 12137.
       NCBI currently records the sequenced strain as Caldicellulosiruptor

--- a/kb/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.yaml
+++ b/kb/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.yaml
@@ -59,9 +59,9 @@ taxonomy:
       gtdb_taxon: Cellulomonas
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Cellulomonadaceae;g__Cellulomonas
       ncbi_source_id: NCBITaxon:1707
-      majority_fraction: 0.858
+      majority_fraction: 0.888
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: >
       The source identifies the cellulolytic member as Cellulomonas sp. strain
       ATCC 21399; curated at the genus level because the publication does not
@@ -93,7 +93,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1061
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: >
       The publication uses Rhodopseudomonas capsulata; NCBI Taxonomy now
       records this organism as Rhodobacter capsulatus.

--- a/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
+++ b/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
@@ -45,7 +45,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1521
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -62,7 +62,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:323259
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:
@@ -79,7 +79,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:2223
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:
@@ -96,7 +96,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:881
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:

--- a/kb/communities/Cheese_Rind_InSitu_InVitro_Model_Community.yaml
+++ b/kb/communities/Cheese_Rind_InSitu_InVitro_Model_Community.yaml
@@ -51,9 +51,9 @@ taxonomy:
       gtdb_taxon: Staphylococcus
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus
       ncbi_source_id: NCBITaxon:1279
-      majority_fraction: 0.993
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Genus-level taxon used because the source record reports community members primarily at genus
       level in amplicon and reconstruction analyses.
   abundance_level: DOMINANT
@@ -73,9 +73,9 @@ taxonomy:
       gtdb_taxon: Brevibacterium
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Brevibacteriaceae;g__Brevibacterium
       ncbi_source_id: NCBITaxon:1696
-      majority_fraction: 0.987
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Genus-level taxon used because the source reports Brevibacterium as a mature-rind genus in
       the natural-rind succession and in vitro reconstruction.
   abundance_level: ABUNDANT

--- a/kb/communities/Chlamydomonas_Bacterial_H2_Consortium.yaml
+++ b/kb/communities/Chlamydomonas_Bacterial_H2_Consortium.yaml
@@ -87,9 +87,9 @@ taxonomy:
       gtdb_taxon: Stenotrophomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Xanthomonadaceae;g__Stenotrophomonas
       ncbi_source_id: NCBITaxon:40323
-      majority_fraction: 0.987
+      majority_fraction: 0.985
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Chlorella_Azospirillum_Synthetic_Mutualism.yaml
+++ b/kb/communities/Chlorella_Azospirillum_Synthetic_Mutualism.yaml
@@ -92,7 +92,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:192
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: >
       Source publications identify strain Cd; ontology grounding is
       species-level because the stable NCBI Taxonomy term used here is

--- a/kb/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.yaml
+++ b/kb/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.yaml
@@ -84,7 +84,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Bacterial partner in the mixotrophic algal-bacterial coculture.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.yaml
+++ b/kb/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.yaml
@@ -87,9 +87,9 @@ taxonomy:
       gtdb_taxon: Pseudomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
-      majority_fraction: 0.596
+      majority_fraction: 0.692
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 17 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: Keystone genus; the taxon enriched by 2% D-mannitol treatment. Resolved at genus level —
       the study does not assign a species.
   evidence:
@@ -119,9 +119,9 @@ taxonomy:
       gtdb_taxon: Duganella
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Duganella
       ncbi_source_id: NCBITaxon:75654
-      majority_fraction: 0.886
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Keystone genus of the Chlorella phytomicrobiome; resolved at genus level.
   evidence:
   - reference: PMID:41937467
@@ -140,9 +140,9 @@ taxonomy:
       gtdb_taxon: Brevibacterium
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Brevibacteriaceae;g__Brevibacterium
       ncbi_source_id: NCBITaxon:1696
-      majority_fraction: 0.987
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Keystone genus of the Chlorella phytomicrobiome; resolved at genus level.
   evidence:
   - reference: PMID:41937467

--- a/kb/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.yaml
+++ b/kb/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.yaml
@@ -87,7 +87,7 @@ taxonomy:
       gtdb_taxon: Pseudomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
-      majority_fraction: 0.692
+      majority_fraction: 0.699
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: Keystone genus; the taxon enriched by 2% D-mannitol treatment. Resolved at genus level —

--- a/kb/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml
+++ b/kb/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml
@@ -61,7 +61,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1436290
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Central non-pigmented motile heterotroph in the barrel-shaped phototrophic consortium.
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Chromium_Sulfur_Reduction_Enrichment.yaml
+++ b/kb/communities/Chromium_Sulfur_Reduction_Enrichment.yaml
@@ -69,9 +69,9 @@ taxonomy:
       gtdb_taxon: Dermatophilaceae
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Dermatophilaceae
       ncbi_source_id: NCBITaxon:85021
-      majority_fraction: 0.997
+      majority_fraction: 0.996
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at f__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at f__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive actinobacterium of the Intrasporangiaceae family, isolated as the dominant chromium-reducing
       organism in sulfur-oxidizing enrichment cultures. The SOCrRB (Sulfur-Oxidizing Chromium-Reducing
       Bacterium) strain exhibits the novel capability to couple Cr(VI) reduction with oxidation of reduced
@@ -123,9 +123,9 @@ taxonomy:
       gtdb_taxon: Pseudomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
-      majority_fraction: 0.596
+      majority_fraction: 0.692
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 17 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: 'Gram-negative gammaproteobacteria contributing to sulfur oxidation, chromium reduction, and
       biofilm formation in the enrichment culture. Pseudomonas species comprise 15-20% of the community
       and perform facultative chemolithotrophic sulfur oxidation, oxidizing thiosulfate, sulfide, and
@@ -172,9 +172,9 @@ taxonomy:
       gtdb_taxon: Bacillus
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
-      majority_fraction: 0.508
+      majority_fraction: 0.57
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive, spore-forming bacteria (Firmicutes phylum) performing Cr(VI) reduction, metal
       biosorption, and organic matter degradation. Bacillus species comprise 10-15% of the enrichment
       community and exhibit broad pH tolerance (6.0-9.0), enabling activity across environmental gradients

--- a/kb/communities/Chromium_Sulfur_Reduction_Enrichment.yaml
+++ b/kb/communities/Chromium_Sulfur_Reduction_Enrichment.yaml
@@ -123,7 +123,7 @@ taxonomy:
       gtdb_taxon: Pseudomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
-      majority_fraction: 0.692
+      majority_fraction: 0.699
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: 'Gram-negative gammaproteobacteria contributing to sulfur oxidation, chromium reduction, and

--- a/kb/communities/Cinnamate_Degradation_Consortium.yaml
+++ b/kb/communities/Cinnamate_Degradation_Consortium.yaml
@@ -28,7 +28,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:100176
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -52,7 +52,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:43773
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -76,7 +76,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:2162
       majority_fraction: 0.94
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.yaml
+++ b/kb/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.yaml
@@ -56,7 +56,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:84023
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Acetogenic syngas-fermenting partner in the defined coculture.
   abundance_level: ABUNDANT
   functional_role:
@@ -84,7 +84,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1534
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Chain-elongating partner that consumes acetogen products in the defined coculture.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.yaml
+++ b/kb/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.yaml
@@ -56,7 +56,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:203119
       majority_fraction: 0.93
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The primary publication uses Clostridium thermocellum ATCC 27405;
       NCBI currently records the strain under Acetivibrio thermocellus ATCC
       27405 with Clostridium thermocellum ATCC 27405 as a homotypic synonym.
@@ -95,7 +95,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:521460
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Type strain DSM 6725 is also available as ATCC BAA-1888 and was
       previously reported as Anaerocellum thermophilum DSM 6725.
   strain_designation:

--- a/kb/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.yaml
+++ b/kb/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.yaml
@@ -62,7 +62,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:217159
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Autotrophic acetogenic/solventogenic partner that reduces C. kluyveri-derived organic acids to alcohols.
   abundance_level: ABUNDANT
   functional_role:
@@ -91,7 +91,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1534
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Chain-elongating partner that generates organic acids from C2 substrates in the coculture.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.yaml
+++ b/kb/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.yaml
@@ -60,7 +60,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1521
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: NCBI Taxonomy treats Clostridium cellulolyticum as the basionym/synonym of Ruminiclostridium
       cellulolyticum; the publications used the historical C. cellulolyticum name.
   abundance_level: ABUNDANT
@@ -90,7 +90,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:35554
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Electrochemically active partner that occupies the anode-attached fraction in particulate
       cellulose-fed MFCs.
   abundance_level: ABUNDANT

--- a/kb/communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.yaml
+++ b/kb/communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.yaml
@@ -57,7 +57,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:573061
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: ATCC 35296 cellulolytic fermenter that supplies H2, formate, acetate, and other VFAs
       from cellulose degradation.
   abundance_level: ABUNDANT
@@ -87,7 +87,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:269797
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: DSM 804 methanogen able to use H2, formate, and acetate-linked metabolism in the
       C. cellulovorans coculture.
   abundance_level: ABUNDANT

--- a/kb/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.yaml
+++ b/kb/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.yaml
@@ -65,7 +65,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:573061
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Cellulolytic dark-fermentative bacterium that degrades cellulose and produces volatile fatty acids.
   abundance_level: ABUNDANT
   functional_role:
@@ -94,7 +94,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:258594
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Purple nonsulfur phototroph that consumes fermentation products and contributes to hydrogen production.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.yaml
+++ b/kb/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.yaml
@@ -60,7 +60,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1538
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Acetogenic carboxydotroph that produces ethanol and acetate from syngas in the coculture.
   abundance_level: ABUNDANT
   functional_role:
@@ -89,7 +89,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1534
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Chain-elongating partner that consumes ethanol and produces butyrate and caproate.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.yaml
+++ b/kb/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.yaml
@@ -66,7 +66,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:357809
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The paper uses the name C. phytofermentans; NCBI currently places strain ISDg under
       Lachnoclostridium phytofermentans.
   strain_designation:
@@ -106,7 +106,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:511145
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Facultative anaerobic secondary-resource specialist in the artificial consortium.
   strain_designation:
     strain_name: K-12 MG1655

--- a/kb/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.yaml
@@ -59,7 +59,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:357809
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The source uses the name C. phytofermentans; NCBI currently represents
       the strain as Lachnoclostridium phytofermentans ISDg.
   strain_designation:

--- a/kb/communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.yaml
@@ -53,7 +53,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:572545
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The publications use Clostridium thermocellum LQRI; NCBI and JGI records place DSM 2360/LQRI
       under Acetivibrio thermocellus.
   strain_designation:
@@ -88,7 +88,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:399726
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The cyclic fed-batch paper names Thermoanaerobacter pseudethanolicus strain X514; NCBI records
       the sequenced strain as Thermoanaerobacter sp. X514.
   strain_designation:

--- a/kb/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.yaml
+++ b/kb/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.yaml
@@ -58,7 +58,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1515
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Cellulolytic member that releases glucose or cellobiose from lignocellulosic substrates.
   strain_designation:
     strain_name: JN4
@@ -83,7 +83,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1517
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Non-cellulolytic fermentative partner with a competitive metabolic advantage in glucose
       or cellobiose conversion.
   strain_designation:

--- a/kb/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.yaml
@@ -54,7 +54,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:203119
       majority_fraction: 0.93
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The primary paper uses Clostridium thermocellum; NCBI currently represents ATCC 27405 as
       Acetivibrio thermocellus ATCC 27405.
   strain_designation:

--- a/kb/communities/Composting_SynCom_Lignocellulose_Degradation_Humus.yaml
+++ b/kb/communities/Composting_SynCom_Lignocellulose_Degradation_Humus.yaml
@@ -29,7 +29,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:83677
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Native lignocellulose-degrading actinobacterial genus enriched by SynCom inoculation. The five
       SynCom member strains are not individually named in the source abstract; grounded taxa here are the
       enriched functional genera reported by metagenomics.
@@ -53,9 +53,9 @@ taxonomy:
       gtdb_taxon: Spirillospora
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Streptosporangiales;f__Streptosporangiaceae;g__Spirillospora
       ncbi_source_id: NCBITaxon:1988
-      majority_fraction: 0.953
+      majority_fraction: 0.956
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Native lignocellulose-degrading actinobacterial genus enriched by SynCom inoculation.
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.yaml
+++ b/kb/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.yaml
@@ -80,7 +80,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:2886510
       majority_fraction: 0.88
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The 2020 consortium paper reports this member as Sphingobacterium multivorum w15;
       later taxonomic analysis proposed renaming strain w15 as Sphingobacterium paramultivorum.
   strain_designation:

--- a/kb/communities/Copper_Biomining_Heap_Leach.yaml
+++ b/kb/communities/Copper_Biomining_Heap_Leach.yaml
@@ -63,7 +63,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Gram-negative γ-proteobacterium that oxidizes both ferrous iron (Fe²⁺) and reduced sulfur
       compounds. Dominates early stages of heap leaching when pH values are over 2 and iron concentrations
       remain low. Reaches peak abundance of ~10⁷ copies/ml around 200 days of operation. As the most abundant
@@ -103,7 +103,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Iron-oxidizing bacterium (Nitrospirae phylum) that becomes dominant in aged copper bioleaching
       heaps as pH drops and Fe³⁺ concentrations increase. Leptospirillum species predominate in sulfide
       mineral-containing environments and are effective primary mineral colonizers. L. ferriphilum oxidizes
@@ -145,7 +145,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:930
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Gram-negative γ-proteobacterium specialized for oxidizing elemental sulfur (S⁰) and reduced
       inorganic sulfur compounds to sulfuric acid. Unlike At. ferrooxidans, At. thiooxidans does not oxidize
       iron and focuses exclusively on sulfur metabolism. Maintains constant copy numbers (10⁵ copies/ml)
@@ -184,7 +184,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:74969
       majority_fraction: 0.91
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Cell wall-lacking archaeon (Thermoplasmatales) that oxidizes ferrous iron in extremely acidic
       environments. Increases with heap age alongside Leptospirillum, reaching ~10⁵ copies/ml in heaps
       >250 days old. Thrives at pH 1.67-1.83 and high Fe³⁺ concentrations (1.86-1.9 g/L) where it fills
@@ -217,7 +217,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:28034
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Gram-positive, spore-forming, moderately thermophilic bacterium (optimum 50-55°C) that oxidizes
       both ferrous iron and reduced sulfur compounds. Sulfobacillus is facultatively autotrophic, capable
       of mixotrophic growth on organic compounds plus Fe²⁺ or S⁰. Displays considerable tolerance of high

--- a/kb/communities/Corynebacterium_glutamicum_Shewanella_oneidensis_Succinic_Acid_Coculture.yaml
+++ b/kb/communities/Corynebacterium_glutamicum_Shewanella_oneidensis_Succinic_Acid_Coculture.yaml
@@ -28,12 +28,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Corynebacterium_glutamicum
       gtdb_taxon: Corynebacterium glutamicum
-      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Corynebacterium;s__Corynebacterium
-        glutamicum
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Corynebacterium;s__Corynebacterium glutamicum
       ncbi_source_id: NCBITaxon:1718
       majority_fraction: 0.99
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: K1
   functional_role:
@@ -56,13 +55,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Shewanella_oneidensis
       gtdb_taxon: Shewanella oneidensis
-      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella
-        oneidensis
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella oneidensis
       ncbi_source_id: NCBITaxon:70863
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped
-        via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   functional_role:
   - ELECTROGEN
   - ELECTRON_DONOR

--- a/kb/communities/Coscinodiscus_Synthetic_Community.yaml
+++ b/kb/communities/Coscinodiscus_Synthetic_Community.yaml
@@ -75,9 +75,9 @@ taxonomy:
       gtdb_taxon: Mameliella
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhodobacterales;f__Rhodobacteraceae;g__Mameliella
       ncbi_source_id: NCBITaxon:1434019
-      majority_fraction: 0.905
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Roseobacteraceae member that extended the diatom''s stationary phase and reduced dead algal
       cells in later culture stages. CS4 possessed complete genes for DMSP metabolism via both demethylation
       and cleavage pathways, indicating capacity for processing diatom-derived organic sulfur compounds.
@@ -106,9 +106,9 @@ taxonomy:
       gtdb_taxon: Roseovarius
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhodobacterales;f__Rhodobacteraceae;g__Roseovarius
       ncbi_source_id: NCBITaxon:74030
-      majority_fraction: 0.971
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Roseobacteraceae member that promoted diatom survival during late growth phases. Rose1 showed
       no significant influence on bacterial growth rates but was capable of both DMSP demethylation and
       cleavage, suggesting a role in sulfur cycling in this marine community.
@@ -139,7 +139,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:216431
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Flavobacterium that consistently inhibited C. radiatus throughout all growth phases. Crocei1
       was heavily dependent on diatom presence for growth and failed to thrive in nutrient-poor medium
       alone. Lacked genes for DMSP catabolism and showed the highest auxotrophic requirements among the
@@ -169,9 +169,9 @@ taxonomy:
       gtdb_taxon: Marinobacter
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Oleiphilaceae;g__Marinobacter
       ncbi_source_id: NCBITaxon:2742
-      majority_fraction: 0.964
+      majority_fraction: 0.974
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Gammaproteobacterium that initially suppressed algal growth but enabled recovery by day nine,
       demonstrating dynamic temporal effects. CS1 grew well independently using HEPES buffer as a carbon
       source and was partially deficient in DMSP demethylation pathways.

--- a/kb/communities/Crucian_Carp_Gut_Disease_Resistance_SynCom.yaml
+++ b/kb/communities/Crucian_Carp_Gut_Disease_Resistance_SynCom.yaml
@@ -28,9 +28,9 @@ taxonomy:
       gtdb_taxon: Cetobacterium_A
       gtdb_lineage: d__Bacteria;p__Fusobacteriota;c__Fusobacteriia;o__Fusobacteriales;f__Fusobacteriaceae;g__Cetobacterium_A
       ncbi_source_id: NCBITaxon:180162
-      majority_fraction: 0.927
+      majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the source reports the genus Cetobacterium (no species/strain
       given). Enriched in mild-symptom fish and part of the disease-resistance SynCom.
   abundance_value: Enriched genus in mild-symptom crucian carp gut (p = 0.013).
@@ -52,7 +52,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1849822
       majority_fraction: 0.995
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the source reports the genus Paraclostridium (no species/strain
       given). Part of the disease-resistance SynCom.
   abundance_value: Genus enriched in mild-symptom crucian carp gut.
@@ -72,9 +72,9 @@ taxonomy:
       gtdb_taxon: Pseudomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
-      majority_fraction: 0.596
+      majority_fraction: 0.692
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 17 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the source reports the genus Pseudomonas (no species/strain
       given). Part of the disease-resistance SynCom.
   abundance_value: Genus enriched in mild-symptom crucian carp gut.

--- a/kb/communities/Crucian_Carp_Gut_Disease_Resistance_SynCom.yaml
+++ b/kb/communities/Crucian_Carp_Gut_Disease_Resistance_SynCom.yaml
@@ -72,7 +72,7 @@ taxonomy:
       gtdb_taxon: Pseudomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
-      majority_fraction: 0.692
+      majority_fraction: 0.699
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the source reports the genus Pseudomonas (no species/strain

--- a/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
+++ b/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
@@ -68,9 +68,9 @@ taxonomy:
       gtdb_taxon: Acidithiobacillus
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus
       ncbi_source_id: NCBITaxon:119977
-      majority_fraction: 0.724
+      majority_fraction: 0.745
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Acidithiobacillus species and strains dominated the enrichments on
       both chalcopyrite and chalcocite.
   abundance_level: DOMINANT
@@ -108,9 +108,9 @@ taxonomy:
       gtdb_taxon: RF32
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__RF32
       ncbi_source_id: NCBITaxon:204441
-      majority_fraction: 0.636
+      majority_fraction: 0.704
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at o__ rank; 30 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 15 GTDB taxa under the NCBI taxon]
   abundance_level: ABUNDANT
   evidence:
   - reference: PMID:41381092
@@ -128,9 +128,9 @@ taxonomy:
       gtdb_taxon: Thermoplasmatales
       gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales
       ncbi_source_id: NCBITaxon:2301
-      majority_fraction: 0.903
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at o__ rank; 9 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 1 GTDB taxa under the NCBI taxon]
   abundance_level: ABUNDANT
   evidence:
   - reference: PMID:41381092

--- a/kb/communities/DIETsimp_Lignocellulose_to_Methane_DIET_Consortia.yaml
+++ b/kb/communities/DIETsimp_Lignocellulose_to_Methane_DIET_Consortia.yaml
@@ -30,12 +30,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Methanosarcina_mazei
       gtdb_taxon: Methanosarcina mazei
-      gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanosarcinia;o__Methanosarcinales;f__Methanosarcinaceae;g__Methanosarcina;s__Methanosarcina
-        mazei
+      gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanosarcinia;o__Methanosarcinales;f__Methanosarcinaceae;g__Methanosarcina;s__Methanosarcina mazei
       ncbi_source_id: NCBITaxon:2209
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - SYNTROPHIC_PARTNER
   - ELECTRON_ACCEPTOR
@@ -58,12 +57,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Sphaerochaeta_globosa
       gtdb_taxon: Sphaerochaeta globosa
-      gtdb_lineage: d__Bacteria;p__Spirochaetota;c__Spirochaetia;o__Sphaerochaetales;f__Sphaerochaetaceae;g__Sphaerochaeta;s__Sphaerochaeta
-        globosa
+      gtdb_lineage: d__Bacteria;p__Spirochaetota;c__Spirochaetia;o__Sphaerochaetales;f__Sphaerochaetaceae;g__Sphaerochaeta;s__Sphaerochaeta globosa
       ncbi_source_id: NCBITaxon:1131703
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - PRIMARY_DEGRADER
   - ELECTRON_DONOR
@@ -89,12 +87,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Clostridium_W_aceticum
       gtdb_taxon: Clostridium_W aceticum
-      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Peptostreptococcales;f__Natronincolaceae;g__Clostridium_W;s__Clostridium_W
-        aceticum
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Peptostreptococcales;f__Natronincolaceae;g__Clostridium_W;s__Clostridium_W aceticum
       ncbi_source_id: NCBITaxon:84022
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - PRIMARY_DEGRADER
   - ELECTRON_DONOR

--- a/kb/communities/DVM_Triculture.yaml
+++ b/kb/communities/DVM_Triculture.yaml
@@ -40,7 +40,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:881
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Sulfate-reducing bacterium that serves as the keystone species in this tri-culture. D. vulgaris
       oxidizes lactate to acetate, CO2, and H2. In the absence of sulfate, it grows syntrophically with
       methanogens by transferring H2 and acetate, relying on the methanogens to maintain low H2 partial
@@ -74,7 +74,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:39152
       majority_fraction: 0.93
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Hydrogenotrophic methanogen that consumes H2 and CO2 to produce methane. M. maripaludis serves
       as a syntrophic partner by maintaining low H2 partial pressure, enabling thermodynamically favorable
       lactate oxidation by D. vulgaris. Its growth is affected by sulfate availability - as sulfate levels

--- a/kb/communities/Dangl_SynComm_35.yaml
+++ b/kb/communities/Dangl_SynComm_35.yaml
@@ -113,7 +113,7 @@ taxonomy:
       gtdb_taxon: Pseudomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
-      majority_fraction: 0.692
+      majority_fraction: 0.699
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON

--- a/kb/communities/Dangl_SynComm_35.yaml
+++ b/kb/communities/Dangl_SynComm_35.yaml
@@ -69,7 +69,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:231455
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -92,7 +92,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:135614
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 1 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -113,9 +113,9 @@ taxonomy:
       gtdb_taxon: Pseudomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
-      majority_fraction: 0.596
+      majority_fraction: 0.692
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 17 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -135,9 +135,9 @@ taxonomy:
       gtdb_taxon: Flavobacterium
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Flavobacteriales;f__Flavobacteriaceae;g__Flavobacterium
       ncbi_source_id: NCBITaxon:237
-      majority_fraction: 0.99
+      majority_fraction: 0.999
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 9 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -158,9 +158,9 @@ taxonomy:
       gtdb_taxon: Stenotrophomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Xanthomonadaceae;g__Stenotrophomonas
       ncbi_source_id: NCBITaxon:40323
-      majority_fraction: 0.987
+      majority_fraction: 0.985
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -174,9 +174,9 @@ taxonomy:
       gtdb_taxon: Microbacterium
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Microbacteriaceae;g__Microbacterium
       ncbi_source_id: NCBITaxon:33882
-      majority_fraction: 0.995
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 6 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -192,7 +192,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:668369
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: COMMON
   functional_role:
   - CROSS_FEEDER

--- a/kb/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.yaml
+++ b/kb/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.yaml
@@ -27,9 +27,9 @@ taxonomy:
       gtdb_taxon: Pseudomonadales
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales
       ncbi_source_id: NCBITaxon:135619
-      majority_fraction: 0.968
+      majority_fraction: 0.974
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at o__ rank; 7 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Early deep-plume bloom related to known petroleum-degrading Oceanospirillales.
   abundance_level: DOMINANT
   functional_role:
@@ -77,7 +77,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:34067
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Aromatic-hydrocarbon-associated genus reported in DWH plume succession studies.
   functional_role:
   - PRIMARY_DEGRADER
@@ -97,9 +97,9 @@ taxonomy:
       gtdb_taxon: Methylophaga
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Nitrosococcales;f__Methylophagaceae;g__Methylophaga
       ncbi_source_id: NCBITaxon:40222
-      majority_fraction: 0.967
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Methylotrophic bacteria implicated in later plume-water hydrocarbon processing.
   functional_role:
   - PRIMARY_DEGRADER
@@ -119,9 +119,9 @@ taxonomy:
       gtdb_taxon: Marinobacter
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Oleiphilaceae;g__Marinobacter
       ncbi_source_id: NCBITaxon:2742
-      majority_fraction: 0.964
+      majority_fraction: 0.974
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Alkane-degrading genus enriched in stable-isotope probing experiments with DWH spill samples.
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/Defined_Multispecies_Enamel_Caries_Model.yaml
+++ b/kb/communities/Defined_Multispecies_Enamel_Caries_Model.yaml
@@ -56,7 +56,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1582
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Study uses the historical name Lactobacillus casei.
   evidence:
   - reference: PMID:23446436
@@ -79,7 +79,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1309
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   evidence:
   - reference: PMID:23446436
     supports: SUPPORT

--- a/kb/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.yaml
+++ b/kb/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.yaml
@@ -58,7 +58,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:243164
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The main 2011 publication uses the historical name Dehalococcoides
       ethenogenes strain 195; this record uses the current NCBI strain taxon.
   strain_designation:
@@ -98,7 +98,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:882
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The publications use Desulfovibrio vulgaris Hildenborough or DvH; NCBI
       currently represents the strain as Nitratidesulfovibrio vulgaris str.
       Hildenborough.

--- a/kb/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.yaml
+++ b/kb/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.yaml
@@ -60,7 +60,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:243164
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Organohalide-respiring strain that depends on partner-supplied hydrogen,
       acetate, vitamins, and corrinoids in simplified dechlorinating consortia.
   strain_designation:
@@ -100,7 +100,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:882
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The source uses Desulfovibrio vulgaris Hildenborough or DvH; NCBI
       currently represents the strain as Nitratidesulfovibrio vulgaris str.
       Hildenborough.
@@ -139,7 +139,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1122947
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The source uses Pelosinus fermentans R7 or PfR7; NCBI represents the
       strain as Pelosinus fermentans DSM 17108 and lists Pelosinus fermentans R7
       as a synonym.

--- a/kb/communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.yaml
@@ -56,7 +56,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:216389
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Strain BAV1 is curated as the organohalide-respiring Dehalococcoides member.
   strain_designation:
     strain_name: BAV1
@@ -85,7 +85,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:269797
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Methanogenic partner population tested for cobamide production and DMB-guided cobalamin support.
   strain_designation:
     strain_name: Fusaro

--- a/kb/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml
@@ -60,7 +60,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:243164
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
     notes: Organohalide-respiring partner used for TCE reductive dechlorination in the defined
       SFB93 coculture.
   strain_designation:
@@ -87,13 +87,13 @@ taxonomy:
       id: NCBITaxon:18
       label: Pelobacter
     gtdb_classification:
-      gtdb_id: GTDB:g__Seleniibacterium
-      gtdb_taxon: Seleniibacterium
-      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Desulfuromonadales;f__Geopsychrobacteraceae;g__Seleniibacterium
+      gtdb_id: GTDB:g__Syntrophotalea
+      gtdb_taxon: Syntrophotalea
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Desulfuromonadales;f__Syntrophotaleaceae;g__Syntrophotalea
       ncbi_source_id: NCBITaxon:18
-      majority_fraction: 0.571
+      majority_fraction: 0.5
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Source literature identifies the acetylene-fermenting partner as Pelobacter strain
       SFB93; current resources also associate SFB93 with Syntrophotalea acetylenivorans.
   strain_designation:

--- a/kb/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml
@@ -60,7 +60,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:243164
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Organohalide-respiring partner used for TCE reductive dechlorination in the defined
       SFB93 coculture.
   strain_designation:
@@ -87,13 +87,13 @@ taxonomy:
       id: NCBITaxon:18
       label: Pelobacter
     gtdb_classification:
-      gtdb_id: GTDB:g__Syntrophotalea
-      gtdb_taxon: Syntrophotalea
-      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Desulfuromonadales;f__Syntrophotaleaceae;g__Syntrophotalea
+      gtdb_id: GTDB:g__Seleniibacterium
+      gtdb_taxon: Seleniibacterium
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Desulfuromonadales;f__Geopsychrobacteraceae;g__Seleniibacterium
       ncbi_source_id: NCBITaxon:18
-      majority_fraction: 0.5
+      majority_fraction: 0.571
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Source literature identifies the acetylene-fermenting partner as Pelobacter strain
       SFB93; current resources also associate SFB93 with Syntrophotalea acetylenivorans.
   strain_designation:

--- a/kb/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.yaml
@@ -66,7 +66,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:243164
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Organohalide-respiring bacterium that uses hydrogen as the electron donor for reductive
       dechlorination of TCE in the coculture.
   strain_designation:

--- a/kb/communities/Desulfovibrio_Methanococcus_Syntrophy.yaml
+++ b/kb/communities/Desulfovibrio_Methanococcus_Syntrophy.yaml
@@ -38,7 +38,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:882
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Anaerobic sulfate-reducing bacterium that can also grow syntrophically in the absence of sulfate.
       When grown without sulfate, D. vulgaris oxidizes lactate to acetate, producing H2 and CO2 as electron
       sink products. This organism is a facultative syntrophic partner that preferentially uses sulfate
@@ -71,7 +71,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:267377
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Hydrogenotrophic methanogen that consumes H2 and CO2 to produce methane. Essential syntrophic
       partner that maintains low H2 partial pressure, enabling thermodynamically unfavorable lactate oxidation
       by D. vulgaris in the absence of sulfate. A genetically tractable model organism for studying methanogenesis

--- a/kb/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.yaml
+++ b/kb/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.yaml
@@ -47,9 +47,9 @@ taxonomy:
       gtdb_taxon: Acetobacter
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acetobacter
       ncbi_source_id: NCBITaxon:434
-      majority_fraction: 0.561
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Represents Acetobacter pomorum DmelCS_004 and Acetobacter tropicalis DmelCS_006 in the defined
       five-species microbiota.
   functional_role:
@@ -77,9 +77,9 @@ taxonomy:
       gtdb_taxon: Lactobacillus
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactobacillus
       ncbi_source_id: NCBITaxon:1578
-      majority_fraction: 0.971
+      majority_fraction: 0.998
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 16 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Represents Lactobacillus brevis DmelCS_003, Lactobacillus fructivorans DmelCS_002, and
       Lactobacillus plantarum DmelCS_001, using names from the source publications.
   functional_role:

--- a/kb/communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.yaml
+++ b/kb/communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.yaml
@@ -35,7 +35,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:201174
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 6 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Drought-enriched Actinobacteria lineage whose abundance is amplified
       by loss of a plant phytosiderophore iron transporter and suppressed by
       exogenous iron amendment.

--- a/kb/communities/ENIGMA_Denitrifying_SynCom.yaml
+++ b/kb/communities/ENIGMA_Denitrifying_SynCom.yaml
@@ -52,7 +52,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:416169
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:
     strain_name: FW510-R12
     isolation_source: heavily nitrate-contaminated superfund site groundwater

--- a/kb/communities/Early_Dental_Biofilm_FiveSpecies.yaml
+++ b/kb/communities/Early_Dental_Biofilm_FiveSpecies.yaml
@@ -96,7 +96,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1317
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   evidence:
   - reference: PMID:21966490
     supports: SUPPORT
@@ -118,7 +118,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1655
       majority_fraction: 0.96
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   evidence:
   - reference: PMID:21966490
     supports: SUPPORT

--- a/kb/communities/East_River_Floodplain_Core_Microbiome.yaml
+++ b/kb/communities/East_River_Floodplain_Core_Microbiome.yaml
@@ -29,7 +29,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:28216
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at c__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Betaproteobacteria had the highest number of representative genomes and dominated the operationally
       defined core floodplain microbiome.
   functional_role:
@@ -76,9 +76,9 @@ taxonomy:
       gtdb_taxon: Acidobacteriota
       gtdb_lineage: d__Bacteria;p__Acidobacteriota
       ncbi_source_id: NCBITaxon:57723
-      majority_fraction: 0.976
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Acidobacteriota were among the abundant representative genomes reconstructed across the three
       meander-bound floodplains.
   functional_role:
@@ -102,7 +102,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:142182
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Gemmatimonadota were reported among abundant reconstructed taxa and among the lower-abundance
       members of the core floodplain microbiome.
   functional_role:

--- a/kb/communities/EcoFAB_Ring_Trial_SynCom17.yaml
+++ b/kb/communities/EcoFAB_Ring_Trial_SynCom17.yaml
@@ -58,9 +58,9 @@ taxonomy:
       gtdb_taxon: Paraburkholderia
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Paraburkholderia
       ncbi_source_id: NCBITaxon:1822464
-      majority_fraction: 0.988
+      majority_fraction: 0.993
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Dominant root colonizer in SynCom17 (~98% relative abundance across all 5 labs). Uniquely
       possesses a Type 3 Secretion System (T3SS), acid resistance genes (glutamate/arginine transporters
       and decarboxylases), and highest motility at 24h among all SynCom members. Formerly classified as
@@ -94,9 +94,9 @@ taxonomy:
       gtdb_taxon: Rhodococcus
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Rhodococcus
       ncbi_source_id: NCBITaxon:1827
-      majority_fraction: 0.996
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Dominant in SynCom16 (without Paraburkholderia) at ~68% relative abundance. Fast growth and
       high motility similar to Paraburkholderia.
 
@@ -127,7 +127,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1763
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: High relative abundance in SynCom16 roots (~14%).
   strain_designation:
     strain_name: OAE908
@@ -151,9 +151,9 @@ taxonomy:
       gtdb_taxon: Methylobacterium
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Methylobacterium
       ncbi_source_id: NCBITaxon:407
-      majority_fraction: 0.992
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: High relative abundance in SynCom16 roots (~15%).
   strain_designation:
     strain_name: OAE515
@@ -177,9 +177,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OAS795
     isolation_source: Switchgrass rhizosphere soil
@@ -200,9 +200,9 @@ taxonomy:
       gtdb_taxon: Rhizobium
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Rhizobium
       ncbi_source_id: NCBITaxon:379
-      majority_fraction: 0.723
+      majority_fraction: 0.87
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 16 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 12 GTDB taxa under the NCBI taxon]
     notes: Most closely related to R. endophyticum.
   strain_designation:
     strain_name: OAE497
@@ -224,9 +224,9 @@ taxonomy:
       gtdb_taxon: Bosea
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Bosea
       ncbi_source_id: NCBITaxon:169215
-      majority_fraction: 0.981
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OAE506
     isolation_source: Switchgrass rhizosphere soil
@@ -247,9 +247,9 @@ taxonomy:
       gtdb_taxon: Bradyrhizobium
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Bradyrhizobium
       ncbi_source_id: NCBITaxon:374
-      majority_fraction: 0.982
+      majority_fraction: 0.995
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 8 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Grown in 1/10 R2A medium (unlike other members grown in R2A).
   strain_designation:
     strain_name: OAE829
@@ -271,9 +271,9 @@ taxonomy:
       gtdb_taxon: Lysobacter
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Xanthomonadaceae;g__Lysobacter
       ncbi_source_id: NCBITaxon:68
-      majority_fraction: 0.748
+      majority_fraction: 0.758
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 8 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Enriched in rhizosphere at 21 DPI (order Xanthomonadales).
   strain_designation:
     strain_name: OAE881
@@ -313,9 +313,9 @@ taxonomy:
       gtdb_taxon: Marmoricola
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Propionibacteriales;f__Nocardioidaceae;g__Marmoricola
       ncbi_source_id: NCBITaxon:86795
-      majority_fraction: 0.923
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OAE513
     isolation_source: Switchgrass rhizosphere soil
@@ -338,7 +338,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:79328
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OAE865
     isolation_source: Switchgrass rhizosphere soil
@@ -361,7 +361,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:423349
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OAE612
     isolation_source: Switchgrass rhizosphere soil
@@ -382,9 +382,9 @@ taxonomy:
       gtdb_taxon: Niastella
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Chitinophagales;f__Chitinophagaceae;g__Niastella
       ncbi_source_id: NCBITaxon:354354
-      majority_fraction: 0.917
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OAS944
     isolation_source: Switchgrass rhizosphere soil
@@ -407,7 +407,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:2837503
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Formerly classified as Bacillus sp. OAE603.
   strain_designation:
     strain_name: OAE603
@@ -429,9 +429,9 @@ taxonomy:
       gtdb_taxon: Brevibacillus
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Brevibacillales;f__Brevibacillaceae;g__Brevibacillus
       ncbi_source_id: NCBITaxon:55080
-      majority_fraction: 0.816
+      majority_fraction: 0.803
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 6 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OAP136
     isolation_source: Switchgrass rhizosphere soil

--- a/kb/communities/Ecoli_Bifidobacterium_bifidum_Infant_gut_HMO_Mutualism_Coculture.yaml
+++ b/kb/communities/Ecoli_Bifidobacterium_bifidum_Infant_gut_HMO_Mutualism_Coculture.yaml
@@ -26,12 +26,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Escherichia_coli
       gtdb_taxon: Escherichia coli
-      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia
-        coli
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - CROSS_FEEDER
   - SYNTROPHIC_PARTNER
@@ -52,12 +51,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Bifidobacterium_bifidum
       gtdb_taxon: Bifidobacterium bifidum
-      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium
-        bifidum
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium bifidum
       ncbi_source_id: NCBITaxon:1681
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - PRIMARY_DEGRADER
   - CROSS_FEEDER

--- a/kb/communities/Electrostimulated_Mixotrophic_VFA_Producing_Enrichment_Consortium.yaml
+++ b/kb/communities/Electrostimulated_Mixotrophic_VFA_Producing_Enrichment_Consortium.yaml
@@ -29,9 +29,9 @@ taxonomy:
       gtdb_taxon: Enterococcus_B
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Enterococcaceae;g__Enterococcus_B
       ncbi_source_id: NCBITaxon:1350
-      majority_fraction: 0.596
+      majority_fraction: 0.598
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 14 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the source reports the taxon only as "Enterococcus". Dominant in
       the planktonic phase and also enriched in the electrode biofilm.
   functional_role:
@@ -73,9 +73,9 @@ taxonomy:
       gtdb_taxon: Desulfovibrio
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Desulfovibrio
       ncbi_source_id: NCBITaxon:872
-      majority_fraction: 0.871
+      majority_fraction: 0.931
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 16 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 9 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the source reports the taxon only as "Desulfovibrio". Enriched in
       the electrode biofilm, where electrode-associated taxa generate reducing equivalents supporting
       autotrophic metabolism.

--- a/kb/communities/Electrosynthetic_Consortia_Shewanella_Clostridium_Acetobacterium_Acetate.yaml
+++ b/kb/communities/Electrosynthetic_Consortia_Shewanella_Clostridium_Acetobacterium_Acetate.yaml
@@ -28,13 +28,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Shewanella_oneidensis
       gtdb_taxon: Shewanella oneidensis
-      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella
-        oneidensis
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella oneidensis
       ncbi_source_id: NCBITaxon:70863
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via
-        NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:
     strain_name: MR-1
   functional_role:
@@ -59,12 +57,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Clostridium_W_aceticum
       gtdb_taxon: Clostridium_W aceticum
-      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Peptostreptococcales;f__Natronincolaceae;g__Clostridium_W;s__Clostridium_W
-        aceticum
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Peptostreptococcales;f__Natronincolaceae;g__Clostridium_W;s__Clostridium_W aceticum
       ncbi_source_id: NCBITaxon:84022
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - ELECTROTROPH
   - ELECTRON_ACCEPTOR
@@ -86,13 +83,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Acetobacterium_woodii
       gtdb_taxon: Acetobacterium woodii
-      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Eubacteriales;f__Eubacteriaceae;g__Acetobacterium;s__Acetobacterium
-        woodii
+      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Eubacteriales;f__Eubacteriaceae;g__Acetobacterium;s__Acetobacterium woodii
       ncbi_source_id: NCBITaxon:33952
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via
-        NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   functional_role:
   - ELECTRON_ACCEPTOR
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Emiliania_Phaeobacter_Dynamic_Interaction.yaml
+++ b/kb/communities/Emiliania_Phaeobacter_Dynamic_Interaction.yaml
@@ -64,7 +64,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:391619
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Heterotrophic Roseobacter-group bacterium that attaches to E. huxleyi and produces IAA.
   strain_designation:
     strain_name: DSM 17395

--- a/kb/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.yaml
+++ b/kb/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.yaml
@@ -50,7 +50,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered gut-associated Enterobacteriaceae member in the four-species consortium.
   functional_role:
   - CROSS_FEEDER
@@ -72,7 +72,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:90371
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered Salmonella member used as a genetically tractable gut-associated strain.
   functional_role:
   - CROSS_FEEDER
@@ -94,7 +94,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:818
       majority_fraction: 0.99
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered Bacteroides member of the consortium; Bacteroides taxa were described as more
       mucosally associated and complex-carbohydrate utilizing.
   functional_role:

--- a/kb/communities/Ensifer_YF2_Sphingobacterium_Y2_Polyethylene_Degrading_Consortium.yaml
+++ b/kb/communities/Ensifer_YF2_Sphingobacterium_Y2_Polyethylene_Degrading_Consortium.yaml
@@ -28,9 +28,9 @@ taxonomy:
       gtdb_taxon: Ensifer
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Ensifer
       ncbi_source_id: NCBITaxon:106591
-      majority_fraction: 0.745
+      majority_fraction: 0.5
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Strain YF2 identified only to genus Ensifer in the source; grounded at genus rank.
   strain_designation:
     strain_name: YF2
@@ -56,7 +56,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:28453
       majority_fraction: 0.996
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Strain Y2 identified only to genus Sphingobacterium in the source; grounded at genus rank.
   strain_designation:
     strain_name: Y2
@@ -79,14 +79,13 @@ taxonomy:
     notes: Strain MF1 identified only to genus Chryseobacterium; grounded at genus rank. Isolated and
       tested in the three-strain combination, but the effective consortium was the dual-strain YF2+Y2.
     gtdb_classification:
-      gtdb_id: GTDB:s__Chryseobacterium_indologenes
-      gtdb_taxon: Chryseobacterium indologenes
-      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Flavobacteriales;f__Weeksellaceae;g__Chryseobacterium;s__Chryseobacterium
-        indologenes
+      gtdb_id: GTDB:g__Chryseobacterium
+      gtdb_taxon: Chryseobacterium
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Flavobacteriales;f__Weeksellaceae;g__Chryseobacterium
       ncbi_source_id: NCBITaxon:59732
-      majority_fraction: 1.0
-      is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      majority_fraction: 0.828
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: MF1
   abundance_value: Isolated candidate member; part of the three-strain combination only.

--- a/kb/communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.yaml
+++ b/kb/communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.yaml
@@ -130,9 +130,9 @@ taxonomy:
       gtdb_taxon: Mesorhizobium
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Mesorhizobium
       ncbi_source_id: NCBITaxon:68287
-      majority_fraction: 0.97
+      majority_fraction: 0.928
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 17 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus level because the paper describes this member as a putative novel
       species identified from metagenome-assembled genomes, with no species assignment available.
   evidence:

--- a/kb/communities/Ewaste_Bioleaching_Consortium.yaml
+++ b/kb/communities/Ewaste_Bioleaching_Consortium.yaml
@@ -63,7 +63,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Dominant iron-oxidizing bacterium in the e-waste bioleaching consortium. Leptospirillum can
       potentially thrive in bioleaching environments as they have greater capacity for iron oxidation
       activity than other iron-oxidizing bacteria (FeOB). This obligate chemolithoautotroph oxidizes Fe²⁺
@@ -102,7 +102,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:453960
       majority_fraction: 0.96
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Gram-positive, moderately thermophilic, facultatively autotrophic bacterium co-occurring with
       Leptospirillum in the e-waste consortium. Sulfobacillus species oxidize both iron and reduced sulfur
       compounds and can grow mixotrophically on organic compounds. S. benefaciens contributes to iron
@@ -136,7 +136,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Mesophilic γ-proteobacterium that oxidizes both ferrous iron and reduced sulfur compounds.
       Widely used in PCB bioleaching research, achieving >94% copper recovery and 90% zinc recovery in
       4-10 days at PCB concentrations of 10-50 g/L. This chemolithoautotroph fixes CO₂ and nitrogen, thriving
@@ -177,7 +177,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:930
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Sulfur-oxidizing bacterium that generates sulfuric acid from elemental sulfur and reduced
       inorganic sulfur compounds. In e-waste bioleaching, At. thiooxidans maintains the extremely low
       pH (1.2-2.0) required for metal solubilization and prevents precipitation of dissolved metals as
@@ -214,7 +214,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:160808
       majority_fraction: 0.95
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Facultatively anaerobic, psychrotolerant iron- and sulfur-oxidizing acidophile. Used in two-step
       e-waste bioleaching processes for PCB metal recovery. This diazotrophic bacterium fixes nitrogen,
       reducing nutrient requirements. A. ferrivorans tolerates lower temperatures than At. ferrooxidans,

--- a/kb/communities/Ferroplasma_Leptospirillum_Syntrophy.yaml
+++ b/kb/communities/Ferroplasma_Leptospirillum_Syntrophy.yaml
@@ -46,7 +46,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Chemolithoautotrophic iron-oxidizing bacterium (Nitrospirae phylum) that oxidizes Fe²⁺ to
       Fe³⁺ as sole energy source while fixing CO₂. Secretes organic matter during growth (cell lysis products,
       extracellular polymeric substances, metabolic byproducts) that accumulates to toxic levels in pure
@@ -94,7 +94,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:74969
       majority_fraction: 0.91
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Cell wall-lacking archaeon (Thermoplasmatales) that grows chemomixotrophically, oxidizing
       ferrous iron while utilizing organic compounds for carbon. In syntrophic partnership with Leptospirillum,
       F. acidiphilum consumes organic matter secreted by the bacterium, maintaining low organic compound

--- a/kb/communities/GLBRC_Populus_Variovorax_SynCom28.yaml
+++ b/kb/communities/GLBRC_Populus_Variovorax_SynCom28.yaml
@@ -50,9 +50,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: BK119
     isolation_source: Populus deltoides root
@@ -81,9 +81,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: BK151
     isolation_source: Populus deltoides root
@@ -112,9 +112,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: BK370
     isolation_source: Populus deltoides root
@@ -143,9 +143,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: BK460
     isolation_source: Populus deltoides root
@@ -174,9 +174,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: BK613
     isolation_source: Populus deltoides root
@@ -205,9 +205,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: BK658
     isolation_source: Populus deltoides root
@@ -236,9 +236,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: BT01
     isolation_source: Populus deltoides rhizosphere
@@ -267,9 +267,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: CF079
     isolation_source: Populus deltoides endosphere
@@ -298,9 +298,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: CF313
     isolation_source: Populus deltoides endosphere
@@ -329,9 +329,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: GV004
     isolation_source: Populus trichocarpa endosphere
@@ -360,9 +360,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: GV008
     isolation_source: Populus trichocarpa endosphere
@@ -391,9 +391,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: GV014
     isolation_source: Populus trichocarpa endosphere
@@ -422,9 +422,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: GV035
     isolation_source: Populus trichocarpa endosphere
@@ -453,9 +453,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: GV040
     isolation_source: Populus trichocarpa endosphere
@@ -484,9 +484,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: GV042
     isolation_source: Populus trichocarpa endosphere
@@ -515,9 +515,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: GV051
     isolation_source: Populus trichocarpa endosphere
@@ -546,9 +546,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OK202
     isolation_source: Populus trichocarpa rhizosphere
@@ -577,9 +577,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OK212
     isolation_source: Populus trichocarpa endosphere
@@ -608,9 +608,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OK605
     isolation_source: Populus trichocarpa endosphere
@@ -639,9 +639,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OV084
     isolation_source: Populus trichocarpa endosphere
@@ -670,9 +670,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OV329
     isolation_source: Populus trichocarpa endosphere
@@ -701,9 +701,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OV700
     isolation_source: Populus trichocarpa endosphere
@@ -732,9 +732,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: PDC80
     isolation_source: Populus deltoides endosphere
@@ -763,9 +763,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: YR216
     isolation_source: Populus deltoides rhizosphere
@@ -794,9 +794,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: YR266
     isolation_source: Populus deltoides endosphere
@@ -825,9 +825,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: YR634
     isolation_source: Populus deltoides endosphere
@@ -856,9 +856,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: YR750
     isolation_source: Populus deltoides endosphere
@@ -887,9 +887,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: YR752
     isolation_source: Populus deltoides endosphere

--- a/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
+++ b/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
@@ -69,7 +69,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:133926
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Dominant Actinobacteriota member (up to 61.5% relative abundance). Degrades lactose via the
       Leloir pathway, producing acetic and lactic acids.
 
@@ -128,7 +128,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:2740557
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Actinobacteriota member (up to 29.6% relative abundance). Produces succinic acid from lactose.
 
       '
@@ -160,7 +160,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1766253
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Firmicutes member (up to 18.7% relative abundance). Performs lactose-based chain elongation
       to medium-chain fatty acids.
 
@@ -192,9 +192,9 @@ taxonomy:
       gtdb_taxon: Bifidobacterium
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium
       ncbi_source_id: NCBITaxon:1678
-      majority_fraction: 0.998
+      majority_fraction: 0.999
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Actinobacteriota member (up to 17.4% relative abundance). Ferments lactose via the bifid shunt
       pathway.
 
@@ -225,9 +225,9 @@ taxonomy:
       gtdb_taxon: Spirochaetota
       gtdb_lineage: d__Bacteria;p__Spirochaetota
       ncbi_source_id: NCBITaxon:203691
-      majority_fraction: 0.995
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 5 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Spirochaetota member (up to 16.1% relative abundance). Produces ethanol which serves as substrate
       for chain elongation by Firmicutes.
 
@@ -259,7 +259,7 @@ taxonomy:
       gtdb_taxon: Bifidobacterium
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium
       ncbi_source_id: NCBITaxon:1678
-      majority_fraction: 0.998
+      majority_fraction: 0.999
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Second Bifidobacterium MAG (up to 15.3% relative abundance). Lactose fermentation via bifid
@@ -326,7 +326,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:33905
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Third Bifidobacterium MAG (up to 11.4% relative abundance). Lactose fermentation.
 
       '
@@ -356,9 +356,9 @@ taxonomy:
       gtdb_taxon: Acidaminococcus
       gtdb_lineage: d__Bacteria;p__Bacillota_C;c__Negativicutes;o__Acidaminococcales;f__Acidaminococcaceae;g__Acidaminococcus
       ncbi_source_id: NCBITaxon:904
-      majority_fraction: 0.991
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Firmicutes member (up to 10.2% relative abundance). Possible ethanol-based chain elongation.
 
       '

--- a/kb/communities/GOM_Oil_Degrading_Consortium.yaml
+++ b/kb/communities/GOM_Oil_Degrading_Consortium.yaml
@@ -43,7 +43,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:857252
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -65,7 +65,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:2782567
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.yaml
+++ b/kb/communities/Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.yaml
@@ -50,7 +50,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:35554
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Anaerobic bacterium serving as the exoelectrogen in this partnership.
       G. sulfurreducens (strain DSM 12127) oxidizes acetate and transfers electrons
       to C. pasteurianum by a route that the cited sources do not resolve - conductive
@@ -97,7 +97,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1501
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Saccharolytic, nitrogen-fixing, spore-forming Gram-positive obligate anaerobe
       that serves as the electron acceptor in this partnership. C. pasteurianum
       (strain DSM 525 = ATCC 6013) ferments glycerol, and when receiving electrons

--- a/kb/communities/Geobacter_Methanosaeta_DIET.yaml
+++ b/kb/communities/Geobacter_Methanosaeta_DIET.yaml
@@ -41,7 +41,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Anaerobic bacterium capable of oxidizing organic compounds (including
       ethanol) and transferring electrons to metal oxides or other microorganisms.
       In DIET cocultures, G. metallireducens uses electrically conductive pili (e-pili)
@@ -76,7 +76,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:301375
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Obligate acetoclastic methanogenic archaeon capable of accepting electrons
       via DIET and using them for CO2 reduction to methane. M. harundinacea is unique
       among acetoclastic methanogens in its ability to participate in DIET, accepting

--- a/kb/communities/Geobacter_Methanosarcina_DIET.yaml
+++ b/kb/communities/Geobacter_Methanosarcina_DIET.yaml
@@ -40,7 +40,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Anaerobic bacterium capable of oxidizing organic compounds (including
       ethanol) and transferring electrons to metal oxides or other microorganisms.
       In DIET cocultures, G. metallireducens uses electrically conductive pili (e-pili)

--- a/kb/communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.yaml
+++ b/kb/communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.yaml
@@ -62,7 +62,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:35554
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Species-level member of the defined Geobacter-Pseudomonas coculture.
   abundance_level: DOMINANT
   abundance_value: Geobacter became dominant during serially adapted cocultures.
@@ -92,7 +92,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:287
       majority_fraction: 0.99
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Species-level member of the defined Geobacter-Pseudomonas coculture.
   abundance_level: COMMON
   functional_role:

--- a/kb/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.yaml
+++ b/kb/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.yaml
@@ -39,7 +39,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:641853
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at c__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Groundwater Elusimicrobia clades with diverse metabolic strategies
       including aerobic and anaerobic respiration and Rnf-dependent acetogenesis.
   functional_role:

--- a/kb/communities/Hanford_300_Area_Unconfined_Aquifer_Community.yaml
+++ b/kb/communities/Hanford_300_Area_Unconfined_Aquifer_Community.yaml
@@ -30,7 +30,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1224
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 14 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Proteobacteria comprised half of the recovered sequences in the Hanford unconfined aquifer
       groundwater study.
   functional_role:
@@ -56,7 +56,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:976
       majority_fraction: 0.999
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 8 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 5 GTDB taxa under the NCBI taxon]
     notes: Bacteroidetes were the second most abundant phylum in the recovered 16S rRNA gene sequences.
   functional_role:
   - PRIMARY_DEGRADER
@@ -81,7 +81,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:201174
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 6 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Actinobacterial ACK-M1 and CL500-29 groups appeared during river-water intrusion and became
       abundant at high water level.
   functional_role:

--- a/kb/communities/Hanford_300_Area_Unconfined_Aquifer_Community.yaml
+++ b/kb/communities/Hanford_300_Area_Unconfined_Aquifer_Community.yaml
@@ -30,7 +30,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1224
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Proteobacteria comprised half of the recovered sequences in the Hanford unconfined aquifer
       groundwater study.
   functional_role:

--- a/kb/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.yaml
+++ b/kb/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.yaml
@@ -62,9 +62,9 @@ taxonomy:
       gtdb_taxon: Clostridia
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia
       ncbi_source_id: NCBITaxon:186801
-      majority_fraction: 0.974
+      majority_fraction: 0.987
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at c__ rank; 39 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 26 GTDB taxa under the NCBI taxon]
     notes: The source reports Clostridia within Firmicutes as dominant contributors of measured CAZymes.
   abundance_level: DOMINANT
   functional_role:
@@ -86,9 +86,9 @@ taxonomy:
       gtdb_taxon: Bacilli
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli
       ncbi_source_id: NCBITaxon:91061
-      majority_fraction: 0.996
+      majority_fraction: 0.999
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at c__ rank; 8 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: The paper describes Bacillus/Bacilli-lineage Firmicutes among dominant CAZyme contributors.
   abundance_level: ABUNDANT
   functional_role:
@@ -110,9 +110,9 @@ taxonomy:
       gtdb_taxon: Chloroflexota
       gtdb_lineage: d__Bacteria;p__Chloroflexota
       ncbi_source_id: NCBITaxon:200795
-      majority_fraction: 0.998
+      majority_fraction: 0.997
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: The publication uses the historical phylum name Chloroflexi and reports fraction-specific
       prevalence of Chloroflexi-derived CAZymes.
   abundance_level: COMMON
@@ -135,9 +135,9 @@ taxonomy:
       gtdb_taxon: Thermotogota
       gtdb_lineage: d__Bacteria;p__Thermotogota
       ncbi_source_id: NCBITaxon:200918
-      majority_fraction: 0.997
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: The publication uses the historical phylum name Thermotogae and reports Thermotogae-derived
       enzymes in supernatant and substrate-bound fractions.
   abundance_level: COMMON

--- a/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
+++ b/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
@@ -49,9 +49,9 @@ taxonomy:
       gtdb_taxon: Leptospirillum
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum
       ncbi_source_id: NCBITaxon:179
-      majority_fraction: 0.575
+      majority_fraction: 0.742
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Iron-oxidizing chemolithoautotroph present in the chemocline and upper layers of stratified
       pit lakes. Leptospirillum oxidizes ferrous iron (Fe²⁺) to ferric iron (Fe³⁺) for energy at extremely
       low pH (1.5-3.0), fixing CO₂ autotrophically via the Calvin-Benson-Bassham cycle. In the chemocline,
@@ -92,7 +92,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Metabolically versatile chemolithoautotroph capable of both iron and sulfur oxidation in the
       oxic layers of stratified pit lakes. At. ferrooxidans oxidizes Fe²⁺ to Fe³⁺ and reduced sulfur compounds
       (sulfide, elemental sulfur, thiosulfate) to sulfuric acid, contributing to acidification and metal
@@ -119,13 +119,13 @@ taxonomy:
       id: NCBITaxon:522
       label: Acidiphilium
     gtdb_classification:
-      gtdb_id: GTDB:g__UBA10281
-      gtdb_taxon: UBA10281
-      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Christensenellales;f__Borkfalkiaceae;g__UBA10281
+      gtdb_id: GTDB:g__Acidiphilium
+      gtdb_taxon: Acidiphilium
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acidiphilium
       ncbi_source_id: NCBITaxon:522
-      majority_fraction: 0.633
-      is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Facultatively heterotrophic acidophilic bacterium that consumes algal-derived organic carbon
       in the oxic surface layers of stratified pit lakes. Acidiphilium is a mixotrophic genus capable
       of both aerobic respiration on organic compounds and facultative iron reduction under microaerobic
@@ -161,9 +161,9 @@ taxonomy:
       gtdb_taxon: Desulfomonile
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfomonilia;o__Desulfomonilales;f__Desulfomonilaceae;g__Desulfomonile
       ncbi_source_id: NCBITaxon:2357
-      majority_fraction: 0.667
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Dominant sulfate-reducing bacterium in the chemocline (~11m depth), representing 43% of amplicon
       sequence variants in this critical transition zone. Desulfomonile performs dissimilatory sulfate
       reduction coupled to organic carbon oxidation, producing hydrogen sulfide (peak concentration 120
@@ -235,9 +235,9 @@ taxonomy:
       gtdb_taxon: Thermoplasmatales
       gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales
       ncbi_source_id: NCBITaxon:2301
-      majority_fraction: 0.903
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at o__ rank; 9 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Dominant archaeal heterotrophs in the deep anoxic monimolimnion, representing 46% ± 2.5% of
       total sequences and serving as the primary carbon scavengers in this extreme environment (pH 3.0-4.5,
       no oxygen, high metals). Thermoplasmatales utilize organic carbon that settles from upper layers,
@@ -282,9 +282,9 @@ taxonomy:
       gtdb_taxon: Methanobrevibacter_A
       gtdb_lineage: d__Archaea;p__Methanobacteriota;c__Methanobacteria;o__Methanobacteriales;f__Methanobacteriaceae;g__Methanobrevibacter_A
       ncbi_source_id: NCBITaxon:2172
-      majority_fraction: 0.955
+      majority_fraction: 0.965
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 8 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 6 GTDB taxa under the NCBI taxon]
     notes: 'Hydrogenotrophic methanogen detected in the deep anoxic monimolimnion and subsurface sediments
       of Iberian Pyrite Belt systems. Methanobrevibacter belongs to the class Methanobacteria and produces
       methane from H₂ and CO₂ (4H₂ + CO₂ → CH₄ + 2H₂O) under strictly anaerobic conditions. While detected

--- a/kb/communities/Industrial_Bioreactor_Consortium.yaml
+++ b/kb/communities/Industrial_Bioreactor_Consortium.yaml
@@ -70,7 +70,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:33059
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Moderately thermophilic chemolithoautotrophic bacterium that oxidizes ferrous iron (Fe²⁺)
       and reduced inorganic sulfur compounds (RISCs) including elemental sulfur, thiosulfate, tetrathionate,
       and sulfide. Optimum temperature 40-50°C with activity up to 52°C, significantly higher than mesophilic
@@ -124,7 +124,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:74969
       majority_fraction: 0.91
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Extremely acidophilic, cell wall-lacking archaeon (Thermoplasmatales, Ferroplasmaceae) that
       oxidizes ferrous iron at pH as low as 1.0-1.5. This pleomorphic organism thrives in late-stage reactor
       conditions when pH drops below 2.0 and Fe³⁺ concentrations increase to >15 g/L. Ferroplasma species
@@ -311,7 +311,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:453960
       majority_fraction: 0.96
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Gram-positive, moderately thermophilic (optimum 45-50°C), facultatively autotrophic bacterium
       that oxidizes both ferrous iron and reduced sulfur compounds. Spore-forming capability provides
       resilience to environmental stress, toxic metals, and nutrient limitation. Grows mixotrophically
@@ -349,7 +349,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Obligate chemolithoautotrophic iron-oxidizing bacterium (Nitrospirae) specialized for extremely
       acidic environments. Highly efficient at colonizing sulfide mineral surfaces and oxidizing Fe²⁺
       at pH approaching 1.5. In moderate thermophilic bioleaching, L. ferriphilum is sensitive to elevated

--- a/kb/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.yaml
+++ b/kb/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.yaml
@@ -53,7 +53,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1064
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Source strain CCL5 was identified to genus level as Rhodocyclus sp.; genus-level taxonomy is
       used because the source did not assign a species.
   strain_designation:

--- a/kb/communities/Infant_Gut_DNA_Phage_Succession_Community.yaml
+++ b/kb/communities/Infant_Gut_DNA_Phage_Succession_Community.yaml
@@ -49,9 +49,9 @@ taxonomy:
       gtdb_taxon: Bacteroides
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides
       ncbi_source_id: NCBITaxon:816
-      majority_fraction: 0.953
+      majority_fraction: 0.997
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 19 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 6 GTDB taxa under the NCBI taxon]
   evidence:
   - reference: PMID:38096814
     supports: SUPPORT

--- a/kb/communities/Infant_Gut_Prebiotic_Response_SynCom.yaml
+++ b/kb/communities/Infant_Gut_Prebiotic_Response_SynCom.yaml
@@ -31,9 +31,9 @@ taxonomy:
       gtdb_taxon: Bifidobacterium
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium
       ncbi_source_id: NCBITaxon:1678
-      majority_fraction: 0.998
+      majority_fraction: 0.999
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the source reports HMO/GOS-driven bifidobacterial expansion without
       resolving a single species for the SynCom member.
   functional_role:
@@ -57,9 +57,9 @@ taxonomy:
       gtdb_taxon: Bacteroides
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides
       ncbi_source_id: NCBITaxon:816
-      majority_fraction: 0.953
+      majority_fraction: 0.997
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 19 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 6 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank (Bacteroides); the source discusses the Bacteroides/Phocaeicola group,
       with Phocaeicola vulgatus resolved separately as a distinct member below.
   functional_role:
@@ -81,12 +81,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Phocaeicola_vulgatus
       gtdb_taxon: Phocaeicola vulgatus
-      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Phocaeicola;s__Phocaeicola
-        vulgatus
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Phocaeicola;s__Phocaeicola vulgatus
       ncbi_source_id: NCBITaxon:821
       majority_fraction: 0.86
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - CROSS_FEEDER
   abundance_value: Context-dependent ecological hub shaping succinate and propionate production.
@@ -106,12 +105,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Escherichia_coli
       gtdb_taxon: Escherichia coli
-      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia
-        coli
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - SECONDARY_FERMENTER
   abundance_value: Abundance unchanged; metabolic activity altered by the P. vulgatus hub.

--- a/kb/communities/Infant_Gut_Strain_Persistence_Maternal_Community.yaml
+++ b/kb/communities/Infant_Gut_Strain_Persistence_Maternal_Community.yaml
@@ -31,9 +31,9 @@ taxonomy:
       gtdb_taxon: Bacteroides
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides
       ncbi_source_id: NCBITaxon:816
-      majority_fraction: 0.953
+      majority_fraction: 0.997
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 19 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 6 GTDB taxa under the NCBI taxon]
     notes: Bacteroides is one of the two main genera among ~11 percent of
       early colonizers that persist through the first year of life.
   abundance_level: ABUNDANT
@@ -57,9 +57,9 @@ taxonomy:
       gtdb_taxon: Bifidobacterium
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium
       ncbi_source_id: NCBITaxon:1678
-      majority_fraction: 0.998
+      majority_fraction: 0.999
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Bifidobacterium is the second main genus among ~11 percent of
       persistent early colonizers.
   abundance_level: ABUNDANT

--- a/kb/communities/Ion_Adsorption_REE_Indigenous_Community.yaml
+++ b/kb/communities/Ion_Adsorption_REE_Indigenous_Community.yaml
@@ -51,7 +51,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1224
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Dominant bacterial phylum (46.9% average abundance) present along the entire weathering profile.
       Proteobacteria members include REE-dissolving genera such as Acinetobacter (5.06%) and Pseudomonas
       (1.25%) that facilitate bioweathering of REE-bearing minerals through organic acid production and

--- a/kb/communities/Ion_Adsorption_REE_Indigenous_Community.yaml
+++ b/kb/communities/Ion_Adsorption_REE_Indigenous_Community.yaml
@@ -51,7 +51,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1224
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 14 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: 'Dominant bacterial phylum (46.9% average abundance) present along the entire weathering profile.
       Proteobacteria members include REE-dissolving genera such as Acinetobacter (5.06%) and Pseudomonas
       (1.25%) that facilitate bioweathering of REE-bearing minerals through organic acid production and
@@ -87,9 +87,9 @@ taxonomy:
       gtdb_taxon: Acidobacteriota
       gtdb_lineage: d__Bacteria;p__Acidobacteriota
       ncbi_source_id: NCBITaxon:57723
-      majority_fraction: 0.976
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Second most abundant bacterial phylum (14.6%) exhibiting oligotrophic K-strategist lifestyle
       adaptations for survival in low-nutrient weathering environments. Acidobacteria are slow-growing
       specialists that thrive in nutrient-depleted regolith-hosted deposits, contributing to long-term
@@ -130,7 +130,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:201174
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 6 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: 'Third most abundant bacterial phylum (9.0%) contributing to bioweathering and REE mobilization
       through organic acid secretion and mineral dissolution. Actinobacteria are well-known producers
       of diverse secondary metabolites, organic acids, and extracellular enzymes that facilitate rock
@@ -160,9 +160,9 @@ taxonomy:
       gtdb_taxon: Bacillus
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
-      majority_fraction: 0.508
+      majority_fraction: 0.57
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive Firmicutes genus demonstrating exceptional HREE selectivity through teichoic
       acid binding. Bacillus pumilus exhibited 77.6% REE adsorption efficiency with preferential HREE
       uptake (82.9%) versus LREE (69.8%), showing a characteristic "leftward-inclined curve" favoring
@@ -207,9 +207,9 @@ taxonomy:
       gtdb_taxon: Micrococcus
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Micrococcaceae;g__Micrococcus
       ncbi_source_id: NCBITaxon:1269
-      majority_fraction: 0.997
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive Actinobacteria genus exhibiting the highest HREE selectivity among tested strains.
       Micrococcus sp. achieved 82.4% overall REE adsorption efficiency with 85.1% HREE uptake versus 78.2%
       LREE, demonstrating stronger HREE preference than even Bacillus. Like Bacillus, Micrococcus cell

--- a/kb/communities/Jala_Maize_PGPB_SynCom.yaml
+++ b/kb/communities/Jala_Maize_PGPB_SynCom.yaml
@@ -42,7 +42,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:380021
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -59,7 +59,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:553
       majority_fraction: 0.99
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -76,7 +76,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:244366
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -91,9 +91,9 @@ taxonomy:
       gtdb_taxon: Burkholderia
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Burkholderia
       ncbi_source_id: NCBITaxon:32008
-      majority_fraction: 0.985
+      majority_fraction: 0.999
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/KB1_Chlorinated_Ethene_Dechlorinating_Consortium.yaml
+++ b/kb/communities/KB1_Chlorinated_Ethene_Dechlorinating_Consortium.yaml
@@ -43,9 +43,9 @@ taxonomy:
       gtdb_taxon: Dehalococcoides
       gtdb_lineage: d__Bacteria;p__Chloroflexota;c__Dehalococcoidia;o__Dehalococcoidales;f__Dehalococcoidaceae;g__Dehalococcoides
       ncbi_source_id: NCBITaxon:61434
-      majority_fraction: 0.909
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Organohalide-respiring bacteria responsible for dechlorination beyond cis-DCE to ethene.
   functional_role:
   - PRIMARY_DEGRADER
@@ -72,7 +72,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:33952
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Dominant acetogen in KB-1 low-pH and vitamin-perturbation experiments; supports cobamide availability.
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -94,7 +94,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:2375
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Acetogenic KB-1 member reported with Acetobacterium in cultures lacking exogenous vitamins.
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/KBase_Models_for_Zahmeeth_Original_PLOS.yaml
+++ b/kb/communities/KBase_Models_for_Zahmeeth_Original_PLOS.yaml
@@ -51,7 +51,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -85,7 +85,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:818
       majority_fraction: 0.99
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:
@@ -104,9 +104,9 @@ taxonomy:
       gtdb_taxon: Klebsiella
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Klebsiella
       ncbi_source_id: NCBITaxon:570
-      majority_fraction: 0.999
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/KBase_ORT_Workflow_Community_Model.yaml
+++ b/kb/communities/KBase_ORT_Workflow_Community_Model.yaml
@@ -84,7 +84,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1236
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 7 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Gammaproteobacterial genome within family Steroidobacteraceae from Columbia River sediments.
       Functions as denitrifier reducing nitrate to nitrogen gas.
   functional_role:
@@ -107,7 +107,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1236
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 7 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Second gammaproteobacterial genome within family Steroidobacteraceae from Columbia River sediments.
       Functions as denitrifier reducing nitrate to nitrogen gas.
   functional_role:

--- a/kb/communities/KBase_Synthetic_Bacterial_Community_R2A.yaml
+++ b/kb/communities/KBase_Synthetic_Bacterial_Community_R2A.yaml
@@ -38,9 +38,9 @@ taxonomy:
       gtdb_taxon: Pantoea
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Pantoea
       ncbi_source_id: NCBITaxon:53335
-      majority_fraction: 0.961
+      majority_fraction: 0.982
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 15 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 6 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: YR343
   abundance_level: DOMINANT
@@ -65,9 +65,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: CF313
   functional_role:

--- a/kb/communities/Kombucha_KMC_IMBG1_Fermentation_Community.yaml
+++ b/kb/communities/Kombucha_KMC_IMBG1_Fermentation_Community.yaml
@@ -27,9 +27,9 @@ taxonomy:
       gtdb_taxon: Komagataeibacter
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Komagataeibacter
       ncbi_source_id: NCBITaxon:1434011
-      majority_fraction: 0.973
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Acetobacterial core member reported as the current genus name for former Gluconacetobacter
       isolates in KMC-IMBG1.
   abundance_level: DOMINANT
@@ -51,9 +51,9 @@ taxonomy:
       gtdb_taxon: Gluconobacter
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Gluconobacter
       ncbi_source_id: NCBITaxon:441
-      majority_fraction: 0.71
+      majority_fraction: 0.744
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Acetobacterial core member of the KMC-IMBG1 kombucha culture.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml
+++ b/kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml
@@ -86,9 +86,9 @@ taxonomy:
       gtdb_taxon: Methylomonadaceae
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylomonadaceae
       ncbi_source_id: NCBITaxon:403
-      majority_fraction: 0.64
+      majority_fraction: 0.695
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at f__ rank; 7 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at f__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: >
       Type I methanotroph family represented in methane-consuming Lake
       Washington sediment microcosms; includes oxygen-dependent genera such as
@@ -119,7 +119,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:32011
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at f__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at f__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: >
       Non-methane-oxidizing methylotrophic family that co-enriches with
       Methylococcaceae in methane-fed Lake Washington sediment microcosms.
@@ -175,9 +175,9 @@ taxonomy:
       gtdb_taxon: Methylotenera
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Methylophilaceae;g__Methylotenera
       ncbi_source_id: NCBITaxon:359407
-      majority_fraction: 0.676
+      majority_fraction: 0.818
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Low-oxygen non-methanotrophic methylotroph genus partnered with Methylobacter.
   functional_role:
   - CROSS_FEEDER
@@ -205,9 +205,9 @@ taxonomy:
       gtdb_taxon: Methylomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylomonadaceae;g__Methylomonas
       ncbi_source_id: NCBITaxon:416
-      majority_fraction: 0.948
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Methanotrophic genus included in genome-scale modeling of the Lake Washington methane-cycling community.
   functional_role:
   - PRIMARY_DEGRADER
@@ -229,7 +229,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:105972
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Higher-oxygen methanotrophic genus in Lake Washington methane-fed microcosms.
   functional_role:
   - PRIMARY_DEGRADER
@@ -251,7 +251,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:16
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Higher-oxygen non-methanotrophic methylotroph genus partnered with Methylosarcina.
   functional_role:
   - CROSS_FEEDER

--- a/kb/communities/Lotus_LjSC3.yaml
+++ b/kb/communities/Lotus_LjSC3.yaml
@@ -52,9 +52,9 @@ taxonomy:
       gtdb_taxon: Mesorhizobium
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Mesorhizobium
       ncbi_source_id: NCBITaxon:68287
-      majority_fraction: 0.97
+      majority_fraction: 0.928
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 17 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_PRODUCER
@@ -75,9 +75,9 @@ taxonomy:
       gtdb_taxon: Mesorhizobium
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Mesorhizobium
       ncbi_source_id: NCBITaxon:68287
-      majority_fraction: 0.97
+      majority_fraction: 0.928
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 17 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - PRIMARY_PRODUCER
@@ -98,9 +98,9 @@ taxonomy:
       gtdb_taxon: Mesorhizobium
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Mesorhizobium
       ncbi_source_id: NCBITaxon:68287
-      majority_fraction: 0.97
+      majority_fraction: 0.928
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 17 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - PRIMARY_PRODUCER
@@ -171,7 +171,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:75682
       majority_fraction: 0.995
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at f__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at f__ rank; 2 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/MAMC_M48_Lignocellulose.yaml
+++ b/kb/communities/MAMC_M48_Lignocellulose.yaml
@@ -90,7 +90,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:363331
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/MSC1_Dominant_Core.yaml
+++ b/kb/communities/MSC1_Dominant_Core.yaml
@@ -27,9 +27,9 @@ taxonomy:
       gtdb_taxon: Rhodococcus
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Rhodococcus
       ncbi_source_id: NCBITaxon:1827
-      majority_fraction: 0.996
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -65,7 +65,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1914288
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -99,9 +99,9 @@ taxonomy:
       gtdb_taxon: Bosea
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Bosea
       ncbi_source_id: NCBITaxon:169215
-      majority_fraction: 0.981
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -123,7 +123,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1911909
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -188,7 +188,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:42445
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -224,7 +224,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:201174
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 6 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
   abundance_level: RARE
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -247,7 +247,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:976
       majority_fraction: 0.999
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 8 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 5 GTDB taxa under the NCBI taxon]
   abundance_level: RARE
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/MSC2_Model_Soil_Consortium.yaml
+++ b/kb/communities/MSC2_Model_Soil_Consortium.yaml
@@ -65,7 +65,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:2093828
       majority_fraction: 0.9
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: MSC1_005
     genome_accession: GCA_023667605.1
@@ -84,7 +84,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1914288
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: MSC1_007
     genome_accession: GCA_023667495.1
@@ -114,7 +114,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:106592
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:
     strain_name: MSC1_011
     genome_accession: GCA_023667555.1
@@ -145,7 +145,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:382
       majority_fraction: 0.97
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: MSC1_014
     genome_accession: GCA_023197145.1
@@ -162,9 +162,9 @@ taxonomy:
       gtdb_taxon: Rhodococcus
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Rhodococcus
       ncbi_source_id: NCBITaxon:1827
-      majority_fraction: 0.996
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: MSC1_016
     genome_accession: GCA_023667485.1

--- a/kb/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.yaml
+++ b/kb/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.yaml
@@ -81,7 +81,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:395331
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Methanoregula is curated at genus level because the study reports it
       as a hub methanogen across networks and a predictor of methane flux.
   functional_role:

--- a/kb/communities/Maize_Root_Simplified_Community.yaml
+++ b/kb/communities/Maize_Root_Simplified_Community.yaml
@@ -129,7 +129,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:92645
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -161,7 +161,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:253
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Mars_Meteorite_EETA79001_Growth_Panel.yaml
+++ b/kb/communities/Mars_Meteorite_EETA79001_Growth_Panel.yaml
@@ -110,9 +110,9 @@ taxonomy:
       gtdb_taxon: Chroococcidiopsis
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Cyanobacteriales;f__Chroococcidiopsidaceae;g__Chroococcidiopsis
       ncbi_source_id: NCBITaxon:54298
-      majority_fraction: 0.778
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: >
       Source designates this cyanobacterium Chr20-20201027-1 (abbreviated Chr20) and
       identifies it as a Chroococcidiopsis sp.; ontology grounding is genus-level.

--- a/kb/communities/Medicago_Nodule_Biofertilizer_SynCom.yaml
+++ b/kb/communities/Medicago_Nodule_Biofertilizer_SynCom.yaml
@@ -43,9 +43,9 @@ taxonomy:
       gtdb_taxon: Ensifer
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Ensifer
       ncbi_source_id: NCBITaxon:106591
-      majority_fraction: 0.745
+      majority_fraction: 0.5
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
+++ b/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
@@ -39,7 +39,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1224
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 14 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: 'Multiple MAGs representing Proteobacteria were reconstructed from EFPC sediment metagenomes.
       Several contained heavy metal resistance genes.
 
@@ -66,9 +66,9 @@ taxonomy:
       gtdb_taxon: Acidobacteriota
       gtdb_lineage: d__Bacteria;p__Acidobacteriota
       ncbi_source_id: NCBITaxon:57723
-      majority_fraction: 0.976
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: MAGs from this phylum were recovered from EFPC sediment metagenomes.
   functional_role:
   - PRIMARY_DEGRADER
@@ -94,7 +94,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:201174
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 6 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: MAGs from this phylum were recovered from EFPC sediment metagenomes.
   functional_role:
   - PRIMARY_DEGRADER
@@ -120,7 +120,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:142182
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: MAGs from this phylum were recovered from EFPC sediment metagenomes.
   functional_role:
   - PRIMARY_DEGRADER
@@ -161,9 +161,9 @@ taxonomy:
       gtdb_taxon: Myxococcota
       gtdb_lineage: d__Bacteria;p__Myxococcota
       ncbi_source_id: NCBITaxon:2818505
-      majority_fraction: 0.903
+      majority_fraction: 0.836
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: MAGs from this phylum were recovered from EFPC sediment metagenomes.
   functional_role:
   - PRIMARY_DEGRADER
@@ -189,7 +189,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:28889
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Archaeal MAGs recovered from EFPC sediment metagenomes.
   functional_role:
   - PRIMARY_DEGRADER
@@ -236,7 +236,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:71518
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Confirmed hgcAB+ mercury methylator. Demonstrated methylmercury production in pure culture.
 
       '
@@ -264,7 +264,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:2201
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Confirmed hgcAB+ mercury methylator. Demonstrated methylmercury production in pure culture.
 
       '
@@ -292,7 +292,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:475088
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Confirmed hgcAB+ mercury methylator. Demonstrated methylmercury production in pure culture.
 
       '

--- a/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
+++ b/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
@@ -39,7 +39,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1224
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Multiple MAGs representing Proteobacteria were reconstructed from EFPC sediment metagenomes.
       Several contained heavy metal resistance genes.
 

--- a/kb/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.yaml
+++ b/kb/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.yaml
@@ -107,7 +107,7 @@ taxonomy:
       gtdb_taxon: Pseudomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
-      majority_fraction: 0.692
+      majority_fraction: 0.699
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: A third member of the early community that declined once the community stabilised, so it

--- a/kb/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.yaml
+++ b/kb/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.yaml
@@ -84,9 +84,9 @@ taxonomy:
       gtdb_taxon: Mesorhizobium
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Mesorhizobium
       ncbi_source_id: NCBITaxon:68287
-      majority_fraction: 0.97
+      majority_fraction: 0.928
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 17 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
     notes: The persistent partner and the proposed vitamin B12 source. Grounded at genus level —
       the isolate is designated only "sp. TaiHu", with no species assignment.
   evidence:
@@ -107,9 +107,9 @@ taxonomy:
       gtdb_taxon: Pseudomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
-      majority_fraction: 0.596
+      majority_fraction: 0.692
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 17 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: A third member of the early community that declined once the community stabilised, so it
       is present in assembly but not in the stable consortium. Grounded at genus level; the isolate
       carries no species assignment.
@@ -132,7 +132,7 @@ taxonomy:
       gtdb_taxon: Microcystis
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Cyanobacteriales;f__Microcystaceae;g__Microcystis
       ncbi_source_id: NCBITaxon:1125
-      majority_fraction: 0.991
+      majority_fraction: 0.986
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: The bloom-forming community co-cultured with Syn7002 to seed the consortium. Grounded at

--- a/kb/communities/Methane_Oxidation_CrVI_Reduction_SynCom.yaml
+++ b/kb/communities/Methane_Oxidation_CrVI_Reduction_SynCom.yaml
@@ -40,9 +40,9 @@ taxonomy:
       gtdb_taxon: Methylocystis
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Methylocystis
       ncbi_source_id: NCBITaxon:133
-      majority_fraction: 0.952
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -66,9 +66,9 @@ taxonomy:
       gtdb_taxon: Thiobacillus
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Thiobacillaceae;g__Thiobacillus
       ncbi_source_id: NCBITaxon:919
-      majority_fraction: 0.714
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.yaml
+++ b/kb/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.yaml
@@ -55,7 +55,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:511746
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: NCBI Taxonomy lists Methylacidiphilum sp. RTK17.1 under Candidatus Methylacidiphilum
       infernorum.
   strain_designation:

--- a/kb/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.yaml
+++ b/kb/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.yaml
@@ -55,7 +55,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1432792
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Marine methanotroph S8 that excretes acetate under both microaerobic and aerobic conditions.
   strain_designation:
     strain_name: S8
@@ -91,7 +91,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1218105
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Non-methylotrophic acetate-utilizing partner selected for bioproduction relevance.
   strain_designation:
     strain_name: NBRC 102504

--- a/kb/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.yaml
+++ b/kb/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.yaml
@@ -52,7 +52,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1432792
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Marine thermotolerant methane-oxidizing bacterium; type strain S8 is also listed by DSM and
       NBRC culture collections.
   strain_designation:
@@ -88,7 +88,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1384459
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Facultative methylotroph isolated from marine sediment near a hydrothermal vent.
   strain_designation:
     strain_name: Gela4

--- a/kb/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.yaml
+++ b/kb/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.yaml
@@ -50,7 +50,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:134
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: NCBI Taxonomy lists Methylocystis parvus at taxon 134; the PHBV study used
       M. parvus as the methanotrophic PHA-producing member.
   abundance_level: ABUNDANT

--- a/kb/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.yaml
+++ b/kb/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.yaml
@@ -63,7 +63,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1091494
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
       The source publication uses Methylomicrobium alcaliphilum 20Z; NCBI
       Taxonomy records the strain as Methylotuvimicrobium alcaliphilum 20Z and

--- a/kb/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.yaml
+++ b/kb/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.yaml
@@ -54,7 +54,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1091494
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Source publications use Methylomicrobium alcaliphilum 20z or 20ZR; NCBI Taxonomy
       records the strain under Methylotuvimicrobium alcaliphilum 20Z.
   strain_designation:
@@ -92,7 +92,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:32049
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Source publications use Synechococcus PCC 7002 or Synechococcus sp. PCC7002; NCBI
       currently labels taxon 32049 as Picosynechococcus sp. PCC 7002.
   strain_designation:

--- a/kb/communities/Microcoleus_Massilia_Cyanosphere_Urea_Mutualism.yaml
+++ b/kb/communities/Microcoleus_Massilia_Cyanosphere_Urea_Mutualism.yaml
@@ -74,9 +74,9 @@ taxonomy:
       gtdb_taxon: Telluria
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Telluria
       ncbi_source_id: NCBITaxon:149698
-      majority_fraction: 0.905
+      majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Heterotrophic cyanosphere isolate METH4; curated at genus level because the papers report the
       isolate as Massilia sp. METH4.
   strain_designation:

--- a/kb/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.yaml
+++ b/kb/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.yaml
@@ -42,9 +42,9 @@ taxonomy:
       gtdb_taxon: Burkholderia
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Burkholderia
       ncbi_source_id: NCBITaxon:32008
-      majority_fraction: 0.985
+      majority_fraction: 0.999
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -59,9 +59,9 @@ taxonomy:
       gtdb_taxon: Paraburkholderia
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Paraburkholderia
       ncbi_source_id: NCBITaxon:1822464
-      majority_fraction: 0.988
+      majority_fraction: 0.993
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -76,9 +76,9 @@ taxonomy:
       gtdb_taxon: Curtobacterium
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Microbacteriaceae;g__Curtobacterium
       ncbi_source_id: NCBITaxon:2034
-      majority_fraction: 0.993
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -93,9 +93,9 @@ taxonomy:
       gtdb_taxon: Leifsonia
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Microbacteriaceae;g__Leifsonia
       ncbi_source_id: NCBITaxon:110932
-      majority_fraction: 0.75
+      majority_fraction: 0.958
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Mixed_Gallium_LED_Recovery_Consortium.yaml
+++ b/kb/communities/Mixed_Gallium_LED_Recovery_Consortium.yaml
@@ -69,7 +69,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:930
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Gram-negative γ-proteobacterium specialized for oxidizing elemental sulfur (S⁰) and reduced
       inorganic sulfur compounds to sulfuric acid. In this consortium, At. thiooxidans is present at equal
       ratio (1:1:1) with At. ferrooxidans and L. ferrooxidans, contributing to the generation of biogenic
@@ -116,7 +116,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Mesophilic γ-proteobacterium that oxidizes both ferrous iron (Fe²⁺) and reduced sulfur compounds.
       Present at equal ratio (1:1:1) in the mixed consortium, At. ferrooxidans generates ferric iron (Fe³⁺)
       that serves as a secondary oxidant for gallium mobilization from LED materials. This chemolithoautotroph
@@ -163,7 +163,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:180
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Obligate iron-oxidizing bacterium (Nitrospirae phylum) specialized for Fe²⁺ oxidation at extremely
       low pH. Present at equal ratio (1:1:1) in the consortium, L. ferrooxidans contributes to ferric
       iron generation for gallium and base metal leaching from waste LEDs. This organism excels at operating

--- a/kb/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.yaml
+++ b/kb/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.yaml
@@ -61,9 +61,9 @@ taxonomy:
       gtdb_taxon: Cyanobacteriota
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota
       ncbi_source_id: NCBITaxon:1117
-      majority_fraction: 0.998
+      majority_fraction: 0.999
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 5 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Five well-characterized model cyanobacterial strains served as the
       phototrophic hosts; specific strain identities are not enumerated in the
       abstract.

--- a/kb/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.yaml
+++ b/kb/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.yaml
@@ -61,9 +61,9 @@ taxonomy:
       gtdb_taxon: Cyanobacteriota
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota
       ncbi_source_id: NCBITaxon:1117
-      majority_fraction: 0.999
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Five well-characterized model cyanobacterial strains served as the
       phototrophic hosts; specific strain identities are not enumerated in the
       abstract.

--- a/kb/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.yaml
+++ b/kb/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.yaml
@@ -74,7 +74,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1708
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Source describes C. fimi as the cellulose degrader and formaldehyde-sensitive member.
   abundance_level: ABUNDANT
   functional_role:
@@ -102,7 +102,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:408
       majority_fraction: 0.88
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Methylotrophic partner included to consume formaldehyde generated during aromatic-substrate
       breakdown.
   abundance_level: ABUNDANT

--- a/kb/communities/Moss_Microbe_Complex_Regolith_Biofertilizer.yaml
+++ b/kb/communities/Moss_Microbe_Complex_Regolith_Biofertilizer.yaml
@@ -107,9 +107,9 @@ taxonomy:
       gtdb_taxon: Devosia
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Devosiaceae;g__Devosia
       ncbi_source_id: NCBITaxon:46913
-      majority_fraction: 0.769
+      majority_fraction: 0.963
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: >
       Detected by 16S rRNA profiling as a stably present genus in moss-treated soils
       (not isolated/selected as an inoculant); ontology grounding is genus-level.

--- a/kb/communities/Mushroom_Spring_Hot_Spring_Phototrophic_Mat_Community.yaml
+++ b/kb/communities/Mushroom_Spring_Hot_Spring_Phototrophic_Mat_Community.yaml
@@ -55,7 +55,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:120961
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: >
       Filamentous anoxygenic phototrophic Chloroflexi that dominate parts of
       the Mushroom Spring undermat and participate in diel carbon and energy
@@ -87,7 +87,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1107
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Filamentous anoxygenic phototrophs in the Mushroom Spring phototrophic mat.
   functional_role:
   - PRIMARY_PRODUCER
@@ -115,7 +115,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:28261
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: >
       Thermophilic sulfate-reducing bacterial lineage detected in the Mushroom
       Spring undermat, where nitrogen fixation potential was inferred from

--- a/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
+++ b/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
@@ -197,7 +197,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:28211
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Alpha-proteobacteria detected in Naica representing oligotrophic heterotrophs or mixotrophs
       adapted to extremely low carbon availability. In deep subsurface environments, Alphaproteobacteria
       perform diverse metabolisms including methylotrophy, sulfur oxidation, and organic acid utilization.

--- a/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
+++ b/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
@@ -49,7 +49,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:651137
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Dominant archaeal lineage representing basal Thaumarchaeota clades adapted to deep subsurface
       thermophilic conditions. Naica Thaumarchaeota possess archaeal ammonia monooxygenase (amoA) genes,
       demonstrating their role in autotrophic ammonia oxidation coupled to CO₂ fixation. High GC content
@@ -93,9 +93,9 @@ taxonomy:
       gtdb_taxon: Thermoplasmatales
       gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales
       ncbi_source_id: NCBITaxon:2301
-      majority_fraction: 0.903
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at o__ rank; 9 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Euryarchaeota belonging to a large clade of environmental sequences branching as a sister
       group to the order Thermoplasmatales. This archaeal lineage is distinct from cultured Thermoplasmatales
       (Thermoplasma, Ferroplasma, Picrophilus) but shares physiological characteristics of cell wall-lacking
@@ -162,9 +162,9 @@ taxonomy:
       gtdb_taxon: Bacillota_A
       gtdb_lineage: d__Bacteria;p__Bacillota_A
       ncbi_source_id: NCBITaxon:1239
-      majority_fraction: 0.55
+      majority_fraction: 0.501
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 21 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 12 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive bacteria detected in Naica subsurface waters, likely representing thermophilic
       spore-forming genera adapted to oligotrophic deep biosphere conditions. Firmicutes in analogous
       geothermal subsurface systems include thermophilic fermenters (Thermoanaerobacter, Moorella) and
@@ -195,9 +195,9 @@ taxonomy:
       gtdb_taxon: Alphaproteobacteria
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria
       ncbi_source_id: NCBITaxon:28211
-      majority_fraction: 0.996
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at c__ rank; 8 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: 'Alpha-proteobacteria detected in Naica representing oligotrophic heterotrophs or mixotrophs
       adapted to extremely low carbon availability. In deep subsurface environments, Alphaproteobacteria
       perform diverse metabolisms including methylotrophy, sulfur oxidation, and organic acid utilization.
@@ -229,7 +229,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:28216
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at c__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Beta-proteobacteria present in Naica subsurface waters, potentially representing autotrophic
       sulfur oxidizers or denitrifiers. In oligotrophic subsurface aquifers, Betaproteobacteria include
       chemolithoautotrophs such as Thiobacillus (sulfur oxidation coupled to denitrification) and heterotrophic

--- a/kb/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.yaml
+++ b/kb/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.yaml
@@ -60,7 +60,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1521
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The primary abstract identifies C. cellulolyticum as the fermentative member.
   abundance_level: DOMINANT
   abundance_value: qPCR monitoring identified C. cellulolyticum as dominant.
@@ -90,7 +90,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:882
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The source uses the historical Desulfovibrio vulgaris Hildenborough name; NCBI
       currently represents this taxon as Nitratidesulfovibrio vulgaris str. Hildenborough.
   abundance_level: COMMON
@@ -121,7 +121,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:35554
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The primary abstract identifies G. sulfurreducens as the partner supplied with fumarate
       as electron acceptor.
   abundance_level: COMMON

--- a/kb/communities/ORNL_PMI_Populus_PD10_SynCom.yaml
+++ b/kb/communities/ORNL_PMI_Populus_PD10_SynCom.yaml
@@ -52,9 +52,9 @@ taxonomy:
       gtdb_taxon: Pantoea
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Pantoea
       ncbi_source_id: NCBITaxon:53335
-      majority_fraction: 0.961
+      majority_fraction: 0.982
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 15 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 6 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: YR343
     isolation_source: Populus deltoides rhizosphere
@@ -100,9 +100,9 @@ taxonomy:
       gtdb_taxon: Sphingobium
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Sphingobium
       ncbi_source_id: NCBITaxon:165695
-      majority_fraction: 0.993
+      majority_fraction: 0.987
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: AP49
     isolation_source: Populus deltoides rhizosphere
@@ -125,9 +125,9 @@ taxonomy:
       gtdb_taxon: Rhizobium
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Rhizobium
       ncbi_source_id: NCBITaxon:379
-      majority_fraction: 0.723
+      majority_fraction: 0.87
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 16 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 12 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: CF142
     isolation_source: Populus deltoides rhizosphere
@@ -150,9 +150,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: CF313
     isolation_source: Populus deltoides rhizosphere
@@ -175,9 +175,9 @@ taxonomy:
       gtdb_taxon: Bacillus
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
-      majority_fraction: 0.508
+      majority_fraction: 0.57
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: BC15
     isolation_source: Populus deltoides rhizosphere
@@ -200,9 +200,9 @@ taxonomy:
       gtdb_taxon: Caulobacter
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Caulobacterales;f__Caulobacteraceae;g__Caulobacter
       ncbi_source_id: NCBITaxon:75
-      majority_fraction: 0.837
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: AP07
     isolation_source: Populus deltoides rhizosphere
@@ -225,9 +225,9 @@ taxonomy:
       gtdb_taxon: Duganella
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Duganella
       ncbi_source_id: NCBITaxon:75654
-      majority_fraction: 0.886
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: CF402
     isolation_source: Populus deltoides rhizosphere
@@ -267,9 +267,9 @@ taxonomy:
       gtdb_taxon: Paraburkholderia
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Paraburkholderia
       ncbi_source_id: NCBITaxon:1822464
-      majority_fraction: 0.988
+      majority_fraction: 0.993
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: BT03
     isolation_source: Populus deltoides rhizosphere

--- a/kb/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.yaml
+++ b/kb/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.yaml
@@ -51,7 +51,7 @@ taxonomy:
       gtdb_taxon: Pseudomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
-      majority_fraction: 0.692
+      majority_fraction: 0.699
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: Pseudomonas was reported among organisms stimulated in the highly contaminated well FW113-47

--- a/kb/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.yaml
+++ b/kb/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.yaml
@@ -51,9 +51,9 @@ taxonomy:
       gtdb_taxon: Pseudomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
-      majority_fraction: 0.596
+      majority_fraction: 0.692
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 17 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: Pseudomonas was reported among organisms stimulated in the highly contaminated well FW113-47
       and associated with uranium and nitrate reduction potential.
   functional_role:
@@ -76,9 +76,9 @@ taxonomy:
       gtdb_taxon: Shewanella
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella
       ncbi_source_id: NCBITaxon:22
-      majority_fraction: 0.996
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Shewanella was reported as a uranium-reducing organism stimulated in the highly contaminated
       Oak Ridge FRC well FW113-47.
   functional_role:
@@ -101,9 +101,9 @@ taxonomy:
       gtdb_taxon: Stenotrophomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Xanthomonadaceae;g__Stenotrophomonas
       ncbi_source_id: NCBITaxon:40323
-      majority_fraction: 0.987
+      majority_fraction: 0.985
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Stenotrophomonas was reported among organisms stimulated in the highly contaminated well FW113-47
       and associated with iron reduction potential.
   functional_role:

--- a/kb/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.yaml
+++ b/kb/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.yaml
@@ -68,7 +68,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:215813
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: DF-12 strain used as the heterotrophic bacterial partner.
   abundance_level: COMMON
   functional_role:

--- a/kb/communities/PET_Artificial_FourSpecies_Degradation_Consortium.yaml
+++ b/kb/communities/PET_Artificial_FourSpecies_Degradation_Consortium.yaml
@@ -54,7 +54,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1423
       majority_fraction: 0.91
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered B. subtilis 168 strain carrying pHP13-P43-LipB-PETase; represented at species level
       for ontology stability.
   abundance_value: Engineered PETase-secretion module in the consortium.
@@ -112,7 +112,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:101510
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Wild-type R. jostii RHA1 added as the terephthalic-acid utilization module.
   abundance_value: TPA-utilization member of the consortium.
   functional_role:
@@ -141,7 +141,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:160488
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Wild-type P. putida KT2440 added as the ethylene-glycol utilization module.
   abundance_value: EG-utilization member of the consortium.
   functional_role:

--- a/kb/communities/PGM_Spent_Catalyst_Bioleaching.yaml
+++ b/kb/communities/PGM_Spent_Catalyst_Bioleaching.yaml
@@ -69,7 +69,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:930
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Primary sulfur-oxidizing bacterium responsible for both alumina dissolution and thiosulfate
       generation in spent catalyst bioleaching. This gram-negative chemolithoautotroph oxidizes elemental
       sulfur (S⁰) and reduced inorganic sulfur compounds (RISC) to sulfuric acid, which dissolves the
@@ -132,7 +132,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Supporting acidophilic bacterium that contributes to bioleaching through dual iron and sulfur
       oxidation capabilities. At. ferrooxidans oxidizes both ferrous iron (Fe²⁺ → Fe³⁺) and reduced sulfur
       compounds, providing supplementary acid generation and metabolic versatility. In spent catalyst
@@ -175,7 +175,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:28034
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Moderately thermophilic, facultatively autotrophic bacterium contributing to sulfur and iron
       oxidation in catalyst bioleaching systems. Sulfobacillus species oxidize reduced sulfur compounds
       and Fe²⁺, providing metabolic redundancy with Acidithiobacillus. The facultative autotrophy enables
@@ -219,7 +219,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:931
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Neutrophilic to slightly acidophilic sulfur-oxidizing bacterium that produces thiosulfate
       as a key metabolic intermediate. While At. thiooxidans operates at extremely low pH (1.5-3.0), T.
       thioparus thrives at pH 5.0-8.0 and contributes to biogenic thiosulfate production under less acidic

--- a/kb/communities/PMI_Variovorax_Thermotolerance_Collection.yaml
+++ b/kb/communities/PMI_Variovorax_Thermotolerance_Collection.yaml
@@ -50,9 +50,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: CF313
     isolation_source: Populus root
@@ -77,9 +77,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: YR634
     isolation_source: Populus root
@@ -102,9 +102,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: GV004
     isolation_source: Populus root
@@ -127,9 +127,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: GV035
     isolation_source: Populus root
@@ -152,9 +152,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: YR752
     isolation_source: Populus root
@@ -177,9 +177,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: OV084
     isolation_source: Populus root

--- a/kb/communities/Panzhihua_Vanadium_Titanium_Tailings.yaml
+++ b/kb/communities/Panzhihua_Vanadium_Titanium_Tailings.yaml
@@ -157,9 +157,9 @@ taxonomy:
       gtdb_taxon: Bacillus
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
-      majority_fraction: 0.508
+      majority_fraction: 0.57
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive spore-forming bacteria representing the most abundant genus (79 of 136 isolates,
       58%) in V-Ti magnetite mine tailing soil from Panzhihua. Bacillus species demonstrate exceptional
       heavy metal resistance and diverse plant growth-promoting activities including IAA production (67%
@@ -204,7 +204,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:94625
       majority_fraction: 0.99
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Alphaproteobacterium (13 isolates) with exceptional heavy metal tolerance and plant growth-promoting
       capabilities in V-Ti tailings. Four Ochrobactrum isolates from P. pinnata nodules were initially
       identified as O. anthropi, closely related to O. intermedium. Ochrobactrum species are known for
@@ -247,9 +247,9 @@ taxonomy:
       gtdb_taxon: Polaromonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Polaromonas
       ncbi_source_id: NCBITaxon:52972
-      majority_fraction: 0.959
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Betaproteobacteria capable of dissimilatory vanadium reduction in contaminated mine environments.
       While not specifically reported in the Panzhihua tailings studies reviewed, Polaromonas is a well-established
       V(V)-reducing organism in circumneutral pH vanadium mine tailings in northern China and likely present

--- a/kb/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.yaml
+++ b/kb/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.yaml
@@ -62,7 +62,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:110500
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Propionate-oxidizing bacterial syntroph in the two-member RNA-seq coculture.
   functional_role:
   - PRIMARY_DEGRADER
@@ -90,7 +90,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1175444
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Hydrogenotrophic methanogenic archaeal partner in the two-member RNA-seq coculture.
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Pelotomaculum_Methanothermobacter_Syntrophy.yaml
+++ b/kb/communities/Pelotomaculum_Methanothermobacter_Syntrophy.yaml
@@ -38,7 +38,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:110500
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Thermophilic, anaerobic, syntrophic, propionate-oxidizing bacterium that oxidizes propionate,
       ethanol, lactate, and various alcohols (1-butanol, 1-pentanol, 1-propanol, 1,3-propanediol, ethylene
       glycol) to acetate, CO2, and H2 in co-culture with hydrogenotrophic methanogens. Cannot grow on
@@ -72,7 +72,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:145262
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Thermophilic hydrogen-utilizing methanogen that consumes H2 and CO2 to produce methane. Essential
       syntrophic partner that maintains low H2 partial pressure, enabling thermodynamically unfavorable
       propionate oxidation by P. thermopropionicum. Operates optimally at thermophilic temperatures (55-65°C).

--- a/kb/communities/Pepper_Phytophthora_SynCom5.yaml
+++ b/kb/communities/Pepper_Phytophthora_SynCom5.yaml
@@ -42,9 +42,9 @@ taxonomy:
       gtdb_taxon: Bacillus
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
-      majority_fraction: 0.508
+      majority_fraction: 0.57
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -59,9 +59,9 @@ taxonomy:
       gtdb_taxon: Flavobacterium
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Flavobacteriales;f__Flavobacteriaceae;g__Flavobacterium
       ncbi_source_id: NCBITaxon:237
-      majority_fraction: 0.99
+      majority_fraction: 0.999
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 9 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Phormidium_Alkaline_Consortium.yaml
+++ b/kb/communities/Phormidium_Alkaline_Consortium.yaml
@@ -86,7 +86,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:976
       majority_fraction: 0.999
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 8 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 5 GTDB taxa under the NCBI taxon]
     notes: 'Multiple heterotrophic Bacteroidota species present in the consortium. These organisms contribute
       to organic matter degradation, polysaccharide utilization, and nutrient cycling. They occupy ecological
       niches related to fermentation product utilization and compatible solute metabolism.
@@ -114,9 +114,9 @@ taxonomy:
       gtdb_taxon: Alphaproteobacteria
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria
       ncbi_source_id: NCBITaxon:28211
-      majority_fraction: 0.996
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at c__ rank; 8 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: 'Diverse alphaproteobacterial species in the consortium that likely contribute to vitamin production,
       siderophore synthesis for iron solubilization, and aerobic metabolism of cyanobacterial exudates.
 
@@ -145,7 +145,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:74201
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Verrucomicrobial species equipped with glycoside hydrolases for degradation of sulfated polysaccharides
       and cell wall components from cyanobacteria. These organisms specialize in degrading complex polymers.
 
@@ -171,9 +171,9 @@ taxonomy:
       gtdb_taxon: Planctomycetota
       gtdb_lineage: d__Bacteria;p__Planctomycetota
       ncbi_source_id: NCBITaxon:203682
-      majority_fraction: 0.995
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Planctomycete species with glycoside hydrolases capable of degrading cyanobacterial cell wall
       polysaccharides and other complex sulfated polymers. They play a key role in recycling cyanobacterial
       biomass.

--- a/kb/communities/Phormidium_Alkaline_Consortium.yaml
+++ b/kb/communities/Phormidium_Alkaline_Consortium.yaml
@@ -116,7 +116,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:28211
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Diverse alphaproteobacterial species in the consortium that likely contribute to vitamin production,
       siderophore synthesis for iron solubilization, and aerobic metabolism of cyanobacterial exudates.
 

--- a/kb/communities/Phosphitivorax_Methanoculleus_Lithosyntrophy_Phosphite_Coculture.yaml
+++ b/kb/communities/Phosphitivorax_Methanoculleus_Lithosyntrophy_Phosphite_Coculture.yaml
@@ -27,12 +27,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__UBA1062_sp001896555
       gtdb_taxon: UBA1062 sp001896555
-      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfomonilia;o__UBA1062;f__UBA1062;g__UBA1062;s__UBA1062
-        sp001896555
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfomonilia;o__UBA1062;f__UBA1062;g__UBA1062;s__UBA1062 sp001896555
       ncbi_source_id: NCBITaxon:1918507
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: Phox-21
   functional_role:
@@ -57,9 +56,9 @@ taxonomy:
       gtdb_taxon: Methanoculleus
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanoculleaceae;g__Methanoculleus
       ncbi_source_id: NCBITaxon:45989
-      majority_fraction: 0.947
+      majority_fraction: 0.951
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the paper reports only "Methanoculleus sp." with no species assignment.
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Phylogenetically_Diverse_Denitrifying_SynCom.yaml
+++ b/kb/communities/Phylogenetically_Diverse_Denitrifying_SynCom.yaml
@@ -41,9 +41,9 @@ taxonomy:
       gtdb_taxon: Shewanella
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella
       ncbi_source_id: NCBITaxon:22
-      majority_fraction: 0.996
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Pinus_armandii_Endophytic_Biocontrol_SynCom.yaml
+++ b/kb/communities/Pinus_armandii_Endophytic_Biocontrol_SynCom.yaml
@@ -63,12 +63,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Bacillus_velezensis
       gtdb_taxon: Bacillus velezensis
-      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus
-        velezensis
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus velezensis
       ncbi_source_id: NCBITaxon:492670
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: OB3
   abundance_value: One of five members of the synthetic community.
@@ -90,12 +89,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Bacillus_velezensis
       gtdb_taxon: Bacillus velezensis
-      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus
-        velezensis
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus velezensis
       ncbi_source_id: NCBITaxon:492670
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: NA3
   abundance_value: One of five members of the synthetic community.
@@ -116,12 +114,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Bacillus_subtilis
       gtdb_taxon: Bacillus subtilis
-      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus
-        subtilis
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
       ncbi_source_id: NCBITaxon:1423
       majority_fraction: 0.91
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: NA11
   abundance_value: One of five members of the synthetic community.

--- a/kb/communities/Pleuromutilin_Degrading_Artificial_Consortium_5_Strain.yaml
+++ b/kb/communities/Pleuromutilin_Degrading_Artificial_Consortium_5_Strain.yaml
@@ -31,12 +31,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Stenotrophomonas_pavanii
       gtdb_taxon: Stenotrophomonas pavanii
-      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Xanthomonadaceae;g__Stenotrophomonas;s__Stenotrophomonas
-        pavanii
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Xanthomonadaceae;g__Stenotrophomonas;s__Stenotrophomonas pavanii
       ncbi_source_id: NCBITaxon:487698
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - PRIMARY_DEGRADER
   abundance_value: One of five members of the artificial degradation consortium.
@@ -88,12 +87,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Lysinibacillus_mangiferihumi
       gtdb_taxon: Lysinibacillus mangiferihumi
-      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales_A;f__Planococcaceae;g__Lysinibacillus;s__Lysinibacillus
-        mangiferihumi
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales_A;f__Planococcaceae;g__Lysinibacillus;s__Lysinibacillus mangiferihumi
       ncbi_source_id: NCBITaxon:1130819
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - PRIMARY_DEGRADER
   abundance_value: One of five members of the artificial degradation consortium.
@@ -114,12 +112,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Stutzerimonas_songnenensis
       gtdb_taxon: Stutzerimonas songnenensis
-      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Stutzerimonas;s__Stutzerimonas
-        songnenensis
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Stutzerimonas;s__Stutzerimonas songnenensis
       ncbi_source_id: NCBITaxon:1176259
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - PRIMARY_DEGRADER
   abundance_value: One of five members of the artificial degradation consortium.

--- a/kb/communities/Polaromonas_Vanadium_Reduction_Community.yaml
+++ b/kb/communities/Polaromonas_Vanadium_Reduction_Community.yaml
@@ -48,9 +48,9 @@ taxonomy:
       gtdb_taxon: Polaromonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Polaromonas
       ncbi_source_id: NCBITaxon:52972
-      majority_fraction: 0.959
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Gram-negative betaproteobacteria (Burkholderiaceae family) dominating the vanadium-contaminated
       tailings community, reaching up to 46% relative abundance in enrichment cultures and 18-24% in natural
       tailings. Polaromonas species are psychrotolerant, facultatively anaerobic bacteria capable of dissimilatory
@@ -92,9 +92,9 @@ taxonomy:
       gtdb_taxon: Desulfovibrio
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Desulfovibrio
       ncbi_source_id: NCBITaxon:872
-      majority_fraction: 0.871
+      majority_fraction: 0.931
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 16 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 9 GTDB taxa under the NCBI taxon]
     notes: 'Gram-negative deltaproteobacteria performing dissimilatory sulfate reduction in the vanadium
       tailings. Desulfovibrio oxidizes organic acids (lactate, pyruvate, formate) and hydrogen coupled
       to sulfate reduction, producing hydrogen sulfide (H₂S) that chemically reduces V(V) to V(IV) and
@@ -141,7 +141,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Deltaproteobacteria specialized in dissimilatory metal reduction, present at 5-8% relative
       abundance in vanadium tailings. Geobacter oxidizes acetate and other organic acids coupled to reduction
       of Fe(III), Mn(IV), and V(V). This genus possesses extensive arrays of c-type cytochromes enabling
@@ -187,9 +187,9 @@ taxonomy:
       gtdb_taxon: Desulfitobacterium
       gtdb_lineage: d__Bacteria;p__Bacillota_B;c__Desulfitobacteriia;o__Desulfitobacteriales;f__Desulfitobacteriaceae;g__Desulfitobacterium
       ncbi_source_id: NCBITaxon:36853
-      majority_fraction: 0.946
+      majority_fraction: 0.939
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive, spore-forming bacteria (Firmicutes phylum) capable of organohalide respiration
       and metal reduction. Desulfitobacterium species comprise 3-6% of the tailings community and perform
       dissimilatory reduction of V(V), Cr(VI), and arsenate using respiratory reductases. This genus couples

--- a/kb/communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.yaml
+++ b/kb/communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.yaml
@@ -37,7 +37,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:561
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Escherichia spp. whose in situ physiological conditions were
       probed via metagenomic and metatranscriptomic sequencing.
   functional_role:

--- a/kb/communities/Prochlorococcus_Alteromonas_Helper_Coculture.yaml
+++ b/kb/communities/Prochlorococcus_Alteromonas_Helper_Coculture.yaml
@@ -68,7 +68,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:28108
       majority_fraction: 0.9
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Heterotrophic helper bacterium that removes hydrogen peroxide and modifies Prochlorococcus oxidative
       stress exposure.
   strain_designation:

--- a/kb/communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.yaml
+++ b/kb/communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.yaml
@@ -115,7 +115,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1866885
       majority_fraction: 0.998
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Dominant genus across all four cDCE-amended enrichments and the
       most abundant in the TCE-amended enrichment from impacted-site sediment
       by community-composition analysis. MAG-level propane monooxygenase
@@ -145,7 +145,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1763
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Second dominant genus in cDCE-amended enrichments after
       Mycolicibacterium; multiple Mycobacterium MAGs from cDCE-amended
       cultures carry propane monooxygenase operons with prmACDB ordering
@@ -172,7 +172,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1847
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Dominant genus in 1,1-DCE-degrading enrichments after re-selection
       on 1,1-DCE; the associated MAG carries a truncated propane monooxygenase
       alpha subunit, indicating that other enzymes likely catalyze 1,1-DCE
@@ -202,7 +202,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:2736640
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Species-level MAGs recovered from the impacted-site (Site 1)
       TCE-amended enrichments only; carry propane monooxygenase operons.
   functional_role:
@@ -226,9 +226,9 @@ taxonomy:
       gtdb_taxon: Methylibium
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Methylibium
       ncbi_source_id: NCBITaxon:316612
-      majority_fraction: 0.607
+      majority_fraction: 0.625
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: One of two non-actinobacterial MAGs containing the propane
       monooxygenase operon, recovered from cDCE-amended T3 enrichments.
   functional_role:
@@ -254,7 +254,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:119060
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at f__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at f__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: One of two non-actinobacterial MAGs containing the propane
       monooxygenase operon, recovered from cDCE-amended T4 enrichments;
       taxon resolved only to family level.

--- a/kb/communities/Pseudomonas_Pedobacter_Social_Spreading_Coculture.yaml
+++ b/kb/communities/Pseudomonas_Pedobacter_Social_Spreading_Coculture.yaml
@@ -65,9 +65,9 @@ taxonomy:
       gtdb_taxon: Pedobacter
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Sphingobacteriales;f__Sphingobacteriaceae;g__Pedobacter
       ncbi_source_id: NCBITaxon:84567
-      majority_fraction: 0.924
+      majority_fraction: 0.902
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Soil-associated Pedobacter isolate V48; represented at genus level because the publication names
       the strain as Pedobacter sp. V48.
   functional_role:

--- a/kb/communities/Pseudomonas_Rhodococcus_Chloronitrobenzene_Coculture.yaml
+++ b/kb/communities/Pseudomonas_Rhodococcus_Chloronitrobenzene_Coculture.yaml
@@ -78,9 +78,9 @@ taxonomy:
       gtdb_taxon: Rhodococcus
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Rhodococcus
       ncbi_source_id: NCBITaxon:1827
-      majority_fraction: 0.996
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Chlorohydroxyacetanilide-degrading partner paired with P. putida HS12 for complete
       chloronitrobenzene mineralization.
   strain_designation:

--- a/kb/communities/Pseudomonas_putida_PpTE_Rhodococcus_RDK17_Terephthalic_Acid_Consortium.yaml
+++ b/kb/communities/Pseudomonas_putida_PpTE_Rhodococcus_RDK17_Terephthalic_Acid_Consortium.yaml
@@ -49,9 +49,9 @@ taxonomy:
       gtdb_taxon: Rhodococcus
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Rhodococcus
       ncbi_source_id: NCBITaxon:1827
-      majority_fraction: 0.996
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Native TPA degrader, strain RDK17. Grounded at genus rank (Rhodococcus sp.) because the
       source does not resolve a species; OAK canonical NCBITaxon label carries the "<high G+C
       Gram-positive bacteria>" disambiguation.

--- a/kb/communities/Pseudomonas_stutzeri_Rhodococcus_Naphthalene_Biochar_Engineered_Consortium.yaml
+++ b/kb/communities/Pseudomonas_stutzeri_Rhodococcus_Naphthalene_Biochar_Engineered_Consortium.yaml
@@ -51,9 +51,9 @@ taxonomy:
       gtdb_taxon: Rhodococcus
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Rhodococcus
       ncbi_source_id: NCBITaxon:1827
-      majority_fraction: 0.996
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Source paper names the strain "Rhodococcus rhodococcus", which is not a valid NCBITaxon
       species name; grounded at the genus rank Rhodococcus. Engineered strain overexpressing nahH
       and catA.

--- a/kb/communities/Rammelsberg_Cobalt_Nickel_Tailings.yaml
+++ b/kb/communities/Rammelsberg_Cobalt_Nickel_Tailings.yaml
@@ -66,7 +66,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Mesophilic chemolithoautotrophic iron-oxidizing bacterium that obtains energy from oxidation
       of ferrous iron (Fe²⁺) to ferric iron (Fe³⁺) and reduced sulfur compounds. This organism is one
       of the two dominant members of the Rammelsberg bioleaching consortium and plays a critical role
@@ -110,7 +110,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:930
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Mesophilic chemolithoautotrophic sulfur-oxidizing bacterium that derives energy from oxidation
       of elemental sulfur, sulfide, and other reduced sulfur compounds to sulfuric acid. This organism
       is the second dominant member of the Rammelsberg bioleaching consortium and plays an essential complementary

--- a/kb/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.yaml
+++ b/kb/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.yaml
@@ -52,7 +52,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.yaml
+++ b/kb/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.yaml
@@ -61,7 +61,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:395960
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Phototrophic Fe(II)-oxidizing member of the coculture.
   abundance_level: ABUNDANT
   functional_role:
@@ -90,7 +90,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:35554
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Anaerobic Fe(III)-reducing member of the coculture.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Rice_Duckweed_Bacillus_SynCom.yaml
+++ b/kb/communities/Rice_Duckweed_Bacillus_SynCom.yaml
@@ -50,9 +50,9 @@ taxonomy:
       gtdb_taxon: Bacillus
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
-      majority_fraction: 0.508
+      majority_fraction: 0.57
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
     notes: Auxin (IAA)-producing specialist within the 8-member SynCom. Division-of-labor member contributing
       to rice growth promotion through indole-3-acetic acid biosynthesis. 8 members total; strain-level
       identifiers available in supplementary data.
@@ -75,9 +75,9 @@ taxonomy:
       gtdb_taxon: Bacillus
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
-      majority_fraction: 0.508
+      majority_fraction: 0.57
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
     notes: Siderophore-producing specialist within the 8-member SynCom. Contributes to rice growth promotion
       through siderophore-linked iron mobilization.
   functional_role:
@@ -99,9 +99,9 @@ taxonomy:
       gtdb_taxon: Bacillus
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
-      majority_fraction: 0.508
+      majority_fraction: 0.57
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
     notes: Lipopeptide-producing antagonist within the 8-member SynCom. Produces surfactin, bacillomycin,
       and fengycin for biocontrol of Rhizoctonia solani sheath blight.
   functional_role:
@@ -123,9 +123,9 @@ taxonomy:
       gtdb_taxon: Bacillus
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
-      majority_fraction: 0.508
+      majority_fraction: 0.57
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
     notes: Polyketide-producing antagonist within the 8-member SynCom. Produces difficidin for biocontrol
       of Rhizoctonia solani sheath blight.
   functional_role:

--- a/kb/communities/Rice_P_Uptake_Intercropping_SynCom4.yaml
+++ b/kb/communities/Rice_P_Uptake_Intercropping_SynCom4.yaml
@@ -53,7 +53,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:48936
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -70,7 +70,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:47421
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -85,9 +85,9 @@ taxonomy:
       gtdb_taxon: Acidovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Acidovorax
       ncbi_source_id: NCBITaxon:12916
-      majority_fraction: 0.867
+      majority_fraction: 0.997
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 9 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
+++ b/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
@@ -76,7 +76,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:97393
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Cell wall-lacking archaeon (Thermoplasmatales order) adapted to extremely
       acidic conditions. Ferroplasma acidarmanus reaches up to 85% of cells in the
       most acidic microniches (pH approaching 0.5). This microaerophilic organism
@@ -151,7 +151,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Gram-negative γ-proteobacterium that oxidizes both iron and reduced sulfur
       compounds. At Richmond Mine, A. ferrooxidans is restricted to higher pH environments
       (pH >1.0) such as the Red Pool (pH 1.4), where it can outcompete Leptospirillum

--- a/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
+++ b/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
@@ -80,7 +80,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:201174
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 6 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:
@@ -101,9 +101,9 @@ taxonomy:
       gtdb_taxon: Bacteroidota
       gtdb_lineage: d__Bacteria;p__Bacteroidota
       ncbi_source_id: NCBITaxon:1134404
-      majority_fraction: 0.987
+      majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:
@@ -122,9 +122,9 @@ taxonomy:
       gtdb_taxon: Chloroflexota
       gtdb_lineage: d__Bacteria;p__Chloroflexota
       ncbi_source_id: NCBITaxon:200795
-      majority_fraction: 0.998
+      majority_fraction: 0.997
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:
@@ -143,9 +143,9 @@ taxonomy:
       gtdb_taxon: Acidobacteriota
       gtdb_lineage: d__Bacteria;p__Acidobacteriota
       ncbi_source_id: NCBITaxon:57723
-      majority_fraction: 0.976
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:
@@ -164,9 +164,9 @@ taxonomy:
       gtdb_taxon: Bacillota_A
       gtdb_lineage: d__Bacteria;p__Bacillota_A
       ncbi_source_id: NCBITaxon:1239
-      majority_fraction: 0.55
+      majority_fraction: 0.501
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 21 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 12 GTDB taxa under the NCBI taxon]
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:
@@ -187,7 +187,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1224
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 14 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:

--- a/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
+++ b/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
@@ -187,7 +187,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1224
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:

--- a/kb/communities/Rifle_Uranium_Reducing_Community.yaml
+++ b/kb/communities/Rifle_Uranium_Reducing_Community.yaml
@@ -44,7 +44,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Geobacter species, primarily G. metallireducens, dominate Phase I of uranium bioremediation
       (days 0-50). Geobacteraceae reach 89% of the groundwater microbial community by day 17, with Geobacter
       genus comprising 83% of Geobacteraceae sequences. These deltaproteobacteria oxidize acetate coupled
@@ -115,7 +115,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:881
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Sulfate-reducing bacterium that contributes to uranium reduction through enzymatic pathways
       and production of hydrogen sulfide (H₂S), which can chemically reduce U(VI). While Desulfovibrio
       was not dominant in initial Rifle studies (unlike Geobacter), it was later isolated from uranium-reducing
@@ -148,7 +148,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:79206
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive, spore-forming, sulfate-reducing bacteria detected during later phases of uranium
       biostimulation at Rifle. Desulfosporosinus species reduce U(VI) via enzymatic pathways distinct
       from Desulfovibrio, lacking certain cytochromes used by other sulfate reducers. This genus becomes
@@ -190,9 +190,9 @@ taxonomy:
       gtdb_taxon: Desulfobacterales
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfobacteria;o__Desulfobacterales
       ncbi_source_id: NCBITaxon:213118
-      majority_fraction: 0.81
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 5 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Family of sulfate-reducing bacteria that becomes dominant during Phase II of uranium biostimulation
       at Rifle (>50 days). By day 80, Desulfobacteraceae comprise 45% of the groundwater microbial community,
       replacing Geobacter as Fe(III) is depleted. This family includes diverse sulfate reducers that oxidize

--- a/kb/communities/SF356_Cellulose_Degrader.yaml
+++ b/kb/communities/SF356_Cellulose_Degrader.yaml
@@ -30,7 +30,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:253314
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -87,9 +87,9 @@ taxonomy:
       gtdb_taxon: Brevibacillus
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Brevibacillales;f__Brevibacillaceae;g__Brevibacillus
       ncbi_source_id: NCBITaxon:55080
-      majority_fraction: 0.816
+      majority_fraction: 0.803
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 6 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/SIHUMIx_Human_Intestinal_Model_Community.yaml
+++ b/kb/communities/SIHUMIx_Human_Intestinal_Model_Community.yaml
@@ -48,7 +48,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:105841
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Human intestinal anaerobe included in SIHUMIx.
   strain_designation:
     strain_name: DSMZ 14662
@@ -76,7 +76,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:818
       majority_fraction: 0.99
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Gut Bacteroides member and dominant SIHUMIx constituent in bioreactor studies.
   strain_designation:
     strain_name: DSMZ 2079
@@ -121,7 +121,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:33035
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Anaerobic gut member included in SIHUMIx.
   strain_designation:
     strain_name: DSMZ 2950
@@ -149,7 +149,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1492
       majority_fraction: 0.97
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Butyrate-associated clostridial member added in the extended SIHUMIx community.
   strain_designation:
     strain_name: DSMZ 10702
@@ -177,7 +177,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1547
       majority_fraction: 0.99
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Literature name retained as preferred term; this organism is also encountered under updated
       clostridial taxonomy in some resources.
   strain_designation:
@@ -206,7 +206,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:511145
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Facultative anaerobic Proteobacteria member of SIHUMIx.
   strain_designation:
     strain_name: MG1655
@@ -231,7 +231,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1590
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Literature name retained in preferred_term; current NCBI label reflects Lactobacillus
       reclassification.
   strain_designation:

--- a/kb/communities/SMutans_CAlbicans_ECC_Biofilm.yaml
+++ b/kb/communities/SMutans_CAlbicans_ECC_Biofilm.yaml
@@ -55,7 +55,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1309
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   evidence:
   - reference: PMID:24566629
     supports: SUPPORT

--- a/kb/communities/SMutans_SSputigena_ECC_Pathobiont.yaml
+++ b/kb/communities/SMutans_SSputigena_ECC_Pathobiont.yaml
@@ -59,7 +59,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1309
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   evidence:
   - reference: PMID:37217495
     supports: SUPPORT
@@ -80,7 +80,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:69823
       majority_fraction: 0.86
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   evidence:
   - reference: PMID:37217495
     supports: SUPPORT

--- a/kb/communities/SMutans_VParvula_ASC_Biofilm.yaml
+++ b/kb/communities/SMutans_VParvula_ASC_Biofilm.yaml
@@ -59,7 +59,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1309
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   evidence:
   - reference: PMID:39345197
     supports: SUPPORT
@@ -81,7 +81,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:29466
       majority_fraction: 0.95
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT
   evidence:
   - reference: PMID:39345197

--- a/kb/communities/SPRUCE_Peatland_Methane_Cycling_Community.yaml
+++ b/kb/communities/SPRUCE_Peatland_Methane_Cycling_Community.yaml
@@ -45,9 +45,9 @@ taxonomy:
       gtdb_taxon: Acidobacteriota
       gtdb_lineage: d__Bacteria;p__Acidobacteriota
       ncbi_source_id: NCBITaxon:57723
-      majority_fraction: 0.976
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Acidobacteriota MAGs contribute to anaerobic peat carbon turnover and sulfur-linked respiratory
       potential in the SPRUCE MAG collection.
   functional_role:

--- a/kb/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.yaml
+++ b/kb/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.yaml
@@ -99,7 +99,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1236
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at c__ rank; 7 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: SUP05 Gammaproteobacteria are represented at class level and described as the dominant denitrifier
       guild in Saanich Inlet.
   functional_role:

--- a/kb/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.yaml
+++ b/kb/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.yaml
@@ -77,7 +77,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:202950
       majority_fraction: 0.96
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered ADP1 strain that bioconverts furan aldehyde inhibitors and
       diverts residual S. cerevisiae carbon into wax esters.
   functional_role:

--- a/kb/communities/Salar_Atacama_Lithium_Brine_Community.yaml
+++ b/kb/communities/Salar_Atacama_Lithium_Brine_Community.yaml
@@ -44,7 +44,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1377992
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Extremely halophilic archaeon of the family Halobacteriaceae. This genus is the most abundant
       archaeal taxon in Salar de Atacama brines, representing 26.8% of archaeal community in natural brine
       and increasing to 41% dominance in concentrated brine. Halovenus species are adapted to chaotropic
@@ -79,9 +79,9 @@ taxonomy:
       gtdb_taxon: Natronomonas
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Halobacteria;o__Halobacteriales;f__Haloarculaceae;g__Natronomonas
       ncbi_source_id: NCBITaxon:63743
-      majority_fraction: 0.957
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Alkaliphilic and extremely halophilic archaeon that thrives in hypersaline soda lake environments
       and lithium brines. This genus represents the second most abundant archaeal taxon (20.1%) in natural
       Atacama brines but shows reduced relative abundance in concentrated brines. Natronomonas species
@@ -113,7 +113,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:2237
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Extremely halophilic archaeon with metabolic versatility including aerobic respiration, nitrate
       reduction, and polymer degradation. Haloarcula represents 14% of archaeal community in natural brine
       and maintains presence in concentrated brine. Species in this genus can utilize diverse carbon sources
@@ -144,7 +144,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:2239
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Model extremely halophilic archaeon with well-characterized physiology including bacteriorhodopsin-mediated
       phototrophy, aerobic respiration, and arginine fermentation. Halobacterium comprises 13% of archaeal
       community in natural brine. This genus can generate ATP through light-driven proton pumping via
@@ -175,7 +175,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:146918
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Extremely halophilic bacterium of the family Rhodothermaceae, representing the dominant bacterial
       taxon in natural Atacama brines. Rhodothermaceae, solely represented by Salinibacter genus, comprises
       56% of bacterial community in natural brine. Salinibacter uses the "salt-in" strategy similar to
@@ -206,9 +206,9 @@ taxonomy:
       gtdb_taxon: Staphylococcaceae
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae
       ncbi_source_id: NCBITaxon:90964
-      majority_fraction: 0.993
+      majority_fraction: 0.997
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at f__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at f__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Halotolerant bacterial family present in the Atacama brine community. Members of Staphylococcaceae
       are among the most abundant bacterial families in natural brine alongside Rhodothermaceae, contributing
       to heterotrophic activity and organic matter processing in the hypersaline environment.

--- a/kb/communities/Shewanella_Denitrifying_Richness_SynComs.yaml
+++ b/kb/communities/Shewanella_Denitrifying_Richness_SynComs.yaml
@@ -40,9 +40,9 @@ taxonomy:
       gtdb_taxon: Shewanella
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella
       ncbi_source_id: NCBITaxon:22
-      majority_fraction: 0.996
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.yaml
+++ b/kb/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.yaml
@@ -66,7 +66,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:70863
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Exoelectrogenic proteobacterium in the defined anode biofilm community.
   abundance_level: ABUNDANT
   common_taxon: CommunityMech:taxon:000001
@@ -96,7 +96,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:35554
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Exoelectrogenic Geobacter member that was detected in the planktonic phase of mixed-culture
       reactors as well as in the anode-associated community.
   abundance_level: ABUNDANT
@@ -127,7 +127,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Exoelectrogenic Geobacter member of the defined biofilm community.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Shewanella_Pseudomonas_Fe0_Electrosyntrophic_Denitrifying_Consortium.yaml
+++ b/kb/communities/Shewanella_Pseudomonas_Fe0_Electrosyntrophic_Denitrifying_Consortium.yaml
@@ -29,13 +29,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Shewanella_oneidensis
       gtdb_taxon: Shewanella oneidensis
-      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella
-        oneidensis
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella oneidensis
       ncbi_source_id: NCBITaxon:70863
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via
-        NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   functional_role:
   - ELECTROGEN
   - ELECTRON_DONOR
@@ -62,12 +60,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Pseudomonas_aeruginosa
       gtdb_taxon: Pseudomonas aeruginosa
-      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas;s__Pseudomonas
-        aeruginosa
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas;s__Pseudomonas aeruginosa
       ncbi_source_id: NCBITaxon:287
       majority_fraction: 0.99
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - ELECTROTROPH
   - ELECTRON_ACCEPTOR

--- a/kb/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.yaml
+++ b/kb/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.yaml
@@ -58,7 +58,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:211586
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Exoelectrogenic strain that generates electricity from lactic acid in the MFC.
   strain_designation:
     strain_name: MR-1

--- a/kb/communities/Shewanella_oneidensis_Rhodopseudomonas_palustris_Electrosyntrophic_Coculture.yaml
+++ b/kb/communities/Shewanella_oneidensis_Rhodopseudomonas_palustris_Electrosyntrophic_Coculture.yaml
@@ -28,13 +28,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Shewanella_oneidensis
       gtdb_taxon: Shewanella oneidensis
-      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella
-        oneidensis
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella oneidensis
       ncbi_source_id: NCBITaxon:70863
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via
-        NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:
     strain_name: MR-1
   functional_role:

--- a/kb/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.yaml
+++ b/kb/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.yaml
@@ -35,7 +35,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:201174
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 6 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -55,9 +55,9 @@ taxonomy:
       gtdb_taxon: Chloroflexota
       gtdb_lineage: d__Bacteria;p__Chloroflexota
       ncbi_source_id: NCBITaxon:200795
-      majority_fraction: 0.998
+      majority_fraction: 0.997
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_DEGRADER
   evidence:

--- a/kb/communities/Soil_Corrinoid_B12_Reservoir_Community.yaml
+++ b/kb/communities/Soil_Corrinoid_B12_Reservoir_Community.yaml
@@ -79,7 +79,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1224
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Soil_Corrinoid_B12_Reservoir_Community.yaml
+++ b/kb/communities/Soil_Corrinoid_B12_Reservoir_Community.yaml
@@ -35,7 +35,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:28889
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_PRODUCER
   evidence:
@@ -57,7 +57,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:201174
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 6 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_PRODUCER
   evidence:
@@ -79,7 +79,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1224
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 14 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Sorghum_SRC1_Subset.yaml
+++ b/kb/communities/Sorghum_SRC1_Subset.yaml
@@ -62,9 +62,9 @@ taxonomy:
       gtdb_taxon: Bacillus
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
-      majority_fraction: 0.508
+      majority_fraction: 0.57
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -101,7 +101,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1889
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -124,7 +124,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1401
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -147,7 +147,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:272772
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.yaml
+++ b/kb/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.yaml
@@ -51,9 +51,9 @@ taxonomy:
       gtdb_taxon: Bradyrhizobium
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Bradyrhizobium
       ncbi_source_id: NCBITaxon:374
-      majority_fraction: 0.982
+      majority_fraction: 0.995
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 8 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
+++ b/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
@@ -50,7 +50,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:29448
       majority_fraction: 0.89
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_PRODUCER
@@ -72,9 +72,9 @@ taxonomy:
       gtdb_taxon: Pantoea
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Pantoea
       ncbi_source_id: NCBITaxon:53335
-      majority_fraction: 0.961
+      majority_fraction: 0.982
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 15 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 6 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -97,9 +97,9 @@ taxonomy:
       gtdb_taxon: Pantoea
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Pantoea
       ncbi_source_id: NCBITaxon:53335
-      majority_fraction: 0.961
+      majority_fraction: 0.982
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 15 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 6 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Sphingobium_Rhodococcus_Lignin_Dimer_Valorization_Coculture.yaml
+++ b/kb/communities/Sphingobium_Rhodococcus_Lignin_Dimer_Valorization_Coculture.yaml
@@ -59,9 +59,9 @@ taxonomy:
       gtdb_taxon: Sphingobium
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Sphingobium
       ncbi_source_id: NCBITaxon:165695
-      majority_fraction: 0.993
+      majority_fraction: 0.987
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: >
       The publication identifies the dimer-cleaving partner at genus level as
       Sphingobium sp.; no species name is asserted here.

--- a/kb/communities/Subsurface_Carboxydocella_CO_Aquifer_Community.yaml
+++ b/kb/communities/Subsurface_Carboxydocella_CO_Aquifer_Community.yaml
@@ -33,7 +33,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:178898
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Native carboxydotrophic Carboxydocella whose relative abundance
       decreased post-scCO2 injection.
   functional_role:

--- a/kb/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.yaml
+++ b/kb/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.yaml
@@ -36,7 +36,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1031
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_PRODUCER
@@ -59,9 +59,9 @@ taxonomy:
       gtdb_taxon: Beggiatoa
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Beggiatoales;f__Beggiatoaceae;g__Beggiatoa
       ncbi_source_id: NCBITaxon:1021
-      majority_fraction: 0.75
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_PRODUCER

--- a/kb/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.yaml
+++ b/kb/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.yaml
@@ -72,9 +72,9 @@ taxonomy:
       gtdb_taxon: Bacillus
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
-      majority_fraction: 0.508
+      majority_fraction: 0.57
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
     notes: Three of the four ARC members. The paper gives isolate codes but no species assignment
       for them, so the taxon is grounded at genus level. Three Bacillus isolates were also the ones
       found to inhibit Bradyrhizobium and were excluded, so Bacillus appears on both sides of the
@@ -97,9 +97,9 @@ taxonomy:
       gtdb_taxon: Enterobacter
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Enterobacter
       ncbi_source_id: NCBITaxon:547
-      majority_fraction: 0.968
+      majority_fraction: 0.999
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 17 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: The fourth ARC member. Isolate code given without a species assignment, so grounded at
       genus level. Enterobacter was among the genera negatively correlated with Aspergillus
       abundance yet not with Bradyrhizobium.
@@ -121,9 +121,9 @@ taxonomy:
       gtdb_taxon: Bradyrhizobium
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Bradyrhizobium
       ncbi_source_id: NCBITaxon:374
-      majority_fraction: 0.982
+      majority_fraction: 0.995
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 8 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: The nitrogen-fixing symbiont whose compatibility constrained community assembly, and
       whose nodulation ARC is designed to induce. Not an inoculated ARC member; it is the mutualist
       the community must not antagonise. The counter-selection that excluded Bradyrhizobium-

--- a/kb/communities/SynCom_BsBv_Cigar_Tobacco_Leaf_Fermentation.yaml
+++ b/kb/communities/SynCom_BsBv_Cigar_Tobacco_Leaf_Fermentation.yaml
@@ -31,7 +31,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:561879
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: One of two SynCom members, screened for high extracellular cellulase, amylase and protease
       activities. No strain designation reported in the abstract.
   functional_role:
@@ -56,7 +56,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:492670
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: One of two SynCom members, screened for high extracellular cellulase, amylase and protease
       activities. No strain designation reported in the abstract.
   functional_role:

--- a/kb/communities/SynCom_MetG2_Rhizobacteria_Sugarcane_Stress_Resilience.yaml
+++ b/kb/communities/SynCom_MetG2_Rhizobacteria_Sugarcane_Stress_Resilience.yaml
@@ -49,7 +49,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1224
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: The abstract names no individual SynCom member species; it reports that flagellar assembly,
       chemotaxis, quorum sensing, and biofilm-formation genes were up-regulated particularly within
       Proteobacteria. Grounded at phylum rank. NCBITaxon canonical label for Proteobacteria is

--- a/kb/communities/SynCom_MetG2_Rhizobacteria_Sugarcane_Stress_Resilience.yaml
+++ b/kb/communities/SynCom_MetG2_Rhizobacteria_Sugarcane_Stress_Resilience.yaml
@@ -49,7 +49,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1224
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 14 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: The abstract names no individual SynCom member species; it reports that flagellar assembly,
       chemotaxis, quorum sensing, and biofilm-formation genes were up-regulated particularly within
       Proteobacteria. Grounded at phylum rank. NCBITaxon canonical label for Proteobacteria is

--- a/kb/communities/SynCom_Pseudomonas_Rahnella_Artemisia_Phytoremediation.yaml
+++ b/kb/communities/SynCom_Pseudomonas_Rahnella_Artemisia_Phytoremediation.yaml
@@ -30,7 +30,7 @@ taxonomy:
       gtdb_taxon: Pseudomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
-      majority_fraction: 0.692
+      majority_fraction: 0.699
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the abstract names the SynCom member only as "Pseudomonas" (no

--- a/kb/communities/SynCom_Pseudomonas_Rahnella_Artemisia_Phytoremediation.yaml
+++ b/kb/communities/SynCom_Pseudomonas_Rahnella_Artemisia_Phytoremediation.yaml
@@ -30,9 +30,9 @@ taxonomy:
       gtdb_taxon: Pseudomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
-      majority_fraction: 0.596
+      majority_fraction: 0.692
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 17 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the abstract names the SynCom member only as "Pseudomonas" (no
       species given).
   functional_role:
@@ -59,7 +59,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:34037
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the abstract names the SynCom member only as "Rahnella" (no
       species given).
   functional_role:

--- a/kb/communities/SynCom_Sesame_Flavor_Baijiu_Fuqu_13Genus.yaml
+++ b/kb/communities/SynCom_Sesame_Flavor_Baijiu_Fuqu_13Genus.yaml
@@ -47,9 +47,9 @@ taxonomy:
       gtdb_taxon: Bacillus
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
-      majority_fraction: 0.508
+      majority_fraction: 0.57
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
     notes: Genus-level identification (core Fuqu microbiota). NCBITaxon canonical label carries a
       "<firmicutes>" disambiguation suffix for the bacterial genus.
   functional_role:
@@ -73,9 +73,9 @@ taxonomy:
       gtdb_taxon: Lactobacillus
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactobacillus
       ncbi_source_id: NCBITaxon:1578
-      majority_fraction: 0.971
+      majority_fraction: 0.998
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 16 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Genus-level identification (core Fuqu microbiota); lactic acid bacterium.
   functional_role:
   - SECONDARY_FERMENTER
@@ -100,7 +100,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1243
       majority_fraction: 0.99
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Genus-level identification (core Fuqu microbiota); lactic acid bacterium.
   functional_role:
   - SECONDARY_FERMENTER
@@ -125,7 +125,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1253
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Genus-level identification (core Fuqu microbiota); lactic acid bacterium.
   functional_role:
   - SECONDARY_FERMENTER
@@ -201,7 +201,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:46255
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Genus-level identification (core Fuqu microbiota); lactic acid bacterium.
   functional_role:
   - SECONDARY_FERMENTER

--- a/kb/communities/SynCom_Y_Agrobacterium_Bacillus_Biofilm_Biocontrol_Coculture.yaml
+++ b/kb/communities/SynCom_Y_Agrobacterium_Bacillus_Biofilm_Biocontrol_Coculture.yaml
@@ -27,12 +27,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Agrobacterium_leguminum
       gtdb_taxon: Agrobacterium leguminum
-      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Agrobacterium;s__Agrobacterium
-        leguminum
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Agrobacterium;s__Agrobacterium leguminum
       ncbi_source_id: NCBITaxon:1183412
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: LSQ16
   functional_role:
@@ -54,12 +53,11 @@ taxonomy:
     gtdb_classification:
       gtdb_id: GTDB:s__Bacillus_velezensis
       gtdb_taxon: Bacillus velezensis
-      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus
-        velezensis
+      gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus velezensis
       ncbi_source_id: NCBITaxon:492670
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: WB
   functional_role:

--- a/kb/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.yaml
+++ b/kb/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.yaml
@@ -55,7 +55,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1140
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered PCC 7942 derivative expressing cscB for sucrose export.
   strain_designation:
     strain_name: PCC 7942 cscB
@@ -91,7 +91,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:354
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The primary publication specifies strain AV3; NCBI Taxonomy resolves the organism at species
       level for this record.
   strain_designation:

--- a/kb/communities/Synechococcus_Bacillus_SPC.yaml
+++ b/kb/communities/Synechococcus_Bacillus_SPC.yaml
@@ -43,7 +43,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:32046
       majority_fraction: 0.85
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_PRODUCER
@@ -71,7 +71,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1423
       majority_fraction: 0.91
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: ABUNDANT
   functional_role:
   - CROSS_FEEDER

--- a/kb/communities/Synechococcus_Ecoli_SPC.yaml
+++ b/kb/communities/Synechococcus_Ecoli_SPC.yaml
@@ -50,7 +50,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:32046
       majority_fraction: 0.85
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Engineered strain expressing E. coli H+/sucrose symporter CscB to enable sucrose export. Wild-type
       strain does not secrete significant sucrose.
 
@@ -83,7 +83,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:83333
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Heterotrophic partner that utilizes secreted sucrose from the cyanobacterium.
 
       '

--- a/kb/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.yaml
+++ b/kb/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.yaml
@@ -55,7 +55,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:32046
       majority_fraction: 0.85
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered PCC 7942 derivative expressing cscB for sucrose export.
   strain_designation:
     strain_name: PCC 7942 cscB
@@ -91,7 +91,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1072583
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The publication and culture collections use Halomonas boliviensis LC1; NCBI Taxonomy currently
       represents the strain as Vreelandella boliviensis LC1.
   strain_designation:

--- a/kb/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.yaml
+++ b/kb/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.yaml
@@ -60,7 +60,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:32046
       majority_fraction: 0.85
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered PCC 7942 derivative expressing the heterologous CscB sucrose permease to export
       photosynthetically fixed carbon as sucrose.
   strain_designation:

--- a/kb/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.yaml
+++ b/kb/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.yaml
@@ -61,7 +61,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1350461
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered Syn2973-omcS-ldh cyanobacterial charging unit that produces D-lactate.
   strain_designation:
     strain_name: UTEX 2973
@@ -91,7 +91,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:211586
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered napA deletion discharging unit used for D-lactate oxidation and anode electron transfer.
   strain_designation:
     strain_name: MR-1

--- a/kb/communities/Synechococcus_Yarrowia_SPC.yaml
+++ b/kb/communities/Synechococcus_Yarrowia_SPC.yaml
@@ -45,7 +45,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:32046
       majority_fraction: 0.85
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_PRODUCER

--- a/kb/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.yaml
+++ b/kb/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.yaml
@@ -45,7 +45,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:32046
       majority_fraction: 0.85
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered cyanobacterial phototroph expressing cscB to secrete sucrose.
   strain_designation:
     strain_name: PCC 7942 cscB+

--- a/kb/communities/Synthetic_Periphyton_Freshwater_Biofilm.yaml
+++ b/kb/communities/Synthetic_Periphyton_Freshwater_Biofilm.yaml
@@ -60,9 +60,9 @@ taxonomy:
       gtdb_taxon: Cyanobacteriota
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota
       ncbi_source_id: NCBITaxon:1117
-      majority_fraction: 0.998
+      majority_fraction: 0.999
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at p__ rank; 5 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Synthetic_Periphyton_Freshwater_Biofilm.yaml
+++ b/kb/communities/Synthetic_Periphyton_Freshwater_Biofilm.yaml
@@ -60,9 +60,9 @@ taxonomy:
       gtdb_taxon: Cyanobacteriota
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota
       ncbi_source_id: NCBITaxon:1117
-      majority_fraction: 0.999
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Syntrophobacter_Methanobacterium_Syntrophy.yaml
+++ b/kb/communities/Syntrophobacter_Methanobacterium_Syntrophy.yaml
@@ -37,7 +37,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:119484
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Anaerobic, syntrophic, propionate-oxidizing bacterium that degrades propionate to acetate
       via the methylmalonyl-CoA pathway. Cannot grow on propionate alone; requires syntrophic association
       with H2/formate-utilizing partners. Uses protons as electron acceptor, producing H2 and formate
@@ -69,7 +69,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:2162
       majority_fraction: 0.94
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Hydrogen and formate-utilizing methanogen that consumes H2/formate and CO2 to produce methane
       via hydrogenotrophic methanogenesis. Essential syntrophic partner that maintains low H2 and formate
       partial pressure, enabling thermodynamically unfavorable propionate oxidation by S. fumaroxidans.

--- a/kb/communities/Syntrophobacter_Methanospirillum_Syntrophy.yaml
+++ b/kb/communities/Syntrophobacter_Methanospirillum_Syntrophy.yaml
@@ -37,7 +37,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:119484
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Anaerobic, syntrophic, propionate-oxidizing bacterium that degrades propionate to acetate
       via the methylmalonyl-CoA pathway. Cannot grow on propionate alone; requires syntrophic association
       with H2/formate-utilizing partners. Uses protons as electron acceptor, producing H2 and formate
@@ -69,7 +69,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:2203
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Hydrogen and formate-utilizing methanogen that consumes H2/formate and CO2 to produce methane
       via hydrogenotrophic methanogenesis. Essential syntrophic partner that maintains low H2 and formate
       partial pressure, enabling thermodynamically unfavorable propionate oxidation by S. fumaroxidans.

--- a/kb/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.yaml
+++ b/kb/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.yaml
@@ -82,7 +82,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:39152
       majority_fraction: 0.93
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Hydrogenotrophic methanogen paired with S. wolfei in the mesophilic coculture.
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Syntrophomonas_Methanospirillum_Syntrophy.yaml
+++ b/kb/communities/Syntrophomonas_Methanospirillum_Syntrophy.yaml
@@ -57,7 +57,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:2203
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Hydrogen-utilizing methanogen that consumes H2 and CO2 to produce methane. Essential syntrophic
       partner that maintains low H2 partial pressure, enabling thermodynamically unfavorable fatty acid
       oxidation by S. wolfei.

--- a/kb/communities/Syntrophus_Benzoate_Degrader.yaml
+++ b/kb/communities/Syntrophus_Benzoate_Degrader.yaml
@@ -37,7 +37,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:56780
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Anaerobic, syntrophic bacterium that degrades benzoate and other aromatic compounds to acetate,
       H2, and formate. Cannot grow on benzoate alone; requires syntrophic association with H2-utilizing
       partners. Uses protons as electron acceptor, producing H2 and formate as electron sink products.
@@ -68,7 +68,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:2203
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Hydrogen-utilizing methanogen that consumes H2 and CO2 to produce methane. Essential syntrophic
       partner that maintains low H2 partial pressure, enabling thermodynamically unfavorable benzoate
       degradation by S. aciditrophicus.

--- a/kb/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.yaml
+++ b/kb/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.yaml
@@ -54,7 +54,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:43775
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Anaerobic syntrophic benzoate-fermenting bacterium in the methanogenic coculture.
   strain_designation:
     strain_name: HQG1
@@ -92,7 +92,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:2203
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Methanogenic archaeal partner in the S. gentianae benzoate-degrading coculture.
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/THOR_Rhizosphere_Model_Community.yaml
+++ b/kb/communities/THOR_Rhizosphere_Model_Community.yaml
@@ -87,7 +87,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:986
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Bacteroidetes/Flavobacteriia member whose abundance and transcriptional state are sensitive
       to P. koreensis and koreenceine.
   strain_designation:

--- a/kb/communities/TYQ1_Nematode_Biocontrol_SynCom.yaml
+++ b/kb/communities/TYQ1_Nematode_Biocontrol_SynCom.yaml
@@ -53,7 +53,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:648995
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Keystone species and central metabolic hub. Directly inhibits root-knot nematodes and coordinates
       biofilm formation across the community. Its enrichment causes restructuring of the rhizobacterial
       community, leading to recruitment of 7 biomarker species.
@@ -85,7 +85,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:237612
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Biomarker species recruited by TYQ1 enrichment (OTU2477).
   strain_designation:
     strain_name: SP
@@ -109,9 +109,9 @@ taxonomy:
       gtdb_taxon: Sphingomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Sphingomonas
       ncbi_source_id: NCBITaxon:13687
-      majority_fraction: 0.777
+      majority_fraction: 0.736
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 24 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 19 GTDB taxa under the NCBI taxon]
     notes: 'Biomarker species recruited by TYQ1 enrichment (OTU1716). Genus-level NCBITaxon used as species-level
       ID not available.
 
@@ -158,9 +158,9 @@ taxonomy:
       gtdb_taxon: Acidovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Acidovorax
       ncbi_source_id: NCBITaxon:12916
-      majority_fraction: 0.867
+      majority_fraction: 0.997
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 9 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Biomarker species with significant nematicidal activity (OTU2649).
   strain_designation:
     strain_name: AF
@@ -185,7 +185,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:48936
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Biomarker species recruited by TYQ1 enrichment (OTU613).
   strain_designation:
     strain_name: NS

--- a/kb/communities/Teosinte_Maize_Biofertilizer_SynCom7.yaml
+++ b/kb/communities/Teosinte_Maize_Biofertilizer_SynCom7.yaml
@@ -61,7 +61,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:244366
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -87,7 +87,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:549
       majority_fraction: 0.9
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.yaml
+++ b/kb/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.yaml
@@ -82,7 +82,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:225937
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
       Diatom-attaching marine gammaproteobacterium originally isolated from
       marine particles in the German Wadden Sea and used as a model bacterium

--- a/kb/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.yaml
+++ b/kb/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.yaml
@@ -78,7 +78,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:246200
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Heterotrophic roseobacter strain DSS-3, inoculated into the diatom culture in pairwise coculture.
   abundance_value: One of two members in the defined coculture.
   functional_role:

--- a/kb/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.yaml
+++ b/kb/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.yaml
@@ -60,7 +60,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1089553
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Type strain PB/DSM 12270; acetate-oxidizing syntrophic bacterium in the defined coculture.
   strain_designation:
     strain_name: PB
@@ -99,7 +99,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:145262
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Source literature also uses the spelling Methanothermobacter thermoautotrophicus;
       this record uses the NCBI current label for the same methanogenic partner.
   strain_designation:

--- a/kb/communities/Thermophilic_Lignocellulose_Composting_SynCom_Biosanitization.yaml
+++ b/kb/communities/Thermophilic_Lignocellulose_Composting_SynCom_Biosanitization.yaml
@@ -46,9 +46,9 @@ taxonomy:
       gtdb_taxon: Achromobacter
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Achromobacter
       ncbi_source_id: NCBITaxon:222
-      majority_fraction: 0.981
+      majority_fraction: 0.991
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Species not specified in the source; grounded at the genus rank confirmed by OAK.
   functional_role:
   - PRIMARY_DEGRADER
@@ -70,9 +70,9 @@ taxonomy:
       gtdb_taxon: Pseudomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
-      majority_fraction: 0.596
+      majority_fraction: 0.692
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 17 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: Species not specified in the source; grounded at the genus rank confirmed by OAK.
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/Thermophilic_Lignocellulose_Composting_SynCom_Biosanitization.yaml
+++ b/kb/communities/Thermophilic_Lignocellulose_Composting_SynCom_Biosanitization.yaml
@@ -70,7 +70,7 @@ taxonomy:
       gtdb_taxon: Pseudomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
-      majority_fraction: 0.692
+      majority_fraction: 0.699
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: Species not specified in the source; grounded at the genus rank confirmed by OAK.

--- a/kb/communities/Thermophilic_Pyrite_QS_Consortium.yaml
+++ b/kb/communities/Thermophilic_Pyrite_QS_Consortium.yaml
@@ -66,7 +66,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Chemolithoautotrophic iron-oxidizing bacterium (Nitrospirae phylum) representing a dominant
       member of moderately thermophilic bioleaching consortia. L. ferriphilum DSM 14647 (type strain)
       oxidizes ferrous iron [Fe(II)] to ferric iron [Fe(III)] as the primary energy source for carbon
@@ -117,7 +117,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:33059
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Gram-negative γ-proteobacterium specialized for oxidizing reduced inorganic sulfur compounds
       (RISCs) including elemental sulfur, tetrathionate, and thiosulfate to sulfuric acid. A. caldus DSM
       8584 (type strain KU) is a moderately thermophilic acidophile with temperature optimum at 45°C and
@@ -179,7 +179,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:28034
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Gram-positive, spore-forming, moderately thermophilic bacterium (Firmicutes) that oxidizes
       both ferrous iron and reduced sulfur compounds. S. thermosulfidooxidans DSM 9293 (type strain AT-1)
       exhibits temperature optimum at 50-55°C with growth range of 20-60°C, representing the most thermophilic

--- a/kb/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.yaml
+++ b/kb/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.yaml
@@ -60,7 +60,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:243274
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Hyperthermophilic anaerobic heterotroph and hydrogen-producing fermentative member.
   strain_designation:
     strain_name: MSB8
@@ -98,7 +98,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:243232
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
       Source publications use the historical name Methanococcus jannaschii.
       NCBI currently represents the DSM 2661/JAL-1 strain as Methanocaldococcus

--- a/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
+++ b/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
@@ -64,9 +64,9 @@ taxonomy:
       gtdb_taxon: Thiobacillus
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Thiobacillaceae;g__Thiobacillus
       ncbi_source_id: NCBITaxon:919
-      majority_fraction: 0.714
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: A single Thiobacillus strain proliferated in all reactors at high
       SCN- loadings.
   abundance_level: DOMINANT
@@ -90,9 +90,9 @@ taxonomy:
       gtdb_taxon: Afipia
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Afipia
       ncbi_source_id: NCBITaxon:1033
-      majority_fraction: 0.957
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: A single Afipia variant dominated the molasses-free reactor at
       moderately high SCN- loadings.
   abundance_level: DOMINANT
@@ -116,9 +116,9 @@ taxonomy:
       gtdb_taxon: Rhizobiales
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales
       ncbi_source_id: NCBITaxon:356
-      majority_fraction: 0.988
+      majority_fraction: 0.994
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at o__ rank; 17 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 5 GTDB taxa under the NCBI taxon]
     notes: Many Rhizobiales strains were present but did not dominate; Afipia
       (within Rhizobiales) was the molasses-free winner.
   functional_role:

--- a/kb/communities/Tinto_River_Iron_Cycling_Community.yaml
+++ b/kb/communities/Tinto_River_Iron_Cycling_Community.yaml
@@ -46,7 +46,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:180
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Dominant iron-oxidizing bacterium (approximately 40% of prokaryotic community) in Rio Tinto
       water column. L. ferrooxidans is an obligate chemolithoautotroph that oxidizes ferrous iron (Fe²⁺)
       to ferric iron (Fe³⁺) for energy, fixing CO₂ autotrophically. The organism thrives at pH 1.0-2.5
@@ -81,7 +81,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Second dominant iron-oxidizing bacterium (~25% of prokaryotic community) with metabolic versatility
       for both iron and sulfur oxidation. At. ferrooxidans oxidizes Fe²⁺ to Fe³⁺ and reduced sulfur compounds
       to sulfuric acid, contributing to acidification and metal solubilization. The organism is chemolithoautotrophic,
@@ -105,13 +105,13 @@ taxonomy:
       id: NCBITaxon:522
       label: Acidiphilium
     gtdb_classification:
-      gtdb_id: GTDB:g__UBA10281
-      gtdb_taxon: UBA10281
-      gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Christensenellales;f__Borkfalkiaceae;g__UBA10281
+      gtdb_id: GTDB:g__Acidiphilium
+      gtdb_taxon: Acidiphilium
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acidiphilium
       ncbi_source_id: NCBITaxon:522
-      majority_fraction: 0.633
-      is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      majority_fraction: 1.0
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Heterotrophic acidophile (~15% of prokaryotic community) forming the critical link between
       carbon and iron cycles in Rio Tinto. Acidiphilium spp. utilize organic carbon from algal exudates,
       cell lysis, and allochthonous inputs, remineralizing nutrients for autotrophs. The genus provides

--- a/kb/communities/Tobacco_Chemotactic_Biocontrol_SynCom.yaml
+++ b/kb/communities/Tobacco_Chemotactic_Biocontrol_SynCom.yaml
@@ -50,9 +50,9 @@ taxonomy:
       gtdb_taxon: Bacillus
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
-      majority_fraction: 0.508
+      majority_fraction: 0.57
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 102 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Tomato_Oxylipin_SynCom3.yaml
+++ b/kb/communities/Tomato_Oxylipin_SynCom3.yaml
@@ -43,7 +43,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:76890
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -60,7 +60,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1769012
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -77,7 +77,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:20
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.yaml
+++ b/kb/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.yaml
@@ -46,7 +46,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:56112
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.yaml
+++ b/kb/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.yaml
@@ -58,7 +58,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:82803
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
       Fermentative strain ES5 was added to the syntrophic coculture; the
       ontology grounding is species-level because the stable NCBI Taxonomy
@@ -116,7 +116,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:2203
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Hydrogen/formate-scavenging methanogenic archaeal partner in the three-member coculture.
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.yaml
+++ b/kb/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.yaml
@@ -75,7 +75,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Bacterial fermentation specialist; source abstract supports species-level identity.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Trichoderma_Lactate_Platform.yaml
+++ b/kb/communities/Trichoderma_Lactate_Platform.yaml
@@ -61,7 +61,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1589
       majority_fraction: 0.99
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: ABUNDANT
   functional_role:
   - SECONDARY_FERMENTER
@@ -83,7 +83,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1519
       majority_fraction: 0.97
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: ABUNDANT
   functional_role:
   - SECONDARY_FERMENTER

--- a/kb/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.yaml
+++ b/kb/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.yaml
@@ -82,7 +82,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:100226
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Noncellulolytic bacterial member dependent on cellulase-derived hydrolysate sugars.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Trichodesmium_Alteromonas_Marine_Consortium.yaml
+++ b/kb/communities/Trichodesmium_Alteromonas_Marine_Consortium.yaml
@@ -30,7 +30,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:203124
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Nitrogen-fixing cyanobacterial colony former and photoautotrophic host of the consortium.
   functional_role:
   - PRIMARY_PRODUCER
@@ -52,7 +52,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:28108
       majority_fraction: 0.9
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Conserved gammaproteobacterial heterotroph associated with Trichodesmium colonies and cultures.
   functional_role:
   - CROSS_FEEDER

--- a/kb/communities/Urine_Nitrification_SynCom.yaml
+++ b/kb/communities/Urine_Nitrification_SynCom.yaml
@@ -43,7 +43,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:915
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [mapped via NCBI species name — no species-level NCBI id in table]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -60,7 +60,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:913
       majority_fraction: 0.88
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.yaml
+++ b/kb/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.yaml
@@ -90,9 +90,9 @@ taxonomy:
       gtdb_taxon: Variovorax
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
-      majority_fraction: 0.99
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: The study identifies a Variovorax species as a thiamine-producing hub
       in the correlation network; species-level identity is not resolved in the
       abstract beyond the genus.

--- a/kb/communities/Wheat_Consortium_C1.yaml
+++ b/kb/communities/Wheat_Consortium_C1.yaml
@@ -45,7 +45,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:151783
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.yaml
+++ b/kb/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.yaml
@@ -51,7 +51,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1423
       majority_fraction: 0.91
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -68,7 +68,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:40214
       majority_fraction: 0.97
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - PRIMARY_DEGRADER
   evidence:

--- a/kb/communities/Yogurt_TwoSpecies_Starter_Culture.yaml
+++ b/kb/communities/Yogurt_TwoSpecies_Starter_Culture.yaml
@@ -60,7 +60,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1308
       majority_fraction: 0.99
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Thermophilic dairy starter species represented at species level because the curated community
       summarizes multiple exact two-species publications that use different S. thermophilus strains.
   functional_role:
@@ -90,7 +90,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1585
       majority_fraction: 1.0
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Literature often uses Lactobacillus bulgaricus; NCBI taxon captures the accepted subspecies.
       The record is species/subspecies-level because publications use different L. bulgaricus strains.
   functional_role:

--- a/kb/communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.yaml
+++ b/kb/communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.yaml
@@ -58,7 +58,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:542
       majority_fraction: 0.89
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Curated at species level because the abstract supports Z. mobilis but does not specify a strain
       in the text used for this record; the interacting population is a ZMO0748 auxotroph.
   functional_role:
@@ -86,7 +86,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Curated at species level; the paper tested E. coli proA, pheA, and ilvA auxotroph partners.
   functional_role:
   - CROSS_FEEDER

--- a/kb/communities/mCAFEs_Brachypodium_RCC.yaml
+++ b/kb/communities/mCAFEs_Brachypodium_RCC.yaml
@@ -47,9 +47,9 @@ taxonomy:
       gtdb_taxon: Methylobacterium
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Methylobacterium
       ncbi_source_id: NCBITaxon:407
-      majority_fraction: 0.992
+      majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Keystone taxon in fast-growing consortia (3-day transfer). Member of Methylobacterium-Methylorubrum
       complex.
   functional_role:
@@ -71,9 +71,9 @@ taxonomy:
       gtdb_taxon: Stenotrophomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Xanthomonadaceae;g__Stenotrophomonas
       ncbi_source_id: NCBITaxon:40323
-      majority_fraction: 0.987
+      majority_fraction: 0.985
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Keystone taxon in fast-growing consortia (3-day transfer).
   functional_role:
   - PRIMARY_DEGRADER
@@ -94,9 +94,9 @@ taxonomy:
       gtdb_taxon: Pseudomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
-      majority_fraction: 0.596
+      majority_fraction: 0.692
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 17 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: Keystone taxon in fast-growing consortia (3-day transfer).
   functional_role:
   - PRIMARY_DEGRADER
@@ -117,9 +117,9 @@ taxonomy:
       gtdb_taxon: Terriglobus
       gtdb_lineage: d__Bacteria;p__Acidobacteriota;c__Terriglobia;o__Terriglobales;f__Acidobacteriaceae;g__Terriglobus
       ncbi_source_id: NCBITaxon:392733
-      majority_fraction: 0.833
+      majority_fraction: 0.778
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Keystone taxon in slow-growing consortia (7-day transfer). Enriched in 1/10 R2A medium. Member
       of Acidobacteria.
   functional_role:
@@ -156,9 +156,9 @@ taxonomy:
       gtdb_taxon: Burkholderia
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Burkholderia
       ncbi_source_id: NCBITaxon:32008
-      majority_fraction: 0.985
+      majority_fraction: 0.999
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Keystone taxon in glycerol stock revivals.
   functional_role:
   - PRIMARY_DEGRADER
@@ -194,9 +194,9 @@ taxonomy:
       gtdb_taxon: Sphingomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Sphingomonas
       ncbi_source_id: NCBITaxon:13687
-      majority_fraction: 0.777
+      majority_fraction: 0.736
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 24 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 19 GTDB taxa under the NCBI taxon]
     notes: Persistent keystone taxon across multiple enrichment conditions.
   functional_role:
   - CROSS_FEEDER
@@ -219,7 +219,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:423349
       majority_fraction: 1.0
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Persistent keystone taxon across multiple enrichment conditions.
   functional_role:
   - CROSS_FEEDER
@@ -240,9 +240,9 @@ taxonomy:
       gtdb_taxon: Bradyrhizobium
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Bradyrhizobium
       ncbi_source_id: NCBITaxon:374
-      majority_fraction: 0.982
+      majority_fraction: 0.995
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 8 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Enriched in asparagine enrichment conditions.
   functional_role:
   - CROSS_FEEDER

--- a/kb/communities/mCAFEs_Brachypodium_RCC.yaml
+++ b/kb/communities/mCAFEs_Brachypodium_RCC.yaml
@@ -94,7 +94,7 @@ taxonomy:
       gtdb_taxon: Pseudomonas
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
-      majority_fraction: 0.692
+      majority_fraction: 0.699
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: Keystone taxon in fast-growing consortia (3-day transfer).

--- a/reports/gtdb_denominators.tsv
+++ b/reports/gtdb_denominators.tsv
@@ -1,581 +1,581 @@
 # mapping: NCBI2GTDB.tsv.gz	bytes=2895086	mtime=1785022111
-# taxa=578	flips=5
-ncbi_id	label	aggregate_gtdb_id	aggregate_fraction	deepest_gtdb_id	deepest_fraction	flip	direction
-NCBITaxon:100176	Papillibacter cinnamivorans	GTDB:s__Papillibacter_cinnamivorans	1.0	GTDB:s__Papillibacter_cinnamivorans	1.0		
-NCBITaxon:100226	Streptomyces coelicolor A3(2)	GTDB:s__Streptomyces_anthocyanicus	1.0	GTDB:s__Streptomyces_anthocyanicus	1.0		
-NCBITaxon:101510	Rhodococcus jostii RHA1	GTDB:s__Rhodococcus_jostii_A	1.0	GTDB:s__Rhodococcus_jostii_A	1.0		
-NCBITaxon:1021	Beggiatoa	GTDB:g__Beggiatoa	0.75	GTDB:g__Beggiatoa	0.727		
-NCBITaxon:10239	Viruses	NONE		NONE			
-NCBITaxon:1031	Thiothrix nivea	GTDB:s__Thiothrix_nivea	1.0	GTDB:s__Thiothrix_nivea	1.0		
-NCBITaxon:1033	Afipia	GTDB:g__Afipia	0.957	GTDB:g__Afipia	0.955		
-NCBITaxon:105841	Anaerostipes caccae	GTDB:s__Anaerostipes_caccae	1.0	GTDB:s__Anaerostipes_caccae	1.0		
-NCBITaxon:105972	Methylosarcina fibrata	GTDB:s__Methylosarcina_fibrata	1.0	GTDB:s__Methylosarcina_fibrata	1.0		
-NCBITaxon:1061	Rhodobacter capsulatus	GTDB:s__Rhodobacter_capsulatus_B	1.0	GTDB:s__Rhodobacter_capsulatus_B	1.0		
-NCBITaxon:1064	Rhodocyclus	GTDB:g__Rhodocyclus	1.0	GTDB:g__Rhodocyclus	1.0		
-NCBITaxon:106591	Ensifer	GTDB:g__Ensifer	0.745	GTDB:g__Ensifer	0.745		
-NCBITaxon:106592	Ensifer adhaerens	GTDB:s__Ensifer_canadensis	1.0	GTDB:s__Ensifer_canadensis	1.0		
-NCBITaxon:1072583	Vreelandella boliviensis LC1	GTDB:s__Vreelandella_boliviensis	1.0	GTDB:s__Vreelandella_boliviensis	1.0		
-NCBITaxon:1076	Rhodopseudomonas palustris	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:1078905	Nitrosotalea devaniterrae	GTDB:s__Nitrosotalea_devanaterra	1.0	GTDB:s__Nitrosotalea_devanaterra	1.0		
-NCBITaxon:1089553	Thermacetogenium phaeum DSM 12270	GTDB:s__Thermacetogenium_phaeum	1.0	GTDB:s__Thermacetogenium_phaeum	1.0		
-NCBITaxon:1090	Chlorobiota	GTDB:p__Bacteroidota	0.989	GTDB:p__Bacteroidota	0.989		
-NCBITaxon:1091494	Methylotuvimicrobium alcaliphilum 20Z	GTDB:s__Methylotuvimicrobium_alcaliphilum	1.0	GTDB:s__Methylotuvimicrobium_alcaliphilum	1.0		
-NCBITaxon:110321	Sinorhizobium medicae	GTDB:s__Sinorhizobium_medicae	1.0	GTDB:s__Sinorhizobium_medicae	1.0		
-NCBITaxon:110500	Pelotomaculum thermopropionicum	GTDB:s__Pelotomaculum_thermopropionicum	1.0	GTDB:s__Pelotomaculum_thermopropionicum	1.0		
-NCBITaxon:1107	Chloroflexus	GTDB:g__Chloroflexus	1.0	GTDB:g__Chloroflexus	1.0		
-NCBITaxon:110932	Leifsonia	GTDB:g__Leifsonia	0.75	GTDB:g__Leifsonia	0.75		
-NCBITaxon:1117	Cyanobacteriota	GTDB:p__Cyanobacteriota	0.998	GTDB:p__Cyanobacteriota	0.998		
-NCBITaxon:1122947	Pelosinus fermentans DSM 17108	GTDB:s__Pelosinus_fermentans	1.0	GTDB:s__Pelosinus_fermentans	1.0		
-NCBITaxon:1125	Microcystis <cyanobacteria>	GTDB:g__Microcystis	0.991	GTDB:g__Microcystis	0.991		
-NCBITaxon:1125364	Coccomyxa onubensis	NONE		NONE			
-NCBITaxon:1129	Synechococcus	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:1130819	Lysinibacillus mangiferihumi	GTDB:s__Lysinibacillus_mangiferihumi	1.0	GTDB:s__Lysinibacillus_mangiferihumi	1.0		
-NCBITaxon:1131703	Sphaerochaeta globosa	GTDB:s__Sphaerochaeta_globosa	1.0	GTDB:s__Sphaerochaeta_globosa	1.0		
-NCBITaxon:1134404	Ignavibacteriota	GTDB:p__Bacteroidota	0.987	GTDB:p__Bacteroidota	0.987		
-NCBITaxon:1140	Synechococcus elongatus PCC 7942 = FACHB-805	GTDB:s__Synechococcus_elongatus	1.0	GTDB:s__Synechococcus_elongatus	1.0		
-NCBITaxon:1163	Anabaena	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:1165	Anabaena cylindrica	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:117187	Fusarium verticillioides	NONE		NONE			
-NCBITaxon:1175444	Methanocella conradii	GTDB:s__Methanocella_conradii	1.0	GTDB:s__Methanocella_conradii	1.0		
-NCBITaxon:1176259	Pseudomonas songnenensis	GTDB:s__Stutzerimonas_songnenensis	1.0	GTDB:s__Stutzerimonas_songnenensis	1.0		
-NCBITaxon:1179	Desmonostoc muscorum	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:1183412	Agrobacterium deltae	GTDB:s__Agrobacterium_leguminum	1.0	GTDB:s__Agrobacterium_leguminum	1.0		
-NCBITaxon:118562	Limnospira platensis	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:118667	Bordetella sp. M1-6	NONE		NONE			
-NCBITaxon:118669	Pseudoxanthomonas sp. M1-3	NONE		NONE			
-NCBITaxon:119060	Burkholderiaceae	GTDB:f__Burkholderiaceae	1.0	GTDB:f__Burkholderiaceae	0.999		
-NCBITaxon:119219	Cupriavidus metallidurans	GTDB:s__Cupriavidus_metallidurans	1.0	GTDB:s__Cupriavidus_metallidurans	1.0		
-NCBITaxon:119484	Syntrophobacter fumaroxidans	GTDB:s__Syntrophobacter_fumaroxidans	1.0	GTDB:s__Syntrophobacter_fumaroxidans	1.0		
-NCBITaxon:119532	Microcoleus vaginatus	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:119977	Acidithiobacillus	GTDB:g__Acidithiobacillus	0.724	GTDB:g__Acidithiobacillus	0.819		
-NCBITaxon:120961	Roseiflexus	GTDB:g__Roseiflexus	1.0	GTDB:g__Roseiflexus	1.0		
-NCBITaxon:121039	Ferrimicrobium acidiphilum	GTDB:s__Ferrimicrobium_acidiphilum	1.0	GTDB:s__Ferrimicrobium_acidiphilum	1.0		
-NCBITaxon:1215089	Planococcus halocryophilus	GTDB:s__Planococcus_halocryophilus	1.0	GTDB:s__Planococcus_halocryophilus	1.0		
-NCBITaxon:1218105	Cupriavidus necator NBRC 102504	GTDB:s__Cupriavidus_necator_D	1.0	GTDB:s__Cupriavidus_necator_D	1.0		
-NCBITaxon:1219	Prochlorococcus marinus	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:1224	Pseudomonadota	GTDB:p__Pseudomonadota	1.0	GTDB:p__Pseudomonadota	1.0		
-NCBITaxon:1234	Nitrospira	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:1236	Gammaproteobacteria	GTDB:c__Gammaproteobacteria	1.0	GTDB:c__Gammaproteobacteria	1.0		
-NCBITaxon:1239	Bacillota	GTDB:p__Bacillota_A	0.55	GTDB:p__Bacillota_A	0.746		
-NCBITaxon:1243	Leuconostoc	GTDB:g__Leuconostoc	0.99	GTDB:g__Leuconostoc	0.995		
-NCBITaxon:1245	Leuconostoc mesenteroides	GTDB:s__Leuconostoc_mesenteroides	0.99	GTDB:s__Leuconostoc_mesenteroides	0.99		
-NCBITaxon:1253	Pediococcus	GTDB:g__Pediococcus	1.0	GTDB:g__Pediococcus	1.0		
-NCBITaxon:1261393	Desulfatiglans parachlorophenolica	NONE		NONE			
-NCBITaxon:1264	Hominimerdicola alba	NONE		NONE			
-NCBITaxon:1269	Micrococcus	GTDB:g__Micrococcus	0.997	GTDB:g__Micrococcus	0.996		
-NCBITaxon:1272	Kocuria varians	NONE		NONE			
-NCBITaxon:1279	Staphylococcus	GTDB:g__Staphylococcus	0.993	GTDB:g__Staphylococcus	0.963		
-NCBITaxon:1280	Staphylococcus aureus	GTDB:s__Staphylococcus_aureus	1.0	GTDB:s__Staphylococcus_aureus	1.0		
-NCBITaxon:12916	Acidovorax	GTDB:g__Acidovorax	0.867	GTDB:g__Acidovorax	0.848		
-NCBITaxon:1303	Streptococcus oralis	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:1304	Streptococcus salivarius	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:1305	Streptococcus sanguinis	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:1308	Streptococcus thermophilus	GTDB:s__Streptococcus_thermophilus	0.99	GTDB:s__Streptococcus_thermophilus	0.99		
-NCBITaxon:1309	Streptococcus mutans	GTDB:s__Streptococcus_mutans	1.0	GTDB:s__Streptococcus_mutans	1.0		
-NCBITaxon:131567	cellular organisms	NONE		NONE			
-NCBITaxon:1317	Streptococcus downei	GTDB:s__Streptococcus_downei	1.0	GTDB:s__Streptococcus_downei	1.0		
-NCBITaxon:133	Methylocystis	GTDB:g__Methylocystis	0.952	GTDB:g__Methylocystis	0.948		
-NCBITaxon:1335	Streptococcus equinus	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:1335640	Clostridium saccharoperbutylacetonicum N1-4	NONE		NONE			
-NCBITaxon:1336235	Paenirhizobium selenitireducens ATCC BAA-1503	NONE		NONE			
-NCBITaxon:13366	Brettanomyces	NONE		NONE			
-NCBITaxon:133926	Olsenella uli	GTDB:s__Olsenella_uli	1.0	GTDB:s__Olsenella_uli	1.0		
-NCBITaxon:134	Methylocystis parvus	GTDB:s__Methylocystis_parva	1.0	GTDB:s__Methylocystis_parva	1.0		
-NCBITaxon:1344414	Trichoderma reesei RUT C-30	NONE		NONE			
-NCBITaxon:1350	Enterococcus	GTDB:g__Enterococcus_B	0.596	AMBIGUOUS		FLIP	loses grounding
-NCBITaxon:1350461	Synechococcus elongatus UTEX 2973	GTDB:s__Synechococcus_elongatus	1.0	GTDB:s__Synechococcus_elongatus	1.0		
-NCBITaxon:1351	Enterococcus faecalis	GTDB:s__Enterococcus_faecalis	1.0	GTDB:s__Enterococcus_faecalis	1.0		
-NCBITaxon:135614	Lysobacterales	GTDB:o__Xanthomonadales	1.0	GTDB:o__Xanthomonadales	0.999		
-NCBITaxon:135619	Oceanospirillales	GTDB:o__Pseudomonadales	0.968	GTDB:o__Pseudomonadales	0.966		
-NCBITaxon:1358	Lactococcus lactis	GTDB:s__Lactococcus_lactis	0.92	GTDB:s__Lactococcus_lactis	0.92		
-NCBITaxon:13687	Sphingomonas	GTDB:g__Sphingomonas	0.777	GTDB:g__Sphingomonas	0.742		
-NCBITaxon:1377992	Halovenus	GTDB:g__Halovenus	1.0	GTDB:g__Halovenus	1.0		
-NCBITaxon:1379858	Mucispirillum schaedleri ASF457	GTDB:s__Mucispirillum_schaedleri	1.0	GTDB:s__Mucispirillum_schaedleri	1.0		
-NCBITaxon:138074	Serratia symbiotica	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:1384459	Methyloceanibacter caenitepidi	GTDB:s__Methyloceanibacter_caenitepidi	1.0	GTDB:s__Methyloceanibacter_caenitepidi	1.0		
-NCBITaxon:1386	Bacillus <firmicutes>	GTDB:g__Bacillus	0.508	AMBIGUOUS		FLIP	loses grounding
-NCBITaxon:1396	Bacillus cereus	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:1398	Heyndrickxia coagulans	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:1401	Paenibacillus lautus	GTDB:s__Paenibacillus_lautus	1.0	GTDB:s__Paenibacillus_lautus	1.0		
-NCBITaxon:1402	Bacillus licheniformis	GTDB:s__Bacillus_licheniformis	0.98	GTDB:s__Bacillus_licheniformis	0.98		
-NCBITaxon:1404	Priestia megaterium	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:1421	Lysinibacillus sphaericus	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:142182	Gemmatimonadota	GTDB:p__Gemmatimonadota	1.0	GTDB:p__Gemmatimonadota	1.0		
-NCBITaxon:1423	Bacillus subtilis	GTDB:s__Bacillus_subtilis	0.91	GTDB:s__Bacillus_subtilis	0.91		
-NCBITaxon:1428	Bacillus thuringiensis	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:1432792	Methylocaldum marinum	GTDB:s__Methylocaldum_marinum	1.0	GTDB:s__Methylocaldum_marinum	1.0		
-NCBITaxon:1434011	Komagataeibacter	GTDB:g__Komagataeibacter	0.973	GTDB:g__Komagataeibacter	0.948		
-NCBITaxon:1434019	Mameliella	GTDB:g__Mameliella	0.905	GTDB:g__Mameliella	0.905		
-NCBITaxon:1436290	Candidatus Symbiobacter mobilis	GTDB:s__Symbiobacter_mobilis	1.0	GTDB:s__Symbiobacter_mobilis	1.0		
-NCBITaxon:145262	Methanothermobacter thermautotrophicus	GTDB:s__Methanothermobacter_thermautotrophicus	1.0	GTDB:s__Methanothermobacter_thermautotrophicus	1.0		
-NCBITaxon:1462422	Candidatus Parvarchaeota	NONE		NONE			
-NCBITaxon:146918	Salinibacter	GTDB:g__Salinibacter	1.0	GTDB:g__Salinibacter	1.0		
-NCBITaxon:1485	Clostridium	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:1492	Clostridium butyricum	GTDB:s__Clostridium_butyricum	0.97	GTDB:s__Clostridium_butyricum	0.97		
-NCBITaxon:149698	Massilia	GTDB:g__Telluria	0.905	GTDB:g__Telluria	0.905		
-NCBITaxon:1501	Clostridium pasteurianum	GTDB:s__Clostridium_I_pasteurianum	1.0	GTDB:s__Clostridium_I_pasteurianum	1.0		
-NCBITaxon:1501972	Brevundimonas sp. R3	NONE		NONE			
-NCBITaxon:1515	Acetivibrio thermocellus	GTDB:s__Hungateiclostridium_thermocellum	1.0	GTDB:s__Hungateiclostridium_thermocellum	1.0		
-NCBITaxon:1517	Thermoanaerobacterium thermosaccharolyticum	GTDB:s__Thermoanaerobacterium_thermosaccharolyticum	1.0	GTDB:s__Thermoanaerobacterium_thermosaccharolyticum	1.0		
-NCBITaxon:151783	Cupriavidus campinensis	GTDB:s__Cupriavidus_campinensis	1.0	GTDB:s__Cupriavidus_campinensis	1.0		
-NCBITaxon:1519	Clostridium tyrobutyricum	GTDB:s__Clostridium_B_tyrobutyricum	0.97	GTDB:s__Clostridium_B_tyrobutyricum	0.97		
-NCBITaxon:1521	Ruminiclostridium cellulolyticum	GTDB:s__Ruminiclostridium_cellulolyticum	1.0	GTDB:s__Ruminiclostridium_cellulolyticum	1.0		
-NCBITaxon:1521555	Eucapsis	NONE		NONE			
-NCBITaxon:1534	Clostridium kluyveri	GTDB:s__Clostridium_B_kluyveri	1.0	GTDB:s__Clostridium_B_kluyveri	1.0		
-NCBITaxon:1538	Clostridium ljungdahlii	GTDB:s__Clostridium_B_ljungdahlii	1.0	GTDB:s__Clostridium_B_ljungdahlii	1.0		
-NCBITaxon:1546519	Sulfitobacter sp. SA11	NONE		NONE			
-NCBITaxon:1547	Thomasclavelia ramosa	GTDB:s__Thomasclavelia_ramosa	0.99	GTDB:s__Thomasclavelia_ramosa	0.99		
-NCBITaxon:1571157	Coniochaeta sp. 2T2.1	NONE		NONE			
-NCBITaxon:1577725	Conticribra weissflogii	NONE		NONE			
-NCBITaxon:1578	Lactobacillus	GTDB:g__Lactobacillus	0.971	GTDB:g__Lactobacillus	0.941		
-NCBITaxon:1582	Lacticaseibacillus casei	GTDB:s__Lacticaseibacillus_paracasei	1.0	GTDB:s__Lacticaseibacillus_paracasei	1.0		
-NCBITaxon:1585	Lactobacillus delbrueckii subsp. bulgaricus	GTDB:s__Lactobacillus_delbrueckii	1.0	GTDB:s__Lactobacillus_delbrueckii	1.0		
-NCBITaxon:1589	Lactiplantibacillus pentosus	GTDB:s__Lactiplantibacillus_pentosus	0.99	GTDB:s__Lactiplantibacillus_pentosus	0.99		
-NCBITaxon:1590	Lactiplantibacillus plantarum	GTDB:s__Lactiplantibacillus_plantarum	1.0	GTDB:s__Lactiplantibacillus_plantarum	1.0		
-NCBITaxon:159743	Paenibacillus terrae	NONE		NONE			
-NCBITaxon:16	Methylophilus	GTDB:g__Methylophilus	1.0	GTDB:g__Methylophilus	1.0		
-NCBITaxon:160488	Pseudomonas putida KT2440	GTDB:s__Pseudomonas_E_alloputida	1.0	GTDB:s__Pseudomonas_E_alloputida	1.0		
-NCBITaxon:1605331	Microbacterium sp. UYFA68	NONE		NONE			
-NCBITaxon:160808	Acidithiobacillus ferrivorans	GTDB:s__Acidithiobacillus_ferrivorans	0.95	GTDB:s__Acidithiobacillus_ferrivorans	0.95		
-NCBITaxon:161493	Anaeromyxobacter dehalogenans	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:1646340	Kosakonia pseudosacchari	GTDB:s__Kosakonia_pseudosacchari	1.0	GTDB:s__Kosakonia_pseudosacchari	1.0		
-NCBITaxon:1655	Actinomyces naeslundii	GTDB:s__Actinomyces_naeslundii	0.96	GTDB:s__Actinomyces_naeslundii	0.96		
-NCBITaxon:165695	Sphingobium	GTDB:g__Sphingobium	0.993	GTDB:g__Sphingobium	0.993		
-NCBITaxon:166486	Roseburia intestinalis	GTDB:s__Roseburia_intestinalis	1.0	GTDB:s__Roseburia_intestinalis	1.0		
-NCBITaxon:1667	Arthrobacter sp.	NONE		NONE			
-NCBITaxon:1673428	Cuniculiplasma divulgatum	NONE		NONE			
-NCBITaxon:1678	Bifidobacterium	GTDB:g__Bifidobacterium	0.998	GTDB:g__Bifidobacterium	0.998		
-NCBITaxon:1681	Bifidobacterium bifidum	GTDB:s__Bifidobacterium_bifidum	1.0	GTDB:s__Bifidobacterium_bifidum	1.0		
-NCBITaxon:1682	Bifidobacterium longum subsp. infantis	GTDB:s__Bifidobacterium_infantis	0.94	GTDB:s__Bifidobacterium_infantis	0.94		
-NCBITaxon:168384	Marvinbryantia formatexigens	GTDB:s__Marvinbryantia_formatexigens	1.0	GTDB:s__Marvinbryantia_formatexigens	1.0		
-NCBITaxon:1685	Bifidobacterium breve	GTDB:s__Bifidobacterium_breve	1.0	GTDB:s__Bifidobacterium_breve	1.0		
-NCBITaxon:169215	Bosea	GTDB:g__Bosea	0.981	GTDB:g__Bosea	0.981		
-NCBITaxon:1696	Brevibacterium	GTDB:g__Brevibacterium	0.987	GTDB:g__Brevibacterium	0.983		
-NCBITaxon:1699721	Neotibicen canicularis	NONE		NONE			
-NCBITaxon:1707	Cellulomonas	GTDB:g__Cellulomonas	0.858	GTDB:g__Cellulomonas	0.859		
-NCBITaxon:1708	Cellulomonas fimi	GTDB:s__Cellulomonas_fimi	1.0	GTDB:s__Cellulomonas_fimi	1.0		
-NCBITaxon:1718	Corynebacterium glutamicum	GTDB:s__Corynebacterium_glutamicum	0.99	GTDB:s__Corynebacterium_glutamicum	0.99		
-NCBITaxon:1763	Mycobacterium	GTDB:g__Mycobacterium	1.0	GTDB:g__Mycobacterium	0.999		
-NCBITaxon:1766253	Agathobacter	GTDB:g__Agathobacter	1.0	GTDB:g__Agathobacter	1.0		
-NCBITaxon:1769012	Arachidicoccus	GTDB:g__Arachidicoccus	1.0	GTDB:g__Arachidicoccus	1.0		
-NCBITaxon:1783273	Patescibacteria group	NONE		NONE			
-NCBITaxon:1783276	Nanobdellati	NONE		NONE			
-NCBITaxon:1785	Mycobacterium sp.	NONE		NONE			
-NCBITaxon:178606	Leptospirillum ferriphilum	GTDB:s__Leptospirillum_A_rubarum	1.0	GTDB:s__Leptospirillum_A_rubarum	1.0		
-NCBITaxon:178898	Carboxydocella	GTDB:g__Carboxydocella	1.0	GTDB:g__Carboxydocella	1.0		
-NCBITaxon:179	Leptospirillum	GTDB:g__Leptospirillum	0.575	GTDB:g__Leptospirillum_A	0.583	FLIP	different taxon
-NCBITaxon:18	Pelobacter	GTDB:g__Syntrophotalea	0.5	GTDB:g__Syntrophotalea	0.583		
-NCBITaxon:180	Leptospirillum ferrooxidans	GTDB:s__Leptospirillum_ferrooxidans	1.0	GTDB:s__Leptospirillum_ferrooxidans	1.0		
-NCBITaxon:180162	Cetobacterium	GTDB:g__Cetobacterium_A	0.927	GTDB:g__Cetobacterium_A	0.927		
-NCBITaxon:1801631	Microcaldota	NONE		NONE			
-NCBITaxon:1807132	Candidatus Phormidium alkaliphilum	NONE		NONE			
-NCBITaxon:1817801	Candidatus Eiseniibacteriota	NONE		NONE			
-NCBITaxon:1822464	Paraburkholderia	GTDB:g__Paraburkholderia	0.988	GTDB:g__Paraburkholderia	0.986		
-NCBITaxon:1827	Rhodococcus <high G+C Gram-positive bacteria>	GTDB:g__Rhodococcus	0.996	GTDB:g__Rhodococcus	0.995		
-NCBITaxon:1847	Pseudonocardia	GTDB:g__Pseudonocardia	1.0	GTDB:g__Pseudonocardia	1.0		
-NCBITaxon:1849822	Paraclostridium	GTDB:g__Paraclostridium	0.995	GTDB:g__Paraclostridium	0.974		
-NCBITaxon:186490	Candidatus Palibaumannia cicadellinicola	NONE		NONE			
-NCBITaxon:1866885	Mycolicibacterium	GTDB:g__Mycobacterium	0.998	GTDB:g__Mycobacterium	0.997		
-NCBITaxon:186801	Clostridia	GTDB:c__Clostridia	0.974	GTDB:c__Clostridia	0.976		
-NCBITaxon:1869185	Taibaiella sp.	NONE		NONE			
-NCBITaxon:1871043	Variovorax sp.	NONE		NONE			
-NCBITaxon:1871068	Phyllobacteriaceae bacterium	NONE		NONE			
-NCBITaxon:1872086	Ensifer sp.	NONE		NONE			
-NCBITaxon:1872114	Acidiplasma sp.	NONE		NONE			
-NCBITaxon:1872122	Acidovorax sp.	NONE		NONE			
-NCBITaxon:1872427	Alcanivorax sp.	NONE		NONE			
-NCBITaxon:1872648	Asticcacaulis sp.	NONE		NONE			
-NCBITaxon:1873462	Microbacteriaceae bacterium	NONE		NONE			
-NCBITaxon:1883	Streptomyces	GTDB:g__Streptomyces	0.973	GTDB:g__Streptomyces	0.972		
-NCBITaxon:1889	Streptomyces ambofaciens	GTDB:s__Streptomyces_ambofaciens	1.0	GTDB:s__Streptomyces_ambofaciens	1.0		
-NCBITaxon:1902583	Candidatus Desulfofervidus	NONE		NONE			
-NCBITaxon:1904413	Suillus clintonianus	NONE		NONE			
-NCBITaxon:1908224	Sphingopyxis sp.	NONE		NONE			
-NCBITaxon:1911909	Neorhizobium sp.	GTDB:s__Neorhizobium_sp028283725	1.0	GTDB:s__Neorhizobium_sp028283725	1.0		
-NCBITaxon:1913961	Rhizobiaceae bacterium	NONE		NONE			
-NCBITaxon:1914288	Dyadobacter sp.	GTDB:s__Dyadobacter_sp017744695	1.0	GTDB:s__Dyadobacter_sp017744695	1.0		
-NCBITaxon:1914538	Pseudomonadaceae bacterium	NONE		NONE			
-NCBITaxon:1918507	Candidatus Phosphitivorax anaerolimi	GTDB:s__UBA1062_sp001896555	1.0	GTDB:s__UBA1062_sp001896555	1.0		
-NCBITaxon:192	Azospirillum brasilense	GTDB:s__Azospirillum_brasilense	1.0	GTDB:s__Azospirillum_brasilense	1.0		
-NCBITaxon:1931	Streptomyces sp.	NONE		NONE			
-NCBITaxon:1935183	Promethearchaeati	NONE		NONE			
-NCBITaxon:1979961	Wenzhouxiangella sp.	NONE		NONE			
-NCBITaxon:198620	Pseudomonas koreensis	NONE		NONE			
-NCBITaxon:1988	Actinomadura	GTDB:g__Spirillospora	0.953	GTDB:g__Spirillospora	0.948		
-NCBITaxon:2	Bacteria	NONE		NONE			
-NCBITaxon:20	Phenylobacterium	GTDB:g__Phenylobacterium	1.0	GTDB:g__Phenylobacterium	1.0		
-NCBITaxon:200795	Chloroflexota	GTDB:p__Chloroflexota	0.998	GTDB:p__Chloroflexota	0.998		
-NCBITaxon:200918	Thermotogota	GTDB:p__Thermotogota	0.997	GTDB:p__Thermotogota	0.996		
-NCBITaxon:201174	Actinomycetota	GTDB:p__Actinomycetota	1.0	GTDB:p__Actinomycetota	1.0		
-NCBITaxon:202950	Acinetobacter baylyi	GTDB:s__Acinetobacter_baylyi	0.96	GTDB:s__Acinetobacter_baylyi	0.96		
-NCBITaxon:2030806	Burkholderiaceae bacterium	NONE		NONE			
-NCBITaxon:203119	Acetivibrio thermocellus ATCC 27405	GTDB:s__Hungateiclostridium_thermocellum	0.93	GTDB:s__Hungateiclostridium_thermocellum	0.93		
-NCBITaxon:203124	Trichodesmium erythraeum IMS101	GTDB:s__Trichodesmium_erythraeum	1.0	GTDB:s__Trichodesmium_erythraeum	1.0		
-NCBITaxon:2034	Curtobacterium	GTDB:g__Curtobacterium	0.993	GTDB:g__Curtobacterium	0.993		
-NCBITaxon:203682	Planctomycetota	GTDB:p__Planctomycetota	0.995	GTDB:p__Planctomycetota	0.995		
-NCBITaxon:203691	Spirochaetota	GTDB:p__Spirochaetota	0.995	GTDB:p__Spirochaetota	0.992		
-NCBITaxon:204441	Rhodospirillales	GTDB:o__RF32	0.636	GTDB:o__RF32	0.647		
-NCBITaxon:2052312	Candidatus Dormiibacterota	NONE		NONE			
-NCBITaxon:2093828	Neorhizobium tomejilense	GTDB:s__Neorhizobium_tomejilense	0.9	GTDB:s__Neorhizobium_tomejilense	0.9		
-NCBITaxon:211586	Shewanella oneidensis MR-1	GTDB:s__Shewanella_oneidensis	1.0	GTDB:s__Shewanella_oneidensis	1.0		
-NCBITaxon:213118	Desulfobacterales	GTDB:o__Desulfobacterales	0.81	GTDB:o__Desulfobacterales	0.79		
-NCBITaxon:213119	Desulfobacteraceae	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:213121	Desulfobulbaceae	GTDB:f__Desulfobulbaceae	0.529	GTDB:f__Desulfobulbaceae	0.517		
-NCBITaxon:2157	Archaea	NONE		NONE			
-NCBITaxon:215813	Dinoroseobacter shibae	GTDB:s__Dinoroseobacter_shibae	1.0	GTDB:s__Dinoroseobacter_shibae	1.0		
-NCBITaxon:2162	Methanobacterium formicicum	GTDB:s__Methanobacterium_formicicum	0.94	GTDB:s__Methanobacterium_formicicum	0.94		
-NCBITaxon:216389	Dehalococcoides mccartyi BAV1	GTDB:s__Dehalococcoides_mccartyi_B	1.0	GTDB:s__Dehalococcoides_mccartyi_B	1.0		
-NCBITaxon:216431	Croceibacter	GTDB:g__Croceibacter	1.0	GTDB:g__Croceibacter	1.0		
-NCBITaxon:216816	Bifidobacterium longum	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:217159	Clostridium carboxidivorans	GTDB:s__Clostridium_AM_carboxidivorans	1.0	GTDB:s__Clostridium_AM_carboxidivorans	1.0		
-NCBITaxon:2172	Methanobrevibacter	GTDB:g__Methanobrevibacter_A	0.955	GTDB:g__Methanobrevibacter_A	0.955		
-NCBITaxon:2173	Methanobrevibacter smithii	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:22	Shewanella	GTDB:g__Shewanella	0.996	GTDB:g__Shewanella	0.994		
-NCBITaxon:2201	Methanofollis liminatans	GTDB:s__Methanofollis_liminatans	1.0	GTDB:s__Methanofollis_liminatans	1.0		
-NCBITaxon:2203	Methanospirillum hungatei	GTDB:s__Methanospirillum_hungatei	1.0	GTDB:s__Methanospirillum_hungatei	1.0		
-NCBITaxon:2208	Methanosarcina barkeri	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:2209	Methanosarcina mazei	GTDB:s__Methanosarcina_mazei	1.0	GTDB:s__Methanosarcina_mazei	1.0		
-NCBITaxon:222	Achromobacter	GTDB:g__Achromobacter	0.981	GTDB:g__Achromobacter	0.981		
-NCBITaxon:2223	Methanothrix soehngenii	GTDB:s__Methanothrix_soehngenii	1.0	GTDB:s__Methanothrix_soehngenii	1.0		
-NCBITaxon:2237	Haloarcula	GTDB:g__Haloarcula	1.0	GTDB:g__Haloarcula	1.0		
-NCBITaxon:2239	Halobacterium	GTDB:g__Halobacterium	1.0	GTDB:g__Halobacterium	1.0		
-NCBITaxon:223967	Methylorubrum populi	GTDB:s__Methylobacterium_thiocyanatum	1.0	GTDB:s__Methylobacterium_thiocyanatum	1.0		
-NCBITaxon:224756	Methanomicrobia	GTDB:c__Methanosarcinia	0.617	GTDB:c__Methanosarcinia	0.617		
-NCBITaxon:225937	Marinobacter adhaerens HP15	GTDB:s__Marinobacter_adhaerens	1.0	GTDB:s__Marinobacter_adhaerens	1.0		
-NCBITaxon:226186	Bacteroides thetaiotaomicron VPI-5482	GTDB:s__Bacteroides_thetaiotaomicron	1.0	GTDB:s__Bacteroides_thetaiotaomicron	1.0		
-NCBITaxon:2268204	Thermoplasmatales archaeon	NONE		NONE			
-NCBITaxon:2283796	Thermoplasmatota	GTDB:p__Thermoplasmatota	1.0	GTDB:p__Thermoplasmatota	0.999		
-NCBITaxon:2301	Thermoplasmatales	GTDB:o__Thermoplasmatales	0.903	GTDB:o__Thermoplasmatales	0.899		
-NCBITaxon:231455	Dyella japonica	GTDB:s__Dyella_marensis	1.0	GTDB:s__Dyella_marensis	1.0		
-NCBITaxon:2357	Desulfomonile	GTDB:g__Desulfomonile	0.667	GTDB:g__Desulfomonile	0.667		
-NCBITaxon:236401	Graphocephala coccinea	NONE		NONE			
-NCBITaxon:237	Flavobacterium	GTDB:g__Flavobacterium	0.99	GTDB:g__Flavobacterium	0.99		
-NCBITaxon:2375	Sporomusa	GTDB:g__Sporomusa	1.0	GTDB:g__Sporomusa	1.0		
-NCBITaxon:237612	Sphingomonas panni	GTDB:s__Sphingomonas_panni	1.0	GTDB:s__Sphingomonas_panni	1.0		
-NCBITaxon:239	Flavobacterium sp.	NONE		NONE			
-NCBITaxon:243164	Dehalococcoides mccartyi 195	GTDB:s__Dehalococcoides_mccartyi	1.0	GTDB:s__Dehalococcoides_mccartyi	1.0		
-NCBITaxon:243232	Methanocaldococcus jannaschii DSM 2661	GTDB:s__Methanocaldococcus_jannaschii	1.0	GTDB:s__Methanocaldococcus_jannaschii	1.0		
-NCBITaxon:243274	Thermotoga maritima MSB8	GTDB:s__Thermotoga_maritima	1.0	GTDB:s__Thermotoga_maritima	1.0		
-NCBITaxon:244366	Klebsiella variicola	GTDB:s__Klebsiella_variicola	1.0	GTDB:s__Klebsiella_variicola	1.0		
-NCBITaxon:246200	Ruegeria pomeroyi DSS-3	GTDB:s__Ruegeria_B_pomeroyi	1.0	GTDB:s__Ruegeria_B_pomeroyi	1.0		
-NCBITaxon:2496117	Variovorax beijingensis	NONE		NONE			
-NCBITaxon:253	Chryseobacterium indologenes	GTDB:s__Chryseobacterium_indologenes	1.0	GTDB:s__Chryseobacterium_indologenes	1.0		
-NCBITaxon:2530459	Galdieria sp.	NONE		NONE			
-NCBITaxon:253314	Acetivibrio straminisolvens	GTDB:s__Hungateiclostridium_straminisolvens	1.0	GTDB:s__Hungateiclostridium_straminisolvens	1.0		
-NCBITaxon:258594	Rhodopseudomonas palustris CGA009	GTDB:s__Rhodopseudomonas_palustris_F	1.0	GTDB:s__Rhodopseudomonas_palustris_F	1.0		
-NCBITaxon:2591003	Ferroplasma sp.	NONE		NONE			
-NCBITaxon:2597222	Candidatus Acidulidesulfobacterium	NONE		NONE			
-NCBITaxon:266	Paracoccus denitrificans	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:267377	Methanococcus maripaludis S2	GTDB:s__Methanococcus_maripaludis	1.0	GTDB:s__Methanococcus_maripaludis	1.0		
-NCBITaxon:2675547	Chlorella sp. HS2	NONE		NONE			
-NCBITaxon:267818	Lactobacillus kefiranofaciens	GTDB:s__Lactobacillus_kefiranofaciens	1.0	GTDB:s__Lactobacillus_kefiranofaciens	1.0		
-NCBITaxon:2697049	Severe acute respiratory syndrome coronavirus 2	NONE		NONE			
-NCBITaxon:269797	Methanosarcina barkeri str. Fusaro	GTDB:s__Methanosarcina_barkeri_B	1.0	GTDB:s__Methanosarcina_barkeri_B	1.0		
-NCBITaxon:270351	Methylobacterium aquaticum	NONE		NONE			
-NCBITaxon:2716471	Sulcia	NONE		NONE			
-NCBITaxon:272772	Pseudomonas pudica	GTDB:s__Pseudomonas_E_pudica	1.0	GTDB:s__Pseudomonas_E_pudica	1.0		
-NCBITaxon:2736640	Pseudonocardia broussonetiae	GTDB:s__Pseudonocardia_broussonetiae	1.0	GTDB:s__Pseudonocardia_broussonetiae	1.0		
-NCBITaxon:2740557	Pauljensenia	GTDB:g__Pauljensenia	1.0	GTDB:g__Pauljensenia	1.0		
-NCBITaxon:2742	Marinobacter	GTDB:g__Marinobacter	0.964	GTDB:g__Marinobacter	0.958		
-NCBITaxon:2759	Eukaryota	NONE		NONE			
-NCBITaxon:2782567	Paenarthrobacter sp. GOM3	GTDB:s__Arthrobacter_sp018215265	1.0	GTDB:s__Arthrobacter_sp018215265	1.0		
-NCBITaxon:280333	Bradyrhizobium pachyrhizi	NONE		NONE			
-NCBITaxon:28034	Sulfobacillus thermosulfidooxidans	GTDB:s__Sulfobacillus_thermosulfidooxidans	1.0	GTDB:s__Sulfobacillus_thermosulfidooxidans	1.0		
-NCBITaxon:28037	Streptococcus mitis	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:28065	Rhodoferax	GTDB:g__Rhodoferax	0.718	GTDB:g__Rhodoferax	0.718		
-NCBITaxon:28108	Alteromonas macleodii	GTDB:s__Alteromonas_macleodii	0.9	GTDB:s__Alteromonas_macleodii	0.9		
-NCBITaxon:2818505	Myxococcota	GTDB:p__Myxococcota	0.903	GTDB:p__Myxococcota	0.9		
-NCBITaxon:28211	Alphaproteobacteria	GTDB:c__Alphaproteobacteria	0.996	GTDB:c__Alphaproteobacteria	0.996		
-NCBITaxon:28216	Betaproteobacteria	GTDB:c__Gammaproteobacteria	1.0	GTDB:c__Gammaproteobacteria	1.0		
-NCBITaxon:28228	Colwellia	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:28231	Geobacter	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:28232	Geobacter metallireducens	GTDB:s__Geobacter_metallireducens	1.0	GTDB:s__Geobacter_metallireducens	1.0		
-NCBITaxon:28261	Thermodesulfovibrio	GTDB:g__Thermodesulfovibrio	1.0	GTDB:g__Thermodesulfovibrio	1.0		
-NCBITaxon:2836	Bacillariophyta	NONE		NONE			
-NCBITaxon:2837503	Gottfriedia	GTDB:g__Gottfriedia	1.0	GTDB:g__Gottfriedia	1.0		
-NCBITaxon:28453	Sphingobacterium	GTDB:g__Sphingobacterium	0.996	GTDB:g__Sphingobacterium	0.996		
-NCBITaxon:286	Pseudomonas	GTDB:g__Pseudomonas	0.596	GTDB:g__Pseudomonas_E	0.852	FLIP	different taxon
-NCBITaxon:287	Pseudomonas aeruginosa	GTDB:s__Pseudomonas_aeruginosa	0.99	GTDB:s__Pseudomonas_aeruginosa	0.99		
-NCBITaxon:2886510	Sphingobacterium paramultivorum	GTDB:s__Sphingobacterium_paramultivorum	0.88	GTDB:s__Sphingobacterium_paramultivorum	0.88		
-NCBITaxon:28889	Thermoproteota	GTDB:p__Thermoproteota	1.0	GTDB:p__Thermoproteota	1.0		
-NCBITaxon:28890	Methanobacteriota	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:2903	Emiliania huxleyi	NONE		NONE			
-NCBITaxon:293387	Bacillus altitudinis	GTDB:s__Bacillus_altitudinis	1.0	GTDB:s__Bacillus_altitudinis	1.0		
-NCBITaxon:29394	Dolosigranulum pigrum	GTDB:s__Dolosigranulum_pigrum	1.0	GTDB:s__Dolosigranulum_pigrum	1.0		
-NCBITaxon:294	Pseudomonas fluorescens	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:29448	Bradyrhizobium elkanii	GTDB:s__Bradyrhizobium_elkanii	0.89	GTDB:s__Bradyrhizobium_elkanii	0.89		
-NCBITaxon:29466	Veillonella parvula	GTDB:s__Veillonella_parvula_A	0.95	GTDB:s__Veillonella_parvula_A	0.95		
-NCBITaxon:29581	Janthinobacterium lividum	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:296543	Thalassiosira pseudonana CCMP1335	NONE		NONE			
-NCBITaxon:2982533	Microbacterium forte	NONE		NONE			
-NCBITaxon:29875	Trichoderma virens	NONE		NONE			
-NCBITaxon:301148	Caldibacillus debilis	GTDB:s__Caldibacillus_debilis	1.0	GTDB:s__Caldibacillus_debilis	1.0		
-NCBITaxon:301375	Methanothrix harundinacea	GTDB:s__Methanocrinis_harundinaceus	1.0	GTDB:s__Methanocrinis_harundinaceus	1.0		
-NCBITaxon:303	Pseudomonas putida	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:3041	Chlorophyta	NONE		NONE			
-NCBITaxon:304371	Methanocella paludicola SANAE	NONE		NONE			
-NCBITaxon:3055	Chlamydomonas reinhardtii	NONE		NONE			
-NCBITaxon:306	Pseudomonas sp.	NONE		NONE			
-NCBITaxon:3071	Chlorella	NONE		NONE			
-NCBITaxon:3073	Scenedesmus fuscus	NONE		NONE			
-NCBITaxon:3074	Parachlorella kessleri	NONE		NONE			
-NCBITaxon:3076	Chlorella sorokiniana	NONE		NONE			
-NCBITaxon:3077	Chlorella vulgaris	NONE		NONE			
-NCBITaxon:316	Stutzerimonas stutzeri	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:316612	Methylibium	GTDB:g__Methylibium	0.607	GTDB:g__Methylibium	0.56		
-NCBITaxon:319464	Clostridium sp. FG4	NONE		NONE			
-NCBITaxon:32008	Burkholderia	GTDB:g__Burkholderia	0.985	GTDB:g__Burkholderia	0.919		
-NCBITaxon:32011	Methylophilaceae	GTDB:f__Methylophilaceae	1.0	GTDB:f__Methylophilaceae	1.0		
-NCBITaxon:32046	Synechococcus elongatus	GTDB:s__Synechococcus_elongatus	0.85	GTDB:s__Synechococcus_elongatus	0.85		
-NCBITaxon:32049	Picosynechococcus sp. PCC 7002	GTDB:s__Limnothrix_sp001693275	1.0	GTDB:s__Limnothrix_sp001693275	1.0		
-NCBITaxon:323259	Methanospirillum hungatei JF-1	GTDB:s__Methanospirillum_hungatei	1.0	GTDB:s__Methanospirillum_hungatei	1.0		
-NCBITaxon:324747	Pseudoxanthomonas byssovorax	NONE		NONE			
-NCBITaxon:33035	Blautia producta	GTDB:s__Blautia_coccoides	1.0	GTDB:s__Blautia_coccoides	1.0		
-NCBITaxon:33038	Mediterraneibacter gnavus	GTDB:s__Ruminococcus_B_gnavus	0.99	GTDB:s__Ruminococcus_B_gnavus	0.99		
-NCBITaxon:33059	Acidithiobacillus caldus	GTDB:s__Acidithiobacillus_A_caldus	1.0	GTDB:s__Acidithiobacillus_A_caldus	1.0		
-NCBITaxon:33075	Acidobacterium capsulatum	NONE		NONE			
-NCBITaxon:332101	Clostridium drakei	GTDB:s__Clostridium_AM_drakei	1.0	GTDB:s__Clostridium_AM_drakei	1.0		
-NCBITaxon:33642	Coscinodiscus radiatus	NONE		NONE			
-NCBITaxon:33849	Bacillariophyceae	NONE		NONE			
-NCBITaxon:3386252	Candidatus Methanogaster	NONE		NONE			
-NCBITaxon:33882	Microbacterium	GTDB:g__Microbacterium	0.995	GTDB:g__Microbacterium	0.995		
-NCBITaxon:33883	Microbacterium arborescens	NONE		NONE			
-NCBITaxon:33905	Bifidobacterium thermophilum	GTDB:s__Bifidobacterium_thermacidophilum	1.0	GTDB:s__Bifidobacterium_thermacidophilum	1.0		
-NCBITaxon:33952	Acetobacterium woodii	GTDB:s__Acetobacterium_woodii	1.0	GTDB:s__Acetobacterium_woodii	1.0		
-NCBITaxon:33962	Lentilactobacillus kefiri	GTDB:s__Lentilactobacillus_kefiri	1.0	GTDB:s__Lentilactobacillus_kefiri	1.0		
-NCBITaxon:340177	Chlorobium chlorochromatii CaD3	NONE	1.0	NONE	1.0		
-NCBITaxon:34037	Rahnella	GTDB:g__Rahnella	1.0	GTDB:g__Rahnella	1.0		
-NCBITaxon:34067	Cycloclasticus	GTDB:g__Cycloclasticus	1.0	GTDB:g__Cycloclasticus	1.0		
-NCBITaxon:34072	Variovorax	GTDB:g__Variovorax	0.99	GTDB:g__Variovorax	0.99		
-NCBITaxon:34073	Variovorax paradoxus	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:34305	Lotus japonicus	NONE		NONE			
-NCBITaxon:34358	Maudiozyma exigua	NONE		NONE			
-NCBITaxon:351627	Caldicellulosiruptor saccharolyticus DSM 8903	GTDB:s__Caldicellulosiruptor_saccharolyticus	1.0	GTDB:s__Caldicellulosiruptor_saccharolyticus	1.0		
-NCBITaxon:353	Azotobacter chroococcum	GTDB:s__Azotobacter_chroococcum	1.0	GTDB:s__Azotobacter_chroococcum	1.0		
-NCBITaxon:354	Azotobacter vinelandii	GTDB:s__Azotobacter_vinelandii	1.0	GTDB:s__Azotobacter_vinelandii	1.0		
-NCBITaxon:354354	Niastella	GTDB:g__Niastella	0.917	GTDB:g__Niastella	0.917		
-NCBITaxon:35554	Geobacter sulfurreducens	GTDB:s__Geobacter_sulfurreducens	1.0	GTDB:s__Geobacter_sulfurreducens	1.0		
-NCBITaxon:356	Hyphomicrobiales	GTDB:o__Rhizobiales	0.988	GTDB:o__Rhizobiales	0.987		
-NCBITaxon:357809	Lachnoclostridium phytofermentans ISDg	GTDB:s__Lachnoclostridium_phytofermentans	1.0	GTDB:s__Lachnoclostridium_phytofermentans	1.0		
-NCBITaxon:358	Agrobacterium tumefaciens	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:359407	Methylotenera	GTDB:g__Methylotenera	0.676	GTDB:g__Methylotenera	0.676		
-NCBITaxon:363331	Chryseobacterium taiwanense	GTDB:s__Chryseobacterium_taiwanense	1.0	GTDB:s__Chryseobacterium_taiwanense	1.0		
-NCBITaxon:36667	Philaenus spumarius	NONE		NONE			
-NCBITaxon:36853	Desulfitobacterium	GTDB:g__Desulfitobacterium	0.946	GTDB:g__Desulfitobacterium	0.943		
-NCBITaxon:36910	Clavispora	NONE		NONE			
-NCBITaxon:3702	Arabidopsis thaliana	NONE		NONE			
-NCBITaxon:372461	Buchnera aphidicola BCc	GTDB:s__Buchnera_aphidicola_F	1.0	GTDB:s__Buchnera_aphidicola_F	1.0		
-NCBITaxon:37319	Pseudo-nitzschia multiseries	NONE		NONE			
-NCBITaxon:374	Bradyrhizobium	GTDB:g__Bradyrhizobium	0.982	GTDB:g__Bradyrhizobium	0.979		
-NCBITaxon:374432	Methylobacterium tardum	GTDB:s__Methylobacterium_tardum	1.0	GTDB:s__Methylobacterium_tardum	1.0		
-NCBITaxon:3747	Fragaria x ananassa	NONE		NONE			
-NCBITaxon:375	Bradyrhizobium japonicum	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:375288	Parabacteroides	GTDB:g__Parabacteroides	0.997	GTDB:g__Parabacteroides	0.997		
-NCBITaxon:375486	Paenibacillus sp. PALXIL05	NONE		NONE			
-NCBITaxon:379	Rhizobium	GTDB:g__Rhizobium	0.723	GTDB:g__Rhizobium	0.723		
-NCBITaxon:37919	Rhodococcus opacus	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:37927	Sinomonas atrocyanea	NONE		NONE			
-NCBITaxon:380021	Pseudomonas protegens	GTDB:s__Pseudomonas_E_protegens	1.0	GTDB:s__Pseudomonas_E_protegens	1.0		
-NCBITaxon:3818	Arachis hypogaea	NONE		NONE			
-NCBITaxon:382	Sinorhizobium meliloti	GTDB:s__Sinorhizobium_meliloti	0.97	GTDB:s__Sinorhizobium_meliloti	0.97		
-NCBITaxon:3847	Glycine max	NONE		NONE			
-NCBITaxon:39152	Methanococcus maripaludis	GTDB:s__Methanococcus_maripaludis	0.93	GTDB:s__Methanococcus_maripaludis	0.93		
-NCBITaxon:391619	Phaeobacter inhibens DSM 17395	GTDB:s__Phaeobacter_inhibens	1.0	GTDB:s__Phaeobacter_inhibens	1.0		
-NCBITaxon:392733	Terriglobus	GTDB:g__Terriglobus	0.833	GTDB:g__Terriglobus	0.818		
-NCBITaxon:3932	Eucalyptus	NONE		NONE			
-NCBITaxon:39488	Anaerobutyricum hallii	GTDB:s__Anaerobutyricum_hallii	1.0	GTDB:s__Anaerobutyricum_hallii	1.0		
-NCBITaxon:395331	Methanoregula	GTDB:g__Methanoregula	1.0	GTDB:g__Methanoregula	1.0		
-NCBITaxon:395960	Rhodopseudomonas palustris TIE-1	GTDB:s__Rhodopseudomonas_palustris_F	1.0	GTDB:s__Rhodopseudomonas_palustris_F	1.0		
-NCBITaxon:399726	Thermoanaerobacter sp. X514	GTDB:s__Thermoanaerobacter_pseudethanolicus	1.0	GTDB:s__Thermoanaerobacter_pseudethanolicus	1.0		
-NCBITaxon:40214	Acinetobacter johnsonii	GTDB:s__Acinetobacter_johnsonii	0.97	GTDB:s__Acinetobacter_johnsonii	0.97		
-NCBITaxon:40222	Methylophaga	GTDB:g__Methylophaga	0.967	GTDB:g__Methylophaga	0.966		
-NCBITaxon:403	Methylococcaceae	GTDB:f__Methylomonadaceae	0.64	GTDB:f__Methylomonadaceae	0.671		
-NCBITaxon:40323	Stenotrophomonas	GTDB:g__Stenotrophomonas	0.987	GTDB:g__Stenotrophomonas	0.987		
-NCBITaxon:40324	Stenotrophomonas maltophilia	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:407	Methylobacterium	GTDB:g__Methylobacterium	0.992	GTDB:g__Methylobacterium	0.991		
-NCBITaxon:408	Methylorubrum extorquens	GTDB:s__Methylobacterium_extorquens	0.88	GTDB:s__Methylobacterium_extorquens	0.88		
-NCBITaxon:4081	Solanum lycopersicum	NONE		NONE			
-NCBITaxon:412449	Leptospirillum ferrodiazotrophum	NONE		NONE			
-NCBITaxon:414878	Catenulispora	GTDB:g__Catenulispora	1.0	GTDB:g__Catenulispora	1.0		
-NCBITaxon:416	Methylomonas	GTDB:g__Methylomonas	0.948	GTDB:g__Methylomonas	0.948		
-NCBITaxon:416169	Rhodanobacter thiooxydans	GTDB:s__Rhodanobacter_thiooxydans	1.0	GTDB:s__Rhodanobacter_thiooxydans	1.0		
-NCBITaxon:419541	Leptospirillum sp. Group II '5-way CG'	NONE		NONE			
-NCBITaxon:423349	Mucilaginibacter	GTDB:g__Mucilaginibacter	1.0	GTDB:g__Mucilaginibacter	1.0		
-NCBITaxon:42445	Sinorhizobium sp.	GTDB:s__Sinorhizobium_sp031178305	1.0	GTDB:s__Sinorhizobium_sp031178305	1.0		
-NCBITaxon:429	Methylobacter	GTDB:g__Methylobacter_A	0.662	GTDB:g__Methylobacter_A	0.682		
-NCBITaxon:429134	Sphingomonas desiccabilis	GTDB:s__Sphingomonas_desiccabilis	1.0	GTDB:s__Sphingomonas_desiccabilis	1.0		
-NCBITaxon:434	Acetobacter	GTDB:g__Acetobacter	0.561	GTDB:g__CAG-267	0.522	FLIP	different taxon
-NCBITaxon:43773	Syntrophus <bacteria>	GTDB:g__Syntrophus	1.0	GTDB:g__Syntrophus	1.0		
-NCBITaxon:43775	Syntrophus gentianae	GTDB:s__Syntrophus_gentianae	1.0	GTDB:s__Syntrophus_gentianae	1.0		
-NCBITaxon:441	Gluconobacter	GTDB:g__Gluconobacter	0.71	GTDB:g__Gluconobacter	0.762		
-NCBITaxon:44249	Paenibacillus	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:44752	Rhodococcus wratislaviensis	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:45200	Methanospirillum sp.	NONE		NONE			
-NCBITaxon:452922	Xenophilus aerolatus	NONE		NONE			
-NCBITaxon:453960	Sulfobacillus benefaciens	GTDB:s__Sulfobacillus_benefaciens	0.96	GTDB:s__Sulfobacillus_benefaciens	0.96		
-NCBITaxon:4547	Saccharum officinarum	NONE		NONE			
-NCBITaxon:4558	Sorghum bicolor	NONE		NONE			
-NCBITaxon:4565	Triticum aestivum	NONE		NONE			
-NCBITaxon:4577	Zea mays	NONE		NONE			
-NCBITaxon:45989	Methanoculleus	GTDB:g__Methanoculleus	0.947	GTDB:g__Methanoculleus	0.947		
-NCBITaxon:46255	Weissella	GTDB:g__Weissella	1.0	GTDB:g__Weissella	1.0		
-NCBITaxon:46913	Devosia	GTDB:g__Devosia	0.769	GTDB:g__Devosia	0.77		
-NCBITaxon:470	Acinetobacter baumannii	GTDB:s__Acinetobacter_baumannii	1.0	GTDB:s__Acinetobacter_baumannii	1.0		
-NCBITaxon:47421	Hydrogenophaga pseudoflava	GTDB:s__Hydrogenophaga_pseudoflava	1.0	GTDB:s__Hydrogenophaga_pseudoflava	1.0		
-NCBITaxon:475088	Methanosphaerula palustris	GTDB:s__Methanosphaerula_palustris	1.0	GTDB:s__Methanosphaerula_palustris	1.0		
-NCBITaxon:4751	Fungi	NONE		NONE			
-NCBITaxon:4757	Neocallimastix frontalis	NONE		NONE			
-NCBITaxon:47715	Lacticaseibacillus rhamnosus	GTDB:s__Lacticaseibacillus_rhamnosus	1.0	GTDB:s__Lacticaseibacillus_rhamnosus	1.0		
-NCBITaxon:47920	Acidovorax delafieldii	NONE		NONE			
-NCBITaxon:483199	Acetobacter fabarum	GTDB:s__Acetobacter_fabarum	1.0	GTDB:s__Acetobacter_fabarum	1.0		
-NCBITaxon:487698	Stenotrophomonas pavanii	GTDB:s__Stenotrophomonas_pavanii	1.0	GTDB:s__Stenotrophomonas_pavanii	1.0		
-NCBITaxon:4890	Ascomycota	NONE		NONE			
-NCBITaxon:48936	Novosphingobium subterraneum	GTDB:s__Novosphingobium_subterraneum	1.0	GTDB:s__Novosphingobium_subterraneum	1.0		
-NCBITaxon:4919	Pichia	NONE		NONE			
-NCBITaxon:492670	Bacillus velezensis	GTDB:s__Bacillus_velezensis	1.0	GTDB:s__Bacillus_velezensis	1.0		
-NCBITaxon:4930	Saccharomyces	NONE		NONE			
-NCBITaxon:4932	Saccharomyces cerevisiae	NONE		NONE			
-NCBITaxon:4948	Torulaspora	NONE		NONE			
-NCBITaxon:4952	Yarrowia lipolytica	NONE		NONE			
-NCBITaxon:4958	Debaryomyces	NONE		NONE			
-NCBITaxon:497726	Nitrososphaera	GTDB:g__Nitrososphaera	0.833	GTDB:g__Nitrososphaera	0.769		
-NCBITaxon:5052	Aspergillus <genus>	NONE		NONE			
-NCBITaxon:5059	Aspergillus flavus	NONE		NONE			
-NCBITaxon:5061	Aspergillus niger	NONE		NONE			
-NCBITaxon:50715	Acidisphaera rubrifaciens	GTDB:s__Acidisphaera_rubrifaciens	1.0	GTDB:s__Acidisphaera_rubrifaciens	1.0		
-NCBITaxon:5073	Penicillium	NONE		NONE			
-NCBITaxon:511145	Escherichia coli str. K-12 substr. MG1655	GTDB:s__Escherichia_coli	1.0	GTDB:s__Escherichia_coli	1.0		
-NCBITaxon:511746	Candidatus Methylacidiphilum infernorum	GTDB:s__Methylacidiphilum_infernorum	1.0	GTDB:s__Methylacidiphilum_infernorum	1.0		
-NCBITaxon:51453	Trichoderma reesei	NONE		NONE			
-NCBITaxon:515619	Agathobacter rectalis ATCC 33656	GTDB:s__Agathobacter_rectalis	1.0	GTDB:s__Agathobacter_rectalis	1.0		
-NCBITaxon:5204	Basidiomycota	NONE		NONE			
-NCBITaxon:5206	Cryptococcus <basidiomycete fungi>	NONE		NONE			
-NCBITaxon:521460	Caldicellulosiruptor bescii DSM 6725	GTDB:s__Caldicellulosiruptor_bescii	1.0	GTDB:s__Caldicellulosiruptor_bescii	1.0		
-NCBITaxon:522	Acidiphilium	GTDB:g__UBA10281	0.633	GTDB:g__UBA10281	0.682		
-NCBITaxon:524	Acidiphilium cryptum	GTDB:s__Acidiphilium_multivorum	1.0	GTDB:s__Acidiphilium_multivorum	1.0		
-NCBITaxon:525	Acidocella facilis	GTDB:s__Acidocella_facilis	1.0	GTDB:s__Acidocella_facilis	1.0		
-NCBITaxon:52972	Polaromonas	GTDB:g__Polaromonas	0.959	GTDB:g__Polaromonas	0.958		
-NCBITaxon:53335	Pantoea	GTDB:g__Pantoea	0.961	GTDB:g__Pantoea	0.928		
-NCBITaxon:542	Zymomonas mobilis	GTDB:s__Zymomonas_mobilis	0.89	GTDB:s__Zymomonas_mobilis	0.89		
-NCBITaxon:54298	Chroococcidiopsis	GTDB:g__Chroococcidiopsis	0.778	GTDB:g__Chroococcidiopsis	0.778		
-NCBITaxon:546	Citrobacter freundii	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:547	Enterobacter	GTDB:g__Enterobacter	0.968	GTDB:g__Enterobacter	0.958		
-NCBITaxon:5475	Candida	NONE		NONE			
-NCBITaxon:5476	Candida albicans	NONE		NONE			
-NCBITaxon:5480	Candida parapsilosis	NONE		NONE			
-NCBITaxon:549	Pantoea agglomerans	GTDB:s__Pantoea_agglomerans	0.9	GTDB:s__Pantoea_agglomerans	0.9		
-NCBITaxon:5498	Cladosporium	NONE		NONE			
-NCBITaxon:550	Enterobacter cloacae	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:5507	Fusarium oxysporum	NONE		NONE			
-NCBITaxon:55080	Brevibacillus	GTDB:g__Brevibacillus	0.816	GTDB:g__Brevibacillus	0.779		
-NCBITaxon:553	Pantoea ananatis	GTDB:s__Pantoea_ananatis	0.99	GTDB:s__Pantoea_ananatis	0.99		
-NCBITaxon:5535	Rhodotorula glutinis	NONE		NONE			
-NCBITaxon:5544	Trichoderma harzianum	NONE		NONE			
-NCBITaxon:5547	Trichoderma viride	NONE		NONE			
-NCBITaxon:5552	Trichosporon	NONE		NONE			
-NCBITaxon:561	Escherichia	GTDB:g__Escherichia	1.0	GTDB:g__Escherichia	0.999		
-NCBITaxon:56112	Dehalobacter	GTDB:g__Dehalobacter	1.0	GTDB:g__Dehalobacter	1.0		
-NCBITaxon:561879	Bacillus safensis	GTDB:s__Bacillus_safensis	1.0	GTDB:s__Bacillus_safensis	1.0		
-NCBITaxon:562	Escherichia coli	GTDB:s__Escherichia_coli	1.0	GTDB:s__Escherichia_coli	1.0		
-NCBITaxon:56780	Syntrophus aciditrophicus SB	GTDB:s__Syntrophus_aciditrophicus	1.0	GTDB:s__Syntrophus_aciditrophicus	1.0		
-NCBITaxon:570	Klebsiella	GTDB:g__Klebsiella	0.999	GTDB:g__Klebsiella	0.999		
-NCBITaxon:571256	Brucella pituitosa	NONE		NONE			
-NCBITaxon:5722	Trichomonas vaginalis	NONE		NONE			
-NCBITaxon:572545	Acetivibrio thermocellus DSM 2360	GTDB:s__Hungateiclostridium_thermocellum	1.0	GTDB:s__Hungateiclostridium_thermocellum	1.0		
-NCBITaxon:573061	Clostridium cellulovorans 743B	GTDB:s__Clostridium_K_cellulovorans	1.0	GTDB:s__Clostridium_K_cellulovorans	1.0		
-NCBITaxon:573657	Candidatus Hodgkinia	NONE		NONE			
-NCBITaxon:574561	Rhizobium pisi	NONE		NONE			
-NCBITaxon:57723	Acidobacteriota	GTDB:p__Acidobacteriota	0.976	GTDB:p__Acidobacteriota	0.975		
-NCBITaxon:587753	Pseudomonas chlororaphis	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:588814	Candidatus Methanophagales	NONE		NONE			
-NCBITaxon:588816	ANME-2 cluster	NONE		NONE			
-NCBITaxon:592050	Acidovorax soli	NONE		NONE			
-NCBITaxon:59732	Chryseobacterium	GTDB:g__Chryseobacterium	0.836	GTDB:g__Chryseobacterium	0.836		
-NCBITaxon:599737	Wickerhamomyces	NONE		NONE			
-NCBITaxon:613	Serratia <enterobacteria>	GTDB:g__Serratia	0.519	GTDB:g__Serratia	0.661		
-NCBITaxon:61434	Dehalococcoides	GTDB:g__Dehalococcoides	0.909	GTDB:g__Dehalococcoides	0.909		
-NCBITaxon:61435	Dehalococcoides mccartyi	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:61624	Paenibacillus mucilaginosus	GTDB:s__Paenibacillus_G_mucilaginosus	0.88	GTDB:s__Paenibacillus_G_mucilaginosus	0.88		
-NCBITaxon:62140	Acidiphilium multivorum	GTDB:s__Acidiphilium_multivorum	1.0	GTDB:s__Acidiphilium_multivorum	1.0		
-NCBITaxon:6239	Caenorhabditis elegans	NONE		NONE			
-NCBITaxon:632335	Caldicellulosiruptor acetigenus I77R1B	GTDB:s__Caldicellulosiruptor_acetigenus	1.0	GTDB:s__Caldicellulosiruptor_acetigenus	1.0		
-NCBITaxon:63743	Natronomonas	GTDB:g__Natronomonas	0.957	GTDB:g__Natronomonas	0.957		
-NCBITaxon:641853	Elusimicrobia	GTDB:c__Elusimicrobia	1.0	GTDB:c__Elusimicrobia	1.0		
-NCBITaxon:644	Aeromonas hydrophila	GTDB:s__Aeromonas_hydrophila	0.96	GTDB:s__Aeromonas_hydrophila	0.96		
-NCBITaxon:648995	Agrobacterium pusense	GTDB:s__Agrobacterium_pusense	1.0	GTDB:s__Agrobacterium_pusense	1.0		
-NCBITaxon:651137	Nitrososphaerota	GTDB:p__Thermoproteota	1.0	GTDB:p__Thermoproteota	1.0		
-NCBITaxon:659243	Bacillus siamensis	GTDB:s__Bacillus_siamensis	0.85	GTDB:s__Bacillus_siamensis	0.85		
-NCBITaxon:666685	Rhodanobacter denitrificans	NONE		NONE			
-NCBITaxon:668369	Escherichia coli DH5[alpha]	GTDB:s__Escherichia_coli	1.0	GTDB:s__Escherichia_coli	1.0		
-NCBITaxon:67812	Candidatus Omnitrophota	NONE		NONE			
-NCBITaxon:68	Lysobacter	GTDB:g__Lysobacter	0.748	GTDB:g__Lysobacter	0.748		
-NCBITaxon:68239	Streptomyces mirabilis	NONE		NONE			
-NCBITaxon:68287	Mesorhizobium	GTDB:g__Mesorhizobium	0.97	GTDB:g__Mesorhizobium	0.969		
-NCBITaxon:69373	Curtobacterium pusillum	NONE		NONE			
-NCBITaxon:69488	Penicillium simplicissimum	NONE		NONE			
-NCBITaxon:69823	Selenomonas sputigena	GTDB:s__Selenomonas_sp905372355	0.86	GTDB:s__Selenomonas_sp905372355	0.86		
-NCBITaxon:70448	Ostreococcus tauri	NONE		NONE			
-NCBITaxon:70863	Shewanella oneidensis	GTDB:s__Shewanella_oneidensis	1.0	GTDB:s__Shewanella_oneidensis	1.0		
-NCBITaxon:71518	Methanocorpusculum bavaricum	GTDB:s__Methanocorpusculum_parvum	1.0	GTDB:s__Methanocorpusculum_parvum	1.0		
-NCBITaxon:7227	Drosophila melanogaster	NONE		NONE			
-NCBITaxon:74030	Roseovarius	GTDB:g__Roseovarius	0.971	GTDB:g__Roseovarius	0.969		
-NCBITaxon:74201	Verrucomicrobiota	GTDB:p__Verrucomicrobiota	1.0	GTDB:p__Verrucomicrobiota	1.0		
-NCBITaxon:74969	Ferroplasma acidiphilum	GTDB:s__Ferroplasma_acidarmanus	0.91	GTDB:s__Ferroplasma_acidarmanus	0.91		
-NCBITaxon:75	Caulobacter	GTDB:g__Caulobacter	0.837	GTDB:g__Caulobacter	0.837		
-NCBITaxon:75105	Paraburkholderia caribensis	GTDB:s__Paraburkholderia_caribensis	0.92	GTDB:s__Paraburkholderia_caribensis	0.92		
-NCBITaxon:75654	Duganella	GTDB:g__Duganella	0.886	GTDB:g__Duganella	0.886		
-NCBITaxon:75682	Oxalobacteraceae	GTDB:f__Burkholderiaceae	0.995	GTDB:f__Burkholderiaceae	0.996		
-NCBITaxon:76759	Pseudomonas monteilii	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:76890	Asticcacaulis	GTDB:g__Asticcacaulis	1.0	GTDB:g__Asticcacaulis	1.0		
-NCBITaxon:79206	Desulfosporosinus	GTDB:g__Desulfosporosinus	1.0	GTDB:g__Desulfosporosinus	1.0		
-NCBITaxon:79328	Chitinophaga	GTDB:g__Chitinophaga	1.0	GTDB:g__Chitinophaga	1.0		
-NCBITaxon:795830	Candidatus Brocadia sinica	GTDB:s__Brocadia_sinica	1.0	GTDB:s__Brocadia_sinica	1.0		
-NCBITaxon:80840	Burkholderiales	GTDB:o__Burkholderiales	1.0	GTDB:o__Burkholderiales	0.999		
-NCBITaxon:80866	Delftia acidovorans	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:816	Bacteroides	GTDB:g__Bacteroides	0.953	GTDB:g__Bacteroides	0.953		
-NCBITaxon:817	Bacteroides fragilis	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:818	Bacteroides thetaiotaomicron	GTDB:s__Bacteroides_thetaiotaomicron	0.99	GTDB:s__Bacteroides_thetaiotaomicron	0.99		
-NCBITaxon:82	Hyphomicrobium sp.	NONE		NONE			
-NCBITaxon:821	Phocaeicola vulgatus	GTDB:s__Phocaeicola_vulgatus	0.86	GTDB:s__Phocaeicola_vulgatus	0.86		
-NCBITaxon:82380	Microbacterium oxydans	NONE		NONE			
-NCBITaxon:82803	Trichococcus flocculiformis	GTDB:s__Trichococcus_flocculiformis	1.0	GTDB:s__Trichococcus_flocculiformis	1.0		
-NCBITaxon:831	Butyrivibrio fibrisolvens	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:83333	Escherichia coli K-12	GTDB:s__Escherichia_coli	1.0	GTDB:s__Escherichia_coli	1.0		
-NCBITaxon:83677	Thermobifida	GTDB:g__Thermobifida	1.0	GTDB:g__Thermobifida	1.0		
-NCBITaxon:84022	Andreesenella acetica	GTDB:s__Clostridium_W_aceticum	1.0	GTDB:s__Clostridium_W_aceticum	1.0		
-NCBITaxon:84023	Clostridium autoethanogenum	GTDB:s__Clostridium_B_ljungdahlii	1.0	GTDB:s__Clostridium_B_ljungdahlii	1.0		
-NCBITaxon:84565	Sodalis	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:84567	Pedobacter	GTDB:g__Pedobacter	0.924	GTDB:g__Pedobacter	0.924		
-NCBITaxon:85021	Intrasporangiaceae	GTDB:f__Dermatophilaceae	0.997	GTDB:f__Dermatophilaceae	0.997		
-NCBITaxon:853	Faecalibacterium prausnitzii	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:857252	Halopseudomonas aestusnigri	GTDB:s__Halopseudomonas_aestusnigri	1.0	GTDB:s__Halopseudomonas_aestusnigri	1.0		
-NCBITaxon:863	Syntrophomonas wolfei	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:86795	Marmoricola	GTDB:g__Marmoricola	0.923	GTDB:g__Marmoricola	0.923		
-NCBITaxon:870529	Bacillus sp. DB7	NONE		NONE			
-NCBITaxon:870530	Klebsiella sp. DB13	NONE		NONE			
-NCBITaxon:870532	Ochrobactrum sp. DB8	NONE		NONE			
-NCBITaxon:872	Desulfovibrio	GTDB:g__Desulfovibrio	0.871	GTDB:g__Desulfovibrio	0.876		
-NCBITaxon:876	Desulfovibrio desulfuricans	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:881	Nitratidesulfovibrio vulgaris	GTDB:s__Nitratidesulfovibrio_vulgaris	1.0	GTDB:s__Nitratidesulfovibrio_vulgaris	1.0		
-NCBITaxon:882	Nitratidesulfovibrio vulgaris str. Hildenborough	GTDB:s__Nitratidesulfovibrio_vulgaris	1.0	GTDB:s__Nitratidesulfovibrio_vulgaris	1.0		
-NCBITaxon:885	Desulfovibrio sp.	NONE		NONE			
-NCBITaxon:88730	Pinus massoniana	NONE		NONE			
-NCBITaxon:901	Desulfovibrio piger	GTDB:s__Desulfovibrio_piger	1.0	GTDB:s__Desulfovibrio_piger	1.0		
-NCBITaxon:90371	Salmonella enterica subsp. enterica serovar Typhimurium	GTDB:s__Salmonella_enterica	1.0	GTDB:s__Salmonella_enterica	1.0		
-NCBITaxon:904	Acidaminococcus	GTDB:g__Acidaminococcus	0.991	GTDB:g__Acidaminococcus	0.991		
-NCBITaxon:90964	Staphylococcaceae	GTDB:f__Staphylococcaceae	0.993	GTDB:f__Staphylococcaceae	0.964		
-NCBITaxon:91061	Bacilli	GTDB:c__Bacilli	0.996	GTDB:c__Bacilli	0.984		
-NCBITaxon:913	Nitrobacter winogradskyi	GTDB:s__Nitrobacter_winogradskyi_A	0.88	GTDB:s__Nitrobacter_winogradskyi_A	0.88		
-NCBITaxon:915	Nitrosomonas europaea	GTDB:s__Nitrosomonas_europaea	1.0	GTDB:s__Nitrosomonas_europaea	1.0		
-NCBITaxon:919	Thiobacillus	GTDB:g__Thiobacillus	0.714	GTDB:g__Thiobacillus	0.708		
-NCBITaxon:920	Acidithiobacillus ferrooxidans	GTDB:s__Acidithiobacillus_ferrooxidans	1.0	GTDB:s__Acidithiobacillus_ferrooxidans	1.0		
-NCBITaxon:92645	Herbaspirillum frisingense	GTDB:s__Herbaspirillum_frisingense	1.0	GTDB:s__Herbaspirillum_frisingense	1.0		
-NCBITaxon:930	Acidithiobacillus thiooxidans	GTDB:s__Acidithiobacillus_thiooxidans	1.0	GTDB:s__Acidithiobacillus_thiooxidans	1.0		
-NCBITaxon:931	Thiobacillus thioparus	GTDB:s__Thiobacillus_thioparus	1.0	GTDB:s__Thiobacillus_thioparus	1.0		
-NCBITaxon:94625	Brucella intermedia	GTDB:s__Ochrobactrum_intermedium	0.99	GTDB:s__Ochrobactrum_intermedium	0.99		
-NCBITaxon:96	Gallionella	GTDB:g__Gallionella	1.0	GTDB:g__Gallionella	1.0		
-NCBITaxon:9606	Homo sapiens	NONE		NONE			
-NCBITaxon:971	Selenomonas ruminantium	AMBIGUOUS		AMBIGUOUS			
-NCBITaxon:97393	Ferroplasma acidarmanus	GTDB:s__Ferroplasma_acidarmanus	1.0	GTDB:s__Ferroplasma_acidarmanus	1.0		
-NCBITaxon:976	Bacteroidota	GTDB:p__Bacteroidota	0.999	GTDB:p__Bacteroidota	0.999		
-NCBITaxon:986	Flavobacterium johnsoniae	GTDB:s__Flavobacterium_johnsoniae	1.0	GTDB:s__Flavobacterium_johnsoniae	1.0		
+# taxa=578	varying=17
+ncbi_id	label	aggregate_id	aggregate_frac	aggregate_named_id	aggregate_named_frac	deepest_id	deepest_frac	deepest_named_id	deepest_named_frac	varies	distinct_answers
+NCBITaxon:100176	Papillibacter cinnamivorans	GTDB:s__Papillibacter_cinnamivorans	1.0	GTDB:s__Papillibacter_cinnamivorans	1.0	GTDB:s__Papillibacter_cinnamivorans	1.0	GTDB:s__Papillibacter_cinnamivorans	1.0		1
+NCBITaxon:100226	Streptomyces coelicolor A3(2)	GTDB:s__Streptomyces_anthocyanicus	1.0	GTDB:s__Streptomyces_anthocyanicus	1.0	GTDB:s__Streptomyces_anthocyanicus	1.0	GTDB:s__Streptomyces_anthocyanicus	1.0		1
+NCBITaxon:101510	Rhodococcus jostii RHA1	GTDB:s__Rhodococcus_jostii_A	1.0	GTDB:s__Rhodococcus_jostii_A	1.0	GTDB:s__Rhodococcus_jostii_A	1.0	GTDB:s__Rhodococcus_jostii_A	1.0		1
+NCBITaxon:1021	Beggiatoa	GTDB:g__Beggiatoa	0.75	GTDB:g__Beggiatoa	1.0	GTDB:g__Beggiatoa	0.727	GTDB:g__Beggiatoa	1.0		1
+NCBITaxon:10239	Viruses	NONE		NONE		NONE		NONE			1
+NCBITaxon:1031	Thiothrix nivea	GTDB:s__Thiothrix_nivea	1.0	GTDB:s__Thiothrix_nivea	1.0	GTDB:s__Thiothrix_nivea	1.0	GTDB:s__Thiothrix_nivea	1.0		1
+NCBITaxon:1033	Afipia	GTDB:g__Afipia	0.957	GTDB:g__Afipia	1.0	GTDB:g__Afipia	0.955	GTDB:g__Afipia	1.0		1
+NCBITaxon:105841	Anaerostipes caccae	GTDB:s__Anaerostipes_caccae	1.0	GTDB:s__Anaerostipes_caccae	1.0	GTDB:s__Anaerostipes_caccae	1.0	GTDB:s__Anaerostipes_caccae	1.0		1
+NCBITaxon:105972	Methylosarcina fibrata	GTDB:s__Methylosarcina_fibrata	1.0	GTDB:s__Methylosarcina_fibrata	1.0	GTDB:s__Methylosarcina_fibrata	1.0	GTDB:s__Methylosarcina_fibrata	1.0		1
+NCBITaxon:1061	Rhodobacter capsulatus	GTDB:s__Rhodobacter_capsulatus_B	1.0	GTDB:s__Rhodobacter_capsulatus_B	1.0	GTDB:s__Rhodobacter_capsulatus_B	1.0	GTDB:s__Rhodobacter_capsulatus_B	1.0		1
+NCBITaxon:1064	Rhodocyclus	GTDB:g__Rhodocyclus	1.0	GTDB:g__Rhodocyclus	1.0	GTDB:g__Rhodocyclus	1.0	GTDB:g__Rhodocyclus	1.0		1
+NCBITaxon:106591	Ensifer	GTDB:g__Ensifer	0.745	GTDB:g__Sinorhizobium	0.5	GTDB:g__Ensifer	0.745	GTDB:g__Sinorhizobium	0.5	VARIES	2
+NCBITaxon:106592	Ensifer adhaerens	GTDB:s__Ensifer_canadensis	1.0	GTDB:s__Ensifer_canadensis	1.0	GTDB:s__Ensifer_canadensis	1.0	GTDB:s__Ensifer_canadensis	1.0		1
+NCBITaxon:1072583	Vreelandella boliviensis LC1	GTDB:s__Vreelandella_boliviensis	1.0	GTDB:s__Vreelandella_boliviensis	1.0	GTDB:s__Vreelandella_boliviensis	1.0	GTDB:s__Vreelandella_boliviensis	1.0		1
+NCBITaxon:1076	Rhodopseudomonas palustris	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:1078905	Nitrosotalea devaniterrae	GTDB:s__Nitrosotalea_devanaterra	1.0	GTDB:s__Nitrosotalea_devanaterra	1.0	GTDB:s__Nitrosotalea_devanaterra	1.0	GTDB:s__Nitrosotalea_devanaterra	1.0		1
+NCBITaxon:1089553	Thermacetogenium phaeum DSM 12270	GTDB:s__Thermacetogenium_phaeum	1.0	GTDB:s__Thermacetogenium_phaeum	1.0	GTDB:s__Thermacetogenium_phaeum	1.0	GTDB:s__Thermacetogenium_phaeum	1.0		1
+NCBITaxon:1090	Chlorobiota	GTDB:p__Bacteroidota	0.989	GTDB:p__Bacteroidota	1.0	GTDB:p__Bacteroidota	0.989	GTDB:p__Bacteroidota	1.0		1
+NCBITaxon:1091494	Methylotuvimicrobium alcaliphilum 20Z	GTDB:s__Methylotuvimicrobium_alcaliphilum	1.0	GTDB:s__Methylotuvimicrobium_alcaliphilum	1.0	GTDB:s__Methylotuvimicrobium_alcaliphilum	1.0	GTDB:s__Methylotuvimicrobium_alcaliphilum	1.0		1
+NCBITaxon:110321	Sinorhizobium medicae	GTDB:s__Sinorhizobium_medicae	1.0	GTDB:s__Sinorhizobium_medicae	1.0	GTDB:s__Sinorhizobium_medicae	1.0	GTDB:s__Sinorhizobium_medicae	1.0		1
+NCBITaxon:110500	Pelotomaculum thermopropionicum	GTDB:s__Pelotomaculum_thermopropionicum	1.0	GTDB:s__Pelotomaculum_thermopropionicum	1.0	GTDB:s__Pelotomaculum_thermopropionicum	1.0	GTDB:s__Pelotomaculum_thermopropionicum	1.0		1
+NCBITaxon:1107	Chloroflexus	GTDB:g__Chloroflexus	1.0	GTDB:g__Chloroflexus	1.0	GTDB:g__Chloroflexus	1.0	GTDB:g__Chloroflexus	1.0		1
+NCBITaxon:110932	Leifsonia	GTDB:g__Leifsonia	0.75	GTDB:g__Leifsonia	0.958	GTDB:g__Leifsonia	0.75	GTDB:g__Leifsonia	0.958		1
+NCBITaxon:1117	Cyanobacteriota	GTDB:p__Cyanobacteriota	0.998	GTDB:p__Cyanobacteriota	0.999	GTDB:p__Cyanobacteriota	0.998	GTDB:p__Cyanobacteriota	0.999		1
+NCBITaxon:1122947	Pelosinus fermentans DSM 17108	GTDB:s__Pelosinus_fermentans	1.0	GTDB:s__Pelosinus_fermentans	1.0	GTDB:s__Pelosinus_fermentans	1.0	GTDB:s__Pelosinus_fermentans	1.0		1
+NCBITaxon:1125	Microcystis <cyanobacteria>	GTDB:g__Microcystis	0.991	GTDB:g__Microcystis	0.986	GTDB:g__Microcystis	0.991	GTDB:g__Microcystis	0.986		1
+NCBITaxon:1125364	Coccomyxa onubensis	NONE		NONE		NONE		NONE			1
+NCBITaxon:1129	Synechococcus	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:1130819	Lysinibacillus mangiferihumi	GTDB:s__Lysinibacillus_mangiferihumi	1.0	GTDB:s__Lysinibacillus_mangiferihumi	1.0	GTDB:s__Lysinibacillus_mangiferihumi	1.0	GTDB:s__Lysinibacillus_mangiferihumi	1.0		1
+NCBITaxon:1131703	Sphaerochaeta globosa	GTDB:s__Sphaerochaeta_globosa	1.0	GTDB:s__Sphaerochaeta_globosa	1.0	GTDB:s__Sphaerochaeta_globosa	1.0	GTDB:s__Sphaerochaeta_globosa	1.0		1
+NCBITaxon:1134404	Ignavibacteriota	GTDB:p__Bacteroidota	0.987	GTDB:p__Bacteroidota	1.0	GTDB:p__Bacteroidota	0.987	GTDB:p__Bacteroidota	1.0		1
+NCBITaxon:1140	Synechococcus elongatus PCC 7942 = FACHB-805	GTDB:s__Synechococcus_elongatus	1.0	GTDB:s__Synechococcus_elongatus	1.0	GTDB:s__Synechococcus_elongatus	1.0	GTDB:s__Synechococcus_elongatus	1.0		1
+NCBITaxon:1163	Anabaena	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:1165	Anabaena cylindrica	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:117187	Fusarium verticillioides	NONE		NONE		NONE		NONE			1
+NCBITaxon:1175444	Methanocella conradii	GTDB:s__Methanocella_conradii	1.0	GTDB:s__Methanocella_conradii	1.0	GTDB:s__Methanocella_conradii	1.0	GTDB:s__Methanocella_conradii	1.0		1
+NCBITaxon:1176259	Pseudomonas songnenensis	GTDB:s__Stutzerimonas_songnenensis	1.0	GTDB:s__Stutzerimonas_songnenensis	1.0	GTDB:s__Stutzerimonas_songnenensis	1.0	GTDB:s__Stutzerimonas_songnenensis	1.0		1
+NCBITaxon:1179	Desmonostoc muscorum	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:1183412	Agrobacterium deltae	GTDB:s__Agrobacterium_leguminum	1.0	GTDB:s__Agrobacterium_leguminum	1.0	GTDB:s__Agrobacterium_leguminum	1.0	GTDB:s__Agrobacterium_leguminum	1.0		1
+NCBITaxon:118562	Limnospira platensis	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:118667	Bordetella sp. M1-6	NONE		NONE		NONE		NONE			1
+NCBITaxon:118669	Pseudoxanthomonas sp. M1-3	NONE		NONE		NONE		NONE			1
+NCBITaxon:119060	Burkholderiaceae	GTDB:f__Burkholderiaceae	1.0	GTDB:f__Burkholderiaceae	1.0	GTDB:f__Burkholderiaceae	0.999	GTDB:f__Burkholderiaceae	1.0		1
+NCBITaxon:119219	Cupriavidus metallidurans	GTDB:s__Cupriavidus_metallidurans	1.0	GTDB:s__Cupriavidus_metallidurans	1.0	GTDB:s__Cupriavidus_metallidurans	1.0	GTDB:s__Cupriavidus_metallidurans	1.0		1
+NCBITaxon:119484	Syntrophobacter fumaroxidans	GTDB:s__Syntrophobacter_fumaroxidans	1.0	GTDB:s__Syntrophobacter_fumaroxidans	1.0	GTDB:s__Syntrophobacter_fumaroxidans	1.0	GTDB:s__Syntrophobacter_fumaroxidans	1.0		1
+NCBITaxon:119532	Microcoleus vaginatus	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:119977	Acidithiobacillus	GTDB:g__Acidithiobacillus	0.724	GTDB:g__Acidithiobacillus	0.745	GTDB:g__Acidithiobacillus	0.819	GTDB:g__Acidithiobacillus	0.888		1
+NCBITaxon:120961	Roseiflexus	GTDB:g__Roseiflexus	1.0	GTDB:g__Roseiflexus	1.0	GTDB:g__Roseiflexus	1.0	GTDB:g__Roseiflexus	1.0		1
+NCBITaxon:121039	Ferrimicrobium acidiphilum	GTDB:s__Ferrimicrobium_acidiphilum	1.0	GTDB:s__Ferrimicrobium_acidiphilum	1.0	GTDB:s__Ferrimicrobium_acidiphilum	1.0	GTDB:s__Ferrimicrobium_acidiphilum	1.0		1
+NCBITaxon:1215089	Planococcus halocryophilus	GTDB:s__Planococcus_halocryophilus	1.0	GTDB:s__Planococcus_halocryophilus	1.0	GTDB:s__Planococcus_halocryophilus	1.0	GTDB:s__Planococcus_halocryophilus	1.0		1
+NCBITaxon:1218105	Cupriavidus necator NBRC 102504	GTDB:s__Cupriavidus_necator_D	1.0	GTDB:s__Cupriavidus_necator_D	1.0	GTDB:s__Cupriavidus_necator_D	1.0	GTDB:s__Cupriavidus_necator_D	1.0		1
+NCBITaxon:1219	Prochlorococcus marinus	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:1224	Pseudomonadota	GTDB:p__Pseudomonadota	1.0	GTDB:p__Pseudomonadota	1.0	GTDB:p__Pseudomonadota	1.0	GTDB:p__Pseudomonadota	1.0		1
+NCBITaxon:1234	Nitrospira	AMBIGUOUS		GTDB:g__Nitrospira_D	0.81	AMBIGUOUS		GTDB:g__Nitrospira_D	0.81	VARIES	2
+NCBITaxon:1236	Gammaproteobacteria	GTDB:c__Gammaproteobacteria	1.0	GTDB:c__Gammaproteobacteria	1.0	GTDB:c__Gammaproteobacteria	1.0	GTDB:c__Gammaproteobacteria	1.0		1
+NCBITaxon:1239	Bacillota	GTDB:p__Bacillota_A	0.55	GTDB:p__Bacillota_A	0.501	GTDB:p__Bacillota_A	0.746	GTDB:p__Bacillota_A	0.734		1
+NCBITaxon:1243	Leuconostoc	GTDB:g__Leuconostoc	0.99	GTDB:g__Leuconostoc	0.99	GTDB:g__Leuconostoc	0.995	GTDB:g__Leuconostoc	0.994		1
+NCBITaxon:1245	Leuconostoc mesenteroides	GTDB:s__Leuconostoc_mesenteroides	0.99	GTDB:s__Leuconostoc_mesenteroides	0.99	GTDB:s__Leuconostoc_mesenteroides	0.99	GTDB:s__Leuconostoc_mesenteroides	0.99		1
+NCBITaxon:1253	Pediococcus	GTDB:g__Pediococcus	1.0	GTDB:g__Pediococcus	1.0	GTDB:g__Pediococcus	1.0	GTDB:g__Pediococcus	1.0		1
+NCBITaxon:1261393	Desulfatiglans parachlorophenolica	NONE		NONE		NONE		NONE			1
+NCBITaxon:1264	Hominimerdicola alba	NONE		NONE		NONE		NONE			1
+NCBITaxon:1269	Micrococcus	GTDB:g__Micrococcus	0.997	GTDB:g__Micrococcus	1.0	GTDB:g__Micrococcus	0.996	GTDB:g__Micrococcus	1.0		1
+NCBITaxon:1272	Kocuria varians	NONE		NONE		NONE		NONE			1
+NCBITaxon:1279	Staphylococcus	GTDB:g__Staphylococcus	0.993	GTDB:g__Staphylococcus	1.0	GTDB:g__Staphylococcus	0.963	GTDB:g__Staphylococcus	1.0		1
+NCBITaxon:1280	Staphylococcus aureus	GTDB:s__Staphylococcus_aureus	1.0	GTDB:s__Staphylococcus_aureus	1.0	GTDB:s__Staphylococcus_aureus	1.0	GTDB:s__Staphylococcus_aureus	1.0		1
+NCBITaxon:12916	Acidovorax	GTDB:g__Acidovorax	0.867	GTDB:g__Acidovorax	0.997	GTDB:g__Acidovorax	0.848	GTDB:g__Acidovorax	0.996		1
+NCBITaxon:1303	Streptococcus oralis	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:1304	Streptococcus salivarius	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:1305	Streptococcus sanguinis	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:1308	Streptococcus thermophilus	GTDB:s__Streptococcus_thermophilus	0.99	GTDB:s__Streptococcus_thermophilus	0.99	GTDB:s__Streptococcus_thermophilus	0.99	GTDB:s__Streptococcus_thermophilus	0.99		1
+NCBITaxon:1309	Streptococcus mutans	GTDB:s__Streptococcus_mutans	1.0	GTDB:s__Streptococcus_mutans	1.0	GTDB:s__Streptococcus_mutans	1.0	GTDB:s__Streptococcus_mutans	1.0		1
+NCBITaxon:131567	cellular organisms	NONE		NONE		NONE		NONE			1
+NCBITaxon:1317	Streptococcus downei	GTDB:s__Streptococcus_downei	1.0	GTDB:s__Streptococcus_downei	1.0	GTDB:s__Streptococcus_downei	1.0	GTDB:s__Streptococcus_downei	1.0		1
+NCBITaxon:133	Methylocystis	GTDB:g__Methylocystis	0.952	GTDB:g__Methylocystis	1.0	GTDB:g__Methylocystis	0.948	GTDB:g__Methylocystis	1.0		1
+NCBITaxon:1335	Streptococcus equinus	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:1335640	Clostridium saccharoperbutylacetonicum N1-4	NONE		NONE		NONE		NONE			1
+NCBITaxon:1336235	Paenirhizobium selenitireducens ATCC BAA-1503	NONE		NONE		NONE		NONE			1
+NCBITaxon:13366	Brettanomyces	NONE		NONE		NONE		NONE			1
+NCBITaxon:133926	Olsenella uli	GTDB:s__Olsenella_uli	1.0	GTDB:s__Olsenella_uli	1.0	GTDB:s__Olsenella_uli	1.0	GTDB:s__Olsenella_uli	1.0		1
+NCBITaxon:134	Methylocystis parvus	GTDB:s__Methylocystis_parva	1.0	GTDB:s__Methylocystis_parva	1.0	GTDB:s__Methylocystis_parva	1.0	GTDB:s__Methylocystis_parva	1.0		1
+NCBITaxon:1344414	Trichoderma reesei RUT C-30	NONE		NONE		NONE		NONE			1
+NCBITaxon:1350	Enterococcus	GTDB:g__Enterococcus_B	0.596	GTDB:g__Enterococcus_B	0.598	AMBIGUOUS		AMBIGUOUS		VARIES	2
+NCBITaxon:1350461	Synechococcus elongatus UTEX 2973	GTDB:s__Synechococcus_elongatus	1.0	GTDB:s__Synechococcus_elongatus	1.0	GTDB:s__Synechococcus_elongatus	1.0	GTDB:s__Synechococcus_elongatus	1.0		1
+NCBITaxon:1351	Enterococcus faecalis	GTDB:s__Enterococcus_faecalis	1.0	GTDB:s__Enterococcus_faecalis	1.0	GTDB:s__Enterococcus_faecalis	1.0	GTDB:s__Enterococcus_faecalis	1.0		1
+NCBITaxon:135614	Lysobacterales	GTDB:o__Xanthomonadales	1.0	GTDB:o__Xanthomonadales	1.0	GTDB:o__Xanthomonadales	0.999	GTDB:o__Xanthomonadales	1.0		1
+NCBITaxon:135619	Oceanospirillales	GTDB:o__Pseudomonadales	0.968	GTDB:o__Pseudomonadales	0.974	GTDB:o__Pseudomonadales	0.966	GTDB:o__Pseudomonadales	0.971		1
+NCBITaxon:1358	Lactococcus lactis	GTDB:s__Lactococcus_lactis	0.92	GTDB:s__Lactococcus_lactis	0.92	GTDB:s__Lactococcus_lactis	0.92	GTDB:s__Lactococcus_lactis	0.92		1
+NCBITaxon:13687	Sphingomonas	GTDB:g__Sphingomonas	0.777	GTDB:g__Sphingomonas	0.736	GTDB:g__Sphingomonas	0.742	GTDB:g__Sphingomonas	0.631		1
+NCBITaxon:1377992	Halovenus	GTDB:g__Halovenus	1.0	GTDB:g__Halovenus	1.0	GTDB:g__Halovenus	1.0	GTDB:g__Halovenus	1.0		1
+NCBITaxon:1379858	Mucispirillum schaedleri ASF457	GTDB:s__Mucispirillum_schaedleri	1.0	GTDB:s__Mucispirillum_schaedleri	1.0	GTDB:s__Mucispirillum_schaedleri	1.0	GTDB:s__Mucispirillum_schaedleri	1.0		1
+NCBITaxon:138074	Serratia symbiotica	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:1384459	Methyloceanibacter caenitepidi	GTDB:s__Methyloceanibacter_caenitepidi	1.0	GTDB:s__Methyloceanibacter_caenitepidi	1.0	GTDB:s__Methyloceanibacter_caenitepidi	1.0	GTDB:s__Methyloceanibacter_caenitepidi	1.0		1
+NCBITaxon:1386	Bacillus <firmicutes>	GTDB:g__Bacillus	0.508	GTDB:g__Bacillus	0.57	AMBIGUOUS		GTDB:g__Bacillus_A	0.531	VARIES	3
+NCBITaxon:1396	Bacillus cereus	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:1398	Heyndrickxia coagulans	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:1401	Paenibacillus lautus	GTDB:s__Paenibacillus_lautus	1.0	GTDB:s__Paenibacillus_lautus	1.0	GTDB:s__Paenibacillus_lautus	1.0	GTDB:s__Paenibacillus_lautus	1.0		1
+NCBITaxon:1402	Bacillus licheniformis	GTDB:s__Bacillus_licheniformis	0.98	GTDB:s__Bacillus_licheniformis	0.98	GTDB:s__Bacillus_licheniformis	0.98	GTDB:s__Bacillus_licheniformis	0.98		1
+NCBITaxon:1404	Priestia megaterium	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:1421	Lysinibacillus sphaericus	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:142182	Gemmatimonadota	GTDB:p__Gemmatimonadota	1.0	GTDB:p__Gemmatimonadota	1.0	GTDB:p__Gemmatimonadota	1.0	GTDB:p__Gemmatimonadota	1.0		1
+NCBITaxon:1423	Bacillus subtilis	GTDB:s__Bacillus_subtilis	0.91	GTDB:s__Bacillus_subtilis	0.91	GTDB:s__Bacillus_subtilis	0.91	GTDB:s__Bacillus_subtilis	0.91		1
+NCBITaxon:1428	Bacillus thuringiensis	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:1432792	Methylocaldum marinum	GTDB:s__Methylocaldum_marinum	1.0	GTDB:s__Methylocaldum_marinum	1.0	GTDB:s__Methylocaldum_marinum	1.0	GTDB:s__Methylocaldum_marinum	1.0		1
+NCBITaxon:1434011	Komagataeibacter	GTDB:g__Komagataeibacter	0.973	GTDB:g__Komagataeibacter	1.0	GTDB:g__Komagataeibacter	0.948	GTDB:g__Komagataeibacter	1.0		1
+NCBITaxon:1434019	Mameliella	GTDB:g__Mameliella	0.905	GTDB:g__Mameliella	1.0	GTDB:g__Mameliella	0.905	GTDB:g__Mameliella	1.0		1
+NCBITaxon:1436290	Candidatus Symbiobacter mobilis	GTDB:s__Symbiobacter_mobilis	1.0	GTDB:s__Symbiobacter_mobilis	1.0	GTDB:s__Symbiobacter_mobilis	1.0	GTDB:s__Symbiobacter_mobilis	1.0		1
+NCBITaxon:145262	Methanothermobacter thermautotrophicus	GTDB:s__Methanothermobacter_thermautotrophicus	1.0	GTDB:s__Methanothermobacter_thermautotrophicus	1.0	GTDB:s__Methanothermobacter_thermautotrophicus	1.0	GTDB:s__Methanothermobacter_thermautotrophicus	1.0		1
+NCBITaxon:1462422	Candidatus Parvarchaeota	NONE		NONE		NONE		NONE			1
+NCBITaxon:146918	Salinibacter	GTDB:g__Salinibacter	1.0	GTDB:g__Salinibacter	1.0	GTDB:g__Salinibacter	1.0	GTDB:g__Salinibacter	1.0		1
+NCBITaxon:1485	Clostridium	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		GTDB:g__Otoolea	0.504	VARIES	2
+NCBITaxon:1492	Clostridium butyricum	GTDB:s__Clostridium_butyricum	0.97	GTDB:s__Clostridium_butyricum	0.97	GTDB:s__Clostridium_butyricum	0.97	GTDB:s__Clostridium_butyricum	0.97		1
+NCBITaxon:149698	Massilia	GTDB:g__Telluria	0.905	GTDB:g__Telluria	1.0	GTDB:g__Telluria	0.905	GTDB:g__Telluria	1.0		1
+NCBITaxon:1501	Clostridium pasteurianum	GTDB:s__Clostridium_I_pasteurianum	1.0	GTDB:s__Clostridium_I_pasteurianum	1.0	GTDB:s__Clostridium_I_pasteurianum	1.0	GTDB:s__Clostridium_I_pasteurianum	1.0		1
+NCBITaxon:1501972	Brevundimonas sp. R3	NONE		NONE		NONE		NONE			1
+NCBITaxon:1515	Acetivibrio thermocellus	GTDB:s__Hungateiclostridium_thermocellum	1.0	GTDB:s__Hungateiclostridium_thermocellum	1.0	GTDB:s__Hungateiclostridium_thermocellum	1.0	GTDB:s__Hungateiclostridium_thermocellum	1.0		1
+NCBITaxon:1517	Thermoanaerobacterium thermosaccharolyticum	GTDB:s__Thermoanaerobacterium_thermosaccharolyticum	1.0	GTDB:s__Thermoanaerobacterium_thermosaccharolyticum	1.0	GTDB:s__Thermoanaerobacterium_thermosaccharolyticum	1.0	GTDB:s__Thermoanaerobacterium_thermosaccharolyticum	1.0		1
+NCBITaxon:151783	Cupriavidus campinensis	GTDB:s__Cupriavidus_campinensis	1.0	GTDB:s__Cupriavidus_campinensis	1.0	GTDB:s__Cupriavidus_campinensis	1.0	GTDB:s__Cupriavidus_campinensis	1.0		1
+NCBITaxon:1519	Clostridium tyrobutyricum	GTDB:s__Clostridium_B_tyrobutyricum	0.97	GTDB:s__Clostridium_B_tyrobutyricum	0.97	GTDB:s__Clostridium_B_tyrobutyricum	0.97	GTDB:s__Clostridium_B_tyrobutyricum	0.97		1
+NCBITaxon:1521	Ruminiclostridium cellulolyticum	GTDB:s__Ruminiclostridium_cellulolyticum	1.0	GTDB:s__Ruminiclostridium_cellulolyticum	1.0	GTDB:s__Ruminiclostridium_cellulolyticum	1.0	GTDB:s__Ruminiclostridium_cellulolyticum	1.0		1
+NCBITaxon:1521555	Eucapsis	NONE		NONE		NONE		NONE			1
+NCBITaxon:1534	Clostridium kluyveri	GTDB:s__Clostridium_B_kluyveri	1.0	GTDB:s__Clostridium_B_kluyveri	1.0	GTDB:s__Clostridium_B_kluyveri	1.0	GTDB:s__Clostridium_B_kluyveri	1.0		1
+NCBITaxon:1538	Clostridium ljungdahlii	GTDB:s__Clostridium_B_ljungdahlii	1.0	GTDB:s__Clostridium_B_ljungdahlii	1.0	GTDB:s__Clostridium_B_ljungdahlii	1.0	GTDB:s__Clostridium_B_ljungdahlii	1.0		1
+NCBITaxon:1546519	Sulfitobacter sp. SA11	NONE		NONE		NONE		NONE			1
+NCBITaxon:1547	Thomasclavelia ramosa	GTDB:s__Thomasclavelia_ramosa	0.99	GTDB:s__Thomasclavelia_ramosa	0.99	GTDB:s__Thomasclavelia_ramosa	0.99	GTDB:s__Thomasclavelia_ramosa	0.99		1
+NCBITaxon:1571157	Coniochaeta sp. 2T2.1	NONE		NONE		NONE		NONE			1
+NCBITaxon:1577725	Conticribra weissflogii	NONE		NONE		NONE		NONE			1
+NCBITaxon:1578	Lactobacillus	GTDB:g__Lactobacillus	0.971	GTDB:g__Lactobacillus	0.998	GTDB:g__Lactobacillus	0.941	GTDB:g__Lactobacillus	0.996		1
+NCBITaxon:1582	Lacticaseibacillus casei	GTDB:s__Lacticaseibacillus_paracasei	1.0	GTDB:s__Lacticaseibacillus_paracasei	1.0	GTDB:s__Lacticaseibacillus_paracasei	1.0	GTDB:s__Lacticaseibacillus_paracasei	1.0		1
+NCBITaxon:1585	Lactobacillus delbrueckii subsp. bulgaricus	GTDB:s__Lactobacillus_delbrueckii	1.0	GTDB:s__Lactobacillus_delbrueckii	1.0	GTDB:s__Lactobacillus_delbrueckii	1.0	GTDB:s__Lactobacillus_delbrueckii	1.0		1
+NCBITaxon:1589	Lactiplantibacillus pentosus	GTDB:s__Lactiplantibacillus_pentosus	0.99	GTDB:s__Lactiplantibacillus_pentosus	0.99	GTDB:s__Lactiplantibacillus_pentosus	0.99	GTDB:s__Lactiplantibacillus_pentosus	0.99		1
+NCBITaxon:1590	Lactiplantibacillus plantarum	GTDB:s__Lactiplantibacillus_plantarum	1.0	GTDB:s__Lactiplantibacillus_plantarum	1.0	GTDB:s__Lactiplantibacillus_plantarum	1.0	GTDB:s__Lactiplantibacillus_plantarum	1.0		1
+NCBITaxon:159743	Paenibacillus terrae	NONE		NONE		NONE		NONE			1
+NCBITaxon:16	Methylophilus	GTDB:g__Methylophilus	1.0	GTDB:g__Methylophilus	1.0	GTDB:g__Methylophilus	1.0	GTDB:g__Methylophilus	1.0		1
+NCBITaxon:160488	Pseudomonas putida KT2440	GTDB:s__Pseudomonas_E_alloputida	1.0	GTDB:s__Pseudomonas_E_alloputida	1.0	GTDB:s__Pseudomonas_E_alloputida	1.0	GTDB:s__Pseudomonas_E_alloputida	1.0		1
+NCBITaxon:1605331	Microbacterium sp. UYFA68	NONE		NONE		NONE		NONE			1
+NCBITaxon:160808	Acidithiobacillus ferrivorans	GTDB:s__Acidithiobacillus_ferrivorans	0.95	GTDB:s__Acidithiobacillus_ferrivorans	0.95	GTDB:s__Acidithiobacillus_ferrivorans	0.95	GTDB:s__Acidithiobacillus_ferrivorans	0.95		1
+NCBITaxon:161493	Anaeromyxobacter dehalogenans	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:1646340	Kosakonia pseudosacchari	GTDB:s__Kosakonia_pseudosacchari	1.0	GTDB:s__Kosakonia_pseudosacchari	1.0	GTDB:s__Kosakonia_pseudosacchari	1.0	GTDB:s__Kosakonia_pseudosacchari	1.0		1
+NCBITaxon:1655	Actinomyces naeslundii	GTDB:s__Actinomyces_naeslundii	0.96	GTDB:s__Actinomyces_naeslundii	0.96	GTDB:s__Actinomyces_naeslundii	0.96	GTDB:s__Actinomyces_naeslundii	0.96		1
+NCBITaxon:165695	Sphingobium	GTDB:g__Sphingobium	0.993	GTDB:g__Sphingobium	0.987	GTDB:g__Sphingobium	0.993	GTDB:g__Sphingobium	0.984		1
+NCBITaxon:166486	Roseburia intestinalis	GTDB:s__Roseburia_intestinalis	1.0	GTDB:s__Roseburia_intestinalis	1.0	GTDB:s__Roseburia_intestinalis	1.0	GTDB:s__Roseburia_intestinalis	1.0		1
+NCBITaxon:1667	Arthrobacter sp.	NONE		NONE		NONE		NONE			1
+NCBITaxon:1673428	Cuniculiplasma divulgatum	NONE		NONE		NONE		NONE			1
+NCBITaxon:1678	Bifidobacterium	GTDB:g__Bifidobacterium	0.998	GTDB:g__Bifidobacterium	0.999	GTDB:g__Bifidobacterium	0.998	GTDB:g__Bifidobacterium	0.999		1
+NCBITaxon:1681	Bifidobacterium bifidum	GTDB:s__Bifidobacterium_bifidum	1.0	GTDB:s__Bifidobacterium_bifidum	1.0	GTDB:s__Bifidobacterium_bifidum	1.0	GTDB:s__Bifidobacterium_bifidum	1.0		1
+NCBITaxon:1682	Bifidobacterium longum subsp. infantis	GTDB:s__Bifidobacterium_infantis	0.94	GTDB:s__Bifidobacterium_infantis	0.94	GTDB:s__Bifidobacterium_infantis	0.94	GTDB:s__Bifidobacterium_infantis	0.94		1
+NCBITaxon:168384	Marvinbryantia formatexigens	GTDB:s__Marvinbryantia_formatexigens	1.0	GTDB:s__Marvinbryantia_formatexigens	1.0	GTDB:s__Marvinbryantia_formatexigens	1.0	GTDB:s__Marvinbryantia_formatexigens	1.0		1
+NCBITaxon:1685	Bifidobacterium breve	GTDB:s__Bifidobacterium_breve	1.0	GTDB:s__Bifidobacterium_breve	1.0	GTDB:s__Bifidobacterium_breve	1.0	GTDB:s__Bifidobacterium_breve	1.0		1
+NCBITaxon:169215	Bosea	GTDB:g__Bosea	0.981	GTDB:g__Bosea	1.0	GTDB:g__Bosea	0.981	GTDB:g__Bosea	1.0		1
+NCBITaxon:1696	Brevibacterium	GTDB:g__Brevibacterium	0.987	GTDB:g__Brevibacterium	1.0	GTDB:g__Brevibacterium	0.983	GTDB:g__Brevibacterium	1.0		1
+NCBITaxon:1699721	Neotibicen canicularis	NONE		NONE		NONE		NONE			1
+NCBITaxon:1707	Cellulomonas	GTDB:g__Cellulomonas	0.858	GTDB:g__Cellulomonas	0.888	GTDB:g__Cellulomonas	0.859	GTDB:g__Cellulomonas	0.897		1
+NCBITaxon:1708	Cellulomonas fimi	GTDB:s__Cellulomonas_fimi	1.0	GTDB:s__Cellulomonas_fimi	1.0	GTDB:s__Cellulomonas_fimi	1.0	GTDB:s__Cellulomonas_fimi	1.0		1
+NCBITaxon:1718	Corynebacterium glutamicum	GTDB:s__Corynebacterium_glutamicum	0.99	GTDB:s__Corynebacterium_glutamicum	0.99	GTDB:s__Corynebacterium_glutamicum	0.99	GTDB:s__Corynebacterium_glutamicum	0.99		1
+NCBITaxon:1763	Mycobacterium	GTDB:g__Mycobacterium	1.0	GTDB:g__Mycobacterium	1.0	GTDB:g__Mycobacterium	0.999	GTDB:g__Mycobacterium	1.0		1
+NCBITaxon:1766253	Agathobacter	GTDB:g__Agathobacter	1.0	GTDB:g__Agathobacter	1.0	GTDB:g__Agathobacter	1.0	GTDB:g__Agathobacter	1.0		1
+NCBITaxon:1769012	Arachidicoccus	GTDB:g__Arachidicoccus	1.0	GTDB:g__Arachidicoccus	1.0	GTDB:g__Arachidicoccus	1.0	GTDB:g__Arachidicoccus	1.0		1
+NCBITaxon:1783273	Patescibacteria group	NONE		NONE		NONE		NONE			1
+NCBITaxon:1783276	Nanobdellati	NONE		NONE		NONE		NONE			1
+NCBITaxon:1785	Mycobacterium sp.	NONE		NONE		NONE		NONE			1
+NCBITaxon:178606	Leptospirillum ferriphilum	GTDB:s__Leptospirillum_A_rubarum	1.0	GTDB:s__Leptospirillum_A_rubarum	1.0	GTDB:s__Leptospirillum_A_rubarum	1.0	GTDB:s__Leptospirillum_A_rubarum	1.0		1
+NCBITaxon:178898	Carboxydocella	GTDB:g__Carboxydocella	1.0	GTDB:g__Carboxydocella	1.0	GTDB:g__Carboxydocella	1.0	GTDB:g__Carboxydocella	1.0		1
+NCBITaxon:179	Leptospirillum	GTDB:g__Leptospirillum	0.575	GTDB:g__Leptospirillum	0.742	GTDB:g__Leptospirillum_A	0.583	GTDB:g__Leptospirillum_A	0.533	VARIES	2
+NCBITaxon:18	Pelobacter	GTDB:g__Syntrophotalea	0.5	GTDB:g__Seleniibacterium	0.571	GTDB:g__Syntrophotalea	0.583	GTDB:g__Seleniibacterium	0.6	VARIES	2
+NCBITaxon:180	Leptospirillum ferrooxidans	GTDB:s__Leptospirillum_ferrooxidans	1.0	GTDB:s__Leptospirillum_ferrooxidans	1.0	GTDB:s__Leptospirillum_ferrooxidans	1.0	GTDB:s__Leptospirillum_ferrooxidans	1.0		1
+NCBITaxon:180162	Cetobacterium	GTDB:g__Cetobacterium_A	0.927	GTDB:g__Cetobacterium_A	1.0	GTDB:g__Cetobacterium_A	0.927	GTDB:g__Cetobacterium_A	1.0		1
+NCBITaxon:1801631	Microcaldota	NONE		NONE		NONE		NONE			1
+NCBITaxon:1807132	Candidatus Phormidium alkaliphilum	NONE		NONE		NONE		NONE			1
+NCBITaxon:1817801	Candidatus Eiseniibacteriota	NONE		NONE		NONE		NONE			1
+NCBITaxon:1822464	Paraburkholderia	GTDB:g__Paraburkholderia	0.988	GTDB:g__Paraburkholderia	0.993	GTDB:g__Paraburkholderia	0.986	GTDB:g__Paraburkholderia	0.99		1
+NCBITaxon:1827	Rhodococcus <high G+C Gram-positive bacteria>	GTDB:g__Rhodococcus	0.996	GTDB:g__Rhodococcus	1.0	GTDB:g__Rhodococcus	0.995	GTDB:g__Rhodococcus	1.0		1
+NCBITaxon:1847	Pseudonocardia	GTDB:g__Pseudonocardia	1.0	GTDB:g__Pseudonocardia	1.0	GTDB:g__Pseudonocardia	1.0	GTDB:g__Pseudonocardia	1.0		1
+NCBITaxon:1849822	Paraclostridium	GTDB:g__Paraclostridium	0.995	GTDB:g__Paraclostridium	0.995	GTDB:g__Paraclostridium	0.974	GTDB:g__Paraclostridium	0.971		1
+NCBITaxon:186490	Candidatus Palibaumannia cicadellinicola	NONE		NONE		NONE		NONE			1
+NCBITaxon:1866885	Mycolicibacterium	GTDB:g__Mycobacterium	0.998	GTDB:g__Mycobacterium	0.998	GTDB:g__Mycobacterium	0.997	GTDB:g__Mycobacterium	0.996		1
+NCBITaxon:186801	Clostridia	GTDB:c__Clostridia	0.974	GTDB:c__Clostridia	0.987	GTDB:c__Clostridia	0.976	GTDB:c__Clostridia	0.991		1
+NCBITaxon:1869185	Taibaiella sp.	NONE		NONE		NONE		NONE			1
+NCBITaxon:1871043	Variovorax sp.	NONE		NONE		NONE		NONE			1
+NCBITaxon:1871068	Phyllobacteriaceae bacterium	NONE		NONE		NONE		NONE			1
+NCBITaxon:1872086	Ensifer sp.	NONE		NONE		NONE		NONE			1
+NCBITaxon:1872114	Acidiplasma sp.	NONE		NONE		NONE		NONE			1
+NCBITaxon:1872122	Acidovorax sp.	NONE		NONE		NONE		NONE			1
+NCBITaxon:1872427	Alcanivorax sp.	NONE		NONE		NONE		NONE			1
+NCBITaxon:1872648	Asticcacaulis sp.	NONE		NONE		NONE		NONE			1
+NCBITaxon:1873462	Microbacteriaceae bacterium	NONE		NONE		NONE		NONE			1
+NCBITaxon:1883	Streptomyces	GTDB:g__Streptomyces	0.973	GTDB:g__Streptomyces	0.99	GTDB:g__Streptomyces	0.972	GTDB:g__Streptomyces	0.99		1
+NCBITaxon:1889	Streptomyces ambofaciens	GTDB:s__Streptomyces_ambofaciens	1.0	GTDB:s__Streptomyces_ambofaciens	1.0	GTDB:s__Streptomyces_ambofaciens	1.0	GTDB:s__Streptomyces_ambofaciens	1.0		1
+NCBITaxon:1902583	Candidatus Desulfofervidus	NONE		NONE		NONE		NONE			1
+NCBITaxon:1904413	Suillus clintonianus	NONE		NONE		NONE		NONE			1
+NCBITaxon:1908224	Sphingopyxis sp.	NONE		NONE		NONE		NONE			1
+NCBITaxon:1911909	Neorhizobium sp.	GTDB:s__Neorhizobium_sp028283725	1.0	GTDB:s__Neorhizobium_sp028283725	1.0	GTDB:s__Neorhizobium_sp028283725	1.0	GTDB:s__Neorhizobium_sp028283725	1.0		1
+NCBITaxon:1913961	Rhizobiaceae bacterium	NONE		NONE		NONE		NONE			1
+NCBITaxon:1914288	Dyadobacter sp.	GTDB:s__Dyadobacter_sp017744695	1.0	GTDB:s__Dyadobacter_sp017744695	1.0	GTDB:s__Dyadobacter_sp017744695	1.0	GTDB:s__Dyadobacter_sp017744695	1.0		1
+NCBITaxon:1914538	Pseudomonadaceae bacterium	NONE		NONE		NONE		NONE			1
+NCBITaxon:1918507	Candidatus Phosphitivorax anaerolimi	GTDB:s__UBA1062_sp001896555	1.0	GTDB:s__UBA1062_sp001896555	1.0	GTDB:s__UBA1062_sp001896555	1.0	GTDB:s__UBA1062_sp001896555	1.0		1
+NCBITaxon:192	Azospirillum brasilense	GTDB:s__Azospirillum_brasilense	1.0	GTDB:s__Azospirillum_brasilense	1.0	GTDB:s__Azospirillum_brasilense	1.0	GTDB:s__Azospirillum_brasilense	1.0		1
+NCBITaxon:1931	Streptomyces sp.	NONE		NONE		NONE		NONE			1
+NCBITaxon:1935183	Promethearchaeati	NONE		NONE		NONE		NONE			1
+NCBITaxon:1979961	Wenzhouxiangella sp.	NONE		NONE		NONE		NONE			1
+NCBITaxon:198620	Pseudomonas koreensis	NONE		NONE		NONE		NONE			1
+NCBITaxon:1988	Actinomadura	GTDB:g__Spirillospora	0.953	GTDB:g__Spirillospora	0.956	GTDB:g__Spirillospora	0.948	GTDB:g__Spirillospora	0.95		1
+NCBITaxon:2	Bacteria	NONE		NONE		NONE		NONE			1
+NCBITaxon:20	Phenylobacterium	GTDB:g__Phenylobacterium	1.0	GTDB:g__Phenylobacterium	1.0	GTDB:g__Phenylobacterium	1.0	GTDB:g__Phenylobacterium	1.0		1
+NCBITaxon:200795	Chloroflexota	GTDB:p__Chloroflexota	0.998	GTDB:p__Chloroflexota	0.997	GTDB:p__Chloroflexota	0.998	GTDB:p__Chloroflexota	0.997		1
+NCBITaxon:200918	Thermotogota	GTDB:p__Thermotogota	0.997	GTDB:p__Thermotogota	1.0	GTDB:p__Thermotogota	0.996	GTDB:p__Thermotogota	1.0		1
+NCBITaxon:201174	Actinomycetota	GTDB:p__Actinomycetota	1.0	GTDB:p__Actinomycetota	1.0	GTDB:p__Actinomycetota	1.0	GTDB:p__Actinomycetota	1.0		1
+NCBITaxon:202950	Acinetobacter baylyi	GTDB:s__Acinetobacter_baylyi	0.96	GTDB:s__Acinetobacter_baylyi	0.96	GTDB:s__Acinetobacter_baylyi	0.96	GTDB:s__Acinetobacter_baylyi	0.96		1
+NCBITaxon:2030806	Burkholderiaceae bacterium	NONE		NONE		NONE		NONE			1
+NCBITaxon:203119	Acetivibrio thermocellus ATCC 27405	GTDB:s__Hungateiclostridium_thermocellum	0.93	GTDB:s__Hungateiclostridium_thermocellum	0.93	GTDB:s__Hungateiclostridium_thermocellum	0.93	GTDB:s__Hungateiclostridium_thermocellum	0.93		1
+NCBITaxon:203124	Trichodesmium erythraeum IMS101	GTDB:s__Trichodesmium_erythraeum	1.0	GTDB:s__Trichodesmium_erythraeum	1.0	GTDB:s__Trichodesmium_erythraeum	1.0	GTDB:s__Trichodesmium_erythraeum	1.0		1
+NCBITaxon:2034	Curtobacterium	GTDB:g__Curtobacterium	0.993	GTDB:g__Curtobacterium	1.0	GTDB:g__Curtobacterium	0.993	GTDB:g__Curtobacterium	1.0		1
+NCBITaxon:203682	Planctomycetota	GTDB:p__Planctomycetota	0.995	GTDB:p__Planctomycetota	1.0	GTDB:p__Planctomycetota	0.995	GTDB:p__Planctomycetota	1.0		1
+NCBITaxon:203691	Spirochaetota	GTDB:p__Spirochaetota	0.995	GTDB:p__Spirochaetota	1.0	GTDB:p__Spirochaetota	0.992	GTDB:p__Spirochaetota	1.0		1
+NCBITaxon:204441	Rhodospirillales	GTDB:o__RF32	0.636	GTDB:o__RF32	0.704	GTDB:o__RF32	0.647	GTDB:o__RF32	0.725		1
+NCBITaxon:2052312	Candidatus Dormiibacterota	NONE		NONE		NONE		NONE			1
+NCBITaxon:2093828	Neorhizobium tomejilense	GTDB:s__Neorhizobium_tomejilense	0.9	GTDB:s__Neorhizobium_tomejilense	0.9	GTDB:s__Neorhizobium_tomejilense	0.9	GTDB:s__Neorhizobium_tomejilense	0.9		1
+NCBITaxon:211586	Shewanella oneidensis MR-1	GTDB:s__Shewanella_oneidensis	1.0	GTDB:s__Shewanella_oneidensis	1.0	GTDB:s__Shewanella_oneidensis	1.0	GTDB:s__Shewanella_oneidensis	1.0		1
+NCBITaxon:213118	Desulfobacterales	GTDB:o__Desulfobacterales	0.81	GTDB:o__Desulfobacterales	1.0	GTDB:o__Desulfobacterales	0.79	GTDB:o__Desulfobacterales	1.0		1
+NCBITaxon:213119	Desulfobacteraceae	AMBIGUOUS		GTDB:f__Desulfobacteraceae	0.791	AMBIGUOUS		GTDB:f__Desulfobacteraceae	0.757	VARIES	2
+NCBITaxon:213121	Desulfobulbaceae	GTDB:f__Desulfobulbaceae	0.529	GTDB:f__Desulfobulbaceae	0.852	GTDB:f__Desulfobulbaceae	0.517	GTDB:f__Desulfobulbaceae	0.845		1
+NCBITaxon:2157	Archaea	NONE		NONE		NONE		NONE			1
+NCBITaxon:215813	Dinoroseobacter shibae	GTDB:s__Dinoroseobacter_shibae	1.0	GTDB:s__Dinoroseobacter_shibae	1.0	GTDB:s__Dinoroseobacter_shibae	1.0	GTDB:s__Dinoroseobacter_shibae	1.0		1
+NCBITaxon:2162	Methanobacterium formicicum	GTDB:s__Methanobacterium_formicicum	0.94	GTDB:s__Methanobacterium_formicicum	0.94	GTDB:s__Methanobacterium_formicicum	0.94	GTDB:s__Methanobacterium_formicicum	0.94		1
+NCBITaxon:216389	Dehalococcoides mccartyi BAV1	GTDB:s__Dehalococcoides_mccartyi_B	1.0	GTDB:s__Dehalococcoides_mccartyi_B	1.0	GTDB:s__Dehalococcoides_mccartyi_B	1.0	GTDB:s__Dehalococcoides_mccartyi_B	1.0		1
+NCBITaxon:216431	Croceibacter	GTDB:g__Croceibacter	1.0	GTDB:g__Croceibacter	1.0	GTDB:g__Croceibacter	1.0	GTDB:g__Croceibacter	1.0		1
+NCBITaxon:216816	Bifidobacterium longum	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:217159	Clostridium carboxidivorans	GTDB:s__Clostridium_AM_carboxidivorans	1.0	GTDB:s__Clostridium_AM_carboxidivorans	1.0	GTDB:s__Clostridium_AM_carboxidivorans	1.0	GTDB:s__Clostridium_AM_carboxidivorans	1.0		1
+NCBITaxon:2172	Methanobrevibacter	GTDB:g__Methanobrevibacter_A	0.955	GTDB:g__Methanobrevibacter_A	0.965	GTDB:g__Methanobrevibacter_A	0.955	GTDB:g__Methanobrevibacter_A	0.965		1
+NCBITaxon:2173	Methanobrevibacter smithii	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:22	Shewanella	GTDB:g__Shewanella	0.996	GTDB:g__Shewanella	1.0	GTDB:g__Shewanella	0.994	GTDB:g__Shewanella	1.0		1
+NCBITaxon:2201	Methanofollis liminatans	GTDB:s__Methanofollis_liminatans	1.0	GTDB:s__Methanofollis_liminatans	1.0	GTDB:s__Methanofollis_liminatans	1.0	GTDB:s__Methanofollis_liminatans	1.0		1
+NCBITaxon:2203	Methanospirillum hungatei	GTDB:s__Methanospirillum_hungatei	1.0	GTDB:s__Methanospirillum_hungatei	1.0	GTDB:s__Methanospirillum_hungatei	1.0	GTDB:s__Methanospirillum_hungatei	1.0		1
+NCBITaxon:2208	Methanosarcina barkeri	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:2209	Methanosarcina mazei	GTDB:s__Methanosarcina_mazei	1.0	GTDB:s__Methanosarcina_mazei	1.0	GTDB:s__Methanosarcina_mazei	1.0	GTDB:s__Methanosarcina_mazei	1.0		1
+NCBITaxon:222	Achromobacter	GTDB:g__Achromobacter	0.981	GTDB:g__Achromobacter	0.991	GTDB:g__Achromobacter	0.981	GTDB:g__Achromobacter	0.99		1
+NCBITaxon:2223	Methanothrix soehngenii	GTDB:s__Methanothrix_soehngenii	1.0	GTDB:s__Methanothrix_soehngenii	1.0	GTDB:s__Methanothrix_soehngenii	1.0	GTDB:s__Methanothrix_soehngenii	1.0		1
+NCBITaxon:2237	Haloarcula	GTDB:g__Haloarcula	1.0	GTDB:g__Haloarcula	1.0	GTDB:g__Haloarcula	1.0	GTDB:g__Haloarcula	1.0		1
+NCBITaxon:2239	Halobacterium	GTDB:g__Halobacterium	1.0	GTDB:g__Halobacterium	1.0	GTDB:g__Halobacterium	1.0	GTDB:g__Halobacterium	1.0		1
+NCBITaxon:223967	Methylorubrum populi	GTDB:s__Methylobacterium_thiocyanatum	1.0	GTDB:s__Methylobacterium_thiocyanatum	1.0	GTDB:s__Methylobacterium_thiocyanatum	1.0	GTDB:s__Methylobacterium_thiocyanatum	1.0		1
+NCBITaxon:224756	Methanomicrobia	GTDB:c__Methanosarcinia	0.617	GTDB:c__Methanosarcinia	0.709	GTDB:c__Methanosarcinia	0.617	GTDB:c__Methanosarcinia	0.709		1
+NCBITaxon:225937	Marinobacter adhaerens HP15	GTDB:s__Marinobacter_adhaerens	1.0	GTDB:s__Marinobacter_adhaerens	1.0	GTDB:s__Marinobacter_adhaerens	1.0	GTDB:s__Marinobacter_adhaerens	1.0		1
+NCBITaxon:226186	Bacteroides thetaiotaomicron VPI-5482	GTDB:s__Bacteroides_thetaiotaomicron	1.0	GTDB:s__Bacteroides_thetaiotaomicron	1.0	GTDB:s__Bacteroides_thetaiotaomicron	1.0	GTDB:s__Bacteroides_thetaiotaomicron	1.0		1
+NCBITaxon:2268204	Thermoplasmatales archaeon	NONE		NONE		NONE		NONE			1
+NCBITaxon:2283796	Thermoplasmatota	GTDB:p__Thermoplasmatota	1.0	GTDB:p__Thermoplasmatota	1.0	GTDB:p__Thermoplasmatota	0.999	GTDB:p__Thermoplasmatota	1.0		1
+NCBITaxon:2301	Thermoplasmatales	GTDB:o__Thermoplasmatales	0.903	GTDB:o__Thermoplasmatales	1.0	GTDB:o__Thermoplasmatales	0.899	GTDB:o__Thermoplasmatales	1.0		1
+NCBITaxon:231455	Dyella japonica	GTDB:s__Dyella_marensis	1.0	GTDB:s__Dyella_marensis	1.0	GTDB:s__Dyella_marensis	1.0	GTDB:s__Dyella_marensis	1.0		1
+NCBITaxon:2357	Desulfomonile	GTDB:g__Desulfomonile	0.667	GTDB:g__Desulfomonile	1.0	GTDB:g__Desulfomonile	0.667	GTDB:g__Desulfomonile	1.0		1
+NCBITaxon:236401	Graphocephala coccinea	NONE		NONE		NONE		NONE			1
+NCBITaxon:237	Flavobacterium	GTDB:g__Flavobacterium	0.99	GTDB:g__Flavobacterium	0.999	GTDB:g__Flavobacterium	0.99	GTDB:g__Flavobacterium	0.999		1
+NCBITaxon:2375	Sporomusa	GTDB:g__Sporomusa	1.0	GTDB:g__Sporomusa	1.0	GTDB:g__Sporomusa	1.0	GTDB:g__Sporomusa	1.0		1
+NCBITaxon:237612	Sphingomonas panni	GTDB:s__Sphingomonas_panni	1.0	GTDB:s__Sphingomonas_panni	1.0	GTDB:s__Sphingomonas_panni	1.0	GTDB:s__Sphingomonas_panni	1.0		1
+NCBITaxon:239	Flavobacterium sp.	NONE		NONE		NONE		NONE			1
+NCBITaxon:243164	Dehalococcoides mccartyi 195	GTDB:s__Dehalococcoides_mccartyi	1.0	GTDB:s__Dehalococcoides_mccartyi	1.0	GTDB:s__Dehalococcoides_mccartyi	1.0	GTDB:s__Dehalococcoides_mccartyi	1.0		1
+NCBITaxon:243232	Methanocaldococcus jannaschii DSM 2661	GTDB:s__Methanocaldococcus_jannaschii	1.0	GTDB:s__Methanocaldococcus_jannaschii	1.0	GTDB:s__Methanocaldococcus_jannaschii	1.0	GTDB:s__Methanocaldococcus_jannaschii	1.0		1
+NCBITaxon:243274	Thermotoga maritima MSB8	GTDB:s__Thermotoga_maritima	1.0	GTDB:s__Thermotoga_maritima	1.0	GTDB:s__Thermotoga_maritima	1.0	GTDB:s__Thermotoga_maritima	1.0		1
+NCBITaxon:244366	Klebsiella variicola	GTDB:s__Klebsiella_variicola	1.0	GTDB:s__Klebsiella_variicola	1.0	GTDB:s__Klebsiella_variicola	1.0	GTDB:s__Klebsiella_variicola	1.0		1
+NCBITaxon:246200	Ruegeria pomeroyi DSS-3	GTDB:s__Ruegeria_B_pomeroyi	1.0	GTDB:s__Ruegeria_B_pomeroyi	1.0	GTDB:s__Ruegeria_B_pomeroyi	1.0	GTDB:s__Ruegeria_B_pomeroyi	1.0		1
+NCBITaxon:2496117	Variovorax beijingensis	NONE		NONE		NONE		NONE			1
+NCBITaxon:253	Chryseobacterium indologenes	GTDB:s__Chryseobacterium_indologenes	1.0	GTDB:s__Chryseobacterium_indologenes	1.0	GTDB:s__Chryseobacterium_indologenes	1.0	GTDB:s__Chryseobacterium_indologenes	1.0		1
+NCBITaxon:2530459	Galdieria sp.	NONE		NONE		NONE		NONE			1
+NCBITaxon:253314	Acetivibrio straminisolvens	GTDB:s__Hungateiclostridium_straminisolvens	1.0	GTDB:s__Hungateiclostridium_straminisolvens	1.0	GTDB:s__Hungateiclostridium_straminisolvens	1.0	GTDB:s__Hungateiclostridium_straminisolvens	1.0		1
+NCBITaxon:258594	Rhodopseudomonas palustris CGA009	GTDB:s__Rhodopseudomonas_palustris_F	1.0	GTDB:s__Rhodopseudomonas_palustris_F	1.0	GTDB:s__Rhodopseudomonas_palustris_F	1.0	GTDB:s__Rhodopseudomonas_palustris_F	1.0		1
+NCBITaxon:2591003	Ferroplasma sp.	NONE		NONE		NONE		NONE			1
+NCBITaxon:2597222	Candidatus Acidulidesulfobacterium	NONE		NONE		NONE		NONE			1
+NCBITaxon:266	Paracoccus denitrificans	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:267377	Methanococcus maripaludis S2	GTDB:s__Methanococcus_maripaludis	1.0	GTDB:s__Methanococcus_maripaludis	1.0	GTDB:s__Methanococcus_maripaludis	1.0	GTDB:s__Methanococcus_maripaludis	1.0		1
+NCBITaxon:2675547	Chlorella sp. HS2	NONE		NONE		NONE		NONE			1
+NCBITaxon:267818	Lactobacillus kefiranofaciens	GTDB:s__Lactobacillus_kefiranofaciens	1.0	GTDB:s__Lactobacillus_kefiranofaciens	1.0	GTDB:s__Lactobacillus_kefiranofaciens	1.0	GTDB:s__Lactobacillus_kefiranofaciens	1.0		1
+NCBITaxon:2697049	Severe acute respiratory syndrome coronavirus 2	NONE		NONE		NONE		NONE			1
+NCBITaxon:269797	Methanosarcina barkeri str. Fusaro	GTDB:s__Methanosarcina_barkeri_B	1.0	GTDB:s__Methanosarcina_barkeri_B	1.0	GTDB:s__Methanosarcina_barkeri_B	1.0	GTDB:s__Methanosarcina_barkeri_B	1.0		1
+NCBITaxon:270351	Methylobacterium aquaticum	NONE		NONE		NONE		NONE			1
+NCBITaxon:2716471	Sulcia	NONE		NONE		NONE		NONE			1
+NCBITaxon:272772	Pseudomonas pudica	GTDB:s__Pseudomonas_E_pudica	1.0	GTDB:s__Pseudomonas_E_pudica	1.0	GTDB:s__Pseudomonas_E_pudica	1.0	GTDB:s__Pseudomonas_E_pudica	1.0		1
+NCBITaxon:2736640	Pseudonocardia broussonetiae	GTDB:s__Pseudonocardia_broussonetiae	1.0	GTDB:s__Pseudonocardia_broussonetiae	1.0	GTDB:s__Pseudonocardia_broussonetiae	1.0	GTDB:s__Pseudonocardia_broussonetiae	1.0		1
+NCBITaxon:2740557	Pauljensenia	GTDB:g__Pauljensenia	1.0	GTDB:g__Pauljensenia	1.0	GTDB:g__Pauljensenia	1.0	GTDB:g__Pauljensenia	1.0		1
+NCBITaxon:2742	Marinobacter	GTDB:g__Marinobacter	0.964	GTDB:g__Marinobacter	0.974	GTDB:g__Marinobacter	0.958	GTDB:g__Marinobacter	0.968		1
+NCBITaxon:2759	Eukaryota	NONE		NONE		NONE		NONE			1
+NCBITaxon:2782567	Paenarthrobacter sp. GOM3	GTDB:s__Arthrobacter_sp018215265	1.0	GTDB:s__Arthrobacter_sp018215265	1.0	GTDB:s__Arthrobacter_sp018215265	1.0	GTDB:s__Arthrobacter_sp018215265	1.0		1
+NCBITaxon:280333	Bradyrhizobium pachyrhizi	NONE		NONE		NONE		NONE			1
+NCBITaxon:28034	Sulfobacillus thermosulfidooxidans	GTDB:s__Sulfobacillus_thermosulfidooxidans	1.0	GTDB:s__Sulfobacillus_thermosulfidooxidans	1.0	GTDB:s__Sulfobacillus_thermosulfidooxidans	1.0	GTDB:s__Sulfobacillus_thermosulfidooxidans	1.0		1
+NCBITaxon:28037	Streptococcus mitis	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:28065	Rhodoferax	GTDB:g__Rhodoferax	0.718	GTDB:g__Rhodoferax	0.706	GTDB:g__Rhodoferax	0.718	GTDB:g__Rhodoferax	0.706		1
+NCBITaxon:28108	Alteromonas macleodii	GTDB:s__Alteromonas_macleodii	0.9	GTDB:s__Alteromonas_macleodii	0.9	GTDB:s__Alteromonas_macleodii	0.9	GTDB:s__Alteromonas_macleodii	0.9		1
+NCBITaxon:2818505	Myxococcota	GTDB:p__Myxococcota	0.903	GTDB:p__Myxococcota	0.836	GTDB:p__Myxococcota	0.9	GTDB:p__Myxococcota	0.826		1
+NCBITaxon:28211	Alphaproteobacteria	GTDB:c__Alphaproteobacteria	0.996	GTDB:c__Alphaproteobacteria	1.0	GTDB:c__Alphaproteobacteria	0.996	GTDB:c__Alphaproteobacteria	1.0		1
+NCBITaxon:28216	Betaproteobacteria	GTDB:c__Gammaproteobacteria	1.0	GTDB:c__Gammaproteobacteria	1.0	GTDB:c__Gammaproteobacteria	1.0	GTDB:c__Gammaproteobacteria	1.0		1
+NCBITaxon:28228	Colwellia	AMBIGUOUS		GTDB:g__Cognaticolwellia	0.548	AMBIGUOUS		GTDB:g__Cognaticolwellia	0.557	VARIES	2
+NCBITaxon:28231	Geobacter	AMBIGUOUS		GTDB:g__Geobacter	0.948	AMBIGUOUS		GTDB:g__Geobacter	0.923	VARIES	2
+NCBITaxon:28232	Geobacter metallireducens	GTDB:s__Geobacter_metallireducens	1.0	GTDB:s__Geobacter_metallireducens	1.0	GTDB:s__Geobacter_metallireducens	1.0	GTDB:s__Geobacter_metallireducens	1.0		1
+NCBITaxon:28261	Thermodesulfovibrio	GTDB:g__Thermodesulfovibrio	1.0	GTDB:g__Thermodesulfovibrio	1.0	GTDB:g__Thermodesulfovibrio	1.0	GTDB:g__Thermodesulfovibrio	1.0		1
+NCBITaxon:2836	Bacillariophyta	NONE		NONE		NONE		NONE			1
+NCBITaxon:2837503	Gottfriedia	GTDB:g__Gottfriedia	1.0	GTDB:g__Gottfriedia	1.0	GTDB:g__Gottfriedia	1.0	GTDB:g__Gottfriedia	1.0		1
+NCBITaxon:28453	Sphingobacterium	GTDB:g__Sphingobacterium	0.996	GTDB:g__Sphingobacterium	0.996	GTDB:g__Sphingobacterium	0.996	GTDB:g__Sphingobacterium	0.996		1
+NCBITaxon:286	Pseudomonas	GTDB:g__Pseudomonas	0.596	GTDB:g__Pseudomonas	0.692	GTDB:g__Pseudomonas_E	0.852	GTDB:g__Pseudomonas_E	0.798	VARIES	2
+NCBITaxon:287	Pseudomonas aeruginosa	GTDB:s__Pseudomonas_aeruginosa	0.99	GTDB:s__Pseudomonas_aeruginosa	0.99	GTDB:s__Pseudomonas_aeruginosa	0.99	GTDB:s__Pseudomonas_aeruginosa	0.99		1
+NCBITaxon:2886510	Sphingobacterium paramultivorum	GTDB:s__Sphingobacterium_paramultivorum	0.88	GTDB:s__Sphingobacterium_paramultivorum	0.88	GTDB:s__Sphingobacterium_paramultivorum	0.88	GTDB:s__Sphingobacterium_paramultivorum	0.88		1
+NCBITaxon:28889	Thermoproteota	GTDB:p__Thermoproteota	1.0	GTDB:p__Thermoproteota	1.0	GTDB:p__Thermoproteota	1.0	GTDB:p__Thermoproteota	1.0		1
+NCBITaxon:28890	Methanobacteriota	AMBIGUOUS		GTDB:p__Methanobacteriota	0.531	AMBIGUOUS		GTDB:p__Methanobacteriota	0.534	VARIES	2
+NCBITaxon:2903	Emiliania huxleyi	NONE		NONE		NONE		NONE			1
+NCBITaxon:293387	Bacillus altitudinis	GTDB:s__Bacillus_altitudinis	1.0	GTDB:s__Bacillus_altitudinis	1.0	GTDB:s__Bacillus_altitudinis	1.0	GTDB:s__Bacillus_altitudinis	1.0		1
+NCBITaxon:29394	Dolosigranulum pigrum	GTDB:s__Dolosigranulum_pigrum	1.0	GTDB:s__Dolosigranulum_pigrum	1.0	GTDB:s__Dolosigranulum_pigrum	1.0	GTDB:s__Dolosigranulum_pigrum	1.0		1
+NCBITaxon:294	Pseudomonas fluorescens	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:29448	Bradyrhizobium elkanii	GTDB:s__Bradyrhizobium_elkanii	0.89	GTDB:s__Bradyrhizobium_elkanii	0.89	GTDB:s__Bradyrhizobium_elkanii	0.89	GTDB:s__Bradyrhizobium_elkanii	0.89		1
+NCBITaxon:29466	Veillonella parvula	GTDB:s__Veillonella_parvula_A	0.95	GTDB:s__Veillonella_parvula_A	0.95	GTDB:s__Veillonella_parvula_A	0.95	GTDB:s__Veillonella_parvula_A	0.95		1
+NCBITaxon:29581	Janthinobacterium lividum	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:296543	Thalassiosira pseudonana CCMP1335	NONE		NONE		NONE		NONE			1
+NCBITaxon:2982533	Microbacterium forte	NONE		NONE		NONE		NONE			1
+NCBITaxon:29875	Trichoderma virens	NONE		NONE		NONE		NONE			1
+NCBITaxon:301148	Caldibacillus debilis	GTDB:s__Caldibacillus_debilis	1.0	GTDB:s__Caldibacillus_debilis	1.0	GTDB:s__Caldibacillus_debilis	1.0	GTDB:s__Caldibacillus_debilis	1.0		1
+NCBITaxon:301375	Methanothrix harundinacea	GTDB:s__Methanocrinis_harundinaceus	1.0	GTDB:s__Methanocrinis_harundinaceus	1.0	GTDB:s__Methanocrinis_harundinaceus	1.0	GTDB:s__Methanocrinis_harundinaceus	1.0		1
+NCBITaxon:303	Pseudomonas putida	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:3041	Chlorophyta	NONE		NONE		NONE		NONE			1
+NCBITaxon:304371	Methanocella paludicola SANAE	NONE		NONE		NONE		NONE			1
+NCBITaxon:3055	Chlamydomonas reinhardtii	NONE		NONE		NONE		NONE			1
+NCBITaxon:306	Pseudomonas sp.	NONE		NONE		NONE		NONE			1
+NCBITaxon:3071	Chlorella	NONE		NONE		NONE		NONE			1
+NCBITaxon:3073	Scenedesmus fuscus	NONE		NONE		NONE		NONE			1
+NCBITaxon:3074	Parachlorella kessleri	NONE		NONE		NONE		NONE			1
+NCBITaxon:3076	Chlorella sorokiniana	NONE		NONE		NONE		NONE			1
+NCBITaxon:3077	Chlorella vulgaris	NONE		NONE		NONE		NONE			1
+NCBITaxon:316	Stutzerimonas stutzeri	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:316612	Methylibium	GTDB:g__Methylibium	0.607	GTDB:g__Methylibium	0.625	GTDB:g__Methylibium	0.56	GTDB:g__Pseudorivibacter	0.6	VARIES	2
+NCBITaxon:319464	Clostridium sp. FG4	NONE		NONE		NONE		NONE			1
+NCBITaxon:32008	Burkholderia	GTDB:g__Burkholderia	0.985	GTDB:g__Burkholderia	0.999	GTDB:g__Burkholderia	0.919	GTDB:g__Burkholderia	0.989		1
+NCBITaxon:32011	Methylophilaceae	GTDB:f__Methylophilaceae	1.0	GTDB:f__Methylophilaceae	1.0	GTDB:f__Methylophilaceae	1.0	GTDB:f__Methylophilaceae	1.0		1
+NCBITaxon:32046	Synechococcus elongatus	GTDB:s__Synechococcus_elongatus	0.85	GTDB:s__Synechococcus_elongatus	0.85	GTDB:s__Synechococcus_elongatus	0.85	GTDB:s__Synechococcus_elongatus	0.85		1
+NCBITaxon:32049	Picosynechococcus sp. PCC 7002	GTDB:s__Limnothrix_sp001693275	1.0	GTDB:s__Limnothrix_sp001693275	1.0	GTDB:s__Limnothrix_sp001693275	1.0	GTDB:s__Limnothrix_sp001693275	1.0		1
+NCBITaxon:323259	Methanospirillum hungatei JF-1	GTDB:s__Methanospirillum_hungatei	1.0	GTDB:s__Methanospirillum_hungatei	1.0	GTDB:s__Methanospirillum_hungatei	1.0	GTDB:s__Methanospirillum_hungatei	1.0		1
+NCBITaxon:324747	Pseudoxanthomonas byssovorax	NONE		NONE		NONE		NONE			1
+NCBITaxon:33035	Blautia producta	GTDB:s__Blautia_coccoides	1.0	GTDB:s__Blautia_coccoides	1.0	GTDB:s__Blautia_coccoides	1.0	GTDB:s__Blautia_coccoides	1.0		1
+NCBITaxon:33038	Mediterraneibacter gnavus	GTDB:s__Ruminococcus_B_gnavus	0.99	GTDB:s__Ruminococcus_B_gnavus	0.99	GTDB:s__Ruminococcus_B_gnavus	0.99	GTDB:s__Ruminococcus_B_gnavus	0.99		1
+NCBITaxon:33059	Acidithiobacillus caldus	GTDB:s__Acidithiobacillus_A_caldus	1.0	GTDB:s__Acidithiobacillus_A_caldus	1.0	GTDB:s__Acidithiobacillus_A_caldus	1.0	GTDB:s__Acidithiobacillus_A_caldus	1.0		1
+NCBITaxon:33075	Acidobacterium capsulatum	NONE		NONE		NONE		NONE			1
+NCBITaxon:332101	Clostridium drakei	GTDB:s__Clostridium_AM_drakei	1.0	GTDB:s__Clostridium_AM_drakei	1.0	GTDB:s__Clostridium_AM_drakei	1.0	GTDB:s__Clostridium_AM_drakei	1.0		1
+NCBITaxon:33642	Coscinodiscus radiatus	NONE		NONE		NONE		NONE			1
+NCBITaxon:33849	Bacillariophyceae	NONE		NONE		NONE		NONE			1
+NCBITaxon:3386252	Candidatus Methanogaster	NONE		NONE		NONE		NONE			1
+NCBITaxon:33882	Microbacterium	GTDB:g__Microbacterium	0.995	GTDB:g__Microbacterium	1.0	GTDB:g__Microbacterium	0.995	GTDB:g__Microbacterium	1.0		1
+NCBITaxon:33883	Microbacterium arborescens	NONE		NONE		NONE		NONE			1
+NCBITaxon:33905	Bifidobacterium thermophilum	GTDB:s__Bifidobacterium_thermacidophilum	1.0	GTDB:s__Bifidobacterium_thermacidophilum	1.0	GTDB:s__Bifidobacterium_thermacidophilum	1.0	GTDB:s__Bifidobacterium_thermacidophilum	1.0		1
+NCBITaxon:33952	Acetobacterium woodii	GTDB:s__Acetobacterium_woodii	1.0	GTDB:s__Acetobacterium_woodii	1.0	GTDB:s__Acetobacterium_woodii	1.0	GTDB:s__Acetobacterium_woodii	1.0		1
+NCBITaxon:33962	Lentilactobacillus kefiri	GTDB:s__Lentilactobacillus_kefiri	1.0	GTDB:s__Lentilactobacillus_kefiri	1.0	GTDB:s__Lentilactobacillus_kefiri	1.0	GTDB:s__Lentilactobacillus_kefiri	1.0		1
+NCBITaxon:340177	Chlorobium chlorochromatii CaD3	NONE	1.0	NONE	1.0	NONE	1.0	NONE	1.0		1
+NCBITaxon:34037	Rahnella	GTDB:g__Rahnella	1.0	GTDB:g__Rahnella	1.0	GTDB:g__Rahnella	1.0	GTDB:g__Rahnella	1.0		1
+NCBITaxon:34067	Cycloclasticus	GTDB:g__Cycloclasticus	1.0	GTDB:g__Cycloclasticus	1.0	GTDB:g__Cycloclasticus	1.0	GTDB:g__Cycloclasticus	1.0		1
+NCBITaxon:34072	Variovorax	GTDB:g__Variovorax	0.99	GTDB:g__Variovorax	1.0	GTDB:g__Variovorax	0.99	GTDB:g__Variovorax	1.0		1
+NCBITaxon:34073	Variovorax paradoxus	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:34305	Lotus japonicus	NONE		NONE		NONE		NONE			1
+NCBITaxon:34358	Maudiozyma exigua	NONE		NONE		NONE		NONE			1
+NCBITaxon:351627	Caldicellulosiruptor saccharolyticus DSM 8903	GTDB:s__Caldicellulosiruptor_saccharolyticus	1.0	GTDB:s__Caldicellulosiruptor_saccharolyticus	1.0	GTDB:s__Caldicellulosiruptor_saccharolyticus	1.0	GTDB:s__Caldicellulosiruptor_saccharolyticus	1.0		1
+NCBITaxon:353	Azotobacter chroococcum	GTDB:s__Azotobacter_chroococcum	1.0	GTDB:s__Azotobacter_chroococcum	1.0	GTDB:s__Azotobacter_chroococcum	1.0	GTDB:s__Azotobacter_chroococcum	1.0		1
+NCBITaxon:354	Azotobacter vinelandii	GTDB:s__Azotobacter_vinelandii	1.0	GTDB:s__Azotobacter_vinelandii	1.0	GTDB:s__Azotobacter_vinelandii	1.0	GTDB:s__Azotobacter_vinelandii	1.0		1
+NCBITaxon:354354	Niastella	GTDB:g__Niastella	0.917	GTDB:g__Niastella	1.0	GTDB:g__Niastella	0.917	GTDB:g__Niastella	1.0		1
+NCBITaxon:35554	Geobacter sulfurreducens	GTDB:s__Geobacter_sulfurreducens	1.0	GTDB:s__Geobacter_sulfurreducens	1.0	GTDB:s__Geobacter_sulfurreducens	1.0	GTDB:s__Geobacter_sulfurreducens	1.0		1
+NCBITaxon:356	Hyphomicrobiales	GTDB:o__Rhizobiales	0.988	GTDB:o__Rhizobiales	0.994	GTDB:o__Rhizobiales	0.987	GTDB:o__Rhizobiales	0.993		1
+NCBITaxon:357809	Lachnoclostridium phytofermentans ISDg	GTDB:s__Lachnoclostridium_phytofermentans	1.0	GTDB:s__Lachnoclostridium_phytofermentans	1.0	GTDB:s__Lachnoclostridium_phytofermentans	1.0	GTDB:s__Lachnoclostridium_phytofermentans	1.0		1
+NCBITaxon:358	Agrobacterium tumefaciens	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:359407	Methylotenera	GTDB:g__Methylotenera	0.676	GTDB:g__Methylotenera	0.818	GTDB:g__Methylotenera	0.676	GTDB:g__Methylotenera	0.818		1
+NCBITaxon:363331	Chryseobacterium taiwanense	GTDB:s__Chryseobacterium_taiwanense	1.0	GTDB:s__Chryseobacterium_taiwanense	1.0	GTDB:s__Chryseobacterium_taiwanense	1.0	GTDB:s__Chryseobacterium_taiwanense	1.0		1
+NCBITaxon:36667	Philaenus spumarius	NONE		NONE		NONE		NONE			1
+NCBITaxon:36853	Desulfitobacterium	GTDB:g__Desulfitobacterium	0.946	GTDB:g__Desulfitobacterium	0.939	GTDB:g__Desulfitobacterium	0.943	GTDB:g__Desulfitobacterium	0.929		1
+NCBITaxon:36910	Clavispora	NONE		NONE		NONE		NONE			1
+NCBITaxon:3702	Arabidopsis thaliana	NONE		NONE		NONE		NONE			1
+NCBITaxon:372461	Buchnera aphidicola BCc	GTDB:s__Buchnera_aphidicola_F	1.0	GTDB:s__Buchnera_aphidicola_F	1.0	GTDB:s__Buchnera_aphidicola_F	1.0	GTDB:s__Buchnera_aphidicola_F	1.0		1
+NCBITaxon:37319	Pseudo-nitzschia multiseries	NONE		NONE		NONE		NONE			1
+NCBITaxon:374	Bradyrhizobium	GTDB:g__Bradyrhizobium	0.982	GTDB:g__Bradyrhizobium	0.995	GTDB:g__Bradyrhizobium	0.979	GTDB:g__Bradyrhizobium	0.992		1
+NCBITaxon:374432	Methylobacterium tardum	GTDB:s__Methylobacterium_tardum	1.0	GTDB:s__Methylobacterium_tardum	1.0	GTDB:s__Methylobacterium_tardum	1.0	GTDB:s__Methylobacterium_tardum	1.0		1
+NCBITaxon:3747	Fragaria x ananassa	NONE		NONE		NONE		NONE			1
+NCBITaxon:375	Bradyrhizobium japonicum	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:375288	Parabacteroides	GTDB:g__Parabacteroides	0.997	GTDB:g__Parabacteroides	1.0	GTDB:g__Parabacteroides	0.997	GTDB:g__Parabacteroides	1.0		1
+NCBITaxon:375486	Paenibacillus sp. PALXIL05	NONE		NONE		NONE		NONE			1
+NCBITaxon:379	Rhizobium	GTDB:g__Rhizobium	0.723	GTDB:g__Rhizobium	0.87	GTDB:g__Rhizobium	0.723	GTDB:g__Rhizobium	0.87		1
+NCBITaxon:37919	Rhodococcus opacus	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:37927	Sinomonas atrocyanea	NONE		NONE		NONE		NONE			1
+NCBITaxon:380021	Pseudomonas protegens	GTDB:s__Pseudomonas_E_protegens	1.0	GTDB:s__Pseudomonas_E_protegens	1.0	GTDB:s__Pseudomonas_E_protegens	1.0	GTDB:s__Pseudomonas_E_protegens	1.0		1
+NCBITaxon:3818	Arachis hypogaea	NONE		NONE		NONE		NONE			1
+NCBITaxon:382	Sinorhizobium meliloti	GTDB:s__Sinorhizobium_meliloti	0.97	GTDB:s__Sinorhizobium_meliloti	0.97	GTDB:s__Sinorhizobium_meliloti	0.97	GTDB:s__Sinorhizobium_meliloti	0.97		1
+NCBITaxon:3847	Glycine max	NONE		NONE		NONE		NONE			1
+NCBITaxon:39152	Methanococcus maripaludis	GTDB:s__Methanococcus_maripaludis	0.93	GTDB:s__Methanococcus_maripaludis	0.93	GTDB:s__Methanococcus_maripaludis	0.93	GTDB:s__Methanococcus_maripaludis	0.93		1
+NCBITaxon:391619	Phaeobacter inhibens DSM 17395	GTDB:s__Phaeobacter_inhibens	1.0	GTDB:s__Phaeobacter_inhibens	1.0	GTDB:s__Phaeobacter_inhibens	1.0	GTDB:s__Phaeobacter_inhibens	1.0		1
+NCBITaxon:392733	Terriglobus	GTDB:g__Terriglobus	0.833	GTDB:g__Terriglobus	0.778	GTDB:g__Terriglobus	0.818	GTDB:g__Terriglobus	0.75		1
+NCBITaxon:3932	Eucalyptus	NONE		NONE		NONE		NONE			1
+NCBITaxon:39488	Anaerobutyricum hallii	GTDB:s__Anaerobutyricum_hallii	1.0	GTDB:s__Anaerobutyricum_hallii	1.0	GTDB:s__Anaerobutyricum_hallii	1.0	GTDB:s__Anaerobutyricum_hallii	1.0		1
+NCBITaxon:395331	Methanoregula	GTDB:g__Methanoregula	1.0	GTDB:g__Methanoregula	1.0	GTDB:g__Methanoregula	1.0	GTDB:g__Methanoregula	1.0		1
+NCBITaxon:395960	Rhodopseudomonas palustris TIE-1	GTDB:s__Rhodopseudomonas_palustris_F	1.0	GTDB:s__Rhodopseudomonas_palustris_F	1.0	GTDB:s__Rhodopseudomonas_palustris_F	1.0	GTDB:s__Rhodopseudomonas_palustris_F	1.0		1
+NCBITaxon:399726	Thermoanaerobacter sp. X514	GTDB:s__Thermoanaerobacter_pseudethanolicus	1.0	GTDB:s__Thermoanaerobacter_pseudethanolicus	1.0	GTDB:s__Thermoanaerobacter_pseudethanolicus	1.0	GTDB:s__Thermoanaerobacter_pseudethanolicus	1.0		1
+NCBITaxon:40214	Acinetobacter johnsonii	GTDB:s__Acinetobacter_johnsonii	0.97	GTDB:s__Acinetobacter_johnsonii	0.97	GTDB:s__Acinetobacter_johnsonii	0.97	GTDB:s__Acinetobacter_johnsonii	0.97		1
+NCBITaxon:40222	Methylophaga	GTDB:g__Methylophaga	0.967	GTDB:g__Methylophaga	1.0	GTDB:g__Methylophaga	0.966	GTDB:g__Methylophaga	1.0		1
+NCBITaxon:403	Methylococcaceae	GTDB:f__Methylomonadaceae	0.64	GTDB:f__Methylomonadaceae	0.695	GTDB:f__Methylomonadaceae	0.671	GTDB:f__Methylomonadaceae	0.787		1
+NCBITaxon:40323	Stenotrophomonas	GTDB:g__Stenotrophomonas	0.987	GTDB:g__Stenotrophomonas	0.985	GTDB:g__Stenotrophomonas	0.987	GTDB:g__Stenotrophomonas	0.985		1
+NCBITaxon:40324	Stenotrophomonas maltophilia	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:407	Methylobacterium	GTDB:g__Methylobacterium	0.992	GTDB:g__Methylobacterium	1.0	GTDB:g__Methylobacterium	0.991	GTDB:g__Methylobacterium	1.0		1
+NCBITaxon:408	Methylorubrum extorquens	GTDB:s__Methylobacterium_extorquens	0.88	GTDB:s__Methylobacterium_extorquens	0.88	GTDB:s__Methylobacterium_extorquens	0.88	GTDB:s__Methylobacterium_extorquens	0.88		1
+NCBITaxon:4081	Solanum lycopersicum	NONE		NONE		NONE		NONE			1
+NCBITaxon:412449	Leptospirillum ferrodiazotrophum	NONE		NONE		NONE		NONE			1
+NCBITaxon:414878	Catenulispora	GTDB:g__Catenulispora	1.0	GTDB:g__Catenulispora	1.0	GTDB:g__Catenulispora	1.0	GTDB:g__Catenulispora	1.0		1
+NCBITaxon:416	Methylomonas	GTDB:g__Methylomonas	0.948	GTDB:g__Methylomonas	1.0	GTDB:g__Methylomonas	0.948	GTDB:g__Methylomonas	1.0		1
+NCBITaxon:416169	Rhodanobacter thiooxydans	GTDB:s__Rhodanobacter_thiooxydans	1.0	GTDB:s__Rhodanobacter_thiooxydans	1.0	GTDB:s__Rhodanobacter_thiooxydans	1.0	GTDB:s__Rhodanobacter_thiooxydans	1.0		1
+NCBITaxon:419541	Leptospirillum sp. Group II '5-way CG'	NONE		NONE		NONE		NONE			1
+NCBITaxon:423349	Mucilaginibacter	GTDB:g__Mucilaginibacter	1.0	GTDB:g__Mucilaginibacter	1.0	GTDB:g__Mucilaginibacter	1.0	GTDB:g__Mucilaginibacter	1.0		1
+NCBITaxon:42445	Sinorhizobium sp.	GTDB:s__Sinorhizobium_sp031178305	1.0	GTDB:s__Sinorhizobium_sp031178305	1.0	GTDB:s__Sinorhizobium_sp031178305	1.0	GTDB:s__Sinorhizobium_sp031178305	1.0		1
+NCBITaxon:429	Methylobacter	GTDB:g__Methylobacter_A	0.662	AMBIGUOUS		GTDB:g__Methylobacter_A	0.682	GTDB:g__Methylobacter_A	0.526	VARIES	2
+NCBITaxon:429134	Sphingomonas desiccabilis	GTDB:s__Sphingomonas_desiccabilis	1.0	GTDB:s__Sphingomonas_desiccabilis	1.0	GTDB:s__Sphingomonas_desiccabilis	1.0	GTDB:s__Sphingomonas_desiccabilis	1.0		1
+NCBITaxon:434	Acetobacter	GTDB:g__Acetobacter	0.561	GTDB:g__Acetobacter	1.0	GTDB:g__CAG-267	0.522	GTDB:g__Acetobacter	1.0	VARIES	2
+NCBITaxon:43773	Syntrophus <bacteria>	GTDB:g__Syntrophus	1.0	GTDB:g__Syntrophus	1.0	GTDB:g__Syntrophus	1.0	GTDB:g__Syntrophus	1.0		1
+NCBITaxon:43775	Syntrophus gentianae	GTDB:s__Syntrophus_gentianae	1.0	GTDB:s__Syntrophus_gentianae	1.0	GTDB:s__Syntrophus_gentianae	1.0	GTDB:s__Syntrophus_gentianae	1.0		1
+NCBITaxon:441	Gluconobacter	GTDB:g__Gluconobacter	0.71	GTDB:g__Gluconobacter	0.744	GTDB:g__Gluconobacter	0.762	GTDB:g__Gluconobacter	0.851		1
+NCBITaxon:44249	Paenibacillus	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:44752	Rhodococcus wratislaviensis	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:45200	Methanospirillum sp.	NONE		NONE		NONE		NONE			1
+NCBITaxon:452922	Xenophilus aerolatus	NONE		NONE		NONE		NONE			1
+NCBITaxon:453960	Sulfobacillus benefaciens	GTDB:s__Sulfobacillus_benefaciens	0.96	GTDB:s__Sulfobacillus_benefaciens	0.96	GTDB:s__Sulfobacillus_benefaciens	0.96	GTDB:s__Sulfobacillus_benefaciens	0.96		1
+NCBITaxon:4547	Saccharum officinarum	NONE		NONE		NONE		NONE			1
+NCBITaxon:4558	Sorghum bicolor	NONE		NONE		NONE		NONE			1
+NCBITaxon:4565	Triticum aestivum	NONE		NONE		NONE		NONE			1
+NCBITaxon:4577	Zea mays	NONE		NONE		NONE		NONE			1
+NCBITaxon:45989	Methanoculleus	GTDB:g__Methanoculleus	0.947	GTDB:g__Methanoculleus	0.951	GTDB:g__Methanoculleus	0.947	GTDB:g__Methanoculleus	0.951		1
+NCBITaxon:46255	Weissella	GTDB:g__Weissella	1.0	GTDB:g__Weissella	1.0	GTDB:g__Weissella	1.0	GTDB:g__Weissella	1.0		1
+NCBITaxon:46913	Devosia	GTDB:g__Devosia	0.769	GTDB:g__Devosia	0.963	GTDB:g__Devosia	0.77	GTDB:g__Devosia	0.975		1
+NCBITaxon:470	Acinetobacter baumannii	GTDB:s__Acinetobacter_baumannii	1.0	GTDB:s__Acinetobacter_baumannii	1.0	GTDB:s__Acinetobacter_baumannii	1.0	GTDB:s__Acinetobacter_baumannii	1.0		1
+NCBITaxon:47421	Hydrogenophaga pseudoflava	GTDB:s__Hydrogenophaga_pseudoflava	1.0	GTDB:s__Hydrogenophaga_pseudoflava	1.0	GTDB:s__Hydrogenophaga_pseudoflava	1.0	GTDB:s__Hydrogenophaga_pseudoflava	1.0		1
+NCBITaxon:475088	Methanosphaerula palustris	GTDB:s__Methanosphaerula_palustris	1.0	GTDB:s__Methanosphaerula_palustris	1.0	GTDB:s__Methanosphaerula_palustris	1.0	GTDB:s__Methanosphaerula_palustris	1.0		1
+NCBITaxon:4751	Fungi	NONE		NONE		NONE		NONE			1
+NCBITaxon:4757	Neocallimastix frontalis	NONE		NONE		NONE		NONE			1
+NCBITaxon:47715	Lacticaseibacillus rhamnosus	GTDB:s__Lacticaseibacillus_rhamnosus	1.0	GTDB:s__Lacticaseibacillus_rhamnosus	1.0	GTDB:s__Lacticaseibacillus_rhamnosus	1.0	GTDB:s__Lacticaseibacillus_rhamnosus	1.0		1
+NCBITaxon:47920	Acidovorax delafieldii	NONE		NONE		NONE		NONE			1
+NCBITaxon:483199	Acetobacter fabarum	GTDB:s__Acetobacter_fabarum	1.0	GTDB:s__Acetobacter_fabarum	1.0	GTDB:s__Acetobacter_fabarum	1.0	GTDB:s__Acetobacter_fabarum	1.0		1
+NCBITaxon:487698	Stenotrophomonas pavanii	GTDB:s__Stenotrophomonas_pavanii	1.0	GTDB:s__Stenotrophomonas_pavanii	1.0	GTDB:s__Stenotrophomonas_pavanii	1.0	GTDB:s__Stenotrophomonas_pavanii	1.0		1
+NCBITaxon:4890	Ascomycota	NONE		NONE		NONE		NONE			1
+NCBITaxon:48936	Novosphingobium subterraneum	GTDB:s__Novosphingobium_subterraneum	1.0	GTDB:s__Novosphingobium_subterraneum	1.0	GTDB:s__Novosphingobium_subterraneum	1.0	GTDB:s__Novosphingobium_subterraneum	1.0		1
+NCBITaxon:4919	Pichia	NONE		NONE		NONE		NONE			1
+NCBITaxon:492670	Bacillus velezensis	GTDB:s__Bacillus_velezensis	1.0	GTDB:s__Bacillus_velezensis	1.0	GTDB:s__Bacillus_velezensis	1.0	GTDB:s__Bacillus_velezensis	1.0		1
+NCBITaxon:4930	Saccharomyces	NONE		NONE		NONE		NONE			1
+NCBITaxon:4932	Saccharomyces cerevisiae	NONE		NONE		NONE		NONE			1
+NCBITaxon:4948	Torulaspora	NONE		NONE		NONE		NONE			1
+NCBITaxon:4952	Yarrowia lipolytica	NONE		NONE		NONE		NONE			1
+NCBITaxon:4958	Debaryomyces	NONE		NONE		NONE		NONE			1
+NCBITaxon:497726	Nitrososphaera	GTDB:g__Nitrososphaera	0.833	GTDB:g__Nitrososphaera	1.0	GTDB:g__Nitrososphaera	0.769	GTDB:g__Nitrososphaera	1.0		1
+NCBITaxon:5052	Aspergillus <genus>	NONE		NONE		NONE		NONE			1
+NCBITaxon:5059	Aspergillus flavus	NONE		NONE		NONE		NONE			1
+NCBITaxon:5061	Aspergillus niger	NONE		NONE		NONE		NONE			1
+NCBITaxon:50715	Acidisphaera rubrifaciens	GTDB:s__Acidisphaera_rubrifaciens	1.0	GTDB:s__Acidisphaera_rubrifaciens	1.0	GTDB:s__Acidisphaera_rubrifaciens	1.0	GTDB:s__Acidisphaera_rubrifaciens	1.0		1
+NCBITaxon:5073	Penicillium	NONE		NONE		NONE		NONE			1
+NCBITaxon:511145	Escherichia coli str. K-12 substr. MG1655	GTDB:s__Escherichia_coli	1.0	GTDB:s__Escherichia_coli	1.0	GTDB:s__Escherichia_coli	1.0	GTDB:s__Escherichia_coli	1.0		1
+NCBITaxon:511746	Candidatus Methylacidiphilum infernorum	GTDB:s__Methylacidiphilum_infernorum	1.0	GTDB:s__Methylacidiphilum_infernorum	1.0	GTDB:s__Methylacidiphilum_infernorum	1.0	GTDB:s__Methylacidiphilum_infernorum	1.0		1
+NCBITaxon:51453	Trichoderma reesei	NONE		NONE		NONE		NONE			1
+NCBITaxon:515619	Agathobacter rectalis ATCC 33656	GTDB:s__Agathobacter_rectalis	1.0	GTDB:s__Agathobacter_rectalis	1.0	GTDB:s__Agathobacter_rectalis	1.0	GTDB:s__Agathobacter_rectalis	1.0		1
+NCBITaxon:5204	Basidiomycota	NONE		NONE		NONE		NONE			1
+NCBITaxon:5206	Cryptococcus <basidiomycete fungi>	NONE		NONE		NONE		NONE			1
+NCBITaxon:521460	Caldicellulosiruptor bescii DSM 6725	GTDB:s__Caldicellulosiruptor_bescii	1.0	GTDB:s__Caldicellulosiruptor_bescii	1.0	GTDB:s__Caldicellulosiruptor_bescii	1.0	GTDB:s__Caldicellulosiruptor_bescii	1.0		1
+NCBITaxon:522	Acidiphilium	GTDB:g__UBA10281	0.633	GTDB:g__Acidiphilium	1.0	GTDB:g__UBA10281	0.682	GTDB:g__Acidiphilium	1.0	VARIES	2
+NCBITaxon:524	Acidiphilium cryptum	GTDB:s__Acidiphilium_multivorum	1.0	GTDB:s__Acidiphilium_multivorum	1.0	GTDB:s__Acidiphilium_multivorum	1.0	GTDB:s__Acidiphilium_multivorum	1.0		1
+NCBITaxon:525	Acidocella facilis	GTDB:s__Acidocella_facilis	1.0	GTDB:s__Acidocella_facilis	1.0	GTDB:s__Acidocella_facilis	1.0	GTDB:s__Acidocella_facilis	1.0		1
+NCBITaxon:52972	Polaromonas	GTDB:g__Polaromonas	0.959	GTDB:g__Polaromonas	1.0	GTDB:g__Polaromonas	0.958	GTDB:g__Polaromonas	1.0		1
+NCBITaxon:53335	Pantoea	GTDB:g__Pantoea	0.961	GTDB:g__Pantoea	0.982	GTDB:g__Pantoea	0.928	GTDB:g__Pantoea	0.953		1
+NCBITaxon:542	Zymomonas mobilis	GTDB:s__Zymomonas_mobilis	0.89	GTDB:s__Zymomonas_mobilis	0.89	GTDB:s__Zymomonas_mobilis	0.89	GTDB:s__Zymomonas_mobilis	0.89		1
+NCBITaxon:54298	Chroococcidiopsis	GTDB:g__Chroococcidiopsis	0.778	GTDB:g__Chroococcidiopsis	1.0	GTDB:g__Chroococcidiopsis	0.778	GTDB:g__Chroococcidiopsis	1.0		1
+NCBITaxon:546	Citrobacter freundii	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:547	Enterobacter	GTDB:g__Enterobacter	0.968	GTDB:g__Enterobacter	0.999	GTDB:g__Enterobacter	0.958	GTDB:g__Enterobacter	0.999		1
+NCBITaxon:5475	Candida	NONE		NONE		NONE		NONE			1
+NCBITaxon:5476	Candida albicans	NONE		NONE		NONE		NONE			1
+NCBITaxon:5480	Candida parapsilosis	NONE		NONE		NONE		NONE			1
+NCBITaxon:549	Pantoea agglomerans	GTDB:s__Pantoea_agglomerans	0.9	GTDB:s__Pantoea_agglomerans	0.9	GTDB:s__Pantoea_agglomerans	0.9	GTDB:s__Pantoea_agglomerans	0.9		1
+NCBITaxon:5498	Cladosporium	NONE		NONE		NONE		NONE			1
+NCBITaxon:550	Enterobacter cloacae	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:5507	Fusarium oxysporum	NONE		NONE		NONE		NONE			1
+NCBITaxon:55080	Brevibacillus	GTDB:g__Brevibacillus	0.816	GTDB:g__Brevibacillus	0.803	GTDB:g__Brevibacillus	0.779	GTDB:g__Brevibacillus	0.741		1
+NCBITaxon:553	Pantoea ananatis	GTDB:s__Pantoea_ananatis	0.99	GTDB:s__Pantoea_ananatis	0.99	GTDB:s__Pantoea_ananatis	0.99	GTDB:s__Pantoea_ananatis	0.99		1
+NCBITaxon:5535	Rhodotorula glutinis	NONE		NONE		NONE		NONE			1
+NCBITaxon:5544	Trichoderma harzianum	NONE		NONE		NONE		NONE			1
+NCBITaxon:5547	Trichoderma viride	NONE		NONE		NONE		NONE			1
+NCBITaxon:5552	Trichosporon	NONE		NONE		NONE		NONE			1
+NCBITaxon:561	Escherichia	GTDB:g__Escherichia	1.0	GTDB:g__Escherichia	1.0	GTDB:g__Escherichia	0.999	GTDB:g__Escherichia	1.0		1
+NCBITaxon:56112	Dehalobacter	GTDB:g__Dehalobacter	1.0	GTDB:g__Dehalobacter	1.0	GTDB:g__Dehalobacter	1.0	GTDB:g__Dehalobacter	1.0		1
+NCBITaxon:561879	Bacillus safensis	GTDB:s__Bacillus_safensis	1.0	GTDB:s__Bacillus_safensis	1.0	GTDB:s__Bacillus_safensis	1.0	GTDB:s__Bacillus_safensis	1.0		1
+NCBITaxon:562	Escherichia coli	GTDB:s__Escherichia_coli	1.0	GTDB:s__Escherichia_coli	1.0	GTDB:s__Escherichia_coli	1.0	GTDB:s__Escherichia_coli	1.0		1
+NCBITaxon:56780	Syntrophus aciditrophicus SB	GTDB:s__Syntrophus_aciditrophicus	1.0	GTDB:s__Syntrophus_aciditrophicus	1.0	GTDB:s__Syntrophus_aciditrophicus	1.0	GTDB:s__Syntrophus_aciditrophicus	1.0		1
+NCBITaxon:570	Klebsiella	GTDB:g__Klebsiella	0.999	GTDB:g__Klebsiella	1.0	GTDB:g__Klebsiella	0.999	GTDB:g__Klebsiella	1.0		1
+NCBITaxon:571256	Brucella pituitosa	NONE		NONE		NONE		NONE			1
+NCBITaxon:5722	Trichomonas vaginalis	NONE		NONE		NONE		NONE			1
+NCBITaxon:572545	Acetivibrio thermocellus DSM 2360	GTDB:s__Hungateiclostridium_thermocellum	1.0	GTDB:s__Hungateiclostridium_thermocellum	1.0	GTDB:s__Hungateiclostridium_thermocellum	1.0	GTDB:s__Hungateiclostridium_thermocellum	1.0		1
+NCBITaxon:573061	Clostridium cellulovorans 743B	GTDB:s__Clostridium_K_cellulovorans	1.0	GTDB:s__Clostridium_K_cellulovorans	1.0	GTDB:s__Clostridium_K_cellulovorans	1.0	GTDB:s__Clostridium_K_cellulovorans	1.0		1
+NCBITaxon:573657	Candidatus Hodgkinia	NONE		NONE		NONE		NONE			1
+NCBITaxon:574561	Rhizobium pisi	NONE		NONE		NONE		NONE			1
+NCBITaxon:57723	Acidobacteriota	GTDB:p__Acidobacteriota	0.976	GTDB:p__Acidobacteriota	1.0	GTDB:p__Acidobacteriota	0.975	GTDB:p__Acidobacteriota	1.0		1
+NCBITaxon:587753	Pseudomonas chlororaphis	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:588814	Candidatus Methanophagales	NONE		NONE		NONE		NONE			1
+NCBITaxon:588816	ANME-2 cluster	NONE		NONE		NONE		NONE			1
+NCBITaxon:592050	Acidovorax soli	NONE		NONE		NONE		NONE			1
+NCBITaxon:59732	Chryseobacterium	GTDB:g__Chryseobacterium	0.836	GTDB:g__Chryseobacterium	0.828	GTDB:g__Chryseobacterium	0.836	GTDB:g__Chryseobacterium	0.828		1
+NCBITaxon:599737	Wickerhamomyces	NONE		NONE		NONE		NONE			1
+NCBITaxon:613	Serratia <enterobacteria>	GTDB:g__Serratia	0.519	AMBIGUOUS		GTDB:g__Serratia	0.661	GTDB:g__Serratia	0.67	VARIES	2
+NCBITaxon:61434	Dehalococcoides	GTDB:g__Dehalococcoides	0.909	GTDB:g__Dehalococcoides	1.0	GTDB:g__Dehalococcoides	0.909	GTDB:g__Dehalococcoides	1.0		1
+NCBITaxon:61435	Dehalococcoides mccartyi	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:61624	Paenibacillus mucilaginosus	GTDB:s__Paenibacillus_G_mucilaginosus	0.88	GTDB:s__Paenibacillus_G_mucilaginosus	0.88	GTDB:s__Paenibacillus_G_mucilaginosus	0.88	GTDB:s__Paenibacillus_G_mucilaginosus	0.88		1
+NCBITaxon:62140	Acidiphilium multivorum	GTDB:s__Acidiphilium_multivorum	1.0	GTDB:s__Acidiphilium_multivorum	1.0	GTDB:s__Acidiphilium_multivorum	1.0	GTDB:s__Acidiphilium_multivorum	1.0		1
+NCBITaxon:6239	Caenorhabditis elegans	NONE		NONE		NONE		NONE			1
+NCBITaxon:632335	Caldicellulosiruptor acetigenus I77R1B	GTDB:s__Caldicellulosiruptor_acetigenus	1.0	GTDB:s__Caldicellulosiruptor_acetigenus	1.0	GTDB:s__Caldicellulosiruptor_acetigenus	1.0	GTDB:s__Caldicellulosiruptor_acetigenus	1.0		1
+NCBITaxon:63743	Natronomonas	GTDB:g__Natronomonas	0.957	GTDB:g__Natronomonas	1.0	GTDB:g__Natronomonas	0.957	GTDB:g__Natronomonas	1.0		1
+NCBITaxon:641853	Elusimicrobia	GTDB:c__Elusimicrobia	1.0	GTDB:c__Elusimicrobia	1.0	GTDB:c__Elusimicrobia	1.0	GTDB:c__Elusimicrobia	1.0		1
+NCBITaxon:644	Aeromonas hydrophila	GTDB:s__Aeromonas_hydrophila	0.96	GTDB:s__Aeromonas_hydrophila	0.96	GTDB:s__Aeromonas_hydrophila	0.96	GTDB:s__Aeromonas_hydrophila	0.96		1
+NCBITaxon:648995	Agrobacterium pusense	GTDB:s__Agrobacterium_pusense	1.0	GTDB:s__Agrobacterium_pusense	1.0	GTDB:s__Agrobacterium_pusense	1.0	GTDB:s__Agrobacterium_pusense	1.0		1
+NCBITaxon:651137	Nitrososphaerota	GTDB:p__Thermoproteota	1.0	GTDB:p__Thermoproteota	1.0	GTDB:p__Thermoproteota	1.0	GTDB:p__Thermoproteota	1.0		1
+NCBITaxon:659243	Bacillus siamensis	GTDB:s__Bacillus_siamensis	0.85	GTDB:s__Bacillus_siamensis	0.85	GTDB:s__Bacillus_siamensis	0.85	GTDB:s__Bacillus_siamensis	0.85		1
+NCBITaxon:666685	Rhodanobacter denitrificans	NONE		NONE		NONE		NONE			1
+NCBITaxon:668369	Escherichia coli DH5[alpha]	GTDB:s__Escherichia_coli	1.0	GTDB:s__Escherichia_coli	1.0	GTDB:s__Escherichia_coli	1.0	GTDB:s__Escherichia_coli	1.0		1
+NCBITaxon:67812	Candidatus Omnitrophota	NONE		NONE		NONE		NONE			1
+NCBITaxon:68	Lysobacter	GTDB:g__Lysobacter	0.748	GTDB:g__Lysobacter	0.758	GTDB:g__Lysobacter	0.748	GTDB:g__Lysobacter	0.758		1
+NCBITaxon:68239	Streptomyces mirabilis	NONE		NONE		NONE		NONE			1
+NCBITaxon:68287	Mesorhizobium	GTDB:g__Mesorhizobium	0.97	GTDB:g__Mesorhizobium	0.928	GTDB:g__Mesorhizobium	0.969	GTDB:g__Mesorhizobium	0.914		1
+NCBITaxon:69373	Curtobacterium pusillum	NONE		NONE		NONE		NONE			1
+NCBITaxon:69488	Penicillium simplicissimum	NONE		NONE		NONE		NONE			1
+NCBITaxon:69823	Selenomonas sputigena	GTDB:s__Selenomonas_sp905372355	0.86	GTDB:s__Selenomonas_sp905372355	0.86	GTDB:s__Selenomonas_sp905372355	0.86	GTDB:s__Selenomonas_sp905372355	0.86		1
+NCBITaxon:70448	Ostreococcus tauri	NONE		NONE		NONE		NONE			1
+NCBITaxon:70863	Shewanella oneidensis	GTDB:s__Shewanella_oneidensis	1.0	GTDB:s__Shewanella_oneidensis	1.0	GTDB:s__Shewanella_oneidensis	1.0	GTDB:s__Shewanella_oneidensis	1.0		1
+NCBITaxon:71518	Methanocorpusculum bavaricum	GTDB:s__Methanocorpusculum_parvum	1.0	GTDB:s__Methanocorpusculum_parvum	1.0	GTDB:s__Methanocorpusculum_parvum	1.0	GTDB:s__Methanocorpusculum_parvum	1.0		1
+NCBITaxon:7227	Drosophila melanogaster	NONE		NONE		NONE		NONE			1
+NCBITaxon:74030	Roseovarius	GTDB:g__Roseovarius	0.971	GTDB:g__Roseovarius	1.0	GTDB:g__Roseovarius	0.969	GTDB:g__Roseovarius	1.0		1
+NCBITaxon:74201	Verrucomicrobiota	GTDB:p__Verrucomicrobiota	1.0	GTDB:p__Verrucomicrobiota	1.0	GTDB:p__Verrucomicrobiota	1.0	GTDB:p__Verrucomicrobiota	1.0		1
+NCBITaxon:74969	Ferroplasma acidiphilum	GTDB:s__Ferroplasma_acidarmanus	0.91	GTDB:s__Ferroplasma_acidarmanus	0.91	GTDB:s__Ferroplasma_acidarmanus	0.91	GTDB:s__Ferroplasma_acidarmanus	0.91		1
+NCBITaxon:75	Caulobacter	GTDB:g__Caulobacter	0.837	GTDB:g__Caulobacter	1.0	GTDB:g__Caulobacter	0.837	GTDB:g__Caulobacter	1.0		1
+NCBITaxon:75105	Paraburkholderia caribensis	GTDB:s__Paraburkholderia_caribensis	0.92	GTDB:s__Paraburkholderia_caribensis	0.92	GTDB:s__Paraburkholderia_caribensis	0.92	GTDB:s__Paraburkholderia_caribensis	0.92		1
+NCBITaxon:75654	Duganella	GTDB:g__Duganella	0.886	GTDB:g__Duganella	1.0	GTDB:g__Duganella	0.886	GTDB:g__Duganella	1.0		1
+NCBITaxon:75682	Oxalobacteraceae	GTDB:f__Burkholderiaceae	0.995	GTDB:f__Burkholderiaceae	0.995	GTDB:f__Burkholderiaceae	0.996	GTDB:f__Burkholderiaceae	0.997		1
+NCBITaxon:76759	Pseudomonas monteilii	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:76890	Asticcacaulis	GTDB:g__Asticcacaulis	1.0	GTDB:g__Asticcacaulis	1.0	GTDB:g__Asticcacaulis	1.0	GTDB:g__Asticcacaulis	1.0		1
+NCBITaxon:79206	Desulfosporosinus	GTDB:g__Desulfosporosinus	1.0	GTDB:g__Desulfosporosinus	1.0	GTDB:g__Desulfosporosinus	1.0	GTDB:g__Desulfosporosinus	1.0		1
+NCBITaxon:79328	Chitinophaga	GTDB:g__Chitinophaga	1.0	GTDB:g__Chitinophaga	1.0	GTDB:g__Chitinophaga	1.0	GTDB:g__Chitinophaga	1.0		1
+NCBITaxon:795830	Candidatus Brocadia sinica	GTDB:s__Brocadia_sinica	1.0	GTDB:s__Brocadia_sinica	1.0	GTDB:s__Brocadia_sinica	1.0	GTDB:s__Brocadia_sinica	1.0		1
+NCBITaxon:80840	Burkholderiales	GTDB:o__Burkholderiales	1.0	GTDB:o__Burkholderiales	1.0	GTDB:o__Burkholderiales	0.999	GTDB:o__Burkholderiales	1.0		1
+NCBITaxon:80866	Delftia acidovorans	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:816	Bacteroides	GTDB:g__Bacteroides	0.953	GTDB:g__Bacteroides	0.997	GTDB:g__Bacteroides	0.953	GTDB:g__Bacteroides	0.997		1
+NCBITaxon:817	Bacteroides fragilis	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:818	Bacteroides thetaiotaomicron	GTDB:s__Bacteroides_thetaiotaomicron	0.99	GTDB:s__Bacteroides_thetaiotaomicron	0.99	GTDB:s__Bacteroides_thetaiotaomicron	0.99	GTDB:s__Bacteroides_thetaiotaomicron	0.99		1
+NCBITaxon:82	Hyphomicrobium sp.	NONE		NONE		NONE		NONE			1
+NCBITaxon:821	Phocaeicola vulgatus	GTDB:s__Phocaeicola_vulgatus	0.86	GTDB:s__Phocaeicola_vulgatus	0.86	GTDB:s__Phocaeicola_vulgatus	0.86	GTDB:s__Phocaeicola_vulgatus	0.86		1
+NCBITaxon:82380	Microbacterium oxydans	NONE		NONE		NONE		NONE			1
+NCBITaxon:82803	Trichococcus flocculiformis	GTDB:s__Trichococcus_flocculiformis	1.0	GTDB:s__Trichococcus_flocculiformis	1.0	GTDB:s__Trichococcus_flocculiformis	1.0	GTDB:s__Trichococcus_flocculiformis	1.0		1
+NCBITaxon:831	Butyrivibrio fibrisolvens	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:83333	Escherichia coli K-12	GTDB:s__Escherichia_coli	1.0	GTDB:s__Escherichia_coli	1.0	GTDB:s__Escherichia_coli	1.0	GTDB:s__Escherichia_coli	1.0		1
+NCBITaxon:83677	Thermobifida	GTDB:g__Thermobifida	1.0	GTDB:g__Thermobifida	1.0	GTDB:g__Thermobifida	1.0	GTDB:g__Thermobifida	1.0		1
+NCBITaxon:84022	Andreesenella acetica	GTDB:s__Clostridium_W_aceticum	1.0	GTDB:s__Clostridium_W_aceticum	1.0	GTDB:s__Clostridium_W_aceticum	1.0	GTDB:s__Clostridium_W_aceticum	1.0		1
+NCBITaxon:84023	Clostridium autoethanogenum	GTDB:s__Clostridium_B_ljungdahlii	1.0	GTDB:s__Clostridium_B_ljungdahlii	1.0	GTDB:s__Clostridium_B_ljungdahlii	1.0	GTDB:s__Clostridium_B_ljungdahlii	1.0		1
+NCBITaxon:84565	Sodalis	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:84567	Pedobacter	GTDB:g__Pedobacter	0.924	GTDB:g__Pedobacter	0.902	GTDB:g__Pedobacter	0.924	GTDB:g__Pedobacter	0.902		1
+NCBITaxon:85021	Intrasporangiaceae	GTDB:f__Dermatophilaceae	0.997	GTDB:f__Dermatophilaceae	0.996	GTDB:f__Dermatophilaceae	0.997	GTDB:f__Dermatophilaceae	0.996		1
+NCBITaxon:853	Faecalibacterium prausnitzii	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:857252	Halopseudomonas aestusnigri	GTDB:s__Halopseudomonas_aestusnigri	1.0	GTDB:s__Halopseudomonas_aestusnigri	1.0	GTDB:s__Halopseudomonas_aestusnigri	1.0	GTDB:s__Halopseudomonas_aestusnigri	1.0		1
+NCBITaxon:863	Syntrophomonas wolfei	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:86795	Marmoricola	GTDB:g__Marmoricola	0.923	GTDB:g__Marmoricola	1.0	GTDB:g__Marmoricola	0.923	GTDB:g__Marmoricola	1.0		1
+NCBITaxon:870529	Bacillus sp. DB7	NONE		NONE		NONE		NONE			1
+NCBITaxon:870530	Klebsiella sp. DB13	NONE		NONE		NONE		NONE			1
+NCBITaxon:870532	Ochrobactrum sp. DB8	NONE		NONE		NONE		NONE			1
+NCBITaxon:872	Desulfovibrio	GTDB:g__Desulfovibrio	0.871	GTDB:g__Desulfovibrio	0.931	GTDB:g__Desulfovibrio	0.876	GTDB:g__Desulfovibrio	0.937		1
+NCBITaxon:876	Desulfovibrio desulfuricans	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:881	Nitratidesulfovibrio vulgaris	GTDB:s__Nitratidesulfovibrio_vulgaris	1.0	GTDB:s__Nitratidesulfovibrio_vulgaris	1.0	GTDB:s__Nitratidesulfovibrio_vulgaris	1.0	GTDB:s__Nitratidesulfovibrio_vulgaris	1.0		1
+NCBITaxon:882	Nitratidesulfovibrio vulgaris str. Hildenborough	GTDB:s__Nitratidesulfovibrio_vulgaris	1.0	GTDB:s__Nitratidesulfovibrio_vulgaris	1.0	GTDB:s__Nitratidesulfovibrio_vulgaris	1.0	GTDB:s__Nitratidesulfovibrio_vulgaris	1.0		1
+NCBITaxon:885	Desulfovibrio sp.	NONE		NONE		NONE		NONE			1
+NCBITaxon:88730	Pinus massoniana	NONE		NONE		NONE		NONE			1
+NCBITaxon:901	Desulfovibrio piger	GTDB:s__Desulfovibrio_piger	1.0	GTDB:s__Desulfovibrio_piger	1.0	GTDB:s__Desulfovibrio_piger	1.0	GTDB:s__Desulfovibrio_piger	1.0		1
+NCBITaxon:90371	Salmonella enterica subsp. enterica serovar Typhimurium	GTDB:s__Salmonella_enterica	1.0	GTDB:s__Salmonella_enterica	1.0	GTDB:s__Salmonella_enterica	1.0	GTDB:s__Salmonella_enterica	1.0		1
+NCBITaxon:904	Acidaminococcus	GTDB:g__Acidaminococcus	0.991	GTDB:g__Acidaminococcus	1.0	GTDB:g__Acidaminococcus	0.991	GTDB:g__Acidaminococcus	1.0		1
+NCBITaxon:90964	Staphylococcaceae	GTDB:f__Staphylococcaceae	0.993	GTDB:f__Staphylococcaceae	0.997	GTDB:f__Staphylococcaceae	0.964	GTDB:f__Staphylococcaceae	0.983		1
+NCBITaxon:91061	Bacilli	GTDB:c__Bacilli	0.996	GTDB:c__Bacilli	0.999	GTDB:c__Bacilli	0.984	GTDB:c__Bacilli	0.996		1
+NCBITaxon:913	Nitrobacter winogradskyi	GTDB:s__Nitrobacter_winogradskyi_A	0.88	GTDB:s__Nitrobacter_winogradskyi_A	0.88	GTDB:s__Nitrobacter_winogradskyi_A	0.88	GTDB:s__Nitrobacter_winogradskyi_A	0.88		1
+NCBITaxon:915	Nitrosomonas europaea	GTDB:s__Nitrosomonas_europaea	1.0	GTDB:s__Nitrosomonas_europaea	1.0	GTDB:s__Nitrosomonas_europaea	1.0	GTDB:s__Nitrosomonas_europaea	1.0		1
+NCBITaxon:919	Thiobacillus	GTDB:g__Thiobacillus	0.714	GTDB:g__Thiobacillus	1.0	GTDB:g__Thiobacillus	0.708	GTDB:g__Thiobacillus	1.0		1
+NCBITaxon:920	Acidithiobacillus ferrooxidans	GTDB:s__Acidithiobacillus_ferrooxidans	1.0	GTDB:s__Acidithiobacillus_ferrooxidans	1.0	GTDB:s__Acidithiobacillus_ferrooxidans	1.0	GTDB:s__Acidithiobacillus_ferrooxidans	1.0		1
+NCBITaxon:92645	Herbaspirillum frisingense	GTDB:s__Herbaspirillum_frisingense	1.0	GTDB:s__Herbaspirillum_frisingense	1.0	GTDB:s__Herbaspirillum_frisingense	1.0	GTDB:s__Herbaspirillum_frisingense	1.0		1
+NCBITaxon:930	Acidithiobacillus thiooxidans	GTDB:s__Acidithiobacillus_thiooxidans	1.0	GTDB:s__Acidithiobacillus_thiooxidans	1.0	GTDB:s__Acidithiobacillus_thiooxidans	1.0	GTDB:s__Acidithiobacillus_thiooxidans	1.0		1
+NCBITaxon:931	Thiobacillus thioparus	GTDB:s__Thiobacillus_thioparus	1.0	GTDB:s__Thiobacillus_thioparus	1.0	GTDB:s__Thiobacillus_thioparus	1.0	GTDB:s__Thiobacillus_thioparus	1.0		1
+NCBITaxon:94625	Brucella intermedia	GTDB:s__Ochrobactrum_intermedium	0.99	GTDB:s__Ochrobactrum_intermedium	0.99	GTDB:s__Ochrobactrum_intermedium	0.99	GTDB:s__Ochrobactrum_intermedium	0.99		1
+NCBITaxon:96	Gallionella	GTDB:g__Gallionella	1.0	GTDB:g__Gallionella	1.0	GTDB:g__Gallionella	1.0	GTDB:g__Gallionella	1.0		1
+NCBITaxon:9606	Homo sapiens	NONE		NONE		NONE		NONE			1
+NCBITaxon:971	Selenomonas ruminantium	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:97393	Ferroplasma acidarmanus	GTDB:s__Ferroplasma_acidarmanus	1.0	GTDB:s__Ferroplasma_acidarmanus	1.0	GTDB:s__Ferroplasma_acidarmanus	1.0	GTDB:s__Ferroplasma_acidarmanus	1.0		1
+NCBITaxon:976	Bacteroidota	GTDB:p__Bacteroidota	0.999	GTDB:p__Bacteroidota	0.999	GTDB:p__Bacteroidota	0.999	GTDB:p__Bacteroidota	0.999		1
+NCBITaxon:986	Flavobacterium johnsoniae	GTDB:s__Flavobacterium_johnsoniae	1.0	GTDB:s__Flavobacterium_johnsoniae	1.0	GTDB:s__Flavobacterium_johnsoniae	1.0	GTDB:s__Flavobacterium_johnsoniae	1.0		1

--- a/reports/gtdb_denominators.tsv
+++ b/reports/gtdb_denominators.tsv
@@ -1,0 +1,579 @@
+ncbi_id	label	aggregate_gtdb_id	aggregate_fraction	deepest_gtdb_id	deepest_fraction	flip	direction
+NCBITaxon:100176	Papillibacter cinnamivorans	GTDB:s__Papillibacter_cinnamivorans	1.0	GTDB:s__Papillibacter_cinnamivorans	1.0		
+NCBITaxon:100226	Streptomyces coelicolor A3(2)	GTDB:s__Streptomyces_anthocyanicus	1.0	GTDB:s__Streptomyces_anthocyanicus	1.0		
+NCBITaxon:101510	Rhodococcus jostii RHA1	GTDB:s__Rhodococcus_jostii_A	1.0	GTDB:s__Rhodococcus_jostii_A	1.0		
+NCBITaxon:1021	Beggiatoa	GTDB:g__Beggiatoa	0.75	GTDB:g__Beggiatoa	0.727		
+NCBITaxon:10239	Viruses	NONE		NONE			
+NCBITaxon:1031	Thiothrix nivea	GTDB:s__Thiothrix_nivea	1.0	GTDB:s__Thiothrix_nivea	1.0		
+NCBITaxon:1033	Afipia	GTDB:g__Afipia	0.957	GTDB:g__Afipia	0.955		
+NCBITaxon:105841	Anaerostipes caccae	GTDB:s__Anaerostipes_caccae	1.0	GTDB:s__Anaerostipes_caccae	1.0		
+NCBITaxon:105972	Methylosarcina fibrata	GTDB:s__Methylosarcina_fibrata	1.0	GTDB:s__Methylosarcina_fibrata	1.0		
+NCBITaxon:1061	Rhodobacter capsulatus	GTDB:s__Rhodobacter_capsulatus_B	1.0	GTDB:s__Rhodobacter_capsulatus_B	1.0		
+NCBITaxon:1064	Rhodocyclus	GTDB:g__Rhodocyclus	1.0	GTDB:g__Rhodocyclus	1.0		
+NCBITaxon:106591	Ensifer	GTDB:g__Ensifer	0.745	GTDB:g__Ensifer	0.745		
+NCBITaxon:106592	Ensifer adhaerens	GTDB:s__Ensifer_canadensis	1.0	GTDB:s__Ensifer_canadensis	1.0		
+NCBITaxon:1072583	Vreelandella boliviensis LC1	GTDB:s__Vreelandella_boliviensis	1.0	GTDB:s__Vreelandella_boliviensis	1.0		
+NCBITaxon:1076	Rhodopseudomonas palustris	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:1078905	Nitrosotalea devaniterrae	GTDB:s__Nitrosotalea_devanaterra	1.0	GTDB:s__Nitrosotalea_devanaterra	1.0		
+NCBITaxon:1089553	Thermacetogenium phaeum DSM 12270	GTDB:s__Thermacetogenium_phaeum	1.0	GTDB:s__Thermacetogenium_phaeum	1.0		
+NCBITaxon:1090	Chlorobiota	GTDB:p__Bacteroidota	0.989	GTDB:p__Bacteroidota	0.989		
+NCBITaxon:1091494	Methylotuvimicrobium alcaliphilum 20Z	GTDB:s__Methylotuvimicrobium_alcaliphilum	1.0	GTDB:s__Methylotuvimicrobium_alcaliphilum	1.0		
+NCBITaxon:110321	Sinorhizobium medicae	GTDB:s__Sinorhizobium_medicae	1.0	GTDB:s__Sinorhizobium_medicae	1.0		
+NCBITaxon:110500	Pelotomaculum thermopropionicum	GTDB:s__Pelotomaculum_thermopropionicum	1.0	GTDB:s__Pelotomaculum_thermopropionicum	1.0		
+NCBITaxon:1107	Chloroflexus	GTDB:g__Chloroflexus	1.0	GTDB:g__Chloroflexus	1.0		
+NCBITaxon:110932	Leifsonia	GTDB:g__Leifsonia	0.75	GTDB:g__Leifsonia	0.75		
+NCBITaxon:1117	Cyanobacteriota	GTDB:p__Cyanobacteriota	0.998	GTDB:p__Cyanobacteriota	0.998		
+NCBITaxon:1122947	Pelosinus fermentans DSM 17108	GTDB:s__Pelosinus_fermentans	1.0	GTDB:s__Pelosinus_fermentans	1.0		
+NCBITaxon:1125	Microcystis <cyanobacteria>	GTDB:g__Microcystis	0.991	GTDB:g__Microcystis	0.991		
+NCBITaxon:1125364	Coccomyxa onubensis	NONE		NONE			
+NCBITaxon:1129	Synechococcus	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:1130819	Lysinibacillus mangiferihumi	GTDB:s__Lysinibacillus_mangiferihumi	1.0	GTDB:s__Lysinibacillus_mangiferihumi	1.0		
+NCBITaxon:1131703	Sphaerochaeta globosa	GTDB:s__Sphaerochaeta_globosa	1.0	GTDB:s__Sphaerochaeta_globosa	1.0		
+NCBITaxon:1134404	Ignavibacteriota	GTDB:p__Bacteroidota	0.987	GTDB:p__Bacteroidota	0.987		
+NCBITaxon:1140	Synechococcus elongatus PCC 7942 = FACHB-805	GTDB:s__Synechococcus_elongatus	1.0	GTDB:s__Synechococcus_elongatus	1.0		
+NCBITaxon:1163	Anabaena	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:1165	Anabaena cylindrica	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:117187	Fusarium verticillioides	NONE		NONE			
+NCBITaxon:1175444	Methanocella conradii	GTDB:s__Methanocella_conradii	1.0	GTDB:s__Methanocella_conradii	1.0		
+NCBITaxon:1176259	Pseudomonas songnenensis	GTDB:s__Stutzerimonas_songnenensis	1.0	GTDB:s__Stutzerimonas_songnenensis	1.0		
+NCBITaxon:1179	Desmonostoc muscorum	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:1183412	Agrobacterium deltae	GTDB:s__Agrobacterium_leguminum	1.0	GTDB:s__Agrobacterium_leguminum	1.0		
+NCBITaxon:118562	Limnospira platensis	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:118667	Bordetella sp. M1-6	NONE		NONE			
+NCBITaxon:118669	Pseudoxanthomonas sp. M1-3	NONE		NONE			
+NCBITaxon:119060	Burkholderiaceae	GTDB:f__Burkholderiaceae	1.0	GTDB:f__Burkholderiaceae	0.999		
+NCBITaxon:119219	Cupriavidus metallidurans	GTDB:s__Cupriavidus_metallidurans	1.0	GTDB:s__Cupriavidus_metallidurans	1.0		
+NCBITaxon:119484	Syntrophobacter fumaroxidans	GTDB:s__Syntrophobacter_fumaroxidans	1.0	GTDB:s__Syntrophobacter_fumaroxidans	1.0		
+NCBITaxon:119532	Microcoleus vaginatus	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:119977	Acidithiobacillus	GTDB:g__Acidithiobacillus	0.724	GTDB:g__Acidithiobacillus	0.819		
+NCBITaxon:120961	Roseiflexus	GTDB:g__Roseiflexus	1.0	GTDB:g__Roseiflexus	1.0		
+NCBITaxon:121039	Ferrimicrobium acidiphilum	GTDB:s__Ferrimicrobium_acidiphilum	1.0	GTDB:s__Ferrimicrobium_acidiphilum	1.0		
+NCBITaxon:1215089	Planococcus halocryophilus	GTDB:s__Planococcus_halocryophilus	1.0	GTDB:s__Planococcus_halocryophilus	1.0		
+NCBITaxon:1218105	Cupriavidus necator NBRC 102504	GTDB:s__Cupriavidus_necator_D	1.0	GTDB:s__Cupriavidus_necator_D	1.0		
+NCBITaxon:1219	Prochlorococcus marinus	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:1224	Pseudomonadota	GTDB:p__Pseudomonadota	1.0	GTDB:p__Pseudomonadota	1.0		
+NCBITaxon:1234	Nitrospira	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:1236	Gammaproteobacteria	GTDB:c__Gammaproteobacteria	1.0	GTDB:c__Gammaproteobacteria	1.0		
+NCBITaxon:1239	Bacillota	GTDB:p__Bacillota_A	0.55	GTDB:p__Bacillota_A	0.746		
+NCBITaxon:1243	Leuconostoc	GTDB:g__Leuconostoc	0.99	GTDB:g__Leuconostoc	0.995		
+NCBITaxon:1245	Leuconostoc mesenteroides	GTDB:s__Leuconostoc_mesenteroides	0.99	GTDB:s__Leuconostoc_mesenteroides	0.99		
+NCBITaxon:1253	Pediococcus	GTDB:g__Pediococcus	1.0	GTDB:g__Pediococcus	1.0		
+NCBITaxon:1261393	Desulfatiglans parachlorophenolica	NONE		NONE			
+NCBITaxon:1264	Hominimerdicola alba	NONE		NONE			
+NCBITaxon:1269	Micrococcus	GTDB:g__Micrococcus	0.997	GTDB:g__Micrococcus	0.996		
+NCBITaxon:1272	Kocuria varians	NONE		NONE			
+NCBITaxon:1279	Staphylococcus	GTDB:g__Staphylococcus	0.993	GTDB:g__Staphylococcus	0.963		
+NCBITaxon:1280	Staphylococcus aureus	GTDB:s__Staphylococcus_aureus	1.0	GTDB:s__Staphylococcus_aureus	1.0		
+NCBITaxon:12916	Acidovorax	GTDB:g__Acidovorax	0.867	GTDB:g__Acidovorax	0.848		
+NCBITaxon:1303	Streptococcus oralis	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:1304	Streptococcus salivarius	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:1305	Streptococcus sanguinis	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:1308	Streptococcus thermophilus	GTDB:s__Streptococcus_thermophilus	0.99	GTDB:s__Streptococcus_thermophilus	0.99		
+NCBITaxon:1309	Streptococcus mutans	GTDB:s__Streptococcus_mutans	1.0	GTDB:s__Streptococcus_mutans	1.0		
+NCBITaxon:131567	cellular organisms	NONE		NONE			
+NCBITaxon:1317	Streptococcus downei	GTDB:s__Streptococcus_downei	1.0	GTDB:s__Streptococcus_downei	1.0		
+NCBITaxon:133	Methylocystis	GTDB:g__Methylocystis	0.952	GTDB:g__Methylocystis	0.948		
+NCBITaxon:1335	Streptococcus equinus	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:1335640	Clostridium saccharoperbutylacetonicum N1-4	NONE		NONE			
+NCBITaxon:1336235	Paenirhizobium selenitireducens ATCC BAA-1503	NONE		NONE			
+NCBITaxon:13366	Brettanomyces	NONE		NONE			
+NCBITaxon:133926	Olsenella uli	GTDB:s__Olsenella_uli	1.0	GTDB:s__Olsenella_uli	1.0		
+NCBITaxon:134	Methylocystis parvus	GTDB:s__Methylocystis_parva	1.0	GTDB:s__Methylocystis_parva	1.0		
+NCBITaxon:1344414	Trichoderma reesei RUT C-30	NONE		NONE			
+NCBITaxon:1350	Enterococcus	GTDB:g__Enterococcus_B	0.596	AMBIGUOUS		FLIP	loses grounding
+NCBITaxon:1350461	Synechococcus elongatus UTEX 2973	GTDB:s__Synechococcus_elongatus	1.0	GTDB:s__Synechococcus_elongatus	1.0		
+NCBITaxon:1351	Enterococcus faecalis	GTDB:s__Enterococcus_faecalis	1.0	GTDB:s__Enterococcus_faecalis	1.0		
+NCBITaxon:135614	Lysobacterales	GTDB:o__Xanthomonadales	1.0	GTDB:o__Xanthomonadales	0.999		
+NCBITaxon:135619	Oceanospirillales	GTDB:o__Pseudomonadales	0.968	GTDB:o__Pseudomonadales	0.966		
+NCBITaxon:1358	Lactococcus lactis	GTDB:s__Lactococcus_lactis	0.92	GTDB:s__Lactococcus_lactis	0.92		
+NCBITaxon:13687	Sphingomonas	GTDB:g__Sphingomonas	0.777	GTDB:g__Sphingomonas	0.742		
+NCBITaxon:1377992	Halovenus	GTDB:g__Halovenus	1.0	GTDB:g__Halovenus	1.0		
+NCBITaxon:1379858	Mucispirillum schaedleri ASF457	GTDB:s__Mucispirillum_schaedleri	1.0	GTDB:s__Mucispirillum_schaedleri	1.0		
+NCBITaxon:138074	Serratia symbiotica	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:1384459	Methyloceanibacter caenitepidi	GTDB:s__Methyloceanibacter_caenitepidi	1.0	GTDB:s__Methyloceanibacter_caenitepidi	1.0		
+NCBITaxon:1386	Bacillus <firmicutes>	GTDB:g__Bacillus	0.508	AMBIGUOUS		FLIP	loses grounding
+NCBITaxon:1396	Bacillus cereus	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:1398	Heyndrickxia coagulans	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:1401	Paenibacillus lautus	GTDB:s__Paenibacillus_lautus	1.0	GTDB:s__Paenibacillus_lautus	1.0		
+NCBITaxon:1402	Bacillus licheniformis	GTDB:s__Bacillus_licheniformis	0.98	GTDB:s__Bacillus_licheniformis	0.98		
+NCBITaxon:1404	Priestia megaterium	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:1421	Lysinibacillus sphaericus	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:142182	Gemmatimonadota	GTDB:p__Gemmatimonadota	1.0	GTDB:p__Gemmatimonadota	1.0		
+NCBITaxon:1423	Bacillus subtilis	GTDB:s__Bacillus_subtilis	0.91	GTDB:s__Bacillus_subtilis	0.91		
+NCBITaxon:1428	Bacillus thuringiensis	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:1432792	Methylocaldum marinum	GTDB:s__Methylocaldum_marinum	1.0	GTDB:s__Methylocaldum_marinum	1.0		
+NCBITaxon:1434011	Komagataeibacter	GTDB:g__Komagataeibacter	0.973	GTDB:g__Komagataeibacter	0.948		
+NCBITaxon:1434019	Mameliella	GTDB:g__Mameliella	0.905	GTDB:g__Mameliella	0.905		
+NCBITaxon:1436290	Candidatus Symbiobacter mobilis	GTDB:s__Symbiobacter_mobilis	1.0	GTDB:s__Symbiobacter_mobilis	1.0		
+NCBITaxon:145262	Methanothermobacter thermautotrophicus	GTDB:s__Methanothermobacter_thermautotrophicus	1.0	GTDB:s__Methanothermobacter_thermautotrophicus	1.0		
+NCBITaxon:1462422	Candidatus Parvarchaeota	NONE		NONE			
+NCBITaxon:146918	Salinibacter	GTDB:g__Salinibacter	1.0	GTDB:g__Salinibacter	1.0		
+NCBITaxon:1485	Clostridium	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:1492	Clostridium butyricum	GTDB:s__Clostridium_butyricum	0.97	GTDB:s__Clostridium_butyricum	0.97		
+NCBITaxon:149698	Massilia	GTDB:g__Telluria	0.905	GTDB:g__Telluria	0.905		
+NCBITaxon:1501	Clostridium pasteurianum	GTDB:s__Clostridium_I_pasteurianum	1.0	GTDB:s__Clostridium_I_pasteurianum	1.0		
+NCBITaxon:1501972	Brevundimonas sp. R3	NONE		NONE			
+NCBITaxon:1515	Acetivibrio thermocellus	GTDB:s__Hungateiclostridium_thermocellum	1.0	GTDB:s__Hungateiclostridium_thermocellum	1.0		
+NCBITaxon:1517	Thermoanaerobacterium thermosaccharolyticum	GTDB:s__Thermoanaerobacterium_thermosaccharolyticum	1.0	GTDB:s__Thermoanaerobacterium_thermosaccharolyticum	1.0		
+NCBITaxon:151783	Cupriavidus campinensis	GTDB:s__Cupriavidus_campinensis	1.0	GTDB:s__Cupriavidus_campinensis	1.0		
+NCBITaxon:1519	Clostridium tyrobutyricum	GTDB:s__Clostridium_B_tyrobutyricum	0.97	GTDB:s__Clostridium_B_tyrobutyricum	0.97		
+NCBITaxon:1521	Ruminiclostridium cellulolyticum	GTDB:s__Ruminiclostridium_cellulolyticum	1.0	GTDB:s__Ruminiclostridium_cellulolyticum	1.0		
+NCBITaxon:1521555	Eucapsis	NONE		NONE			
+NCBITaxon:1534	Clostridium kluyveri	GTDB:s__Clostridium_B_kluyveri	1.0	GTDB:s__Clostridium_B_kluyveri	1.0		
+NCBITaxon:1538	Clostridium ljungdahlii	GTDB:s__Clostridium_B_ljungdahlii	1.0	GTDB:s__Clostridium_B_ljungdahlii	1.0		
+NCBITaxon:1546519	Sulfitobacter sp. SA11	NONE		NONE			
+NCBITaxon:1547	Thomasclavelia ramosa	GTDB:s__Thomasclavelia_ramosa	0.99	GTDB:s__Thomasclavelia_ramosa	0.99		
+NCBITaxon:1571157	Coniochaeta sp. 2T2.1	NONE		NONE			
+NCBITaxon:1577725	Conticribra weissflogii	NONE		NONE			
+NCBITaxon:1578	Lactobacillus	GTDB:g__Lactobacillus	0.971	GTDB:g__Lactobacillus	0.941		
+NCBITaxon:1582	Lacticaseibacillus casei	GTDB:s__Lacticaseibacillus_paracasei	1.0	GTDB:s__Lacticaseibacillus_paracasei	1.0		
+NCBITaxon:1585	Lactobacillus delbrueckii subsp. bulgaricus	GTDB:s__Lactobacillus_delbrueckii	1.0	GTDB:s__Lactobacillus_delbrueckii	1.0		
+NCBITaxon:1589	Lactiplantibacillus pentosus	GTDB:s__Lactiplantibacillus_pentosus	0.99	GTDB:s__Lactiplantibacillus_pentosus	0.99		
+NCBITaxon:1590	Lactiplantibacillus plantarum	GTDB:s__Lactiplantibacillus_plantarum	1.0	GTDB:s__Lactiplantibacillus_plantarum	1.0		
+NCBITaxon:159743	Paenibacillus terrae	NONE		NONE			
+NCBITaxon:16	Methylophilus	GTDB:g__Methylophilus	1.0	GTDB:g__Methylophilus	1.0		
+NCBITaxon:160488	Pseudomonas putida KT2440	GTDB:s__Pseudomonas_E_alloputida	1.0	GTDB:s__Pseudomonas_E_alloputida	1.0		
+NCBITaxon:1605331	Microbacterium sp. UYFA68	NONE		NONE			
+NCBITaxon:160808	Acidithiobacillus ferrivorans	GTDB:s__Acidithiobacillus_ferrivorans	0.95	GTDB:s__Acidithiobacillus_ferrivorans	0.95		
+NCBITaxon:161493	Anaeromyxobacter dehalogenans	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:1646340	Kosakonia pseudosacchari	GTDB:s__Kosakonia_pseudosacchari	1.0	GTDB:s__Kosakonia_pseudosacchari	1.0		
+NCBITaxon:1655	Actinomyces naeslundii	GTDB:s__Actinomyces_naeslundii	0.96	GTDB:s__Actinomyces_naeslundii	0.96		
+NCBITaxon:165695	Sphingobium	GTDB:g__Sphingobium	0.993	GTDB:g__Sphingobium	0.993		
+NCBITaxon:166486	Roseburia intestinalis	GTDB:s__Roseburia_intestinalis	1.0	GTDB:s__Roseburia_intestinalis	1.0		
+NCBITaxon:1667	Arthrobacter sp.	NONE		NONE			
+NCBITaxon:1673428	Cuniculiplasma divulgatum	NONE		NONE			
+NCBITaxon:1678	Bifidobacterium	GTDB:g__Bifidobacterium	0.998	GTDB:g__Bifidobacterium	0.998		
+NCBITaxon:1681	Bifidobacterium bifidum	GTDB:s__Bifidobacterium_bifidum	1.0	GTDB:s__Bifidobacterium_bifidum	1.0		
+NCBITaxon:1682	Bifidobacterium longum subsp. infantis	GTDB:s__Bifidobacterium_infantis	0.94	GTDB:s__Bifidobacterium_infantis	0.94		
+NCBITaxon:168384	Marvinbryantia formatexigens	GTDB:s__Marvinbryantia_formatexigens	1.0	GTDB:s__Marvinbryantia_formatexigens	1.0		
+NCBITaxon:1685	Bifidobacterium breve	GTDB:s__Bifidobacterium_breve	1.0	GTDB:s__Bifidobacterium_breve	1.0		
+NCBITaxon:169215	Bosea	GTDB:g__Bosea	0.981	GTDB:g__Bosea	0.981		
+NCBITaxon:1696	Brevibacterium	GTDB:g__Brevibacterium	0.987	GTDB:g__Brevibacterium	0.983		
+NCBITaxon:1699721	Neotibicen canicularis	NONE		NONE			
+NCBITaxon:1707	Cellulomonas	GTDB:g__Cellulomonas	0.858	GTDB:g__Cellulomonas	0.859		
+NCBITaxon:1708	Cellulomonas fimi	GTDB:s__Cellulomonas_fimi	1.0	GTDB:s__Cellulomonas_fimi	1.0		
+NCBITaxon:1718	Corynebacterium glutamicum	GTDB:s__Corynebacterium_glutamicum	0.99	GTDB:s__Corynebacterium_glutamicum	0.99		
+NCBITaxon:1763	Mycobacterium	GTDB:g__Mycobacterium	1.0	GTDB:g__Mycobacterium	0.999		
+NCBITaxon:1766253	Agathobacter	GTDB:g__Agathobacter	1.0	GTDB:g__Agathobacter	1.0		
+NCBITaxon:1769012	Arachidicoccus	GTDB:g__Arachidicoccus	1.0	GTDB:g__Arachidicoccus	1.0		
+NCBITaxon:1783273	Patescibacteria group	NONE		NONE			
+NCBITaxon:1783276	Nanobdellati	NONE		NONE			
+NCBITaxon:1785	Mycobacterium sp.	NONE		NONE			
+NCBITaxon:178606	Leptospirillum ferriphilum	GTDB:s__Leptospirillum_A_rubarum	1.0	GTDB:s__Leptospirillum_A_rubarum	1.0		
+NCBITaxon:178898	Carboxydocella	GTDB:g__Carboxydocella	1.0	GTDB:g__Carboxydocella	1.0		
+NCBITaxon:179	Leptospirillum	GTDB:g__Leptospirillum	0.575	GTDB:g__Leptospirillum_A	0.583	FLIP	different taxon
+NCBITaxon:18	Pelobacter	GTDB:g__Syntrophotalea	0.5	GTDB:g__Syntrophotalea	0.583		
+NCBITaxon:180	Leptospirillum ferrooxidans	GTDB:s__Leptospirillum_ferrooxidans	1.0	GTDB:s__Leptospirillum_ferrooxidans	1.0		
+NCBITaxon:180162	Cetobacterium	GTDB:g__Cetobacterium_A	0.927	GTDB:g__Cetobacterium_A	0.927		
+NCBITaxon:1801631	Microcaldota	NONE		NONE			
+NCBITaxon:1807132	Candidatus Phormidium alkaliphilum	NONE		NONE			
+NCBITaxon:1817801	Candidatus Eiseniibacteriota	NONE		NONE			
+NCBITaxon:1822464	Paraburkholderia	GTDB:g__Paraburkholderia	0.988	GTDB:g__Paraburkholderia	0.986		
+NCBITaxon:1827	Rhodococcus <high G+C Gram-positive bacteria>	GTDB:g__Rhodococcus	0.996	GTDB:g__Rhodococcus	0.995		
+NCBITaxon:1847	Pseudonocardia	GTDB:g__Pseudonocardia	1.0	GTDB:g__Pseudonocardia	1.0		
+NCBITaxon:1849822	Paraclostridium	GTDB:g__Paraclostridium	0.995	GTDB:g__Paraclostridium	0.974		
+NCBITaxon:186490	Candidatus Palibaumannia cicadellinicola	NONE		NONE			
+NCBITaxon:1866885	Mycolicibacterium	GTDB:g__Mycobacterium	0.998	GTDB:g__Mycobacterium	0.997		
+NCBITaxon:186801	Clostridia	GTDB:c__Clostridia	0.974	GTDB:c__Clostridia	0.976		
+NCBITaxon:1869185	Taibaiella sp.	NONE		NONE			
+NCBITaxon:1871043	Variovorax sp.	NONE		NONE			
+NCBITaxon:1871068	Phyllobacteriaceae bacterium	NONE		NONE			
+NCBITaxon:1872086	Ensifer sp.	NONE		NONE			
+NCBITaxon:1872114	Acidiplasma sp.	NONE		NONE			
+NCBITaxon:1872122	Acidovorax sp.	NONE		NONE			
+NCBITaxon:1872427	Alcanivorax sp.	NONE		NONE			
+NCBITaxon:1872648	Asticcacaulis sp.	NONE		NONE			
+NCBITaxon:1873462	Microbacteriaceae bacterium	NONE		NONE			
+NCBITaxon:1883	Streptomyces	GTDB:g__Streptomyces	0.973	GTDB:g__Streptomyces	0.972		
+NCBITaxon:1889	Streptomyces ambofaciens	GTDB:s__Streptomyces_ambofaciens	1.0	GTDB:s__Streptomyces_ambofaciens	1.0		
+NCBITaxon:1902583	Candidatus Desulfofervidus	NONE		NONE			
+NCBITaxon:1904413	Suillus clintonianus	NONE		NONE			
+NCBITaxon:1908224	Sphingopyxis sp.	NONE		NONE			
+NCBITaxon:1911909	Neorhizobium sp.	GTDB:s__Neorhizobium_sp028283725	1.0	GTDB:s__Neorhizobium_sp028283725	1.0		
+NCBITaxon:1913961	Rhizobiaceae bacterium	NONE		NONE			
+NCBITaxon:1914288	Dyadobacter sp.	GTDB:s__Dyadobacter_sp017744695	1.0	GTDB:s__Dyadobacter_sp017744695	1.0		
+NCBITaxon:1914538	Pseudomonadaceae bacterium	NONE		NONE			
+NCBITaxon:1918507	Candidatus Phosphitivorax anaerolimi	GTDB:s__UBA1062_sp001896555	1.0	GTDB:s__UBA1062_sp001896555	1.0		
+NCBITaxon:192	Azospirillum brasilense	GTDB:s__Azospirillum_brasilense	1.0	GTDB:s__Azospirillum_brasilense	1.0		
+NCBITaxon:1931	Streptomyces sp.	NONE		NONE			
+NCBITaxon:1935183	Promethearchaeati	NONE		NONE			
+NCBITaxon:1979961	Wenzhouxiangella sp.	NONE		NONE			
+NCBITaxon:198620	Pseudomonas koreensis	NONE		NONE			
+NCBITaxon:1988	Actinomadura	GTDB:g__Spirillospora	0.953	GTDB:g__Spirillospora	0.948		
+NCBITaxon:2	Bacteria	NONE		NONE			
+NCBITaxon:20	Phenylobacterium	GTDB:g__Phenylobacterium	1.0	GTDB:g__Phenylobacterium	1.0		
+NCBITaxon:200795	Chloroflexota	GTDB:p__Chloroflexota	0.998	GTDB:p__Chloroflexota	0.998		
+NCBITaxon:200918	Thermotogota	GTDB:p__Thermotogota	0.997	GTDB:p__Thermotogota	0.996		
+NCBITaxon:201174	Actinomycetota	GTDB:p__Actinomycetota	1.0	GTDB:p__Actinomycetota	1.0		
+NCBITaxon:202950	Acinetobacter baylyi	GTDB:s__Acinetobacter_baylyi	0.96	GTDB:s__Acinetobacter_baylyi	0.96		
+NCBITaxon:2030806	Burkholderiaceae bacterium	NONE		NONE			
+NCBITaxon:203119	Acetivibrio thermocellus ATCC 27405	GTDB:s__Hungateiclostridium_thermocellum	0.93	GTDB:s__Hungateiclostridium_thermocellum	0.93		
+NCBITaxon:203124	Trichodesmium erythraeum IMS101	GTDB:s__Trichodesmium_erythraeum	1.0	GTDB:s__Trichodesmium_erythraeum	1.0		
+NCBITaxon:2034	Curtobacterium	GTDB:g__Curtobacterium	0.993	GTDB:g__Curtobacterium	0.993		
+NCBITaxon:203682	Planctomycetota	GTDB:p__Planctomycetota	0.995	GTDB:p__Planctomycetota	0.995		
+NCBITaxon:203691	Spirochaetota	GTDB:p__Spirochaetota	0.995	GTDB:p__Spirochaetota	0.992		
+NCBITaxon:204441	Rhodospirillales	GTDB:o__RF32	0.636	GTDB:o__RF32	0.647		
+NCBITaxon:2052312	Candidatus Dormiibacterota	NONE		NONE			
+NCBITaxon:2093828	Neorhizobium tomejilense	GTDB:s__Neorhizobium_tomejilense	0.9	GTDB:s__Neorhizobium_tomejilense	0.9		
+NCBITaxon:211586	Shewanella oneidensis MR-1	GTDB:s__Shewanella_oneidensis	1.0	GTDB:s__Shewanella_oneidensis	1.0		
+NCBITaxon:213118	Desulfobacterales	GTDB:o__Desulfobacterales	0.81	GTDB:o__Desulfobacterales	0.79		
+NCBITaxon:213119	Desulfobacteraceae	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:213121	Desulfobulbaceae	GTDB:f__Desulfobulbaceae	0.529	GTDB:f__Desulfobulbaceae	0.517		
+NCBITaxon:2157	Archaea	NONE		NONE			
+NCBITaxon:215813	Dinoroseobacter shibae	GTDB:s__Dinoroseobacter_shibae	1.0	GTDB:s__Dinoroseobacter_shibae	1.0		
+NCBITaxon:2162	Methanobacterium formicicum	GTDB:s__Methanobacterium_formicicum	0.94	GTDB:s__Methanobacterium_formicicum	0.94		
+NCBITaxon:216389	Dehalococcoides mccartyi BAV1	GTDB:s__Dehalococcoides_mccartyi_B	1.0	GTDB:s__Dehalococcoides_mccartyi_B	1.0		
+NCBITaxon:216431	Croceibacter	GTDB:g__Croceibacter	1.0	GTDB:g__Croceibacter	1.0		
+NCBITaxon:216816	Bifidobacterium longum	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:217159	Clostridium carboxidivorans	GTDB:s__Clostridium_AM_carboxidivorans	1.0	GTDB:s__Clostridium_AM_carboxidivorans	1.0		
+NCBITaxon:2172	Methanobrevibacter	GTDB:g__Methanobrevibacter_A	0.955	GTDB:g__Methanobrevibacter_A	0.955		
+NCBITaxon:2173	Methanobrevibacter smithii	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:22	Shewanella	GTDB:g__Shewanella	0.996	GTDB:g__Shewanella	0.994		
+NCBITaxon:2201	Methanofollis liminatans	GTDB:s__Methanofollis_liminatans	1.0	GTDB:s__Methanofollis_liminatans	1.0		
+NCBITaxon:2203	Methanospirillum hungatei	GTDB:s__Methanospirillum_hungatei	1.0	GTDB:s__Methanospirillum_hungatei	1.0		
+NCBITaxon:2208	Methanosarcina barkeri	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:2209	Methanosarcina mazei	GTDB:s__Methanosarcina_mazei	1.0	GTDB:s__Methanosarcina_mazei	1.0		
+NCBITaxon:222	Achromobacter	GTDB:g__Achromobacter	0.981	GTDB:g__Achromobacter	0.981		
+NCBITaxon:2223	Methanothrix soehngenii	GTDB:s__Methanothrix_soehngenii	1.0	GTDB:s__Methanothrix_soehngenii	1.0		
+NCBITaxon:2237	Haloarcula	GTDB:g__Haloarcula	1.0	GTDB:g__Haloarcula	1.0		
+NCBITaxon:2239	Halobacterium	GTDB:g__Halobacterium	1.0	GTDB:g__Halobacterium	1.0		
+NCBITaxon:223967	Methylorubrum populi	GTDB:s__Methylobacterium_thiocyanatum	1.0	GTDB:s__Methylobacterium_thiocyanatum	1.0		
+NCBITaxon:224756	Methanomicrobia	GTDB:c__Methanosarcinia	0.617	GTDB:c__Methanosarcinia	0.617		
+NCBITaxon:225937	Marinobacter adhaerens HP15	GTDB:s__Marinobacter_adhaerens	1.0	GTDB:s__Marinobacter_adhaerens	1.0		
+NCBITaxon:226186	Bacteroides thetaiotaomicron VPI-5482	GTDB:s__Bacteroides_thetaiotaomicron	1.0	GTDB:s__Bacteroides_thetaiotaomicron	1.0		
+NCBITaxon:2268204	Thermoplasmatales archaeon	NONE		NONE			
+NCBITaxon:2283796	Thermoplasmatota	GTDB:p__Thermoplasmatota	1.0	GTDB:p__Thermoplasmatota	0.999		
+NCBITaxon:2301	Thermoplasmatales	GTDB:o__Thermoplasmatales	0.903	GTDB:o__Thermoplasmatales	0.899		
+NCBITaxon:231455	Dyella japonica	GTDB:s__Dyella_marensis	1.0	GTDB:s__Dyella_marensis	1.0		
+NCBITaxon:2357	Desulfomonile	GTDB:g__Desulfomonile	0.667	GTDB:g__Desulfomonile	0.667		
+NCBITaxon:236401	Graphocephala coccinea	NONE		NONE			
+NCBITaxon:237	Flavobacterium	GTDB:g__Flavobacterium	0.99	GTDB:g__Flavobacterium	0.99		
+NCBITaxon:2375	Sporomusa	GTDB:g__Sporomusa	1.0	GTDB:g__Sporomusa	1.0		
+NCBITaxon:237612	Sphingomonas panni	GTDB:s__Sphingomonas_panni	1.0	GTDB:s__Sphingomonas_panni	1.0		
+NCBITaxon:239	Flavobacterium sp.	NONE		NONE			
+NCBITaxon:243164	Dehalococcoides mccartyi 195	GTDB:s__Dehalococcoides_mccartyi	1.0	GTDB:s__Dehalococcoides_mccartyi	1.0		
+NCBITaxon:243232	Methanocaldococcus jannaschii DSM 2661	GTDB:s__Methanocaldococcus_jannaschii	1.0	GTDB:s__Methanocaldococcus_jannaschii	1.0		
+NCBITaxon:243274	Thermotoga maritima MSB8	GTDB:s__Thermotoga_maritima	1.0	GTDB:s__Thermotoga_maritima	1.0		
+NCBITaxon:244366	Klebsiella variicola	GTDB:s__Klebsiella_variicola	1.0	GTDB:s__Klebsiella_variicola	1.0		
+NCBITaxon:246200	Ruegeria pomeroyi DSS-3	GTDB:s__Ruegeria_B_pomeroyi	1.0	GTDB:s__Ruegeria_B_pomeroyi	1.0		
+NCBITaxon:2496117	Variovorax beijingensis	NONE		NONE			
+NCBITaxon:253	Chryseobacterium indologenes	GTDB:s__Chryseobacterium_indologenes	1.0	GTDB:s__Chryseobacterium_indologenes	1.0		
+NCBITaxon:2530459	Galdieria sp.	NONE		NONE			
+NCBITaxon:253314	Acetivibrio straminisolvens	GTDB:s__Hungateiclostridium_straminisolvens	1.0	GTDB:s__Hungateiclostridium_straminisolvens	1.0		
+NCBITaxon:258594	Rhodopseudomonas palustris CGA009	GTDB:s__Rhodopseudomonas_palustris_F	1.0	GTDB:s__Rhodopseudomonas_palustris_F	1.0		
+NCBITaxon:2591003	Ferroplasma sp.	NONE		NONE			
+NCBITaxon:2597222	Candidatus Acidulidesulfobacterium	NONE		NONE			
+NCBITaxon:266	Paracoccus denitrificans	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:267377	Methanococcus maripaludis S2	GTDB:s__Methanococcus_maripaludis	1.0	GTDB:s__Methanococcus_maripaludis	1.0		
+NCBITaxon:2675547	Chlorella sp. HS2	NONE		NONE			
+NCBITaxon:267818	Lactobacillus kefiranofaciens	GTDB:s__Lactobacillus_kefiranofaciens	1.0	GTDB:s__Lactobacillus_kefiranofaciens	1.0		
+NCBITaxon:2697049	Severe acute respiratory syndrome coronavirus 2	NONE		NONE			
+NCBITaxon:269797	Methanosarcina barkeri str. Fusaro	GTDB:s__Methanosarcina_barkeri_B	1.0	GTDB:s__Methanosarcina_barkeri_B	1.0		
+NCBITaxon:270351	Methylobacterium aquaticum	NONE		NONE			
+NCBITaxon:2716471	Sulcia	NONE		NONE			
+NCBITaxon:272772	Pseudomonas pudica	GTDB:s__Pseudomonas_E_pudica	1.0	GTDB:s__Pseudomonas_E_pudica	1.0		
+NCBITaxon:2736640	Pseudonocardia broussonetiae	GTDB:s__Pseudonocardia_broussonetiae	1.0	GTDB:s__Pseudonocardia_broussonetiae	1.0		
+NCBITaxon:2740557	Pauljensenia	GTDB:g__Pauljensenia	1.0	GTDB:g__Pauljensenia	1.0		
+NCBITaxon:2742	Marinobacter	GTDB:g__Marinobacter	0.964	GTDB:g__Marinobacter	0.958		
+NCBITaxon:2759	Eukaryota	NONE		NONE			
+NCBITaxon:2782567	Paenarthrobacter sp. GOM3	GTDB:s__Arthrobacter_sp018215265	1.0	GTDB:s__Arthrobacter_sp018215265	1.0		
+NCBITaxon:280333	Bradyrhizobium pachyrhizi	NONE		NONE			
+NCBITaxon:28034	Sulfobacillus thermosulfidooxidans	GTDB:s__Sulfobacillus_thermosulfidooxidans	1.0	GTDB:s__Sulfobacillus_thermosulfidooxidans	1.0		
+NCBITaxon:28037	Streptococcus mitis	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:28065	Rhodoferax	GTDB:g__Rhodoferax	0.718	GTDB:g__Rhodoferax	0.718		
+NCBITaxon:28108	Alteromonas macleodii	GTDB:s__Alteromonas_macleodii	0.9	GTDB:s__Alteromonas_macleodii	0.9		
+NCBITaxon:2818505	Myxococcota	GTDB:p__Myxococcota	0.903	GTDB:p__Myxococcota	0.9		
+NCBITaxon:28211	Alphaproteobacteria	GTDB:c__Alphaproteobacteria	0.996	GTDB:c__Alphaproteobacteria	0.996		
+NCBITaxon:28216	Betaproteobacteria	GTDB:c__Gammaproteobacteria	1.0	GTDB:c__Gammaproteobacteria	1.0		
+NCBITaxon:28228	Colwellia	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:28231	Geobacter	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:28232	Geobacter metallireducens	GTDB:s__Geobacter_metallireducens	1.0	GTDB:s__Geobacter_metallireducens	1.0		
+NCBITaxon:28261	Thermodesulfovibrio	GTDB:g__Thermodesulfovibrio	1.0	GTDB:g__Thermodesulfovibrio	1.0		
+NCBITaxon:2836	Bacillariophyta	NONE		NONE			
+NCBITaxon:2837503	Gottfriedia	GTDB:g__Gottfriedia	1.0	GTDB:g__Gottfriedia	1.0		
+NCBITaxon:28453	Sphingobacterium	GTDB:g__Sphingobacterium	0.996	GTDB:g__Sphingobacterium	0.996		
+NCBITaxon:286	Pseudomonas	GTDB:g__Pseudomonas	0.596	GTDB:g__Pseudomonas_E	0.852	FLIP	different taxon
+NCBITaxon:287	Pseudomonas aeruginosa	GTDB:s__Pseudomonas_aeruginosa	0.99	GTDB:s__Pseudomonas_aeruginosa	0.99		
+NCBITaxon:2886510	Sphingobacterium paramultivorum	GTDB:s__Sphingobacterium_paramultivorum	0.88	GTDB:s__Sphingobacterium_paramultivorum	0.88		
+NCBITaxon:28889	Thermoproteota	GTDB:p__Thermoproteota	1.0	GTDB:p__Thermoproteota	1.0		
+NCBITaxon:28890	Methanobacteriota	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:2903	Emiliania huxleyi	NONE		NONE			
+NCBITaxon:293387	Bacillus altitudinis	GTDB:s__Bacillus_altitudinis	1.0	GTDB:s__Bacillus_altitudinis	1.0		
+NCBITaxon:29394	Dolosigranulum pigrum	GTDB:s__Dolosigranulum_pigrum	1.0	GTDB:s__Dolosigranulum_pigrum	1.0		
+NCBITaxon:294	Pseudomonas fluorescens	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:29448	Bradyrhizobium elkanii	GTDB:s__Bradyrhizobium_elkanii	0.89	GTDB:s__Bradyrhizobium_elkanii	0.89		
+NCBITaxon:29466	Veillonella parvula	GTDB:s__Veillonella_parvula_A	0.95	GTDB:s__Veillonella_parvula_A	0.95		
+NCBITaxon:29581	Janthinobacterium lividum	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:296543	Thalassiosira pseudonana CCMP1335	NONE		NONE			
+NCBITaxon:2982533	Microbacterium forte	NONE		NONE			
+NCBITaxon:29875	Trichoderma virens	NONE		NONE			
+NCBITaxon:301148	Caldibacillus debilis	GTDB:s__Caldibacillus_debilis	1.0	GTDB:s__Caldibacillus_debilis	1.0		
+NCBITaxon:301375	Methanothrix harundinacea	GTDB:s__Methanocrinis_harundinaceus	1.0	GTDB:s__Methanocrinis_harundinaceus	1.0		
+NCBITaxon:303	Pseudomonas putida	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:3041	Chlorophyta	NONE		NONE			
+NCBITaxon:304371	Methanocella paludicola SANAE	NONE		NONE			
+NCBITaxon:3055	Chlamydomonas reinhardtii	NONE		NONE			
+NCBITaxon:306	Pseudomonas sp.	NONE		NONE			
+NCBITaxon:3071	Chlorella	NONE		NONE			
+NCBITaxon:3073	Scenedesmus fuscus	NONE		NONE			
+NCBITaxon:3074	Parachlorella kessleri	NONE		NONE			
+NCBITaxon:3076	Chlorella sorokiniana	NONE		NONE			
+NCBITaxon:3077	Chlorella vulgaris	NONE		NONE			
+NCBITaxon:316	Stutzerimonas stutzeri	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:316612	Methylibium	GTDB:g__Methylibium	0.607	GTDB:g__Methylibium	0.56		
+NCBITaxon:319464	Clostridium sp. FG4	NONE		NONE			
+NCBITaxon:32008	Burkholderia	GTDB:g__Burkholderia	0.985	GTDB:g__Burkholderia	0.919		
+NCBITaxon:32011	Methylophilaceae	GTDB:f__Methylophilaceae	1.0	GTDB:f__Methylophilaceae	1.0		
+NCBITaxon:32046	Synechococcus elongatus	GTDB:s__Synechococcus_elongatus	0.85	GTDB:s__Synechococcus_elongatus	0.85		
+NCBITaxon:32049	Picosynechococcus sp. PCC 7002	GTDB:s__Limnothrix_sp001693275	1.0	GTDB:s__Limnothrix_sp001693275	1.0		
+NCBITaxon:323259	Methanospirillum hungatei JF-1	GTDB:s__Methanospirillum_hungatei	1.0	GTDB:s__Methanospirillum_hungatei	1.0		
+NCBITaxon:324747	Pseudoxanthomonas byssovorax	NONE		NONE			
+NCBITaxon:33035	Blautia producta	GTDB:s__Blautia_coccoides	1.0	GTDB:s__Blautia_coccoides	1.0		
+NCBITaxon:33038	Mediterraneibacter gnavus	GTDB:s__Ruminococcus_B_gnavus	0.99	GTDB:s__Ruminococcus_B_gnavus	0.99		
+NCBITaxon:33059	Acidithiobacillus caldus	GTDB:s__Acidithiobacillus_A_caldus	1.0	GTDB:s__Acidithiobacillus_A_caldus	1.0		
+NCBITaxon:33075	Acidobacterium capsulatum	NONE		NONE			
+NCBITaxon:332101	Clostridium drakei	GTDB:s__Clostridium_AM_drakei	1.0	GTDB:s__Clostridium_AM_drakei	1.0		
+NCBITaxon:33642	Coscinodiscus radiatus	NONE		NONE			
+NCBITaxon:33849	Bacillariophyceae	NONE		NONE			
+NCBITaxon:3386252	Candidatus Methanogaster	NONE		NONE			
+NCBITaxon:33882	Microbacterium	GTDB:g__Microbacterium	0.995	GTDB:g__Microbacterium	0.995		
+NCBITaxon:33883	Microbacterium arborescens	NONE		NONE			
+NCBITaxon:33905	Bifidobacterium thermophilum	GTDB:s__Bifidobacterium_thermacidophilum	1.0	GTDB:s__Bifidobacterium_thermacidophilum	1.0		
+NCBITaxon:33952	Acetobacterium woodii	GTDB:s__Acetobacterium_woodii	1.0	GTDB:s__Acetobacterium_woodii	1.0		
+NCBITaxon:33962	Lentilactobacillus kefiri	GTDB:s__Lentilactobacillus_kefiri	1.0	GTDB:s__Lentilactobacillus_kefiri	1.0		
+NCBITaxon:340177	Chlorobium chlorochromatii CaD3	NONE	1.0	NONE	1.0		
+NCBITaxon:34037	Rahnella	GTDB:g__Rahnella	1.0	GTDB:g__Rahnella	1.0		
+NCBITaxon:34067	Cycloclasticus	GTDB:g__Cycloclasticus	1.0	GTDB:g__Cycloclasticus	1.0		
+NCBITaxon:34072	Variovorax	GTDB:g__Variovorax	0.99	GTDB:g__Variovorax	0.99		
+NCBITaxon:34073	Variovorax paradoxus	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:34305	Lotus japonicus	NONE		NONE			
+NCBITaxon:34358	Maudiozyma exigua	NONE		NONE			
+NCBITaxon:351627	Caldicellulosiruptor saccharolyticus DSM 8903	GTDB:s__Caldicellulosiruptor_saccharolyticus	1.0	GTDB:s__Caldicellulosiruptor_saccharolyticus	1.0		
+NCBITaxon:353	Azotobacter chroococcum	GTDB:s__Azotobacter_chroococcum	1.0	GTDB:s__Azotobacter_chroococcum	1.0		
+NCBITaxon:354	Azotobacter vinelandii	GTDB:s__Azotobacter_vinelandii	1.0	GTDB:s__Azotobacter_vinelandii	1.0		
+NCBITaxon:354354	Niastella	GTDB:g__Niastella	0.917	GTDB:g__Niastella	0.917		
+NCBITaxon:35554	Geobacter sulfurreducens	GTDB:s__Geobacter_sulfurreducens	1.0	GTDB:s__Geobacter_sulfurreducens	1.0		
+NCBITaxon:356	Hyphomicrobiales	GTDB:o__Rhizobiales	0.988	GTDB:o__Rhizobiales	0.987		
+NCBITaxon:357809	Lachnoclostridium phytofermentans ISDg	GTDB:s__Lachnoclostridium_phytofermentans	1.0	GTDB:s__Lachnoclostridium_phytofermentans	1.0		
+NCBITaxon:358	Agrobacterium tumefaciens	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:359407	Methylotenera	GTDB:g__Methylotenera	0.676	GTDB:g__Methylotenera	0.676		
+NCBITaxon:363331	Chryseobacterium taiwanense	GTDB:s__Chryseobacterium_taiwanense	1.0	GTDB:s__Chryseobacterium_taiwanense	1.0		
+NCBITaxon:36667	Philaenus spumarius	NONE		NONE			
+NCBITaxon:36853	Desulfitobacterium	GTDB:g__Desulfitobacterium	0.946	GTDB:g__Desulfitobacterium	0.943		
+NCBITaxon:36910	Clavispora	NONE		NONE			
+NCBITaxon:3702	Arabidopsis thaliana	NONE		NONE			
+NCBITaxon:372461	Buchnera aphidicola BCc	GTDB:s__Buchnera_aphidicola_F	1.0	GTDB:s__Buchnera_aphidicola_F	1.0		
+NCBITaxon:37319	Pseudo-nitzschia multiseries	NONE		NONE			
+NCBITaxon:374	Bradyrhizobium	GTDB:g__Bradyrhizobium	0.982	GTDB:g__Bradyrhizobium	0.979		
+NCBITaxon:374432	Methylobacterium tardum	GTDB:s__Methylobacterium_tardum	1.0	GTDB:s__Methylobacterium_tardum	1.0		
+NCBITaxon:3747	Fragaria x ananassa	NONE		NONE			
+NCBITaxon:375	Bradyrhizobium japonicum	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:375288	Parabacteroides	GTDB:g__Parabacteroides	0.997	GTDB:g__Parabacteroides	0.997		
+NCBITaxon:375486	Paenibacillus sp. PALXIL05	NONE		NONE			
+NCBITaxon:379	Rhizobium	GTDB:g__Rhizobium	0.723	GTDB:g__Rhizobium	0.723		
+NCBITaxon:37919	Rhodococcus opacus	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:37927	Sinomonas atrocyanea	NONE		NONE			
+NCBITaxon:380021	Pseudomonas protegens	GTDB:s__Pseudomonas_E_protegens	1.0	GTDB:s__Pseudomonas_E_protegens	1.0		
+NCBITaxon:3818	Arachis hypogaea	NONE		NONE			
+NCBITaxon:382	Sinorhizobium meliloti	GTDB:s__Sinorhizobium_meliloti	0.97	GTDB:s__Sinorhizobium_meliloti	0.97		
+NCBITaxon:3847	Glycine max	NONE		NONE			
+NCBITaxon:39152	Methanococcus maripaludis	GTDB:s__Methanococcus_maripaludis	0.93	GTDB:s__Methanococcus_maripaludis	0.93		
+NCBITaxon:391619	Phaeobacter inhibens DSM 17395	GTDB:s__Phaeobacter_inhibens	1.0	GTDB:s__Phaeobacter_inhibens	1.0		
+NCBITaxon:392733	Terriglobus	GTDB:g__Terriglobus	0.833	GTDB:g__Terriglobus	0.818		
+NCBITaxon:3932	Eucalyptus	NONE		NONE			
+NCBITaxon:39488	Anaerobutyricum hallii	GTDB:s__Anaerobutyricum_hallii	1.0	GTDB:s__Anaerobutyricum_hallii	1.0		
+NCBITaxon:395331	Methanoregula	GTDB:g__Methanoregula	1.0	GTDB:g__Methanoregula	1.0		
+NCBITaxon:395960	Rhodopseudomonas palustris TIE-1	GTDB:s__Rhodopseudomonas_palustris_F	1.0	GTDB:s__Rhodopseudomonas_palustris_F	1.0		
+NCBITaxon:399726	Thermoanaerobacter sp. X514	GTDB:s__Thermoanaerobacter_pseudethanolicus	1.0	GTDB:s__Thermoanaerobacter_pseudethanolicus	1.0		
+NCBITaxon:40214	Acinetobacter johnsonii	GTDB:s__Acinetobacter_johnsonii	0.97	GTDB:s__Acinetobacter_johnsonii	0.97		
+NCBITaxon:40222	Methylophaga	GTDB:g__Methylophaga	0.967	GTDB:g__Methylophaga	0.966		
+NCBITaxon:403	Methylococcaceae	GTDB:f__Methylomonadaceae	0.64	GTDB:f__Methylomonadaceae	0.671		
+NCBITaxon:40323	Stenotrophomonas	GTDB:g__Stenotrophomonas	0.987	GTDB:g__Stenotrophomonas	0.987		
+NCBITaxon:40324	Stenotrophomonas maltophilia	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:407	Methylobacterium	GTDB:g__Methylobacterium	0.992	GTDB:g__Methylobacterium	0.991		
+NCBITaxon:408	Methylorubrum extorquens	GTDB:s__Methylobacterium_extorquens	0.88	GTDB:s__Methylobacterium_extorquens	0.88		
+NCBITaxon:4081	Solanum lycopersicum	NONE		NONE			
+NCBITaxon:412449	Leptospirillum ferrodiazotrophum	NONE		NONE			
+NCBITaxon:414878	Catenulispora	GTDB:g__Catenulispora	1.0	GTDB:g__Catenulispora	1.0		
+NCBITaxon:416	Methylomonas	GTDB:g__Methylomonas	0.948	GTDB:g__Methylomonas	0.948		
+NCBITaxon:416169	Rhodanobacter thiooxydans	GTDB:s__Rhodanobacter_thiooxydans	1.0	GTDB:s__Rhodanobacter_thiooxydans	1.0		
+NCBITaxon:419541	Leptospirillum sp. Group II '5-way CG'	NONE		NONE			
+NCBITaxon:423349	Mucilaginibacter	GTDB:g__Mucilaginibacter	1.0	GTDB:g__Mucilaginibacter	1.0		
+NCBITaxon:42445	Sinorhizobium sp.	GTDB:s__Sinorhizobium_sp031178305	1.0	GTDB:s__Sinorhizobium_sp031178305	1.0		
+NCBITaxon:429	Methylobacter	GTDB:g__Methylobacter_A	0.662	GTDB:g__Methylobacter_A	0.682		
+NCBITaxon:429134	Sphingomonas desiccabilis	GTDB:s__Sphingomonas_desiccabilis	1.0	GTDB:s__Sphingomonas_desiccabilis	1.0		
+NCBITaxon:434	Acetobacter	GTDB:g__Acetobacter	0.561	GTDB:g__CAG-267	0.522	FLIP	different taxon
+NCBITaxon:43773	Syntrophus <bacteria>	GTDB:g__Syntrophus	1.0	GTDB:g__Syntrophus	1.0		
+NCBITaxon:43775	Syntrophus gentianae	GTDB:s__Syntrophus_gentianae	1.0	GTDB:s__Syntrophus_gentianae	1.0		
+NCBITaxon:441	Gluconobacter	GTDB:g__Gluconobacter	0.71	GTDB:g__Gluconobacter	0.762		
+NCBITaxon:44249	Paenibacillus	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:44752	Rhodococcus wratislaviensis	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:45200	Methanospirillum sp.	NONE		NONE			
+NCBITaxon:452922	Xenophilus aerolatus	NONE		NONE			
+NCBITaxon:453960	Sulfobacillus benefaciens	GTDB:s__Sulfobacillus_benefaciens	0.96	GTDB:s__Sulfobacillus_benefaciens	0.96		
+NCBITaxon:4547	Saccharum officinarum	NONE		NONE			
+NCBITaxon:4558	Sorghum bicolor	NONE		NONE			
+NCBITaxon:4565	Triticum aestivum	NONE		NONE			
+NCBITaxon:4577	Zea mays	NONE		NONE			
+NCBITaxon:45989	Methanoculleus	GTDB:g__Methanoculleus	0.947	GTDB:g__Methanoculleus	0.947		
+NCBITaxon:46255	Weissella	GTDB:g__Weissella	1.0	GTDB:g__Weissella	1.0		
+NCBITaxon:46913	Devosia	GTDB:g__Devosia	0.769	GTDB:g__Devosia	0.77		
+NCBITaxon:470	Acinetobacter baumannii	GTDB:s__Acinetobacter_baumannii	1.0	GTDB:s__Acinetobacter_baumannii	1.0		
+NCBITaxon:47421	Hydrogenophaga pseudoflava	GTDB:s__Hydrogenophaga_pseudoflava	1.0	GTDB:s__Hydrogenophaga_pseudoflava	1.0		
+NCBITaxon:475088	Methanosphaerula palustris	GTDB:s__Methanosphaerula_palustris	1.0	GTDB:s__Methanosphaerula_palustris	1.0		
+NCBITaxon:4751	Fungi	NONE		NONE			
+NCBITaxon:4757	Neocallimastix frontalis	NONE		NONE			
+NCBITaxon:47715	Lacticaseibacillus rhamnosus	GTDB:s__Lacticaseibacillus_rhamnosus	1.0	GTDB:s__Lacticaseibacillus_rhamnosus	1.0		
+NCBITaxon:47920	Acidovorax delafieldii	NONE		NONE			
+NCBITaxon:483199	Acetobacter fabarum	GTDB:s__Acetobacter_fabarum	1.0	GTDB:s__Acetobacter_fabarum	1.0		
+NCBITaxon:487698	Stenotrophomonas pavanii	GTDB:s__Stenotrophomonas_pavanii	1.0	GTDB:s__Stenotrophomonas_pavanii	1.0		
+NCBITaxon:4890	Ascomycota	NONE		NONE			
+NCBITaxon:48936	Novosphingobium subterraneum	GTDB:s__Novosphingobium_subterraneum	1.0	GTDB:s__Novosphingobium_subterraneum	1.0		
+NCBITaxon:4919	Pichia	NONE		NONE			
+NCBITaxon:492670	Bacillus velezensis	GTDB:s__Bacillus_velezensis	1.0	GTDB:s__Bacillus_velezensis	1.0		
+NCBITaxon:4930	Saccharomyces	NONE		NONE			
+NCBITaxon:4932	Saccharomyces cerevisiae	NONE		NONE			
+NCBITaxon:4948	Torulaspora	NONE		NONE			
+NCBITaxon:4952	Yarrowia lipolytica	NONE		NONE			
+NCBITaxon:4958	Debaryomyces	NONE		NONE			
+NCBITaxon:497726	Nitrososphaera	GTDB:g__Nitrososphaera	0.833	GTDB:g__Nitrososphaera	0.769		
+NCBITaxon:5052	Aspergillus <genus>	NONE		NONE			
+NCBITaxon:5059	Aspergillus flavus	NONE		NONE			
+NCBITaxon:5061	Aspergillus niger	NONE		NONE			
+NCBITaxon:50715	Acidisphaera rubrifaciens	GTDB:s__Acidisphaera_rubrifaciens	1.0	GTDB:s__Acidisphaera_rubrifaciens	1.0		
+NCBITaxon:5073	Penicillium	NONE		NONE			
+NCBITaxon:511145	Escherichia coli str. K-12 substr. MG1655	GTDB:s__Escherichia_coli	1.0	GTDB:s__Escherichia_coli	1.0		
+NCBITaxon:511746	Candidatus Methylacidiphilum infernorum	GTDB:s__Methylacidiphilum_infernorum	1.0	GTDB:s__Methylacidiphilum_infernorum	1.0		
+NCBITaxon:51453	Trichoderma reesei	NONE		NONE			
+NCBITaxon:515619	Agathobacter rectalis ATCC 33656	GTDB:s__Agathobacter_rectalis	1.0	GTDB:s__Agathobacter_rectalis	1.0		
+NCBITaxon:5204	Basidiomycota	NONE		NONE			
+NCBITaxon:5206	Cryptococcus <basidiomycete fungi>	NONE		NONE			
+NCBITaxon:521460	Caldicellulosiruptor bescii DSM 6725	GTDB:s__Caldicellulosiruptor_bescii	1.0	GTDB:s__Caldicellulosiruptor_bescii	1.0		
+NCBITaxon:522	Acidiphilium	GTDB:g__UBA10281	0.633	GTDB:g__UBA10281	0.682		
+NCBITaxon:524	Acidiphilium cryptum	GTDB:s__Acidiphilium_multivorum	1.0	GTDB:s__Acidiphilium_multivorum	1.0		
+NCBITaxon:525	Acidocella facilis	GTDB:s__Acidocella_facilis	1.0	GTDB:s__Acidocella_facilis	1.0		
+NCBITaxon:52972	Polaromonas	GTDB:g__Polaromonas	0.959	GTDB:g__Polaromonas	0.958		
+NCBITaxon:53335	Pantoea	GTDB:g__Pantoea	0.961	GTDB:g__Pantoea	0.928		
+NCBITaxon:542	Zymomonas mobilis	GTDB:s__Zymomonas_mobilis	0.89	GTDB:s__Zymomonas_mobilis	0.89		
+NCBITaxon:54298	Chroococcidiopsis	GTDB:g__Chroococcidiopsis	0.778	GTDB:g__Chroococcidiopsis	0.778		
+NCBITaxon:546	Citrobacter freundii	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:547	Enterobacter	GTDB:g__Enterobacter	0.968	GTDB:g__Enterobacter	0.958		
+NCBITaxon:5475	Candida	NONE		NONE			
+NCBITaxon:5476	Candida albicans	NONE		NONE			
+NCBITaxon:5480	Candida parapsilosis	NONE		NONE			
+NCBITaxon:549	Pantoea agglomerans	GTDB:s__Pantoea_agglomerans	0.9	GTDB:s__Pantoea_agglomerans	0.9		
+NCBITaxon:5498	Cladosporium	NONE		NONE			
+NCBITaxon:550	Enterobacter cloacae	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:5507	Fusarium oxysporum	NONE		NONE			
+NCBITaxon:55080	Brevibacillus	GTDB:g__Brevibacillus	0.816	GTDB:g__Brevibacillus	0.779		
+NCBITaxon:553	Pantoea ananatis	GTDB:s__Pantoea_ananatis	0.99	GTDB:s__Pantoea_ananatis	0.99		
+NCBITaxon:5535	Rhodotorula glutinis	NONE		NONE			
+NCBITaxon:5544	Trichoderma harzianum	NONE		NONE			
+NCBITaxon:5547	Trichoderma viride	NONE		NONE			
+NCBITaxon:5552	Trichosporon	NONE		NONE			
+NCBITaxon:561	Escherichia	GTDB:g__Escherichia	1.0	GTDB:g__Escherichia	0.999		
+NCBITaxon:56112	Dehalobacter	GTDB:g__Dehalobacter	1.0	GTDB:g__Dehalobacter	1.0		
+NCBITaxon:561879	Bacillus safensis	GTDB:s__Bacillus_safensis	1.0	GTDB:s__Bacillus_safensis	1.0		
+NCBITaxon:562	Escherichia coli	GTDB:s__Escherichia_coli	1.0	GTDB:s__Escherichia_coli	1.0		
+NCBITaxon:56780	Syntrophus aciditrophicus SB	GTDB:s__Syntrophus_aciditrophicus	1.0	GTDB:s__Syntrophus_aciditrophicus	1.0		
+NCBITaxon:570	Klebsiella	GTDB:g__Klebsiella	0.999	GTDB:g__Klebsiella	0.999		
+NCBITaxon:571256	Brucella pituitosa	NONE		NONE			
+NCBITaxon:5722	Trichomonas vaginalis	NONE		NONE			
+NCBITaxon:572545	Acetivibrio thermocellus DSM 2360	GTDB:s__Hungateiclostridium_thermocellum	1.0	GTDB:s__Hungateiclostridium_thermocellum	1.0		
+NCBITaxon:573061	Clostridium cellulovorans 743B	GTDB:s__Clostridium_K_cellulovorans	1.0	GTDB:s__Clostridium_K_cellulovorans	1.0		
+NCBITaxon:573657	Candidatus Hodgkinia	NONE		NONE			
+NCBITaxon:574561	Rhizobium pisi	NONE		NONE			
+NCBITaxon:57723	Acidobacteriota	GTDB:p__Acidobacteriota	0.976	GTDB:p__Acidobacteriota	0.975		
+NCBITaxon:587753	Pseudomonas chlororaphis	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:588814	Candidatus Methanophagales	NONE		NONE			
+NCBITaxon:588816	ANME-2 cluster	NONE		NONE			
+NCBITaxon:592050	Acidovorax soli	NONE		NONE			
+NCBITaxon:59732	Chryseobacterium	GTDB:g__Chryseobacterium	0.836	GTDB:g__Chryseobacterium	0.836		
+NCBITaxon:599737	Wickerhamomyces	NONE		NONE			
+NCBITaxon:613	Serratia <enterobacteria>	GTDB:g__Serratia	0.519	GTDB:g__Serratia	0.661		
+NCBITaxon:61434	Dehalococcoides	GTDB:g__Dehalococcoides	0.909	GTDB:g__Dehalococcoides	0.909		
+NCBITaxon:61435	Dehalococcoides mccartyi	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:61624	Paenibacillus mucilaginosus	GTDB:s__Paenibacillus_G_mucilaginosus	0.88	GTDB:s__Paenibacillus_G_mucilaginosus	0.88		
+NCBITaxon:62140	Acidiphilium multivorum	GTDB:s__Acidiphilium_multivorum	1.0	GTDB:s__Acidiphilium_multivorum	1.0		
+NCBITaxon:6239	Caenorhabditis elegans	NONE		NONE			
+NCBITaxon:632335	Caldicellulosiruptor acetigenus I77R1B	GTDB:s__Caldicellulosiruptor_acetigenus	1.0	GTDB:s__Caldicellulosiruptor_acetigenus	1.0		
+NCBITaxon:63743	Natronomonas	GTDB:g__Natronomonas	0.957	GTDB:g__Natronomonas	0.957		
+NCBITaxon:641853	Elusimicrobia	GTDB:c__Elusimicrobia	1.0	GTDB:c__Elusimicrobia	1.0		
+NCBITaxon:644	Aeromonas hydrophila	GTDB:s__Aeromonas_hydrophila	0.96	GTDB:s__Aeromonas_hydrophila	0.96		
+NCBITaxon:648995	Agrobacterium pusense	GTDB:s__Agrobacterium_pusense	1.0	GTDB:s__Agrobacterium_pusense	1.0		
+NCBITaxon:651137	Nitrososphaerota	GTDB:p__Thermoproteota	1.0	GTDB:p__Thermoproteota	1.0		
+NCBITaxon:659243	Bacillus siamensis	GTDB:s__Bacillus_siamensis	0.85	GTDB:s__Bacillus_siamensis	0.85		
+NCBITaxon:666685	Rhodanobacter denitrificans	NONE		NONE			
+NCBITaxon:668369	Escherichia coli DH5[alpha]	GTDB:s__Escherichia_coli	1.0	GTDB:s__Escherichia_coli	1.0		
+NCBITaxon:67812	Candidatus Omnitrophota	NONE		NONE			
+NCBITaxon:68	Lysobacter	GTDB:g__Lysobacter	0.748	GTDB:g__Lysobacter	0.748		
+NCBITaxon:68239	Streptomyces mirabilis	NONE		NONE			
+NCBITaxon:68287	Mesorhizobium	GTDB:g__Mesorhizobium	0.97	GTDB:g__Mesorhizobium	0.969		
+NCBITaxon:69373	Curtobacterium pusillum	NONE		NONE			
+NCBITaxon:69488	Penicillium simplicissimum	NONE		NONE			
+NCBITaxon:69823	Selenomonas sputigena	GTDB:s__Selenomonas_sp905372355	0.86	GTDB:s__Selenomonas_sp905372355	0.86		
+NCBITaxon:70448	Ostreococcus tauri	NONE		NONE			
+NCBITaxon:70863	Shewanella oneidensis	GTDB:s__Shewanella_oneidensis	1.0	GTDB:s__Shewanella_oneidensis	1.0		
+NCBITaxon:71518	Methanocorpusculum bavaricum	GTDB:s__Methanocorpusculum_parvum	1.0	GTDB:s__Methanocorpusculum_parvum	1.0		
+NCBITaxon:7227	Drosophila melanogaster	NONE		NONE			
+NCBITaxon:74030	Roseovarius	GTDB:g__Roseovarius	0.971	GTDB:g__Roseovarius	0.969		
+NCBITaxon:74201	Verrucomicrobiota	GTDB:p__Verrucomicrobiota	1.0	GTDB:p__Verrucomicrobiota	1.0		
+NCBITaxon:74969	Ferroplasma acidiphilum	GTDB:s__Ferroplasma_acidarmanus	0.91	GTDB:s__Ferroplasma_acidarmanus	0.91		
+NCBITaxon:75	Caulobacter	GTDB:g__Caulobacter	0.837	GTDB:g__Caulobacter	0.837		
+NCBITaxon:75105	Paraburkholderia caribensis	GTDB:s__Paraburkholderia_caribensis	0.92	GTDB:s__Paraburkholderia_caribensis	0.92		
+NCBITaxon:75654	Duganella	GTDB:g__Duganella	0.886	GTDB:g__Duganella	0.886		
+NCBITaxon:75682	Oxalobacteraceae	GTDB:f__Burkholderiaceae	0.995	GTDB:f__Burkholderiaceae	0.996		
+NCBITaxon:76759	Pseudomonas monteilii	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:76890	Asticcacaulis	GTDB:g__Asticcacaulis	1.0	GTDB:g__Asticcacaulis	1.0		
+NCBITaxon:79206	Desulfosporosinus	GTDB:g__Desulfosporosinus	1.0	GTDB:g__Desulfosporosinus	1.0		
+NCBITaxon:79328	Chitinophaga	GTDB:g__Chitinophaga	1.0	GTDB:g__Chitinophaga	1.0		
+NCBITaxon:795830	Candidatus Brocadia sinica	GTDB:s__Brocadia_sinica	1.0	GTDB:s__Brocadia_sinica	1.0		
+NCBITaxon:80840	Burkholderiales	GTDB:o__Burkholderiales	1.0	GTDB:o__Burkholderiales	0.999		
+NCBITaxon:80866	Delftia acidovorans	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:816	Bacteroides	GTDB:g__Bacteroides	0.953	GTDB:g__Bacteroides	0.953		
+NCBITaxon:817	Bacteroides fragilis	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:818	Bacteroides thetaiotaomicron	GTDB:s__Bacteroides_thetaiotaomicron	0.99	GTDB:s__Bacteroides_thetaiotaomicron	0.99		
+NCBITaxon:82	Hyphomicrobium sp.	NONE		NONE			
+NCBITaxon:821	Phocaeicola vulgatus	GTDB:s__Phocaeicola_vulgatus	0.86	GTDB:s__Phocaeicola_vulgatus	0.86		
+NCBITaxon:82380	Microbacterium oxydans	NONE		NONE			
+NCBITaxon:82803	Trichococcus flocculiformis	GTDB:s__Trichococcus_flocculiformis	1.0	GTDB:s__Trichococcus_flocculiformis	1.0		
+NCBITaxon:831	Butyrivibrio fibrisolvens	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:83333	Escherichia coli K-12	GTDB:s__Escherichia_coli	1.0	GTDB:s__Escherichia_coli	1.0		
+NCBITaxon:83677	Thermobifida	GTDB:g__Thermobifida	1.0	GTDB:g__Thermobifida	1.0		
+NCBITaxon:84022	Andreesenella acetica	GTDB:s__Clostridium_W_aceticum	1.0	GTDB:s__Clostridium_W_aceticum	1.0		
+NCBITaxon:84023	Clostridium autoethanogenum	GTDB:s__Clostridium_B_ljungdahlii	1.0	GTDB:s__Clostridium_B_ljungdahlii	1.0		
+NCBITaxon:84565	Sodalis	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:84567	Pedobacter	GTDB:g__Pedobacter	0.924	GTDB:g__Pedobacter	0.924		
+NCBITaxon:85021	Intrasporangiaceae	GTDB:f__Dermatophilaceae	0.997	GTDB:f__Dermatophilaceae	0.997		
+NCBITaxon:853	Faecalibacterium prausnitzii	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:857252	Halopseudomonas aestusnigri	GTDB:s__Halopseudomonas_aestusnigri	1.0	GTDB:s__Halopseudomonas_aestusnigri	1.0		
+NCBITaxon:863	Syntrophomonas wolfei	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:86795	Marmoricola	GTDB:g__Marmoricola	0.923	GTDB:g__Marmoricola	0.923		
+NCBITaxon:870529	Bacillus sp. DB7	NONE		NONE			
+NCBITaxon:870530	Klebsiella sp. DB13	NONE		NONE			
+NCBITaxon:870532	Ochrobactrum sp. DB8	NONE		NONE			
+NCBITaxon:872	Desulfovibrio	GTDB:g__Desulfovibrio	0.871	GTDB:g__Desulfovibrio	0.876		
+NCBITaxon:876	Desulfovibrio desulfuricans	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:881	Nitratidesulfovibrio vulgaris	GTDB:s__Nitratidesulfovibrio_vulgaris	1.0	GTDB:s__Nitratidesulfovibrio_vulgaris	1.0		
+NCBITaxon:882	Nitratidesulfovibrio vulgaris str. Hildenborough	GTDB:s__Nitratidesulfovibrio_vulgaris	1.0	GTDB:s__Nitratidesulfovibrio_vulgaris	1.0		
+NCBITaxon:885	Desulfovibrio sp.	NONE		NONE			
+NCBITaxon:88730	Pinus massoniana	NONE		NONE			
+NCBITaxon:901	Desulfovibrio piger	GTDB:s__Desulfovibrio_piger	1.0	GTDB:s__Desulfovibrio_piger	1.0		
+NCBITaxon:90371	Salmonella enterica subsp. enterica serovar Typhimurium	GTDB:s__Salmonella_enterica	1.0	GTDB:s__Salmonella_enterica	1.0		
+NCBITaxon:904	Acidaminococcus	GTDB:g__Acidaminococcus	0.991	GTDB:g__Acidaminococcus	0.991		
+NCBITaxon:90964	Staphylococcaceae	GTDB:f__Staphylococcaceae	0.993	GTDB:f__Staphylococcaceae	0.964		
+NCBITaxon:91061	Bacilli	GTDB:c__Bacilli	0.996	GTDB:c__Bacilli	0.984		
+NCBITaxon:913	Nitrobacter winogradskyi	GTDB:s__Nitrobacter_winogradskyi_A	0.88	GTDB:s__Nitrobacter_winogradskyi_A	0.88		
+NCBITaxon:915	Nitrosomonas europaea	GTDB:s__Nitrosomonas_europaea	1.0	GTDB:s__Nitrosomonas_europaea	1.0		
+NCBITaxon:919	Thiobacillus	GTDB:g__Thiobacillus	0.714	GTDB:g__Thiobacillus	0.708		
+NCBITaxon:920	Acidithiobacillus ferrooxidans	GTDB:s__Acidithiobacillus_ferrooxidans	1.0	GTDB:s__Acidithiobacillus_ferrooxidans	1.0		
+NCBITaxon:92645	Herbaspirillum frisingense	GTDB:s__Herbaspirillum_frisingense	1.0	GTDB:s__Herbaspirillum_frisingense	1.0		
+NCBITaxon:930	Acidithiobacillus thiooxidans	GTDB:s__Acidithiobacillus_thiooxidans	1.0	GTDB:s__Acidithiobacillus_thiooxidans	1.0		
+NCBITaxon:931	Thiobacillus thioparus	GTDB:s__Thiobacillus_thioparus	1.0	GTDB:s__Thiobacillus_thioparus	1.0		
+NCBITaxon:94625	Brucella intermedia	GTDB:s__Ochrobactrum_intermedium	0.99	GTDB:s__Ochrobactrum_intermedium	0.99		
+NCBITaxon:96	Gallionella	GTDB:g__Gallionella	1.0	GTDB:g__Gallionella	1.0		
+NCBITaxon:9606	Homo sapiens	NONE		NONE			
+NCBITaxon:971	Selenomonas ruminantium	AMBIGUOUS		AMBIGUOUS			
+NCBITaxon:97393	Ferroplasma acidarmanus	GTDB:s__Ferroplasma_acidarmanus	1.0	GTDB:s__Ferroplasma_acidarmanus	1.0		
+NCBITaxon:976	Bacteroidota	GTDB:p__Bacteroidota	0.999	GTDB:p__Bacteroidota	0.999		
+NCBITaxon:986	Flavobacterium johnsoniae	GTDB:s__Flavobacterium_johnsoniae	1.0	GTDB:s__Flavobacterium_johnsoniae	1.0		

--- a/reports/gtdb_denominators.tsv
+++ b/reports/gtdb_denominators.tsv
@@ -1,5 +1,5 @@
 # mapping: NCBI2GTDB.tsv.gz	bytes=2895086	mtime=1785022111
-# taxa=578	varying=17
+# taxa=578	varying=16
 ncbi_id	label	aggregate_id	aggregate_frac	aggregate_named_id	aggregate_named_frac	deepest_id	deepest_frac	deepest_named_id	deepest_named_frac	varies	distinct_answers
 NCBITaxon:100176	Papillibacter cinnamivorans	GTDB:s__Papillibacter_cinnamivorans	1.0	GTDB:s__Papillibacter_cinnamivorans	1.0	GTDB:s__Papillibacter_cinnamivorans	1.0	GTDB:s__Papillibacter_cinnamivorans	1.0		1
 NCBITaxon:100226	Streptomyces coelicolor A3(2)	GTDB:s__Streptomyces_anthocyanicus	1.0	GTDB:s__Streptomyces_anthocyanicus	1.0	GTDB:s__Streptomyces_anthocyanicus	1.0	GTDB:s__Streptomyces_anthocyanicus	1.0		1
@@ -12,7 +12,7 @@ NCBITaxon:105841	Anaerostipes caccae	GTDB:s__Anaerostipes_caccae	1.0	GTDB:s__Ana
 NCBITaxon:105972	Methylosarcina fibrata	GTDB:s__Methylosarcina_fibrata	1.0	GTDB:s__Methylosarcina_fibrata	1.0	GTDB:s__Methylosarcina_fibrata	1.0	GTDB:s__Methylosarcina_fibrata	1.0		1
 NCBITaxon:1061	Rhodobacter capsulatus	GTDB:s__Rhodobacter_capsulatus_B	1.0	GTDB:s__Rhodobacter_capsulatus_B	1.0	GTDB:s__Rhodobacter_capsulatus_B	1.0	GTDB:s__Rhodobacter_capsulatus_B	1.0		1
 NCBITaxon:1064	Rhodocyclus	GTDB:g__Rhodocyclus	1.0	GTDB:g__Rhodocyclus	1.0	GTDB:g__Rhodocyclus	1.0	GTDB:g__Rhodocyclus	1.0		1
-NCBITaxon:106591	Ensifer	GTDB:g__Ensifer	0.745	GTDB:g__Sinorhizobium	0.5	GTDB:g__Ensifer	0.745	GTDB:g__Sinorhizobium	0.5	VARIES	2
+NCBITaxon:106591	Ensifer	GTDB:g__Ensifer	0.745	GTDB:g__Ensifer	0.5	GTDB:g__Ensifer	0.745	GTDB:g__Ensifer	0.5		1
 NCBITaxon:106592	Ensifer adhaerens	GTDB:s__Ensifer_canadensis	1.0	GTDB:s__Ensifer_canadensis	1.0	GTDB:s__Ensifer_canadensis	1.0	GTDB:s__Ensifer_canadensis	1.0		1
 NCBITaxon:1072583	Vreelandella boliviensis LC1	GTDB:s__Vreelandella_boliviensis	1.0	GTDB:s__Vreelandella_boliviensis	1.0	GTDB:s__Vreelandella_boliviensis	1.0	GTDB:s__Vreelandella_boliviensis	1.0		1
 NCBITaxon:1076	Rhodopseudomonas palustris	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
@@ -24,7 +24,7 @@ NCBITaxon:110321	Sinorhizobium medicae	GTDB:s__Sinorhizobium_medicae	1.0	GTDB:s_
 NCBITaxon:110500	Pelotomaculum thermopropionicum	GTDB:s__Pelotomaculum_thermopropionicum	1.0	GTDB:s__Pelotomaculum_thermopropionicum	1.0	GTDB:s__Pelotomaculum_thermopropionicum	1.0	GTDB:s__Pelotomaculum_thermopropionicum	1.0		1
 NCBITaxon:1107	Chloroflexus	GTDB:g__Chloroflexus	1.0	GTDB:g__Chloroflexus	1.0	GTDB:g__Chloroflexus	1.0	GTDB:g__Chloroflexus	1.0		1
 NCBITaxon:110932	Leifsonia	GTDB:g__Leifsonia	0.75	GTDB:g__Leifsonia	0.958	GTDB:g__Leifsonia	0.75	GTDB:g__Leifsonia	0.958		1
-NCBITaxon:1117	Cyanobacteriota	GTDB:p__Cyanobacteriota	0.998	GTDB:p__Cyanobacteriota	0.999	GTDB:p__Cyanobacteriota	0.998	GTDB:p__Cyanobacteriota	0.999		1
+NCBITaxon:1117	Cyanobacteriota	GTDB:p__Cyanobacteriota	0.998	GTDB:p__Cyanobacteriota	1.0	GTDB:p__Cyanobacteriota	0.998	GTDB:p__Cyanobacteriota	1.0		1
 NCBITaxon:1122947	Pelosinus fermentans DSM 17108	GTDB:s__Pelosinus_fermentans	1.0	GTDB:s__Pelosinus_fermentans	1.0	GTDB:s__Pelosinus_fermentans	1.0	GTDB:s__Pelosinus_fermentans	1.0		1
 NCBITaxon:1125	Microcystis <cyanobacteria>	GTDB:g__Microcystis	0.991	GTDB:g__Microcystis	0.986	GTDB:g__Microcystis	0.991	GTDB:g__Microcystis	0.986		1
 NCBITaxon:1125364	Coccomyxa onubensis	NONE		NONE		NONE		NONE			1
@@ -294,11 +294,11 @@ NCBITaxon:28261	Thermodesulfovibrio	GTDB:g__Thermodesulfovibrio	1.0	GTDB:g__Ther
 NCBITaxon:2836	Bacillariophyta	NONE		NONE		NONE		NONE			1
 NCBITaxon:2837503	Gottfriedia	GTDB:g__Gottfriedia	1.0	GTDB:g__Gottfriedia	1.0	GTDB:g__Gottfriedia	1.0	GTDB:g__Gottfriedia	1.0		1
 NCBITaxon:28453	Sphingobacterium	GTDB:g__Sphingobacterium	0.996	GTDB:g__Sphingobacterium	0.996	GTDB:g__Sphingobacterium	0.996	GTDB:g__Sphingobacterium	0.996		1
-NCBITaxon:286	Pseudomonas	GTDB:g__Pseudomonas	0.596	GTDB:g__Pseudomonas	0.692	GTDB:g__Pseudomonas_E	0.852	GTDB:g__Pseudomonas_E	0.798	VARIES	2
+NCBITaxon:286	Pseudomonas	GTDB:g__Pseudomonas	0.596	GTDB:g__Pseudomonas	0.699	GTDB:g__Pseudomonas_E	0.852	GTDB:g__Pseudomonas_E	0.793	VARIES	2
 NCBITaxon:287	Pseudomonas aeruginosa	GTDB:s__Pseudomonas_aeruginosa	0.99	GTDB:s__Pseudomonas_aeruginosa	0.99	GTDB:s__Pseudomonas_aeruginosa	0.99	GTDB:s__Pseudomonas_aeruginosa	0.99		1
 NCBITaxon:2886510	Sphingobacterium paramultivorum	GTDB:s__Sphingobacterium_paramultivorum	0.88	GTDB:s__Sphingobacterium_paramultivorum	0.88	GTDB:s__Sphingobacterium_paramultivorum	0.88	GTDB:s__Sphingobacterium_paramultivorum	0.88		1
 NCBITaxon:28889	Thermoproteota	GTDB:p__Thermoproteota	1.0	GTDB:p__Thermoproteota	1.0	GTDB:p__Thermoproteota	1.0	GTDB:p__Thermoproteota	1.0		1
-NCBITaxon:28890	Methanobacteriota	AMBIGUOUS		GTDB:p__Methanobacteriota	0.531	AMBIGUOUS		GTDB:p__Methanobacteriota	0.534	VARIES	2
+NCBITaxon:28890	Methanobacteriota	AMBIGUOUS		GTDB:p__Methanobacteriota	0.531	AMBIGUOUS		GTDB:p__Methanobacteriota	0.535	VARIES	2
 NCBITaxon:2903	Emiliania huxleyi	NONE		NONE		NONE		NONE			1
 NCBITaxon:293387	Bacillus altitudinis	GTDB:s__Bacillus_altitudinis	1.0	GTDB:s__Bacillus_altitudinis	1.0	GTDB:s__Bacillus_altitudinis	1.0	GTDB:s__Bacillus_altitudinis	1.0		1
 NCBITaxon:29394	Dolosigranulum pigrum	GTDB:s__Dolosigranulum_pigrum	1.0	GTDB:s__Dolosigranulum_pigrum	1.0	GTDB:s__Dolosigranulum_pigrum	1.0	GTDB:s__Dolosigranulum_pigrum	1.0		1

--- a/reports/gtdb_denominators.tsv
+++ b/reports/gtdb_denominators.tsv
@@ -1,3 +1,5 @@
+# mapping: NCBI2GTDB.tsv.gz	bytes=2895086	mtime=1785022111
+# taxa=578	flips=5
 ncbi_id	label	aggregate_gtdb_id	aggregate_fraction	deepest_gtdb_id	deepest_fraction	flip	direction
 NCBITaxon:100176	Papillibacter cinnamivorans	GTDB:s__Papillibacter_cinnamivorans	1.0	GTDB:s__Papillibacter_cinnamivorans	1.0		
 NCBITaxon:100226	Streptomyces coelicolor A3(2)	GTDB:s__Streptomyces_anthocyanicus	1.0	GTDB:s__Streptomyces_anthocyanicus	1.0		

--- a/scripts/gtdb_denominator_compare.py
+++ b/scripts/gtdb_denominator_compare.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Compare the two GTDB majority denominators over every taxon in the KB (#371).
+
+`NCBI2GTDB.tsv.gz` is an upstream crosswalk (Bork group / metatraits) in which
+each row is an independent NCBI->GTDB assignment carrying its own genome support.
+`gtdb_ground.py` sums that support over every matched row. Because a genome
+supports the assignment of its strain *and* its species *and* its genus, the
+supports total 1.84M across the table against ~600k genomes in a GTDB release.
+
+That is a weighting choice, not an arithmetic error, and the alternative — one
+row per lineage at the deepest depth available — is equally defensible. It is
+also the rule `kg-microbe-paper` settled on for the same shape of problem.
+
+Neither is provably right, so this script does not pick. It emits the comparison
+so the choice can be made from the table rather than in the abstract, which is
+the process that prior art used: write every scenario out, and be explicit that
+the preferred one was not chosen for producing the nicer answer.
+
+    uv run python scripts/gtdb_denominator_compare.py [--out reports/gtdb_denominators.tsv]
+
+Columns: the taxon, both grounded ids, both majority fractions, and whether the
+outcome flips — and in which direction.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).parent.parent
+COMMUNITIES = REPO / "kb/communities"
+
+
+def _load_grounder():
+    spec = importlib.util.spec_from_file_location("gtdb_ground", REPO / "scripts/gtdb_ground.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _kb_taxa() -> list:
+    """Every distinct (ncbi_id, label) in the KB, deduplicated on the id."""
+    seen: dict[str, str] = {}
+    for path in sorted(COMMUNITIES.glob("*.yaml")):
+        data = yaml.safe_load(path.read_text()) or {}
+        for taxon in data.get("taxonomy") or []:
+            if not isinstance(taxon, dict):
+                continue
+            term = (taxon.get("taxon_term") or {}).get("term") or {}
+            tid = str(term.get("id") or "")
+            if tid.startswith("NCBITaxon:"):
+                seen.setdefault(tid, term.get("label") or "")
+    return sorted(seen.items())
+
+
+def _outcome(result) -> tuple:
+    """(gtdb_id, majority_fraction) for a resolve_target result; AMBIGUOUS if split."""
+    if not result:
+        return ("NONE", "")
+    if result.get("ambiguous"):
+        return ("AMBIGUOUS", "")
+    return (result.get("gtdb_id") or "NONE", result.get("majority_fraction", ""))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, default=REPO / "reports/gtdb_denominators.tsv")
+    parser.add_argument("--kg-microbe-dir", default=None)
+    args = parser.parse_args()
+
+    grounder = _load_grounder()
+    try:
+        mapping = grounder.resolve_kg_microbe_dir(args.kg_microbe_dir) / "data/raw/NCBI2GTDB.tsv.gz"
+    except SystemExit as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    taxa = _kb_taxa()
+    ids = {tid.split(":")[1] for tid, _ in taxa}
+    species = {grounder._clean_label(l).lower() for _, l in taxa if " " in grounder._clean_label(l)}
+    higher = {
+        grounder._clean_label(l).lower() for _, l in taxa if " " not in grounder._clean_label(l)
+    }
+    by_id, by_name, by_higher = grounder.collect_rows(mapping, ids, species, higher)
+
+    rows, flips = [], 0
+    for tid, label in taxa:
+        core = tid.split(":")[1]
+        agg = grounder.resolve_target(core, label, by_id, by_name, by_higher)
+        # Only the higher-rank path has a denominator choice; species/id paths
+        # resolve a single row and are identical under both.
+        deep = grounder.resolve_target(
+            core, label, by_id, by_name, by_higher, denominator="deepest"
+        )
+        a_id, a_frac = _outcome(agg)
+        d_id, d_frac = _outcome(deep)
+        if a_id != d_id:
+            flips += 1
+            direction = (
+                "gains grounding"
+                if a_id in ("AMBIGUOUS", "NONE") and d_id.startswith("GTDB:")
+                else (
+                    "loses grounding"
+                    if d_id in ("AMBIGUOUS", "NONE") and a_id.startswith("GTDB:")
+                    else "different taxon"
+                )
+            )
+        else:
+            direction = ""
+        rows.append((tid, label, a_id, a_frac, d_id, d_frac, "FLIP" if direction else "", direction))
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.out, "w") as fh:
+        fh.write(
+            "ncbi_id\tlabel\taggregate_gtdb_id\taggregate_fraction\t"
+            "deepest_gtdb_id\tdeepest_fraction\tflip\tdirection\n"
+        )
+        for row in rows:
+            fh.write("\t".join(str(c) for c in row) + "\n")
+
+    print(f"taxa compared: {len(rows)}")
+    print(f"outcome flips: {flips}")
+    for row in rows:
+        if row[6]:
+            print(f"  {row[0]:<20s} {row[1][:26]:<28s} {row[2]} {row[3]} -> {row[4]} {row[5]}"
+                  f"   [{row[7]}]")
+    print(f"\nwritten to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gtdb_denominator_compare.py
+++ b/scripts/gtdb_denominator_compare.py
@@ -18,8 +18,13 @@ the preferred one was not chosen for producing the nicer answer.
 
     uv run python scripts/gtdb_denominator_compare.py [--out reports/gtdb_denominators.tsv]
 
-Columns: the taxon, both grounded ids, both majority fractions, and whether the
-outcome flips — and in which direction.
+Columns: the taxon, then an id and a majority fraction for each of the four
+scenarios, then whether the outcome varies and how many distinct answers there
+are — twelve columns in all.
+
+The report is a snapshot, not a gate: nothing in `just qc` regenerates it, so it
+goes stale silently. It was stale once already, recording a tie-break the code no
+longer produces. Re-run this script after any change to the grounding rules.
 """
 
 from __future__ import annotations

--- a/scripts/gtdb_denominator_compare.py
+++ b/scripts/gtdb_denominator_compare.py
@@ -86,7 +86,7 @@ def main() -> int:
     higher = {c.lower() for c in cleaned if " " not in c}
     by_id, by_name, by_higher = grounder.collect_rows(mapping, ids, species, higher)
 
-    SCENARIOS = [
+    scenarios = [
         ("aggregate", "aggregate", False),
         ("aggregate+named", "aggregate", True),
         ("deepest", "deepest", False),
@@ -105,9 +105,8 @@ def main() -> int:
                     denominator=den, exclude_unnamed=filt,
                 )
             )
-            for name, den, filt in SCENARIOS
+            for name, den, filt in scenarios
         }
-        default = answers["aggregate"][0]
         varies = sorted({a[0] for a in answers.values()})
         if len(varies) > 1:
             differ_from_default += 1

--- a/scripts/gtdb_denominator_compare.py
+++ b/scripts/gtdb_denominator_compare.py
@@ -81,10 +81,9 @@ def main() -> int:
 
     taxa = _kb_taxa()
     ids = {tid.split(":")[1] for tid, _ in taxa}
-    species = {grounder._clean_label(l).lower() for _, l in taxa if " " in grounder._clean_label(l)}
-    higher = {
-        grounder._clean_label(l).lower() for _, l in taxa if " " not in grounder._clean_label(l)
-    }
+    cleaned = [grounder._clean_label(label) for _, label in taxa]
+    species = {c.lower() for c in cleaned if " " in c}
+    higher = {c.lower() for c in cleaned if " " not in c}
     by_id, by_name, by_higher = grounder.collect_rows(mapping, ids, species, higher)
 
     rows, flips = [], 0
@@ -100,21 +99,28 @@ def main() -> int:
         d_id, d_frac = _outcome(deep)
         if a_id != d_id:
             flips += 1
-            direction = (
-                "gains grounding"
-                if a_id in ("AMBIGUOUS", "NONE") and d_id.startswith("GTDB:")
-                else (
-                    "loses grounding"
-                    if d_id in ("AMBIGUOUS", "NONE") and a_id.startswith("GTDB:")
-                    else "different taxon"
-                )
-            )
+            unresolved = ("AMBIGUOUS", "NONE")
+            if a_id in unresolved and d_id.startswith("GTDB:"):
+                direction = "gains grounding"
+            elif d_id in unresolved and a_id.startswith("GTDB:"):
+                direction = "loses grounding"
+            elif a_id in unresolved and d_id in unresolved:
+                direction = "unresolved either way"
+            else:
+                direction = "different taxon"
         else:
             direction = ""
-        rows.append((tid, label, a_id, a_frac, d_id, d_frac, "FLIP" if direction else "", direction))
+        rows.append(
+            (tid, label, a_id, a_frac, d_id, d_frac, "FLIP" if direction else "", direction)
+        )
 
     args.out.parent.mkdir(parents=True, exist_ok=True)
+    stat = mapping.stat()
     with open(args.out, "w") as fh:
+        # Provenance: the upstream crosswalk churns (the KB already carries two
+        # build vintages), so a bare table would go stale silently.
+        fh.write(f"# mapping: {mapping.name}\tbytes={stat.st_size}\tmtime={int(stat.st_mtime)}\n")
+        fh.write(f"# taxa={len(rows)}\tflips={flips}\n")
         fh.write(
             "ncbi_id\tlabel\taggregate_gtdb_id\taggregate_fraction\t"
             "deepest_gtdb_id\tdeepest_fraction\tflip\tdirection\n"
@@ -126,8 +132,10 @@ def main() -> int:
     print(f"outcome flips: {flips}")
     for row in rows:
         if row[6]:
-            print(f"  {row[0]:<20s} {row[1][:26]:<28s} {row[2]} {row[3]} -> {row[4]} {row[5]}"
-                  f"   [{row[7]}]")
+            print(
+                f"  {row[0]:<20s} {row[1][:26]:<28s} {row[2]} {row[3]} -> {row[4]} {row[5]}"
+                f"   [{row[7]}]"
+            )
     print(f"\nwritten to {args.out}")
     return 0
 

--- a/scripts/gtdb_denominator_compare.py
+++ b/scripts/gtdb_denominator_compare.py
@@ -86,33 +86,33 @@ def main() -> int:
     higher = {c.lower() for c in cleaned if " " not in c}
     by_id, by_name, by_higher = grounder.collect_rows(mapping, ids, species, higher)
 
-    rows, flips = [], 0
+    SCENARIOS = [
+        ("aggregate", "aggregate", False),
+        ("aggregate+named", "aggregate", True),
+        ("deepest", "deepest", False),
+        ("deepest+named", "deepest", True),
+    ]
+
+    rows, differ_from_default = [], 0
     for tid, label in taxa:
         core = tid.split(":")[1]
-        agg = grounder.resolve_target(core, label, by_id, by_name, by_higher)
-        # Only the higher-rank path has a denominator choice; species/id paths
-        # resolve a single row and are identical under both.
-        deep = grounder.resolve_target(
-            core, label, by_id, by_name, by_higher, denominator="deepest"
-        )
-        a_id, a_frac = _outcome(agg)
-        d_id, d_frac = _outcome(deep)
-        if a_id != d_id:
-            flips += 1
-            unresolved = ("AMBIGUOUS", "NONE")
-            if a_id in unresolved and d_id.startswith("GTDB:"):
-                direction = "gains grounding"
-            elif d_id in unresolved and a_id.startswith("GTDB:"):
-                direction = "loses grounding"
-            elif a_id in unresolved and d_id in unresolved:
-                direction = "unresolved either way"
-            else:
-                direction = "different taxon"
-        else:
-            direction = ""
-        rows.append(
-            (tid, label, a_id, a_frac, d_id, d_frac, "FLIP" if direction else "", direction)
-        )
+        # Only the higher-rank path has these choices; the species and id paths
+        # resolve a single row and are identical under all four.
+        answers = {
+            name: _outcome(
+                grounder.resolve_target(
+                    core, label, by_id, by_name, by_higher,
+                    denominator=den, exclude_unnamed=filt,
+                )
+            )
+            for name, den, filt in SCENARIOS
+        }
+        default = answers["aggregate"][0]
+        varies = sorted({a[0] for a in answers.values()})
+        if len(varies) > 1:
+            differ_from_default += 1
+        rows.append((tid, label, *[x for a in answers.values() for x in a],
+                     "VARIES" if len(varies) > 1 else "", len(varies)))
 
     args.out.parent.mkdir(parents=True, exist_ok=True)
     stat = mapping.stat()
@@ -120,22 +120,25 @@ def main() -> int:
         # Provenance: the upstream crosswalk churns (the KB already carries two
         # build vintages), so a bare table would go stale silently.
         fh.write(f"# mapping: {mapping.name}\tbytes={stat.st_size}\tmtime={int(stat.st_mtime)}\n")
-        fh.write(f"# taxa={len(rows)}\tflips={flips}\n")
+        fh.write(f"# taxa={len(rows)}\tvarying={differ_from_default}\n")
         fh.write(
-            "ncbi_id\tlabel\taggregate_gtdb_id\taggregate_fraction\t"
-            "deepest_gtdb_id\tdeepest_fraction\tflip\tdirection\n"
+            "ncbi_id\tlabel\t"
+            "aggregate_id\taggregate_frac\t"
+            "aggregate_named_id\taggregate_named_frac\t"
+            "deepest_id\tdeepest_frac\t"
+            "deepest_named_id\tdeepest_named_frac\t"
+            "varies\tdistinct_answers\n"
         )
         for row in rows:
             fh.write("\t".join(str(c) for c in row) + "\n")
 
     print(f"taxa compared: {len(rows)}")
-    print(f"outcome flips: {flips}")
+    print(f"taxa where the four scenarios disagree: {differ_from_default}")
     for row in rows:
-        if row[6]:
-            print(
-                f"  {row[0]:<20s} {row[1][:26]:<28s} {row[2]} {row[3]} -> {row[4]} {row[5]}"
-                f"   [{row[7]}]"
-            )
+        if row[10]:
+            print(f"  {row[0]:<18s} {row[1][:24]:<26s} "
+                  f"agg={row[2]:<26s} agg+named={row[4]:<26s} "
+                  f"deep={row[6]:<26s} deep+named={row[8]}")
     print(f"\nwritten to {args.out}")
     return 0
 

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -248,7 +248,7 @@ def deepest_only(matched: list) -> list:
 
 
 def resolve_higher(clean_lc, source_id, label, by_higher, denominator="aggregate",
-                   exclude_unnamed=False):
+                   exclude_unnamed=True):
     """Ground a genus/family/... input to the majority GTDB taxon at that rank.
 
     `denominator` selects how genome support is summed: "aggregate" (default,
@@ -289,7 +289,12 @@ def resolve_higher(clean_lc, source_id, label, by_higher, denominator="aggregate
         if not weights:
             return None
         total = sum(weights.values())
-        top, tw = max(weights.items(), key=lambda kv: kv[1])
+        # Break ties by name, not by row order. `max` returns the first maximum,
+        # which for an exact tie is whichever row the mapping happened to list
+        # first — reversing the input flipped Ensifer/Sinorhizobium (both at 0.5).
+        # Whether a 50/50 split should ground *at all* is a separate question
+        # (#382); this only makes the answer reproducible.
+        top, tw = sorted(weights.items(), key=lambda kv: (-kv[1], kv[0]))[0]
         frac = tw / total
         if frac >= 0.5:
             return {
@@ -315,7 +320,7 @@ def resolve_higher(clean_lc, source_id, label, by_higher, denominator="aggregate
 
 
 def resolve_target(ncbi_id, label, by_id, by_name, by_higher, denominator="aggregate",
-                   exclude_unnamed=False):
+                   exclude_unnamed=True):
     """Species: id then name (split-aware). Genus/higher: majority GTDB rank taxon.
 
     `denominator` is forwarded to `resolve_higher`; the species and id paths

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -11,9 +11,16 @@ input:
   miss on id alone). When GTDB splits one NCBI species into several, report
   AMBIGUOUS rather than guessing.
 * genus / family / order / ... (single-name label) -> ``GTDB:g__...`` (or
-  ``f__``/``o__``/...): aggregate the GTDB rank column over all genomes under the
-  NCBI taxon; ground to the GTDB taxon holding a majority (>=50%) of genomes, else
+  ``f__``/``o__``/...): aggregate the GTDB rank column over the genomes under the
+  NCBI taxon; ground to the GTDB taxon holding a majority (>=50%) of them, else
   report AMBIGUOUS (e.g. NCBI genus Bacillus shatters into ~100 GTDB genera).
+
+  Since #372 that aggregation counts only rows naming an actual binomial —
+  ``exclude_unnamed`` defaults to True, so ``sp.``/``uncultured``/informal rows
+  are excluded (#375). It is a real change of denominator, not a tidy-up: it
+  moved 219 of the KB's 647 stored fractions. A tie is broken by name, which
+  makes it reproducible but still a tie (#382), and the block does not record how
+  many genomes the fraction was computed from (#383).
 
 GTDB frequently reclassifies relative to NCBI (e.g. NCBITaxon "Agrobacterium
 deltae" -> GTDB "Agrobacterium leguminum"); ``is_reclassified`` flags it.
@@ -173,8 +180,28 @@ def _ground_species(rows, source_id, label, via):
 # and explicit placeholders. `Candidatus` is deliberately absent — a Candidatus
 # name is a provisional *species* name for an uncultivated organism, not a
 # placeholder, and excluding it would discard legitimate taxonomy.
+# Measured over all 92711 crosswalk rows. Three of the original alternations
+# under-matched because `\b` anchors the *start* of a compound word:
+#   `\bsymbiont\b`  missed `endosymbiont`      -> 331 rows survived as binomials
+#   `\bsp\.`         missed `genomosp.`         -> 72 rows
+#   `\bbacterium\b` missed `proteobacterium`   -> 94 rows
+# Allowing a preceding word-part fixes all three. `metagenome` and `unclassified`
+# match nothing in this table today; both are kept as cheap forward guards.
 UNNAMED_SPECIES = re.compile(
-    r"\bsp\.|\b(?:bacterium|archaeon|symbiont|metagenome)\b"
+    # `\b` anchors the start of a compound word, so the original alternations
+    # under-matched: `symbiont` missed `endosymbiont` (331 rows survived as if
+    # binomial), `bacterium` missed `proteobacterium` (94), `sp.` missed
+    # `genomosp.` (72). Measured over all 92711 crosswalk rows.
+    #
+    # The compound forms must stay **case-sensitive and lowercase-only**, hence
+    # the scoped `(?-i:)`. An informal descriptor is lowercase (`gamma
+    # proteobacterium`, `Wolbachia endosymbiont of ...`); a genus that merely
+    # ends in the same letters is capitalised, and dropping those would discard
+    # 1700+ real binomials — *Acetobacterium woodii*, *Acidipropionibacterium
+    # jensenii*. `genomosp.` is listed explicitly rather than as `\w*sp\.`,
+    # which would also swallow the legitimate `subsp.`.
+    r"\bsp\.|\bgenomosp\."
+    r"|(?-i:\b[a-z]*(?:bacterium|archaeon|symbiont|metagenome)\b)"
     r"|^(?:uncultured|unclassified|unidentified)\b",
     re.IGNORECASE,
 )
@@ -193,10 +220,12 @@ def named_species_only(matched: list) -> list:
     this filter, all 257 binomial Acetobacter genomes map to `g__Acetobacter` and
     both denominators agree (#375).
 
-    Opt-in, because it is not uniformly better: it also turns `Serratia` from a
-    type-anchored answer into AMBIGUOUS, and it does *not* make the two
-    denominators agree in general — 8 taxa still differ with it applied, against
-    5 without. See reports/gtdb_denominators.tsv.
+    **On by default** as of #372, but not uniformly better: it turns `Serratia`
+    from a type-anchored answer into AMBIGUOUS, and it does not make the two
+    denominators agree in general. It also shrinks the evidence behind a
+    grounding without recording that it did — `majority_fraction` reads the same
+    at 4 genomes as at 4000, which is #383. See reports/gtdb_denominators.tsv for
+    the current scenario counts rather than a number quoted here, which rots.
     """
     return [r for r in matched if r[COL_NCBI_SPECIES].strip()
             and not UNNAMED_SPECIES.search(r[COL_NCBI_SPECIES].strip())]
@@ -251,10 +280,21 @@ def resolve_higher(clean_lc, source_id, label, by_higher, denominator="aggregate
                    exclude_unnamed=True):
     """Ground a genus/family/... input to the majority GTDB taxon at that rank.
 
-    `denominator` selects how genome support is summed: "aggregate" (default,
-    unchanged) sums every matched row; "deepest" keeps one row per lineage.
-    See `deepest_only` and #371.
+    `denominator` selects how genome support is summed: "aggregate" (the default)
+    sums every matched row; "deepest" keeps one row per lineage. See `deepest_only`
+    and #371 — that choice is published in reports/gtdb_denominators.tsv rather
+    than argued here.
+
+    `exclude_unnamed` is the orthogonal axis and defaults to **True** (#375): rows
+    whose NCBI species is not a binomial are dropped before the count. Pass False
+    for the pre-#372 behaviour. Note the two interact — with the filter on, every
+    blank-species row is gone before `deepest_only` ever sees it.
     """
+    # Validate before any early return. This used to sit inside the rank loop, so
+    # a typo'd denominator returned None instead of raising whenever the taxon had
+    # no rows or no rank matched (#372 review).
+    if denominator not in ("aggregate", "deepest"):
+        raise ValueError(f"unknown denominator {denominator!r}; expected 'aggregate' or 'deepest'")
     rows = by_higher.get(clean_lc)
     if not rows:
         return None
@@ -268,10 +308,6 @@ def resolve_higher(clean_lc, source_id, label, by_higher, denominator="aggregate
             # from MAG bins would otherwise go from a grounding to nothing.
             if filtered:
                 matched = filtered
-        if denominator not in ("aggregate", "deepest"):
-            raise ValueError(
-                f"unknown denominator {denominator!r}; expected 'aggregate' or 'deepest'"
-            )
         if denominator == "deepest":
             matched = deepest_only(matched)
         weights: dict[str, float] = defaultdict(float)
@@ -307,7 +343,9 @@ def resolve_higher(clean_lc, source_id, label, by_higher, denominator="aggregate
                 "via": f"ncbi_rank_{prefix}",
                 "n_alt": len(weights),
             }
-        ranked = [k for k, _ in sorted(weights.items(), key=lambda kv: -kv[1])]
+        # Same tie-break as `top` above: ties here were still row-ordered, so the
+        # AMBIGUOUS option list a curator reads was not reproducible (#382 review).
+        ranked = [k for k, _ in sorted(weights.items(), key=lambda kv: (-kv[1], kv[0]))]
         return {
             "ambiguous": True,
             "via": f"ncbi_rank_{prefix}",
@@ -418,7 +456,14 @@ def _block_span(lines: list[str], anchor: int, end: int) -> tuple[int, int] | No
 
 
 def apply_to_community(
-    path: Path, by_id, by_name, by_higher, mapping_source, refresh: bool = False
+    path: Path,
+    by_id,
+    by_name,
+    by_higher,
+    mapping_source,
+    refresh: bool = False,
+    denominator: str = "aggregate",
+    exclude_unnamed: bool = True,
 ) -> int:
     """Insert or refresh gtdb_classification in taxonomy taxon_terms, line-level.
 
@@ -452,7 +497,15 @@ def apply_to_community(
             # normal: act on ungrounded only. refresh: act on grounded only.
             wanted.append(None)
             continue
-        g = resolve_target(tid.split(":", 1)[1], term.get("label", ""), by_id, by_name, by_higher)
+        g = resolve_target(
+            tid.split(":", 1)[1],
+            term.get("label", ""),
+            by_id,
+            by_name,
+            by_higher,
+            denominator=denominator,
+            exclude_unnamed=exclude_unnamed,
+        )
         # A result with no gtdb_id is not a grounding: `_ground_species` returns
         # one when the GTDB species cell is empty. Writing it replaced a curated
         # `g__Chlorobium` with nulls on refresh, so treat it as ungroundable and
@@ -634,6 +687,19 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="With --apply: recompute blocks that already exist. Creates none.",
     )
+    p.add_argument(
+        "--denominator",
+        choices=("aggregate", "deepest"),
+        default="aggregate",
+        help="How genome support is summed (#371). aggregate: every matched row. "
+        "deepest: one row per lineage, at the deepest rank present.",
+    )
+    p.add_argument(
+        "--include-unnamed",
+        action="store_true",
+        help="Count rows whose NCBI species is not a binomial (sp./uncultured/informal). "
+        "Off by default since #375; this restores the pre-#372 denominator.",
+    )
     args = p.parse_args(argv)
 
     kg_dir = resolve_kg_microbe_dir(args.kg_microbe_dir)
@@ -664,14 +730,29 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.community and args.apply:
         n = apply_to_community(
-            args.community, by_id, by_name, by_higher, mapping_source, refresh=args.refresh
+            args.community,
+            by_id,
+            by_name,
+            by_higher,
+            mapping_source,
+            refresh=args.refresh,
+            denominator=args.denominator,
+            exclude_unnamed=not args.include_unnamed,
         )
         print(f"[gtdb] applied {n} block(s) to {args.community.name}", file=sys.stderr)
         return 0
 
     n_ok = 0
     for ncbi_id, label in targets:
-        g = resolve_target(ncbi_id, label, by_id, by_name, by_higher)
+        g = resolve_target(
+            ncbi_id,
+            label,
+            by_id,
+            by_name,
+            by_higher,
+            denominator=args.denominator,
+            exclude_unnamed=not args.include_unnamed,
+        )
         head = f"\nNCBITaxon:{ncbi_id}" if ncbi_id else f"\n{label}"
         if label and ncbi_id:
             head += f"  {label}"

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -198,10 +198,13 @@ def deepest_only(matched: list) -> list:
     lineages: dict[str, dict[str, list]] = {}
     for row in matched:
         species = row[COL_NCBI_SPECIES].strip().lower()
-        strain = row[COL_NCBI_STRAIN].strip() if len(row) > COL_NCBI_STRAIN else ""
+        strain = row[COL_NCBI_STRAIN].strip()
         # A strain row with no species names its own lineage; without this it
-        # would be pooled under "" with every other speciesless strain.
-        key = species or (strain.lower() if strain else f"__row{id(row)}")
+        # would pool under "" with every other speciesless strain and lose to
+        # whichever the sort happened to favour. Rows with neither share one
+        # lineage, which is harmless: with no strain bucket to prefer, every one
+        # of them is kept regardless.
+        key = species or strain.lower()
         lineages.setdefault(key, {"strain": [], "species": []})
         lineages[key]["strain" if strain else "species"].append(row)
 
@@ -225,6 +228,10 @@ def resolve_higher(clean_lc, source_id, label, by_higher, denominator="aggregate
         matched = [r for r in rows if r[ncbi_col].strip().lower() == clean_lc]
         if not matched:
             continue
+        if denominator not in ("aggregate", "deepest"):
+            raise ValueError(
+                f"unknown denominator {denominator!r}; expected 'aggregate' or 'deepest'"
+            )
         if denominator == "deepest":
             matched = deepest_only(matched)
         weights: dict[str, float] = defaultdict(float)

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -54,6 +54,7 @@ COL_NCBI_ID = 0
 COL_TOTAL_GENOMES = 2
 COL_MAJORITY = 3
 COL_NCBI_SPECIES = 10
+COL_NCBI_STRAIN = 11
 COL_GTDB_SPECIES = 18
 # (ncbi_col, gtdb_col, rank_prefix) for higher ranks, finest -> coarsest.
 HIGHER_RANKS = [(9, 17, "g"), (8, 16, "f"), (7, 15, "o"), (6, 14, "c"), (5, 13, "p")]
@@ -168,8 +169,55 @@ def _ground_species(rows, source_id, label, via):
     }
 
 
-def resolve_higher(clean_lc, source_id, label, by_higher):
-    """Ground a genus/family/... input to the majority GTDB taxon at that rank."""
+def deepest_only(matched: list) -> list:
+    """Keep one depth per lineage: strain rows where a lineage has any, else its species row.
+
+    `NCBI2GTDB.tsv.gz` is an upstream crosswalk (Bork group / metatraits) in which
+    every row is an independent NCBI->GTDB assignment carrying its own genome
+    support. Summing across depths therefore aggregates evidence rather than
+    double-counting a ledger — a genome legitimately supports its strain's
+    assignment and its species' — but it weights deeply sequenced lineages more
+    heavily. Over all 92711 rows the supports total 1.84M against ~600k genomes
+    in a release.
+
+    This is the alternative denominator: one row per lineage, at the deepest
+    depth available. It mirrors the rule kg-microbe-paper settled on for the same
+    shape of problem ("deepest available level, one level only, per parent").
+
+    The leaf case is handled first and deliberately: a row that is itself a
+    strain with no species is kept as its own lineage. In the prior art, the
+    equivalent branch looked up a leaf as if it were a parent, found nothing, and
+    silently dropped the taxon.
+
+    Note this is *not* provably the correct denominator. Containment does not
+    hold in this table: of the 2827 species carrying both a species row and
+    strain rows, 1363 have strain supports exceeding the species row — e.g.
+    Agathobacter rectalis, 418 genomes at the species node against 13850 at its
+    type strain. See #371.
+    """
+    lineages: dict[str, dict[str, list]] = {}
+    for row in matched:
+        species = row[COL_NCBI_SPECIES].strip().lower()
+        strain = row[COL_NCBI_STRAIN].strip() if len(row) > COL_NCBI_STRAIN else ""
+        # A strain row with no species names its own lineage; without this it
+        # would be pooled under "" with every other speciesless strain.
+        key = species or (strain.lower() if strain else f"__row{id(row)}")
+        lineages.setdefault(key, {"strain": [], "species": []})
+        lineages[key]["strain" if strain else "species"].append(row)
+
+    kept = []
+    for group in lineages.values():
+        kept.extend(group["strain"] or group["species"])
+    return kept
+
+
+def resolve_higher(clean_lc, source_id, label, by_higher, denominator="aggregate"):
+    """Ground a genus/family/... input to the majority GTDB taxon at that rank.
+
+    `denominator` selects how genome support is summed: "aggregate" (default,
+    unchanged) sums every matched row; "deepest" keeps one row per lineage.
+    See `deepest_only` and #371.
+    """
     rows = by_higher.get(clean_lc)
     if not rows:
         return None
@@ -177,6 +225,8 @@ def resolve_higher(clean_lc, source_id, label, by_higher):
         matched = [r for r in rows if r[ncbi_col].strip().lower() == clean_lc]
         if not matched:
             continue
+        if denominator == "deepest":
+            matched = deepest_only(matched)
         weights: dict[str, float] = defaultdict(float)
         rep: dict[str, list] = {}
         for r in matched:
@@ -217,8 +267,12 @@ def resolve_higher(clean_lc, source_id, label, by_higher):
     return None
 
 
-def resolve_target(ncbi_id, label, by_id, by_name, by_higher):
-    """Species: id then name (split-aware). Genus/higher: majority GTDB rank taxon."""
+def resolve_target(ncbi_id, label, by_id, by_name, by_higher, denominator="aggregate"):
+    """Species: id then name (split-aware). Genus/higher: majority GTDB rank taxon.
+
+    `denominator` is forwarded to `resolve_higher`; the species and id paths
+    resolve a single row and are identical under either choice (#371).
+    """
     source_id = f"NCBITaxon:{ncbi_id}" if ncbi_id else None
     clean = _clean_label(label)
     if _is_species(clean):
@@ -243,7 +297,7 @@ def resolve_target(ncbi_id, label, by_id, by_name, by_higher):
                     "n_alt": len(species),
                 }
         return None
-    return resolve_higher(clean.lower(), source_id, label, by_higher)
+    return resolve_higher(clean.lower(), source_id, label, by_higher, denominator)
 
 
 def _block(g: dict, mapping_source: str) -> dict:

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -169,6 +169,39 @@ def _ground_species(rows, source_id, label, via):
     }
 
 
+# NCBI species strings that name no species: metagenome bins, informal lineages
+# and explicit placeholders. `Candidatus` is deliberately absent — a Candidatus
+# name is a provisional *species* name for an uncultivated organism, not a
+# placeholder, and excluding it would discard legitimate taxonomy.
+UNNAMED_SPECIES = re.compile(
+    r"\bsp\.|\b(?:bacterium|archaeon|symbiont|metagenome)\b"
+    r"|^(?:uncultured|unclassified|unidentified)\b",
+    re.IGNORECASE,
+)
+
+
+def named_species_only(matched: list) -> list:
+    """Drop rows whose NCBI species is not an actual binomial.
+
+    Half the crosswalk is unbinomialed — 33.7% `sp.`, 10.9% informal
+    (`Firmicutes bacterium CAG:176`), 5.2% placeholder-prefixed. Those rows carry
+    genome counts like any other, so a heavily-binned MAG lineage can outvote the
+    cultivated species that share the NCBI taxon.
+
+    `Acetobacter` is the worked case: `g__CAG-267` draws its entire 338-genome
+    support from two `sp.` rows, and wins under the `deepest` denominator. With
+    this filter, all 257 binomial Acetobacter genomes map to `g__Acetobacter` and
+    both denominators agree (#375).
+
+    Opt-in, because it is not uniformly better: it also turns `Serratia` from a
+    type-anchored answer into AMBIGUOUS, and it does *not* make the two
+    denominators agree in general — 8 taxa still differ with it applied, against
+    5 without. See reports/gtdb_denominators.tsv.
+    """
+    return [r for r in matched if r[COL_NCBI_SPECIES].strip()
+            and not UNNAMED_SPECIES.search(r[COL_NCBI_SPECIES].strip())]
+
+
 def deepest_only(matched: list) -> list:
     """Keep one depth per lineage: strain rows where a lineage has any, else its species row.
 
@@ -214,7 +247,8 @@ def deepest_only(matched: list) -> list:
     return kept
 
 
-def resolve_higher(clean_lc, source_id, label, by_higher, denominator="aggregate"):
+def resolve_higher(clean_lc, source_id, label, by_higher, denominator="aggregate",
+                   exclude_unnamed=False):
     """Ground a genus/family/... input to the majority GTDB taxon at that rank.
 
     `denominator` selects how genome support is summed: "aggregate" (default,
@@ -228,6 +262,12 @@ def resolve_higher(clean_lc, source_id, label, by_higher, denominator="aggregate
         matched = [r for r in rows if r[ncbi_col].strip().lower() == clean_lc]
         if not matched:
             continue
+        if exclude_unnamed:
+            filtered = named_species_only(matched)
+            # Never let the filter empty a taxon out entirely: a genus known only
+            # from MAG bins would otherwise go from a grounding to nothing.
+            if filtered:
+                matched = filtered
         if denominator not in ("aggregate", "deepest"):
             raise ValueError(
                 f"unknown denominator {denominator!r}; expected 'aggregate' or 'deepest'"
@@ -274,7 +314,8 @@ def resolve_higher(clean_lc, source_id, label, by_higher, denominator="aggregate
     return None
 
 
-def resolve_target(ncbi_id, label, by_id, by_name, by_higher, denominator="aggregate"):
+def resolve_target(ncbi_id, label, by_id, by_name, by_higher, denominator="aggregate",
+                   exclude_unnamed=False):
     """Species: id then name (split-aware). Genus/higher: majority GTDB rank taxon.
 
     `denominator` is forwarded to `resolve_higher`; the species and id paths
@@ -304,7 +345,7 @@ def resolve_target(ncbi_id, label, by_id, by_name, by_higher, denominator="aggre
                     "n_alt": len(species),
                 }
         return None
-    return resolve_higher(clean.lower(), source_id, label, by_higher, denominator)
+    return resolve_higher(clean.lower(), source_id, label, by_higher, denominator, exclude_unnamed)
 
 
 def _block(g: dict, mapping_source: str) -> dict:

--- a/tests/test_gtdb_batch_independence.py
+++ b/tests/test_gtdb_batch_independence.py
@@ -15,7 +15,8 @@ were starved worst — over the whole KB, `pseudomonadota` went from 238 rows to
 That is not academic. It changed three whole-KB outcomes, one of which was live
 in the KB: `NCBITaxon:403` (*Methylococcaceae*) had been grounded to
 `GTDB:f__Methylococcaceae` on a bare 0.505 majority computed from a starved row
-set. With the full set it resolves to `GTDB:f__Methylomonadaceae` at 0.64, and
+set. With the full set it resolves to `GTDB:f__Methylomonadaceae` at 0.695 (0.64 before the
+named-species filter became the default in #372), and
 `is_reclassified` flips to true. GTDB did not *rename* Methylococcaceae —
 `f__Methylococcaceae` still exists and holds 31% of the NCBI family, including
 the type genus *Methylococcus*. It **split** it, and the majority moved. The
@@ -129,7 +130,7 @@ def test_the_regrounded_record_matches_the_tool(gtdb, mapping):
     """`NCBITaxon:403` is the live outcome the fix changed, pinned to the tool.
 
     The stored block claimed `GTDB:f__Methylococcaceae` at a 0.505 majority and
-    `is_reclassified: false`; the full row set gives `Methylomonadaceae` at 0.64,
+    `is_reclassified: false`; the full row set gives `Methylomonadaceae` at 0.695,
     reclassified. If these drift apart again, one of them is stale.
     """
     import yaml
@@ -149,7 +150,7 @@ def test_the_regrounded_record_matches_the_tool(gtdb, mapping):
     # Pin the tool's own values too. Asserting only on the stored YAML let two
     # mutants through: destroying the genome weighting, and hard-wiring
     # is_reclassified False in resolve_higher.
-    assert fresh["majority_fraction"] == stored["majority_fraction"] == 0.64
+    assert fresh["majority_fraction"] == stored["majority_fraction"] == 0.695
     assert (
         fresh["is_reclassified"] is stored["is_reclassified"] is True
     ), "GTDB's name for this family differs from NCBI's, so both must say so"

--- a/tests/test_gtdb_denominator.py
+++ b/tests/test_gtdb_denominator.py
@@ -8,13 +8,24 @@ present — the rule `kg-microbe-paper` settled on for the same shape of problem
 The comparison is the point, not a winner. `scripts/gtdb_denominator_compare.py`
 writes both answers for all 578 KB taxa; 5 flip, affecting 26 stored blocks.
 
-The tests below pin the mechanics and one diagnostic result. `deepest` is *not*
-a neutral correction: dropping a lineage's species rows while keeping its strain
-rows shifts weight toward lineages that happen to be annotated at strain rank.
-`Acetobacter` is the clearest case — `CAG-267`'s support is two strain rows (336
-and 2 genomes), so it survives intact while Acetobacter's own support falls from
-458 to 289, and a cultivated genus in a Drosophila gut record grounds to an
-uncultivated MAG lineage. That is why the default did not change.
+`deepest` is *not* a neutral correction: dropping a lineage's species rows while
+keeping its strain rows shifts weight toward lineages that happen to be annotated
+at strain rank. Table-wide it discards 801367 of 1837914 genome-supports (43.6%).
+
+Judged against GTDB's own rule — the lineage holding the nomenclatural type keeps
+the unsuffixed name — `aggregate` is the better answer for 4 of the 5 taxa where
+they differ. The sharpest is Pseudomonas: `deepest` discards *P. aeruginosa*'s
+17191-genome species row in favour of 615 genomes across 289 strain rows, and
+lands on `g__Pseudomonas_E` at 0.852 — more confidently wrong than the Acetobacter
+case, which is only 0.522.
+
+**The default is not uniformly right.** For Enterococcus it grounds to
+`g__Enterococcus_B`, the *E. faecium* clade, purely because faecium is more
+sequenced than the type species *E. faecalis* — see #373 and #374. `deepest`
+returns AMBIGUOUS there, which is the honest answer.
+
+A third option neither denominator covers would fix Acetobacter under both:
+exclude `sp.`/`uncultured` MAG rows (#375).
 """
 
 import importlib.util
@@ -94,6 +105,34 @@ def test_a_strain_row_with_no_species_is_its_own_lineage(gtdb):
     assert len(kept) == 2, "distinct speciesless strains must not collapse into one lineage"
 
 
+def test_a_row_with_neither_species_nor_strain_is_kept_separately(gtdb):
+    """The both-blank branch — the one the narrative leans on, previously untested.
+
+    Keying on the species alone pools every such row under `""`. Mixed with a
+    speciesless *strain* row that pooling is detectable: the blank row would land
+    in the same lineage and be suppressed as its "species" alternative, so the
+    count drops. Without this case, deleting the fallback entirely passed.
+    """
+    blank_a = _row(genomes="3")
+    blank_b = _row(genomes="4")
+    speciesless_strain = _row(strain="Strain Z", genomes="9")
+
+    kept = gtdb.deepest_only([blank_a, blank_b, speciesless_strain])
+
+    assert len(kept) == 3, "three unrelated rows must remain three lineages"
+    assert blank_a in kept and blank_b in kept and speciesless_strain in kept
+
+
+def test_species_key_is_normalised(gtdb):
+    """Case and surrounding whitespace must not split one lineage in two."""
+    species_row = _row(species="Escherichia coli")
+    strain_row = _row(species="  escherichia COLI  ", strain="K-12")
+
+    kept = gtdb.deepest_only([species_row, strain_row])
+
+    assert kept == [strain_row], "the species row must be recognised as the same lineage"
+
+
 def test_default_denominator_is_unchanged(gtdb, mapping):
     """`aggregate` must reproduce what the KB was grounded with."""
     _, _, by_higher = gtdb.collect_rows(mapping, set(), set(), {"methylococcaceae"})
@@ -111,11 +150,15 @@ def test_default_denominator_is_unchanged(gtdb, mapping):
 
 
 def test_deepest_shifts_weight_toward_strain_annotated_lineages(gtdb, mapping):
-    """The diagnostic that kept `aggregate` as the default.
+    """One of four cases favouring the default, and the narrowest.
 
     Acetobacter is a cultivated genus; CAG-267 is an uncultivated MAG lineage
     whose support here is entirely strain rows. Under `deepest` it wins, which is
     the wrong answer for the Drosophila gut record that carries this taxon.
+
+    The margin is thin — 458 against 338, and CAG-267 grew 33 -> 120 genomes
+    between R214 and R220 — so this assertion doubles as a tripwire on the
+    default itself (#375).
     """
     _, _, by_higher = gtdb.collect_rows(mapping, set(), set(), {"acetobacter"})
 

--- a/tests/test_gtdb_denominator.py
+++ b/tests/test_gtdb_denominator.py
@@ -1,0 +1,131 @@
+"""The two GTDB majority denominators, and why the default stays `aggregate` (#371).
+
+`NCBI2GTDB.tsv.gz` is an upstream crosswalk in which each row is an independent
+NCBI->GTDB assignment carrying its own genome support. `aggregate` (the default)
+sums every matched row; `deepest` keeps one row per lineage, at the deepest rank
+present — the rule `kg-microbe-paper` settled on for the same shape of problem.
+
+The comparison is the point, not a winner. `scripts/gtdb_denominator_compare.py`
+writes both answers for all 578 KB taxa; 5 flip, affecting 26 stored blocks.
+
+The tests below pin the mechanics and one diagnostic result. `deepest` is *not*
+a neutral correction: dropping a lineage's species rows while keeping its strain
+rows shifts weight toward lineages that happen to be annotated at strain rank.
+`Acetobacter` is the clearest case — `CAG-267`'s support is two strain rows (336
+and 2 genomes), so it survives intact while Acetobacter's own support falls from
+458 to 289, and a cultivated genus in a Drosophila gut record grounds to an
+uncultivated MAG lineage. That is why the default did not change.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).parent.parent
+
+
+@pytest.fixture(scope="module")
+def gtdb():
+    spec = importlib.util.spec_from_file_location("gtdb_ground", REPO / "scripts/gtdb_ground.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def mapping(gtdb):
+    try:
+        path = gtdb.resolve_kg_microbe_dir(None) / "data/raw/NCBI2GTDB.tsv.gz"
+    except SystemExit as exc:
+        pytest.skip(f"kg-microbe mapping unavailable: {str(exc).splitlines()[0]}")
+    if not path.exists():
+        pytest.skip(f"kg-microbe NCBI2GTDB mapping not available at {path}")
+    return path
+
+
+def _row(species="", strain="", genomes="1"):
+    """A mapping row with only the columns `deepest_only` reads."""
+    cells = [""] * 20
+    cells[2], cells[10], cells[11] = genomes, species, strain
+    return cells
+
+
+def test_a_lineage_with_strain_rows_keeps_only_those(gtdb):
+    species_row = _row(species="Escherichia coli")
+    strain_a = _row(species="Escherichia coli", strain="K-12")
+    strain_b = _row(species="Escherichia coli", strain="B")
+
+    kept = gtdb.deepest_only([species_row, strain_a, strain_b])
+
+    assert kept == [strain_a, strain_b], "the species row must not be summed alongside its strains"
+
+
+def test_a_lineage_without_strain_rows_keeps_its_species_row(gtdb):
+    species_row = _row(species="Methylococcus capsulatus")
+    assert gtdb.deepest_only([species_row]) == [species_row]
+
+
+def test_lineages_are_independent(gtdb):
+    """One lineage having strains must not suppress another's species row."""
+    a_species = _row(species="Species A")
+    a_strain = _row(species="Species A", strain="A1")
+    b_species = _row(species="Species B")
+
+    kept = gtdb.deepest_only([a_species, a_strain, b_species])
+
+    assert a_strain in kept and b_species in kept
+    assert a_species not in kept
+
+
+def test_a_strain_row_with_no_species_is_its_own_lineage(gtdb):
+    """The leaf case, handled first and deliberately.
+
+    In the prior art this was the one real bug: a taxon already at strain rank
+    was looked up as if it were a parent, found nothing, and was silently
+    dropped. Here, pooling speciesless strain rows under one `""` key would make
+    them compete as a single lineage.
+    """
+    orphan_a = _row(strain="Strain X", genomes="5")
+    orphan_b = _row(strain="Strain Y", genomes="7")
+
+    kept = gtdb.deepest_only([orphan_a, orphan_b])
+
+    assert len(kept) == 2, "distinct speciesless strains must not collapse into one lineage"
+
+
+def test_default_denominator_is_unchanged(gtdb, mapping):
+    """`aggregate` must reproduce what the KB was grounded with."""
+    _, _, by_higher = gtdb.collect_rows(mapping, set(), set(), {"methylococcaceae"})
+
+    default = gtdb.resolve_higher(
+        "methylococcaceae", "NCBITaxon:403", "Methylococcaceae", by_higher
+    )
+    explicit = gtdb.resolve_higher(
+        "methylococcaceae", "NCBITaxon:403", "Methylococcaceae", by_higher, "aggregate"
+    )
+
+    assert default == explicit
+    assert default["gtdb_id"] == "GTDB:f__Methylomonadaceae"
+    assert default["majority_fraction"] == 0.64
+
+
+def test_deepest_shifts_weight_toward_strain_annotated_lineages(gtdb, mapping):
+    """The diagnostic that kept `aggregate` as the default.
+
+    Acetobacter is a cultivated genus; CAG-267 is an uncultivated MAG lineage
+    whose support here is entirely strain rows. Under `deepest` it wins, which is
+    the wrong answer for the Drosophila gut record that carries this taxon.
+    """
+    _, _, by_higher = gtdb.collect_rows(mapping, set(), set(), {"acetobacter"})
+
+    aggregate = gtdb.resolve_higher("acetobacter", "NCBITaxon:434", "Acetobacter", by_higher)
+    deepest = gtdb.resolve_higher(
+        "acetobacter", "NCBITaxon:434", "Acetobacter", by_higher, "deepest"
+    )
+
+    assert aggregate["gtdb_id"] == "GTDB:g__Acetobacter"
+    assert deepest["gtdb_id"] == "GTDB:g__CAG-267", (
+        "if this no longer holds, re-run scripts/gtdb_denominator_compare.py — the "
+        "argument for the current default rests on it"
+    )

--- a/tests/test_gtdb_denominator.py
+++ b/tests/test_gtdb_denominator.py
@@ -172,3 +172,81 @@ def test_deepest_shifts_weight_toward_strain_annotated_lineages(gtdb, mapping):
         "if this no longer holds, re-run scripts/gtdb_denominator_compare.py — the "
         "argument for the current default rests on it"
     )
+
+
+# ---------------------------------------------------------------------------
+# The named-species filter (#375): a third axis, also opt-in.
+# ---------------------------------------------------------------------------
+
+
+def test_unnamed_species_rows_are_dropped(gtdb):
+    kept = gtdb.named_species_only(
+        [
+            _row(species="Acetobacter aceti"),
+            _row(species="Acetobacter sp. 46_36"),
+            _row(species="uncultured Acetobacter"),
+            _row(species="Firmicutes bacterium CAG:176"),
+            _row(species="unclassified Acetobacter"),
+            _row(species=""),
+        ]
+    )
+    assert [r[10] for r in kept] == ["Acetobacter aceti"]
+
+
+def test_candidatus_names_are_kept(gtdb):
+    """A Candidatus name is a provisional *species* name, not a placeholder.
+
+    Excluding it would discard legitimate taxonomy for uncultivated organisms,
+    which is the opposite of what this filter is for.
+    """
+    row = _row(species="Candidatus Cibiobacter qucibialis")
+    assert gtdb.named_species_only([row]) == [row]
+
+
+def test_filter_never_empties_a_taxon(gtdb, mapping):
+    """A genus known only from bins must keep its grounding, not lose it.
+
+    The filter is a tie-breaker among named species, not a reason to abandon a
+    taxon that has none.
+    """
+    _, _, by_higher = gtdb.collect_rows(mapping, set(), set(), {"acetobacter"})
+    rows = [r for r in by_higher["acetobacter"] if r[9].strip().lower() == "acetobacter"]
+    unnamed = [r for r in rows if not gtdb.named_species_only([r])]
+    assert unnamed, "expected some unnamed rows in this genus"
+
+    only_unnamed = {"acetobacter": unnamed}
+    result = gtdb.resolve_higher(
+        "acetobacter", "NCBITaxon:434", "Acetobacter", only_unnamed, exclude_unnamed=True
+    )
+    assert result, "filtering to nothing must fall back rather than drop the taxon"
+
+
+def test_the_filter_makes_both_denominators_agree_on_acetobacter(gtdb, mapping):
+    """#375's claim, and the reason the filter exists.
+
+    Without it the two denominators disagree here — `g__Acetobacter` against the
+    uncultivated `g__CAG-267`. With it, both reach `g__Acetobacter`.
+    """
+    _, _, by_higher = gtdb.collect_rows(mapping, set(), set(), {"acetobacter"})
+    answers = {
+        den: gtdb.resolve_higher(
+            "acetobacter", "NCBITaxon:434", "Acetobacter", by_higher, den, exclude_unnamed=True
+        )["gtdb_id"]
+        for den in ("aggregate", "deepest")
+    }
+    assert answers == {"aggregate": "GTDB:g__Acetobacter", "deepest": "GTDB:g__Acetobacter"}
+
+
+def test_the_filter_does_not_settle_the_denominator_question(gtdb, mapping):
+    """It fixes the MAG pathology; it does not make the choice moot.
+
+    Pseudomonas still diverges with the filter applied, so #371 stays open.
+    """
+    _, _, by_higher = gtdb.collect_rows(mapping, set(), set(), {"pseudomonas"})
+    agg = gtdb.resolve_higher(
+        "pseudomonas", "NCBITaxon:286", "Pseudomonas", by_higher, "aggregate", exclude_unnamed=True
+    )
+    deep = gtdb.resolve_higher(
+        "pseudomonas", "NCBITaxon:286", "Pseudomonas", by_higher, "deepest", exclude_unnamed=True
+    )
+    assert agg["gtdb_id"] != deep["gtdb_id"]

--- a/tests/test_gtdb_denominator.py
+++ b/tests/test_gtdb_denominator.py
@@ -5,6 +5,11 @@ NCBI->GTDB assignment carrying its own genome support. `aggregate` (the default)
 sums every matched row; `deepest` keeps one row per lineage, at the deepest rank
 present — the rule `kg-microbe-paper` settled on for the same shape of problem.
 
+Orthogonal to that choice, the named-species filter (#375) drops `sp.` /
+`uncultured` / `bacterium` MAG rows from the count. It is **on by default** as of
+#372; `exclude_unnamed=False` restores the older, unfiltered behaviour, which
+several tests below still pin because the argument for the default rests on it.
+
 The comparison is the point, not a winner. `scripts/gtdb_denominator_compare.py`
 writes both answers for all 578 KB taxa; 5 flip, affecting 26 stored blocks.
 
@@ -24,8 +29,9 @@ case, which is only 0.522.
 sequenced than the type species *E. faecalis* — see #373 and #374. `deepest`
 returns AMBIGUOUS there, which is the honest answer.
 
-A third option neither denominator covers would fix Acetobacter under both:
-exclude `sp.`/`uncultured` MAG rows (#375).
+That third axis — excluding `sp.`/`uncultured` MAG rows (#375) — is what fixes
+Acetobacter under *both* denominators, which is why it is now the default. It
+does not settle #371: Pseudomonas still diverges with the filter applied.
 """
 
 import importlib.util
@@ -146,36 +152,45 @@ def test_default_denominator_is_unchanged(gtdb, mapping):
 
     assert default == explicit
     assert default["gtdb_id"] == "GTDB:f__Methylomonadaceae"
-    assert default["majority_fraction"] == 0.64
+    assert default["majority_fraction"] == 0.695  # filter on by default (#375)
 
 
 def test_deepest_shifts_weight_toward_strain_annotated_lineages(gtdb, mapping):
-    """One of four cases favouring the default, and the narrowest.
+    """The case that motivated turning the named-species filter on by default.
 
     Acetobacter is a cultivated genus; CAG-267 is an uncultivated MAG lineage
-    whose support here is entirely strain rows. Under `deepest` it wins, which is
-    the wrong answer for the Drosophila gut record that carries this taxon.
+    whose support here is entirely strain rows. `deepest` keeps a lineage's strain
+    rows and drops its species rows, which hands CAG-267 the majority — the wrong
+    answer for the Drosophila gut record that carries this taxon.
 
-    The margin is thin — 458 against 338, and CAG-267 grew 33 -> 120 genomes
-    between R214 and R220 — so this assertion doubles as a tripwire on the
-    default itself (#375).
+    With the filter on (now the default) the MAG rows never enter the count, so
+    both denominators reach the cultivated genus and this divergence is gone. The
+    second half pins the *unfiltered* behaviour, because that is the observation
+    the filter's default rests on: if it stops holding, the argument for the
+    default has changed and `scripts/gtdb_denominator_compare.py` wants re-running.
     """
     _, _, by_higher = gtdb.collect_rows(mapping, set(), set(), {"acetobacter"})
 
-    aggregate = gtdb.resolve_higher("acetobacter", "NCBITaxon:434", "Acetobacter", by_higher)
-    deepest = gtdb.resolve_higher(
-        "acetobacter", "NCBITaxon:434", "Acetobacter", by_higher, "deepest"
+    def ground(denominator, **kwargs):
+        return gtdb.resolve_higher(
+            "acetobacter", "NCBITaxon:434", "Acetobacter", by_higher, denominator, **kwargs
+        )
+
+    assert ground("aggregate")["gtdb_id"] == "GTDB:g__Acetobacter"
+    assert ground("deepest")["gtdb_id"] == "GTDB:g__Acetobacter", (
+        "the filter is on by default, so the MAG lineage must no longer win under "
+        "`deepest` — see #375"
     )
 
-    assert aggregate["gtdb_id"] == "GTDB:g__Acetobacter"
-    assert deepest["gtdb_id"] == "GTDB:g__CAG-267", (
+    # The pathology the filter suppresses, still present when it is switched off.
+    assert ground("deepest", exclude_unnamed=False)["gtdb_id"] == "GTDB:g__CAG-267", (
         "if this no longer holds, re-run scripts/gtdb_denominator_compare.py — the "
         "argument for the current default rests on it"
     )
 
 
 # ---------------------------------------------------------------------------
-# The named-species filter (#375): a third axis, also opt-in.
+# The named-species filter (#375): a third axis, on by default since #372.
 # ---------------------------------------------------------------------------
 
 
@@ -250,3 +265,46 @@ def test_the_filter_does_not_settle_the_denominator_question(gtdb, mapping):
         "pseudomonas", "NCBITaxon:286", "Pseudomonas", by_higher, "deepest", exclude_unnamed=True
     )
     assert agg["gtdb_id"] != deep["gtdb_id"]
+
+
+def test_a_tied_majority_does_not_depend_on_row_order(gtdb, mapping):
+    """An exact 50/50 split must give the same answer whichever way the rows come.
+
+    `max()` returns the *first* maximum, so a tie was decided by the order the
+    mapping happened to list its rows: reversing the input flipped NCBITaxon:106591
+    between `g__Ensifer` and `g__Sinorhizobium`, both at 0.5. Two live KB blocks
+    sat on that coin flip. Whether a tie should ground at all is #382; this pins
+    only that the answer is reproducible.
+    """
+    _, _, by_higher = gtdb.collect_rows(mapping, set(), set(), {"ensifer"})
+    rows = by_higher["ensifer"]
+
+    forward = gtdb.resolve_higher("ensifer", "NCBITaxon:106591", "Ensifer", {"ensifer": rows})
+    reverse = gtdb.resolve_higher(
+        "ensifer", "NCBITaxon:106591", "Ensifer", {"ensifer": list(reversed(rows))}
+    )
+
+    assert forward["majority_fraction"] == 0.5, "expected the tie this test is about"
+    assert forward["gtdb_id"] == reverse["gtdb_id"], (
+        "reversing the row order changed the grounding — the tie-break is falling "
+        "through to mapping row order"
+    )
+
+
+def test_ties_break_toward_the_lexically_first_name(gtdb):
+    """The tie-break rule itself, without depending on the mapping's contents."""
+
+    def row(gtdb_genus, genomes):
+        # col 2 = genome count, col 9 = NCBI genus (the match key), col 17 = GTDB
+        # genus; see HIGHER_RANKS / COL_TOTAL_GENOMES in the script.
+        cells = [""] * 20
+        cells[2], cells[9], cells[17] = genomes, "Testgenus", gtdb_genus
+        cells[10] = "Testgenus namedspecies"  # survive the named-species filter
+        return cells
+
+    by_higher = {"testgenus": [row("g__Zeta", "10"), row("g__Alpha", "10")]}
+    result = gtdb.resolve_higher(
+        "testgenus", "NCBITaxon:1", "Testgenus", by_higher, exclude_unnamed=False
+    )
+
+    assert result["gtdb_taxon"] == "g__Alpha", "a tie must resolve to the lexically first name"

--- a/tests/test_gtdb_denominator.py
+++ b/tests/test_gtdb_denominator.py
@@ -11,14 +11,16 @@ Orthogonal to that choice, the named-species filter (#375) drops `sp.` /
 several tests below still pin because the argument for the default rests on it.
 
 The comparison is the point, not a winner. `scripts/gtdb_denominator_compare.py`
-writes both answers for all 578 KB taxa; 5 flip, affecting 26 stored blocks.
+writes all four answers for the 578 distinct KB taxa; 16 vary across the four
+scenarios. Counts here are deliberately few and cheap to re-derive — the report
+is the source, and quoted numbers rot (this docstring has been wrong twice).
 
 `deepest` is *not* a neutral correction: dropping a lineage's species rows while
 keeping its strain rows shifts weight toward lineages that happen to be annotated
 at strain rank. Table-wide it discards 801367 of 1837914 genome-supports (43.6%).
 
 Judged against GTDB's own rule — the lineage holding the nomenclatural type keeps
-the unsuffixed name — `aggregate` is the better answer for 4 of the 5 taxa where
+the unsuffixed name — `aggregate` is the better answer on most of the taxa where
 they differ. The sharpest is Pseudomonas: `deepest` discards *P. aeruginosa*'s
 17191-genome species row in favour of 615 genomes across 289 strain rows, and
 lands on `g__Pseudomonas_E` at 0.852 — more confidently wrong than the Acetobacter
@@ -308,3 +310,88 @@ def test_ties_break_toward_the_lexically_first_name(gtdb):
     )
 
     assert result["gtdb_taxon"] == "g__Alpha", "a tie must resolve to the lexically first name"
+
+
+@pytest.mark.parametrize(
+    "species",
+    [
+        "Wolbachia endosymbiont of Culex quinquefasciatus",  # \b missed the compound
+        "Pseudomonas syringae group genomosp. 3",
+        "gamma proteobacterium HTCC2080",
+        "Firmicutes bacterium CAG:176",
+        "Methanococci archaeon",
+    ],
+)
+def test_compound_placeholder_words_are_dropped(gtdb, species):
+    """`\\b` anchors the start of a word, so compounds slipped through (#372 review).
+
+    `\\bsymbiont\\b` cannot match `endosymbiont`, and 331 crosswalk rows named that
+    way were being counted as though they were binomials.
+    """
+    assert gtdb.named_species_only([_row(species=species)]) == []
+
+
+@pytest.mark.parametrize(
+    "species",
+    [
+        "Acetobacterium woodii",  # genus ends in -bacterium; a real binomial
+        "Acidipropionibacterium jensenii",
+        "Bacillus subtilis subsp. spizizenii",  # `subsp.` is not `sp.`
+        "Syntrophotalea acetylenivorans",
+        "Candidatus Cibiobacter qucibialis",
+    ],
+)
+def test_real_binomials_survive_the_compound_match(gtdb, species):
+    """The fix must not become an over-match.
+
+    Relaxing to `\\w*bacterium` swallowed 1805 binomial-shaped names — every genus
+    ending in *-bacterium*. The compound alternations are case-sensitive and
+    lowercase-only precisely so a capitalised genus cannot match.
+    """
+    row = _row(species=species)
+    assert gtdb.named_species_only([row]) == [row]
+
+
+def test_ambiguous_options_are_ordered_deterministically(gtdb):
+    """The tie-break fix reached `top` but not the option list a curator reads."""
+
+    def row(gtdb_genus, genomes):
+        cells = [""] * 20
+        cells[2], cells[9], cells[17] = genomes, "Testgenus", gtdb_genus
+        cells[10] = "Testgenus namedspecies"
+        return cells
+
+    rows = [row("g__Zeta", "5"), row("g__Alpha", "5"), row("g__Mu", "5")]
+    forward = gtdb.resolve_higher("testgenus", "NCBITaxon:1", "Testgenus", {"testgenus": rows})
+    reverse = gtdb.resolve_higher(
+        "testgenus", "NCBITaxon:1", "Testgenus", {"testgenus": list(reversed(rows))}
+    )
+
+    assert forward["ambiguous"] and reverse["ambiguous"], "expected a three-way split"
+    assert forward["gtdb_options"] == reverse["gtdb_options"] == ["g__Alpha", "g__Mu", "g__Zeta"]
+
+
+@pytest.mark.parametrize("bad", ["TYPO", "", None, "Aggregate"])
+def test_an_unknown_denominator_always_raises(gtdb, bad):
+    """Validation sat inside the rank loop, so it was skipped on every early return."""
+    with pytest.raises(ValueError, match="unknown denominator"):
+        gtdb.resolve_higher("nothing-matches-this", "NCBITaxon:1", "X", {}, bad)
+
+
+def test_the_cli_can_reach_both_denominators(gtdb, mapping, capsys):
+    """Without flags, `deepest_only` is dead code in production (#372 review).
+
+    `main()` had no `--denominator` / `--include-unnamed`, and both `resolve_target`
+    call sites used bare defaults — so the only thing that could reach the
+    alternative denominator was the comparison script, which just writes a report.
+    """
+    assert gtdb.main(["--name", "Acetobacter"]) == 0
+    default = capsys.readouterr().out
+
+    assert (
+        gtdb.main(["--name", "Acetobacter", "--include-unnamed", "--denominator", "deepest"]) == 0
+    )
+    alternative = capsys.readouterr().out
+
+    assert "g__Acetobacter" in default
+    assert "g__CAG-267" in alternative, "the flags did not reach the grounding"

--- a/tests/test_gtdb_ground_apply.py
+++ b/tests/test_gtdb_ground_apply.py
@@ -77,7 +77,10 @@ def always_grounds(monkeypatch):
     monkeypatch.setattr(
         gtdb_ground,
         "resolve_target",
-        lambda ncbi_id, label, by_id, by_name, by_higher: {
+        # **kwargs absorbs denominator / exclude_unnamed, which apply_to_community
+        # now threads through (#372 review). A positional-only stub silently ties
+        # this fixture to one call signature.
+        lambda ncbi_id, label, by_id, by_name, by_higher, **kwargs: {
             "gtdb_id": GROUNDED_BLOCK["gtdb_id"],
             "gtdb_taxon": GROUNDED_BLOCK["gtdb_taxon"],
             "gtdb_lineage": GROUNDED_BLOCK["gtdb_lineage"],

--- a/tests/test_gtdb_refresh.py
+++ b/tests/test_gtdb_refresh.py
@@ -191,23 +191,28 @@ def test_the_gate_refuses_unparseable_output(gtdb, record):
 # The shape that broke it: a wrapped scalar inside an existing block.
 # ---------------------------------------------------------------------------
 
-WRAPPED = (
-    REPO
-    / "kb/communities/Corynebacterium_glutamicum_Shewanella_oneidensis_Succinic_Acid_Coculture.yaml"
-)
-
 
 @pytest.fixture
 def wrapped_record(tmp_path):
-    """A real record whose block contains a PyYAML line-wrap continuation.
+    """A record whose block carries a PyYAML line-wrap continuation.
 
-    13 records carry one, written by the `--emit-yaml` path, which dumps at
-    width=100 rather than the width=4096 `apply_to_community` uses. Continuations
-    sit at 8 spaces, so a span scan matching *exactly* 6 stopped a line short and
-    orphaned them into duplicate keys.
+    Built rather than borrowed. 13 KB records had this shape, pasted from the
+    `--emit-yaml` path, which dumps at width ~100 while `--apply` uses 4096
+    (#380) — but a refresh normalises them, so a fixture pointing at a real
+    record stops testing anything the moment the KB is swept.
+
+    Continuations sit deeper than the block keys, so a span matching *exactly*
+    six spaces stopped short and orphaned them into duplicate keys.
     """
-    dest = tmp_path / WRAPPED.name
-    shutil.copy(WRAPPED, dest)
+    source = REPO / "kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml"
+    text = source.read_text()
+    marker = "      mapping_source: "
+    i = text.index(marker)
+    eol = text.index("\n", i)
+    cut = i + len(marker) + 40
+    wrapped = text[i:cut] + "\n        " + text[cut:eol].strip()
+    dest = tmp_path / source.name
+    dest.write_text(text[:i] + wrapped + text[eol:])
     assert re.search(r"^        \S", dest.read_text(), re.M), "fixture lost its wrapped line"
     return dest
 
@@ -244,13 +249,15 @@ def test_refresh_of_a_wrapped_block_produces_no_duplicate_keys(gtdb, wrapped_rec
     )
     for key in ("ncbi_source_id", "majority_fraction", "mapping_source"):
         assert text.count(f"      {key}:") == grounded, f"duplicate {key} after refresh"
-    assert "built 2026-06-19" not in text, "the stale block survived — refresh did nothing"
 
 
 def test_span_covers_a_wrapped_continuation(gtdb, wrapped_record):
     """Unit-level: the span must run past a deeper-indented continuation line."""
     lines = wrapped_record.read_text().splitlines()
-    anchor = next(i for i, ln in enumerate(lines) if re.match(r"^\s+id: NCBITaxon:\d+\s*$", ln))
+    # The anchor of the entry that actually carries the wrapped block — the
+    # nearest `id:` line above it, not simply the first in the file.
+    wrapped_at = next(i for i, ln in enumerate(lines) if re.match(r"^\s{8,}\S", ln))
+    anchor = max(i for i in range(wrapped_at) if re.match(r"^\s+id: NCBITaxon:\d+\s*$", lines[i]))
     span = gtdb._block_span(lines, anchor, len(lines))
     assert span, "expected a block for this entry"
     assert not re.match(

--- a/tests/test_gtdb_refresh.py
+++ b/tests/test_gtdb_refresh.py
@@ -240,9 +240,17 @@ def test_refresh_of_a_wrapped_block_produces_no_duplicate_keys(gtdb, wrapped_rec
         {c.lower() for c in cleaned if " " not in c},
     )
 
-    gtdb.apply_to_community(wrapped_record, *rows, "test-source", refresh=True)
+    before = wrapped_record.read_text()
+    written = gtdb.apply_to_community(wrapped_record, *rows, "test-source", refresh=True)
 
     text = wrapped_record.read_text()
+    # Without these three, every assertion below passes on the *un-refreshed*
+    # fixture — it already has 7 grounded blocks and one of each key, so a
+    # regression making refresh a silent no-op would go undetected (#372 review).
+    assert written, "refresh reported writing no blocks"
+    assert text != before, "refresh left the file byte-identical — it did nothing"
+    assert "test-source" in text, "the refreshed blocks do not carry the new mapping_source"
+
     after = yaml.safe_load(text)
     grounded = sum(
         1 for e in after["taxonomy"] if (e.get("taxon_term") or {}).get("gtdb_classification")

--- a/tests/test_gtdb_withheld_groundings.py
+++ b/tests/test_gtdb_withheld_groundings.py
@@ -72,3 +72,49 @@ def test_withheld_taxon_stays_ungrounded(record: str, preferred: str):
         f"To ground it properly, fix the NCBITaxon id first (#292), then drop this "
         f"entry from WITHHELD."
     )
+
+
+# ---------------------------------------------------------------------------
+# The mirror case: a grounding the tool *will* produce, and must not (#372, #384).
+# ---------------------------------------------------------------------------
+
+# (record, preferred_term) -> (required gtdb_id, why the majority vote is wrong)
+CURATED = {
+    (
+        "Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml",
+        "Pelobacter strain SFB93",
+    ): (
+        "GTDB:g__Syntrophotalea",
+        "The organism is an acetylene fermenter, and the entry's own notes tie SFB93 "
+        "to Syntrophotalea acetylenivorans. GTDB moved the acetylene-fermenting "
+        "Pelobacters into Syntrophotalea (s__Syntrophotalea acetylenica, 8 genomes; "
+        "s__Syntrophotalea_A acetylenivorans, 3). But all three NCBI Pelobacter "
+        "rows naming Syntrophotalea are `sp.` rows, so the named-species filter "
+        "(#375) discards the plurality lineage and the majority vote lands on "
+        "g__Seleniibacterium at 0.571 — derived from P. seleniigenes, a selenate "
+        "reducer. The tool has no memory of this, so `--refresh` re-breaks it.",
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    ("record", "preferred"), list(CURATED), ids=[f"{r}::{p}" for r, p in CURATED]
+)
+def test_curated_grounding_is_not_overwritten_by_the_majority_vote(record: str, preferred: str):
+    """A grounding chosen on evidence must survive a tool re-run.
+
+    `WITHHELD` above protects taxa that must stay *ungrounded*. This protects the
+    opposite: a taxon that is grounded correctly, where re-running the tool would
+    replace a right answer with a confidently-wrong one.
+    """
+    term = _taxon_term(record, preferred)
+    assert term is not None, f"'{preferred}' is no longer in {record}; update CURATED."
+
+    expected, why = CURATED[(record, preferred)]
+    grounding = term.get("gtdb_classification")
+    assert grounding, f"'{preferred}' in {record} lost its curated grounding. {why}"
+    assert grounding.get("gtdb_id") == expected, (
+        f"'{preferred}' in {record} is grounded to {grounding.get('gtdb_id')}, not "
+        f"the curated {expected}. {why} This is most likely an unreviewed "
+        f"`gtdb_ground.py --refresh` — revert this block."
+    )


### PR DESCRIPTION
Closes #371 in the sense it can be closed — by measuring the choice rather than asserting one. Also carries #375 through to a default and a full KB re-grounding.

> **Numbers below were corrected after review.** My first verification script keyed grounded blocks by NCBITaxon id *within* a record, so records listing one id many times (`GLBRC_Populus_Variovorax_SynCom28` has 28 isolates on `NCBITaxon:34072`) collapsed to a single entry and 44 blocks were never inspected. That is the same keying bug `apply_to_community` carries a comment warning about. Everything here is re-measured positionally.

## The denominator question (#371)

`NCBI2GTDB.tsv.gz` is an upstream crosswalk where each row is an independent NCBI->GTDB assignment carrying its own genome support. A genome supports its strain *and* its species *and* its genus, so supports total 1.84M against ~600k genomes in a release. `aggregate` (the existing default) sums every matched row; `deepest` keeps one row per lineage at the deepest rank present — the rule `kg-microbe-paper` settled on for the same shape of problem.

Neither is provably right, so this does not pick by argument. `scripts/gtdb_denominator_compare.py` writes all four scenarios (aggregate/deepest x filter on/off) to `reports/gtdb_denominators.tsv`; **16 of 578 taxa vary** across them.

`deepest` is **not** a neutral correction: dropping a lineage's species rows while keeping its strain rows shifts weight toward whichever lineages happen to be annotated at strain rank, discarding 801367 of 1837914 genome-supports (43.6%). Judged against GTDB's own rule — the lineage holding the nomenclatural type keeps the unsuffixed name — `aggregate` is the better answer on most taxa where they differ. The sharpest is *Pseudomonas*: `deepest` throws away *P. aeruginosa*'s 17191-genome species row for 615 genomes across 289 strain rows and lands on `g__Pseudomonas_E` at 0.852.

**The default is not uniformly right, and the tests say so.** For *Enterococcus* `aggregate` grounds to `g__Enterococcus_B`, the *E. faecium* clade, purely because faecium is more sequenced than the type species *E. faecalis* (#373, #374). `deepest` returns AMBIGUOUS there, which is the honest answer. So `aggregate` stays the default, `deepest` becomes reachable via `--denominator`, and #371 is answered with a measurement rather than a patch.

## The filter, now on by default (#375)

`exclude_unnamed` drops `sp.` / `uncultured` / informal rows from the count. It fixes Acetobacter under **both** denominators, so it is now the default; `--include-unnamed` restores the old behaviour.

`Candidatus` names are deliberately kept — provisional *species* names, not placeholders. The filter never empties a taxon: a genus known only from bins keeps its grounding.

Review found the regex **under-matched on compound words**: `\b` anchors the start of a word, so `\bsymbiont\b` never matched `endosymbiont` (331 rows counted as binomials), plus 72 `genomosp.` and 94 `proteobacterium`. Relaxing to `\w*` overcorrected — it swallowed 1805 real binomials (every genus ending in *-bacterium*, e.g. *Acetobacterium woodii*) and `subsp.` names. The compound alternations are now case-sensitive and lowercase-only, since an informal descriptor is lowercase and a genus is capitalised. Net: 105 binomial-shaped names drop against 102 pre-PR.

## The KB re-grounding

Applied with `gtdb_ground.py --refresh --apply`, the gated path from #379 — not by hand. Measured against `main`, keyed positionally:

| | |
|---|---|
| grounded blocks before / after | **647 / 647** — none gained, none lost |
| records changed outside `gtdb_classification` | **0** |
| `mapping_source` only | 392 |
| `majority_fraction` (+ `mapping_source`) | 219 + 2 |
| grounding actually changed | **3** |

The three:

- **`NCBITaxon:522` *Acidiphilium*** (x2 records) — `g__UBA10281` -> `g__Acidiphilium` at 1.0. An uncultivated MAG lineage displaced by the cultivated genus NCBI names.
- **`NCBITaxon:59732` *Chryseobacterium*** — `s__Chryseobacterium_indologenes` -> `g__Chryseobacterium` at 0.828. The entry is `Chryseobacterium sp. MF1`, an *unnamed* species; grounding it to a specific named species claimed more than the source does. This also resolves half of #376.

### One flip was a regression, caught in review and reverted

**`NCBITaxon:18` *Pelobacter*** was re-grounded `g__Syntrophotalea` -> `g__Seleniibacterium` at 0.571. That is wrong. The organism is `Pelobacter strain SFB93`, an acetylene fermenter, and the entry's own `notes` already tie SFB93 to *Syntrophotalea acetylenivorans*. GTDB moved the acetylene-fermenting Pelobacters into *Syntrophotalea* — but all three Pelobacter rows naming it are `sp.` rows, so the filter discarded the plurality lineage and the vote landed on a lineage derived from *P. seleniigenes*, a selenate reducer.

The record is restored from `main` byte-for-byte (not hand-edited) and pinned in a new `CURATED` map beside `WITHHELD` — the mirror case: `WITHHELD` keeps taxa *ungrounded*, `CURATED` keeps a right answer from being overwritten by the majority vote. The tool has memory of neither, which is **#384**.

## Also found in review

- **The committed report was stale on arrival** — generated before the tie-break commit, so it recorded an Ensifer grounding the code will not produce and a `varying=17` contradicting this description. Regenerated; nothing in `just qc` refreshes it, now said plainly in its docstring.
- **A refresh test was vacuous** — its only assertion that the refresh *ran* had been removed, and the rest pass on the un-refreshed fixture. Restored as three, verified against a no-op mutant.
- **`deepest_only` was unreachable in production** — no CLI flag, both `resolve_target` call sites on bare defaults. ~90 lines and 8 tests behind a switch nothing could flip. Hence `--denominator` / `--include-unnamed`. Denominator validation also moved out of the rank loop, where every early return skipped it.
- **`gtdb_options` kept the order-dependence** the tie-break fixed for `top`.
- **Stale narrative** in the module docstring, `resolve_higher`, the comparison script, two test docstrings, and `.claude/skills/ground-taxa-gtdb/SKILL.md` — the last is what a curator reads to interpret `majority_fraction`, and its meaning changed underneath it.

### A tie-break bug found while measuring

`resolve_higher` used `max()`, which returns the *first* maximum, so an exact 50/50 split was decided by mapping row order. The filter had pushed two live blocks (`NCBITaxon:106591`, *Ensifer*) onto that coin flip. Ties now break on name; both new tests fail against the original. Whether a tie should ground **at all** is policy, filed as **#382**.

### Withdrawn claim

An earlier commit message described the sweep as unifying the KB's two build vintages, "which is the drift #369 is about". That is false. The sweep does not resolve the drift — `--refresh` cannot withdraw a grounding that has become AMBIGUOUS, so the drift is now *concentrated* in the three records where the tool and the KB disagree (Chlorobium, curated; Methylobacter and Serratia, newly ambiguous under the filter). #376 updated with the current set.

## Issues from this work

New: **#382** (tie policy), **#383** (a fraction records no denominator), **#384** (no memory of a curated grounding). Updated: **#376**.

`just validate-all` clean, 1048 passed, lint clean.
