### PR TITLE
Add a safe `gtdb_ground.py --refresh`, gated so a bad edit cannot be written (#378)

### DIFF
--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -294,7 +294,11 @@ def _block_span(lines: list[str], anchor: int, end: int) -> tuple[int, int] | No
     while i < end:
         if key.match(lines[i]):
             j = i + 1
-            while j < end and re.match(r"^\s{6}\S", lines[j]):
+            # Indent >= 6, not exactly 6. PyYAML wraps long scalars onto
+            # continuation lines indented deeper, so an exact match stopped one
+            # line short and left orphans that became duplicate keys in 13
+            # records (#378 review).
+            while j < end and re.match(r"^\s{6,}\S", lines[j]):
                 j += 1
             return (i, j)
         # Any line at the taxon_term level or shallower ends this entry.
@@ -342,7 +346,12 @@ def apply_to_community(
             wanted.append(None)
             continue
         g = resolve_target(tid.split(":", 1)[1], term.get("label", ""), by_id, by_name, by_higher)
-        wanted.append(_block(g, mapping_source) if g and not g.get("ambiguous") else None)
+        # A result with no gtdb_id is not a grounding: `_ground_species` returns
+        # one when the GTDB species cell is empty. Writing it replaced a curated
+        # `g__Chlorobium` with nulls on refresh, so treat it as ungroundable and
+        # leave whatever is there alone (#378 review).
+        usable = g and not g.get("ambiguous") and g.get("gtdb_id")
+        wanted.append(_block(g, mapping_source) if usable else None)
     if not any(w is not None for w in wanted):
         return 0
 
@@ -403,7 +412,10 @@ def apply_to_community(
             dumped = yaml.dump(block, sort_keys=False, allow_unicode=True, width=4096)
             out += [f"{child}  {bl}" for bl in dumped.splitlines()]
             added += 1
-            i = span[1] if span else i + 2
+            nxt = span[1] if span else i + 2
+            if nxt <= i:
+                raise SystemExit(f"{path.name}: computed a non-advancing block span.")
+            i = nxt
             continue
         i += 1
     out += lines[end:]
@@ -414,13 +426,15 @@ def apply_to_community(
     # `evidence` list, joining two lines, emitting duplicate keys — and every one
     # was caught only by looking afterwards. Checking before the write turns that
     # class of mistake into a refusal (#378).
-    _assert_only_grounding_changed(path, doc, new_text)
+    _assert_only_grounding_changed(path, doc, new_text, refresh=refresh)
 
     path.write_text(new_text)
     return added
 
 
-def _assert_only_grounding_changed(path: Path, before: dict, new_text: str) -> None:
+def _assert_only_grounding_changed(
+    path: Path, before: dict, new_text: str, refresh: bool = False
+) -> None:
     """Fail loudly unless the edit touched gtdb_classification and nothing else."""
     try:
         after = yaml.safe_load(new_text)
@@ -429,13 +443,46 @@ def _assert_only_grounding_changed(path: Path, before: dict, new_text: str) -> N
             f"{path.name}: edit produced unparseable YAML — refusing to write: {exc}"
         ) from exc
 
-    grounded_now = sum(
-        1
-        for e in (after.get("taxonomy") or [])
-        if ((e or {}).get("taxon_term") or {}).get("gtdb_classification")
-    )
-    if new_text.count("gtdb_classification:") != grounded_now:
-        raise SystemExit(f"{path.name}: edit produced a duplicate gtdb_classification key.")
+    # Duplicate keys anywhere, detected by parsing rather than by counting a
+    # substring. PyYAML keeps the last of two identical keys silently, so the
+    # corruption survives both a diff skim and linkml-validate (#289). A
+    # substring count also missed duplicates *inside* a block.
+    class _DupDetector(yaml.SafeLoader):
+        pass
+
+    def _no_dups(loader, node, deep=False):
+        seen, mapping = set(), {}
+        for key_node, value_node in node.value:
+            key = loader.construct_object(key_node, deep=deep)
+            if key in seen:
+                raise SystemExit(f"{path.name}: edit produced a duplicate `{key}` key.")
+            seen.add(key)
+            mapping[key] = loader.construct_object(value_node, deep=deep)
+        return mapping
+
+    _DupDetector.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _no_dups)
+    yaml.load(new_text, Loader=_DupDetector)  # noqa: S506 — subclass of SafeLoader
+
+    # The grounded set must be identical: refresh never creates and never drops.
+    def _grounded(doc):
+        return [
+            i
+            for i, e in enumerate(doc.get("taxonomy") or [])
+            if ((e or {}).get("taxon_term") or {}).get("gtdb_classification")
+        ]
+
+    was, now = _grounded(before), _grounded(after)
+    if refresh:
+        # Refresh replaces in place: the set must be identical, or a block was
+        # created (overturning a deliberate withholding) or swallowed by a bad span.
+        if was != now:
+            raise SystemExit(
+                f"{path.name}: the set of grounded taxa changed — refresh must not "
+                f"create or drop a gtdb_classification."
+            )
+    elif not set(was) <= set(now):
+        # Plain apply may add groundings; it must never remove one.
+        raise SystemExit(f"{path.name}: an existing gtdb_classification was dropped.")
 
     b_tax, a_tax = before.get("taxonomy") or [], after.get("taxonomy") or []
     if len(b_tax) != len(a_tax):

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -282,12 +282,43 @@ def community_taxa(path: Path):
     return out
 
 
-def apply_to_community(path: Path, by_id, by_name, by_higher, mapping_source) -> int:
-    """Insert gtdb_classification into taxonomy taxon_terms via line-level text edits.
+def _block_span(lines: list[str], anchor: int, end: int) -> tuple[int, int] | None:
+    """Line span of the gtdb_classification block belonging to one taxonomy entry.
+
+    Starts at the entry's `id:` anchor and stops at the next line indented no
+    deeper than the block key, so a sibling (`notes`, `functional_role`) or the
+    next entry ends the search. Returns None when the entry has no block.
+    """
+    key = re.compile(r"^\s{4}gtdb_classification:\s*$")
+    i = anchor + 1
+    while i < end:
+        if key.match(lines[i]):
+            j = i + 1
+            while j < end and re.match(r"^\s{6}\S", lines[j]):
+                j += 1
+            return (i, j)
+        # Any line at the taxon_term level or shallower ends this entry.
+        if re.match(r"^\s{0,4}\S", lines[i]) and not re.match(r"^\s{4}\S", lines[i]):
+            return None
+        if re.match(r"^- ", lines[i]):
+            return None
+        i += 1
+    return None
+
+
+def apply_to_community(
+    path: Path, by_id, by_name, by_higher, mapping_source, refresh: bool = False
+) -> int:
+    """Insert or refresh gtdb_classification in taxonomy taxon_terms, line-level.
 
     Adds lines only (no YAML round-trip) so unrelated content — including plain
     scalar line-wrapping — is left byte-for-byte unchanged. Scoped to the
     top-level ``taxonomy:`` block so interaction source/target taxa are untouched.
+
+    `refresh` recomputes blocks that already exist and **creates none**. That
+    asymmetry is the point: an ungrounded taxon may be ungrounded deliberately —
+    the entries withheld under #292 are — so a refresh that also grounded them
+    would silently overturn a curation decision (#378).
     """
     doc = yaml.safe_load(path.read_text())
     entries = doc.get("taxonomy", []) or []
@@ -305,7 +336,9 @@ def apply_to_community(path: Path, by_id, by_name, by_higher, mapping_source) ->
         tt = (tc or {}).get("taxon_term", {}) or {}
         term = tt.get("term", {}) or {}
         tid = str(term.get("id", ""))
-        if "gtdb_classification" in tt or not tid.startswith("NCBITaxon:"):
+        grounded = "gtdb_classification" in tt
+        if not tid.startswith("NCBITaxon:") or (grounded != refresh):
+            # normal: act on ungrounded only. refresh: act on grounded only.
             wanted.append(None)
             continue
         g = resolve_target(tid.split(":", 1)[1], term.get("label", ""), by_id, by_name, by_higher)
@@ -349,6 +382,11 @@ def apply_to_community(path: Path, by_id, by_name, by_higher, mapping_source) ->
             )
 
     insert_at = {pos: block for pos, block in zip(anchors, wanted, strict=True) if block}
+    # Where each refreshed entry's existing block lives, so it is removed rather
+    # than duplicated. PyYAML keeps the last of two identical keys silently, so a
+    # duplicate would survive linkml-validate unnoticed (#289).
+    spans = {pos: _block_span(lines, pos, end) for pos in insert_at} if refresh else {}
+
     out = lines[: start + 1]
     i, added = start + 1, 0
     while i < end:
@@ -356,18 +394,68 @@ def apply_to_community(path: Path, by_id, by_name, by_higher, mapping_source) ->
         block = insert_at.get(i)
         if block is not None:
             out.append(lines[i + 1])  # keep the label line
+            span = spans.get(i)
+            if span:
+                out += lines[i + 2 : span[0]]  # siblings written before the block
             indent = re.match(r"^(\s+)", lines[i]).group(1)
             child = " " * (len(indent) - 2)  # taxon_term child indent (sibling of `term`)
             out.append(f"{child}gtdb_classification:")
             dumped = yaml.dump(block, sort_keys=False, allow_unicode=True, width=4096)
             out += [f"{child}  {bl}" for bl in dumped.splitlines()]
             added += 1
-            i += 2
+            i = span[1] if span else i + 2
             continue
         i += 1
     out += lines[end:]
-    path.write_text("\n".join(out) + "\n")
+    new_text = "\n".join(out) + "\n"
+
+    # Refuse to write anything that changed more than the grounding blocks. Four
+    # hand-rolled attempts at this edit corrupted records — deleting a sibling
+    # `evidence` list, joining two lines, emitting duplicate keys — and every one
+    # was caught only by looking afterwards. Checking before the write turns that
+    # class of mistake into a refusal (#378).
+    _assert_only_grounding_changed(path, doc, new_text)
+
+    path.write_text(new_text)
     return added
+
+
+def _assert_only_grounding_changed(path: Path, before: dict, new_text: str) -> None:
+    """Fail loudly unless the edit touched gtdb_classification and nothing else."""
+    try:
+        after = yaml.safe_load(new_text)
+    except yaml.YAMLError as exc:
+        raise SystemExit(
+            f"{path.name}: edit produced unparseable YAML — refusing to write: {exc}"
+        ) from exc
+
+    grounded_now = sum(
+        1
+        for e in (after.get("taxonomy") or [])
+        if ((e or {}).get("taxon_term") or {}).get("gtdb_classification")
+    )
+    if new_text.count("gtdb_classification:") != grounded_now:
+        raise SystemExit(f"{path.name}: edit produced a duplicate gtdb_classification key.")
+
+    b_tax, a_tax = before.get("taxonomy") or [], after.get("taxonomy") or []
+    if len(b_tax) != len(a_tax):
+        raise SystemExit(f"{path.name}: taxonomy went from {len(b_tax)} to {len(a_tax)} entries.")
+    if {k: v for k, v in before.items() if k != "taxonomy"} != {
+        k: v for k, v in after.items() if k != "taxonomy"
+    }:
+        raise SystemExit(f"{path.name}: content outside taxonomy changed.")
+
+    for b, a in zip(b_tax, a_tax, strict=True):
+        bt = dict((b or {}).get("taxon_term") or {})
+        at = dict((a or {}).get("taxon_term") or {})
+        bt.pop("gtdb_classification", None)
+        at.pop("gtdb_classification", None)
+        if bt != at:
+            raise SystemExit(f"{path.name}: a taxon_term changed outside its grounding block.")
+        if {k: v for k, v in (b or {}).items() if k != "taxon_term"} != {
+            k: v for k, v in (a or {}).items() if k != "taxon_term"
+        }:
+            raise SystemExit(f"{path.name}: a taxonomy entry changed outside taxon_term.")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -386,6 +474,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     p.add_argument(
         "--apply", action="store_true", help="With --community: write blocks into the file."
+    )
+    p.add_argument(
+        "--refresh",
+        action="store_true",
+        help="With --apply: recompute blocks that already exist. Creates none.",
     )
     args = p.parse_args(argv)
 
@@ -416,7 +509,9 @@ def main(argv: list[str] | None = None) -> int:
     by_id, by_name, by_higher = collect_rows(mapping_path, want_ids, want_species, want_higher)
 
     if args.community and args.apply:
-        n = apply_to_community(args.community, by_id, by_name, by_higher, mapping_source)
+        n = apply_to_community(
+            args.community, by_id, by_name, by_higher, mapping_source, refresh=args.refresh
+        )
         print(f"[gtdb] applied {n} block(s) to {args.community.name}", file=sys.stderr)
         return 0
 

--- a/tests/test_gtdb_refresh.py
+++ b/tests/test_gtdb_refresh.py
@@ -1,0 +1,186 @@
+"""`--refresh` must replace grounding blocks and change nothing else (#378).
+
+`gtdb_ground.py --apply` skips taxa that already carry a `gtdb_classification`,
+so there was no supported way to re-ground the KB — which any mapping-release
+bump requires, and which flipping a denominator or filter default requires too.
+
+Four hand-rolled attempts at this edit corrupted records: one deleted a sibling
+`evidence` list and a PMID reference, one dropped a newline and joined two lines,
+one emitted duplicate `gtdb_classification` keys across 11 records, and one
+grounded taxa that are withheld on purpose (#292). Each was caught only by
+inspecting afterwards.
+
+So the two invariants are enforced in the code, not by the caller:
+
+* **refresh only, never create** — an ungrounded taxon stays ungrounded, because
+  it may be ungrounded deliberately;
+* **a structural gate before the write** — parse the result and refuse unless the
+  only difference is inside `gtdb_classification`.
+"""
+
+import importlib.util
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).parent.parent
+SAMPLE = REPO / "kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml"
+
+
+@pytest.fixture(scope="module")
+def gtdb():
+    spec = importlib.util.spec_from_file_location("gtdb_ground", REPO / "scripts/gtdb_ground.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def rows(gtdb):
+    try:
+        mapping = gtdb.resolve_kg_microbe_dir(None) / "data/raw/NCBI2GTDB.tsv.gz"
+    except SystemExit as exc:
+        pytest.skip(f"kg-microbe mapping unavailable: {str(exc).splitlines()[0]}")
+    if not mapping.exists():
+        pytest.skip("kg-microbe NCBI2GTDB mapping not available")
+    doc = yaml.safe_load(SAMPLE.read_text())
+    pairs = [
+        (
+            (e["taxon_term"].get("term") or {}).get("id", ""),
+            (e["taxon_term"].get("term") or {}).get("label", ""),
+        )
+        for e in doc["taxonomy"]
+    ]
+    cleaned = [gtdb._clean_label(lb) for _, lb in pairs]
+    return gtdb.collect_rows(
+        mapping,
+        {i.split(":")[1] for i, _ in pairs if i},
+        {c.lower() for c in cleaned if " " in c},
+        {c.lower() for c in cleaned if " " not in c},
+    )
+
+
+@pytest.fixture
+def record(tmp_path):
+    dest = tmp_path / SAMPLE.name
+    shutil.copy(SAMPLE, dest)
+    return dest
+
+
+def test_refresh_replaces_blocks_without_duplicating_the_key(gtdb, rows, record):
+    before = yaml.safe_load(record.read_text())
+    n = gtdb.apply_to_community(record, *rows, "test-source", refresh=True)
+    after = yaml.safe_load(record.read_text())
+
+    assert n > 0, "expected some blocks to be refreshed"
+    grounded = sum(
+        1 for e in after["taxonomy"] if (e.get("taxon_term") or {}).get("gtdb_classification")
+    )
+    assert record.read_text().count("gtdb_classification:") == grounded
+    assert len(after["taxonomy"]) == len(before["taxonomy"])
+
+
+def _grounded_ids(path):
+    return {
+        (e["taxon_term"].get("term") or {}).get("id")
+        for e in yaml.safe_load(path.read_text())["taxonomy"]
+        if (e.get("taxon_term") or {}).get("gtdb_classification")
+    }
+
+
+def test_refresh_creates_no_new_groundings(gtdb, rows, record):
+    """The withheld set (#292) depends on this asymmetry.
+
+    One block is removed first, so the record contains a taxon that is
+    ungrounded *and* groundable — otherwise there is nothing for a
+    creates-anyway bug to create, and the test passes vacuously.
+    """
+    text = record.read_text()
+    start = text.index("    gtdb_classification:")
+    end = start + len("    gtdb_classification:\n")
+    while end < len(text):
+        line_end = text.index("\n", end) + 1
+        if not text[end:line_end].startswith("      "):
+            break
+        end = line_end
+    record.write_text(text[:start] + text[end:])
+
+    before = _grounded_ids(record)
+    assert len(before) >= 1
+
+    gtdb.apply_to_community(record, *rows, "test-source", refresh=True)
+
+    assert _grounded_ids(record) == before, (
+        "refresh grounded a taxon that had no block — an ungrounded taxon may be "
+        "ungrounded deliberately (#292)"
+    )
+
+
+def test_the_gate_runs_on_every_write(gtdb, rows, record, monkeypatch):
+    """Removing the gate must not go unnoticed.
+
+    It never fires on a correct edit, so nothing else here exercises it.
+    """
+    calls = []
+    real = gtdb._assert_only_grounding_changed
+    monkeypatch.setattr(
+        gtdb,
+        "_assert_only_grounding_changed",
+        lambda path, doc, text: (calls.append(path), real(path, doc, text))[1],
+    )
+
+    gtdb.apply_to_community(record, *rows, "test-source", refresh=True)
+
+    assert calls, "apply_to_community wrote without running the structural gate"
+
+
+def test_refresh_preserves_everything_outside_the_grounding(gtdb, rows, record):
+    before = yaml.safe_load(record.read_text())
+    gtdb.apply_to_community(record, *rows, "test-source", refresh=True)
+    after = yaml.safe_load(record.read_text())
+
+    assert {k: v for k, v in before.items() if k != "taxonomy"} == {
+        k: v for k, v in after.items() if k != "taxonomy"
+    }
+    for b, a in zip(before["taxonomy"], after["taxonomy"], strict=True):
+        bt, at = dict(b["taxon_term"]), dict(a["taxon_term"])
+        bt.pop("gtdb_classification", None)
+        at.pop("gtdb_classification", None)
+        assert bt == at, "a taxon_term changed outside its grounding block"
+        assert {k: v for k, v in b.items() if k != "taxon_term"} == {
+            k: v for k, v in a.items() if k != "taxon_term"
+        }
+
+
+def test_without_refresh_existing_blocks_are_left_alone(gtdb, rows, record):
+    original = record.read_text()
+    gtdb.apply_to_community(record, *rows, "test-source")
+    assert record.read_text() == original, "default apply must not touch grounded taxa"
+
+
+def test_the_gate_refuses_an_edit_that_drops_a_sibling(gtdb, record):
+    """The failure that deleted `evidence` and a PMID reference."""
+    doc = yaml.safe_load(record.read_text())
+    broken = record.read_text().replace("  evidence:\n", "", 1)
+    with pytest.raises(SystemExit, match="outside taxonomy|taxon_term|taxonomy entry"):
+        gtdb._assert_only_grounding_changed(record, doc, broken)
+
+
+def test_the_gate_refuses_a_duplicate_key(gtdb, record):
+    """PyYAML keeps the last of two identical keys, so linkml-validate is blind."""
+    doc = yaml.safe_load(record.read_text())
+    dup = record.read_text().replace(
+        "    gtdb_classification:\n",
+        "    gtdb_classification:\n      x: 1\n    gtdb_classification:\n",
+        1,
+    )
+    with pytest.raises(SystemExit, match="duplicate"):
+        gtdb._assert_only_grounding_changed(record, doc, dup)
+
+
+def test_the_gate_refuses_unparseable_output(gtdb, record):
+    doc = yaml.safe_load(record.read_text())
+    with pytest.raises(SystemExit, match="unparseable"):
+        gtdb._assert_only_grounding_changed(record, doc, "taxonomy:\n  - : :\n bad: [\n")

--- a/tests/test_gtdb_refresh.py
+++ b/tests/test_gtdb_refresh.py
@@ -19,6 +19,7 @@ So the two invariants are enforced in the code, not by the caller:
 """
 
 import importlib.util
+import re
 import shutil
 from pathlib import Path
 
@@ -128,7 +129,7 @@ def test_the_gate_runs_on_every_write(gtdb, rows, record, monkeypatch):
     monkeypatch.setattr(
         gtdb,
         "_assert_only_grounding_changed",
-        lambda path, doc, text: (calls.append(path), real(path, doc, text))[1],
+        lambda path, doc, text, **kw: (calls.append(path), real(path, doc, text, **kw))[1],
     )
 
     gtdb.apply_to_community(record, *rows, "test-source", refresh=True)
@@ -184,3 +185,118 @@ def test_the_gate_refuses_unparseable_output(gtdb, record):
     doc = yaml.safe_load(record.read_text())
     with pytest.raises(SystemExit, match="unparseable"):
         gtdb._assert_only_grounding_changed(record, doc, "taxonomy:\n  - : :\n bad: [\n")
+
+
+# ---------------------------------------------------------------------------
+# The shape that broke it: a wrapped scalar inside an existing block.
+# ---------------------------------------------------------------------------
+
+WRAPPED = (
+    REPO
+    / "kb/communities/Corynebacterium_glutamicum_Shewanella_oneidensis_Succinic_Acid_Coculture.yaml"
+)
+
+
+@pytest.fixture
+def wrapped_record(tmp_path):
+    """A real record whose block contains a PyYAML line-wrap continuation.
+
+    13 records carry one, written by the `--emit-yaml` path, which dumps at
+    width=100 rather than the width=4096 `apply_to_community` uses. Continuations
+    sit at 8 spaces, so a span scan matching *exactly* 6 stopped a line short and
+    orphaned them into duplicate keys.
+    """
+    dest = tmp_path / WRAPPED.name
+    shutil.copy(WRAPPED, dest)
+    assert re.search(r"^        \S", dest.read_text(), re.M), "fixture lost its wrapped line"
+    return dest
+
+
+def test_refresh_of_a_wrapped_block_produces_no_duplicate_keys(gtdb, wrapped_record):
+    doc = yaml.safe_load(wrapped_record.read_text())
+    pairs = [
+        (
+            (e["taxon_term"].get("term") or {}).get("id", ""),
+            (e["taxon_term"].get("term") or {}).get("label", ""),
+        )
+        for e in doc["taxonomy"]
+    ]
+    cleaned = [gtdb._clean_label(lb) for _, lb in pairs]
+    try:
+        mapping = gtdb.resolve_kg_microbe_dir(None) / "data/raw/NCBI2GTDB.tsv.gz"
+    except SystemExit:
+        pytest.skip("kg-microbe mapping unavailable")
+    if not mapping.exists():
+        pytest.skip("kg-microbe mapping unavailable")
+    rows = gtdb.collect_rows(
+        mapping,
+        {i.split(":")[1] for i, _ in pairs if i},
+        {c.lower() for c in cleaned if " " in c},
+        {c.lower() for c in cleaned if " " not in c},
+    )
+
+    gtdb.apply_to_community(wrapped_record, *rows, "test-source", refresh=True)
+
+    text = wrapped_record.read_text()
+    after = yaml.safe_load(text)
+    grounded = sum(
+        1 for e in after["taxonomy"] if (e.get("taxon_term") or {}).get("gtdb_classification")
+    )
+    for key in ("ncbi_source_id", "majority_fraction", "mapping_source"):
+        assert text.count(f"      {key}:") == grounded, f"duplicate {key} after refresh"
+    assert "built 2026-06-19" not in text, "the stale block survived — refresh did nothing"
+
+
+def test_span_covers_a_wrapped_continuation(gtdb, wrapped_record):
+    """Unit-level: the span must run past a deeper-indented continuation line."""
+    lines = wrapped_record.read_text().splitlines()
+    anchor = next(i for i, ln in enumerate(lines) if re.match(r"^\s+id: NCBITaxon:\d+\s*$", ln))
+    span = gtdb._block_span(lines, anchor, len(lines))
+    assert span, "expected a block for this entry"
+    assert not re.match(
+        r"^\s{6,}\S", lines[span[1]]
+    ), "span ended while the block was still going — a wrapped line was orphaned"
+
+
+# ---------------------------------------------------------------------------
+# The gate's per-entry checks. The document-level check alone satisfied the
+# earlier sibling test, so removing any of these passed (#378 review).
+# ---------------------------------------------------------------------------
+
+
+def test_the_gate_refuses_a_changed_taxon_term_sibling(gtdb, record):
+    doc = yaml.safe_load(record.read_text())
+    broken = record.read_text().replace("    notes:", "    notes_RENAMED:", 1)
+    with pytest.raises(SystemExit, match="taxon_term changed"):
+        gtdb._assert_only_grounding_changed(record, doc, broken)
+
+
+def test_the_gate_refuses_a_changed_entry_level_sibling(gtdb, record):
+    """A key beside `taxon_term` on a taxonomy entry — `evidence`, `notes`."""
+    doc = yaml.safe_load(record.read_text())
+    after = yaml.safe_load(record.read_text())
+    target = next(e for e in after["taxonomy"] if "evidence" in e)
+    target["evidence"] = []
+    with pytest.raises(SystemExit, match="outside taxon_term"):
+        gtdb._assert_only_grounding_changed(record, doc, yaml.dump(after, sort_keys=False))
+
+
+def test_the_gate_refuses_a_dropped_taxonomy_entry(gtdb, record):
+    doc = yaml.safe_load(record.read_text())
+    after = yaml.safe_load(record.read_text())
+    after["taxonomy"] = after["taxonomy"][:-1]
+    with pytest.raises(SystemExit, match="taxonomy went from|was dropped"):
+        gtdb._assert_only_grounding_changed(record, doc, yaml.dump(after, sort_keys=False))
+
+
+def test_the_gate_refuses_a_dropped_grounding_on_refresh(gtdb, record):
+    """A span that swallowed a block would otherwise be written silently."""
+    doc = yaml.safe_load(record.read_text())
+    after = yaml.safe_load(record.read_text())
+    for entry in after["taxonomy"]:
+        if (entry.get("taxon_term") or {}).pop("gtdb_classification", None):
+            break
+    with pytest.raises(SystemExit, match="set of grounded taxa changed"):
+        gtdb._assert_only_grounding_changed(
+            record, doc, yaml.dump(after, sort_keys=False), refresh=True
+        )


### PR DESCRIPTION
Closes #378.

## Why

`--apply` skips taxa that already carry a `gtdb_classification`, so **there is no supported way to re-ground the KB**. Any mapping-release bump needs one; so does changing a denominator or filter default, which is what surfaced this while attempting #375.

## Two invariants, enforced in the code

**Refresh only, never create.** An ungrounded taxon stays ungrounded, because it may be ungrounded *deliberately* — the entries withheld under #292 are, and an earlier attempt grounded two of them.

**A structural gate before the write.** The result is parsed and the write **refused** unless the only difference is inside `gtdb_classification`: taxon count, non-taxonomy content, every sibling key, and the absence of a duplicate `gtdb_classification` are all checked first.

That gate exists for a concrete reason. Four hand-rolled attempts at this edit corrupted records:

| attempt | damage |
|---|---|
| 1 | deleted a sibling `evidence` list and a PMID reference |
| 2 | dropped a newline, joining two lines |
| 3 | emitted duplicate keys across **11** records |
| 4 | grounded two **withheld** taxa (#292) |

Every one was caught by looking *afterwards*, which is luck rather than method. PyYAML keeps the last of two identical keys silently, so the duplicate case in particular sails past `linkml-validate` (#289).

## Verification

Exercised over all **312** records: **0 refusals**, grounded set unchanged everywhere, no duplicate keys, withheld entries still withheld.

**The KB is deliberately not changed here.** Applying it would refresh 559 blocks — mostly a `mapping_source` build-date bump (2026-06-19 → 2026-07-25), plus **25 with real value drift**. That is a data decision that belongs with whatever motivates it, not with the capability.

## Mutation testing found my tests weak first

Two of the first three mutants **survived**, and both were the central guarantees:

- *refresh also creates new groundings* — passed, because the sample record had every taxon already grounded, so there was nothing to create
- *structural gate removed* — passed, because the gate never fires on a correct edit

The fixtures now strip a block to produce a groundable-but-ungrounded taxon, and a separate test asserts the gate is invoked on every write. All three mutants now fail.

`just lint`, `mypy` clean; **1010 passed, 9 skipped**.

---

## Round two — the review's verdict was do-not-merge, and it was right

Running `--refresh` over the KB **corrupted 13 of 312 records while reporting 0 refusals.**

**`_block_span` matched exactly six spaces.** PyYAML wraps long scalars onto continuation lines indented *deeper*, so the span stopped a line short and orphaned them — they reattached after the freshly written block as duplicate keys. 12 records ended up with duplicate `ncbi_source_id` / `majority_fraction` / `mapping_source`, and since PyYAML keeps the **last** of two identical keys, the *stale* value won: the refresh silently did nothing while appearing to succeed. A 13th had a continuation glue onto the new scalar, producing a dangling bracket and nulling out a curated `g__Chlorobium`.

That is **attempt #3 from this PR's own table, recurring — in the commit meant to prevent it.**

**The gate was blind to the only region the tool writes.** It popped `gtdb_classification` before comparing, so nonsense inside a block, a duplicate key inside a block, and *an entire block deleted* all passed. It now parses with a duplicate-detecting loader — the same approach as `tests/test_no_duplicate_yaml_keys.py`, which would have caught every one of these — and compares the grounded set.

That set check has to be **mode-aware**, which the existing apply tests caught immediately: plain `--apply` may add groundings, so requiring equality broke it. Refresh requires the set identical; apply requires only that none is dropped.

**A result with no `gtdb_id` is not a grounding.** `_ground_species` returns one when the GTDB species cell is empty and does not flag it ambiguous, so refresh wrote it over a valid curated block.

Also guarded the write loop against a non-advancing span, which previously **hung** rather than refused.

## My verification was the problem, not just the code

The earlier claim rested on **counting diff lines**, which is exactly what let me report 25 corrupted blocks as *"25 with real value drift"*. Corrected: of the 559 blocks a sweep touches, **533 are pure date bumps, 25 were the corruption, and only 2 are genuine value changes**.

The check now is the one the review used: **sweep all 312 records and run the repo's own suite on the result** — 1010 passed, 0 refusals, no duplicate keys, withheld entries intact.

Four mutants survived the previous tests, including **the real bug in mutant form** (`_block_span` off-by-one end). All four now fail, plus the three from before. The fixture is now a real record carrying a wrapped block, not the one record whose blocks are all single-line.

## Filed

- **#380** — `--emit-yaml` dumps at width ~100 while `--apply` uses 4096, which is what created the 13 wrapped blocks in the first place.
- **#381** — `just lint` does not scan `scripts/`; three PRs in a row have hit this, and `mypy` has a pre-existing error there that the gate cannot see.

**1016 passed, 9 skipped.**
