### PR TITLE
Record the genomes behind a GTDB majority_fraction (#383)

### DIFF
--- a/.claude/skills/ground-taxa-gtdb/SKILL.md
+++ b/.claude/skills/ground-taxa-gtdb/SKILL.md
@@ -127,19 +127,24 @@ Grounding happens at the **rank of the input**:
   on the chosen GTDB taxon. Lower values (e.g. *Bacillus* 0.57) warrant a curator
   glance.
 
-- **`support_genomes` / `total_genomes`** — the numerator and denominator the
-  fraction came from (#383). Read these *before* trusting a fraction: `1.0` on
-  `7/7` genomes and `1.0` on `7000/7000` are the same number and very different
-  claims, and 19 of the KB's higher-rank groundings rest on fewer than 10
-  genomes. `majority_fraction` is rounded to 3 places, so the counts cannot be
-  recovered from it. The CLI prints them inline and marks a total under 10
-  `⚠ THIN`.
+- **`total_genomes`** — how many genomes the majority was computed over, i.e.
+  what the fraction is a fraction *of* (#383). Read it *before* trusting a
+  fraction: `1.0` on `7/7` and `1.0` on `7000/7000` are the same number and very
+  different claims. **197 of the KB's groundings rest on fewer than 10 genomes
+  and 25 on a single genome**, almost all reading `1.0`. `majority_fraction` is
+  rounded, so this cannot be recovered from it. The CLI prints it inline and
+  marks a total under 10 `⚠ THIN`.
 
-  `total_genomes` counts only what was *counted* — rows dropped by the
-  named-species filter are excluded, so it shrinks when the filter bites. It is
-  **absent on species-level groundings**, where `majority_fraction` is the
-  crosswalk's own column rather than something the script computes; publishing a
-  locally-summed denominator there would contradict the stored fraction.
+  For genus-and-higher it counts only what was *counted* — rows dropped by the
+  named-species filter are excluded, so it shrinks when the filter bites. For
+  species it is the chosen mapping row's own genome count.
+
+- **`support_genomes`** — the numerator, on genus-and-higher groundings only.
+  Species blocks deliberately carry none: there `majority_fraction` is the
+  crosswalk's own column, which holds **two decimal places**, so a numerator
+  derived from it would assert precision the source lacks — at 17191 genomes and
+  `0.99` the true count spans ~170. A thin grounding is not automatically wrong;
+  a small genus is legitimately small. The point is that you can now tell.
 
   A fraction of exactly **0.5** is a two-way tie, not a majority — it is broken by
   name so the answer is reproducible, but it is still a coin flip (#382).

--- a/.claude/skills/ground-taxa-gtdb/SKILL.md
+++ b/.claude/skills/ground-taxa-gtdb/SKILL.md
@@ -127,11 +127,19 @@ Grounding happens at the **rank of the input**:
   on the chosen GTDB taxon. Lower values (e.g. *Bacillus* 0.57) warrant a curator
   glance.
 
-  **It does not tell you how much evidence is behind it**, and the filter above
-  shrinks that evidence: 0.571 can mean 4 genomes and 1.0 can mean 7. 19 of the
-  KB's 158 higher-rank groundings now rest on fewer than 10 genomes. Before
-  trusting a genus/higher grounding, re-run the tool on that taxon and read the
-  row counts. Adding the denominator to the block is #383.
+- **`support_genomes` / `total_genomes`** — the numerator and denominator the
+  fraction came from (#383). Read these *before* trusting a fraction: `1.0` on
+  `7/7` genomes and `1.0` on `7000/7000` are the same number and very different
+  claims, and 19 of the KB's higher-rank groundings rest on fewer than 10
+  genomes. `majority_fraction` is rounded to 3 places, so the counts cannot be
+  recovered from it. The CLI prints them inline and marks a total under 10
+  `⚠ THIN`.
+
+  `total_genomes` counts only what was *counted* — rows dropped by the
+  named-species filter are excluded, so it shrinks when the filter bites. It is
+  **absent on species-level groundings**, where `majority_fraction` is the
+  crosswalk's own column rather than something the script computes; publishing a
+  locally-summed denominator there would contradict the stored fraction.
 
   A fraction of exactly **0.5** is a two-way tie, not a majority — it is broken by
   name so the answer is reproducible, but it is still a coin flip (#382).

--- a/kb/communities/AMD_Acidophile_Heterotroph_Network.yaml
+++ b/kb/communities/AMD_Acidophile_Heterotroph_Network.yaml
@@ -48,6 +48,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acidiphilium;s__Acidiphilium multivorum
       ncbi_source_id: NCBITaxon:62140
       majority_fraction: 1.0
+      support_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Facultative anaerobic acidophilic heterotroph isolated from pyritic acid mine drainage. This
@@ -92,6 +93,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Acidimicrobiia;o__Acidimicrobiales;f__Acidimicrobiaceae;g__Ferrimicrobium;s__Ferrimicrobium acidiphilum
       ncbi_source_id: NCBITaxon:121039
       majority_fraction: 1.0
+      support_genomes: 4
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Obligately heterotrophic iron-oxidizing actinobacterium from the subclass Acidimicrobidae.
@@ -135,6 +137,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acidiphilium;s__Acidiphilium multivorum
       ncbi_source_id: NCBITaxon:524
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Facultative anaerobic acidophile capable of coupling complete oxidation of organic substrates
@@ -177,6 +180,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acidocella;s__Acidocella facilis
       ncbi_source_id: NCBITaxon:525
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Obligately aerobic heterotrophic α-proteobacterium with strict respiratory metabolism. Unlike
@@ -216,6 +220,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acidisphaera;s__Acidisphaera rubrifaciens
       ncbi_source_id: NCBITaxon:50715
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Aerobic photoheterotrophic α-proteobacterium that produces bacteriochlorophyll a and carotenoids

--- a/kb/communities/AMD_Acidophile_Heterotroph_Network.yaml
+++ b/kb/communities/AMD_Acidophile_Heterotroph_Network.yaml
@@ -48,7 +48,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acidiphilium;s__Acidiphilium multivorum
       ncbi_source_id: NCBITaxon:62140
       majority_fraction: 1.0
-      support_genomes: 7
+      total_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Facultative anaerobic acidophilic heterotroph isolated from pyritic acid mine drainage. This
@@ -93,7 +93,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Acidimicrobiia;o__Acidimicrobiales;f__Acidimicrobiaceae;g__Ferrimicrobium;s__Ferrimicrobium acidiphilum
       ncbi_source_id: NCBITaxon:121039
       majority_fraction: 1.0
-      support_genomes: 4
+      total_genomes: 4
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Obligately heterotrophic iron-oxidizing actinobacterium from the subclass Acidimicrobidae.
@@ -137,7 +137,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acidiphilium;s__Acidiphilium multivorum
       ncbi_source_id: NCBITaxon:524
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Facultative anaerobic acidophile capable of coupling complete oxidation of organic substrates
@@ -180,7 +180,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acidocella;s__Acidocella facilis
       ncbi_source_id: NCBITaxon:525
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Obligately aerobic heterotrophic α-proteobacterium with strict respiratory metabolism. Unlike
@@ -220,7 +220,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acidisphaera;s__Acidisphaera rubrifaciens
       ncbi_source_id: NCBITaxon:50715
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Aerobic photoheterotrophic α-proteobacterium that produces bacteriochlorophyll a and carotenoids

--- a/kb/communities/AMD_Nitrososphaerota_Archaeal.yaml
+++ b/kb/communities/AMD_Nitrososphaerota_Archaeal.yaml
@@ -51,6 +51,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Thermoproteota;c__Nitrososphaeria;o__Nitrososphaerales;f__Nitrosopumilaceae;g__Nitrosotalea;s__Nitrosotalea devanaterra
       ncbi_source_id: NCBITaxon:1078905
       majority_fraction: 1.0
+      support_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Obligately acidophilic ammonia-oxidizing archaeon from the phylum Nitrososphaerota, class
@@ -108,6 +109,8 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Thermoproteota;c__Nitrososphaeria;o__Nitrososphaerales;f__Nitrososphaeraceae;g__Nitrososphaera
       ncbi_source_id: NCBITaxon:497726
       majority_fraction: 1.0
+      support_genomes: 11
+      total_genomes: 11
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Mesophilic ammonia-oxidizing archaea related to Nitrososphaera viennensis but adapted to acidic
@@ -153,6 +156,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales;f__Thermoplasmataceae;g__Ferroplasma;s__Ferroplasma acidarmanus
       ncbi_source_id: NCBITaxon:74969
       majority_fraction: 0.91
+      support_genomes: 22
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Cell wall-lacking archaeon (Thermoplasmatales, Thermoplasmata) found in acid mine drainage

--- a/kb/communities/AMD_Nitrososphaerota_Archaeal.yaml
+++ b/kb/communities/AMD_Nitrososphaerota_Archaeal.yaml
@@ -51,7 +51,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Thermoproteota;c__Nitrososphaeria;o__Nitrososphaerales;f__Nitrosopumilaceae;g__Nitrosotalea;s__Nitrosotalea devanaterra
       ncbi_source_id: NCBITaxon:1078905
       majority_fraction: 1.0
-      support_genomes: 4
+      total_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Obligately acidophilic ammonia-oxidizing archaeon from the phylum Nitrososphaerota, class
@@ -156,7 +156,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales;f__Thermoplasmataceae;g__Ferroplasma;s__Ferroplasma acidarmanus
       ncbi_source_id: NCBITaxon:74969
       majority_fraction: 0.91
-      support_genomes: 22
+      total_genomes: 22
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Cell wall-lacking archaeon (Thermoplasmatales, Thermoplasmata) found in acid mine drainage

--- a/kb/communities/ANME_SRB_Anaerobic_Methanotrophic_Syntrophic_Consortia.yaml
+++ b/kb/communities/ANME_SRB_Anaerobic_Methanotrophic_Syntrophic_Consortia.yaml
@@ -127,6 +127,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfobacteria;o__Desulfobacterales
       ncbi_source_id: NCBITaxon:213118
       majority_fraction: 1.0
+      support_genomes: 109
+      total_genomes: 109
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Seep-SRB2 is an informal deltaproteobacterial SRB clade of uncertain family; grounded

--- a/kb/communities/ANME_SRB_Marine_Methane_Seep_Consortium.yaml
+++ b/kb/communities/ANME_SRB_Marine_Methane_Seep_Consortium.yaml
@@ -48,6 +48,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfobacteria;o__Desulfobacterales
       ncbi_source_id: NCBITaxon:213118
       majority_fraction: 1.0
+      support_genomes: 109
+      total_genomes: 109
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Desulfobacterales is used as a conservative NCBI-grounded representation for common marine

--- a/kb/communities/Aalborg_East_Full_Scale_EBPR_Community.yaml
+++ b/kb/communities/Aalborg_East_Full_Scale_EBPR_Community.yaml
@@ -45,6 +45,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria
       ncbi_source_id: NCBITaxon:28216
       majority_fraction: 1.0
+      support_genomes: 41937
+      total_genomes: 41937
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Accumulibacter is represented with the validated Betaproteobacteria class term because the record
@@ -80,6 +82,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota
       ncbi_source_id: NCBITaxon:201174
       majority_fraction: 1.0
+      support_genomes: 91744
+      total_genomes: 91751
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Tetrasphaera-related Actinobacteria were abundant by qFISH but underrepresented in the metagenome,
@@ -114,6 +118,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota
       ncbi_source_id: NCBITaxon:976
       majority_fraction: 0.999
+      support_genomes: 151365
+      total_genomes: 151454
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 5 GTDB taxa under the NCBI taxon]
     notes: Bacteroidetes-related Saprospiraceae and other flanking bacteria contribute to biomass processing

--- a/kb/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.yaml
+++ b/kb/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.yaml
@@ -54,6 +54,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Eubacteriales;f__Eubacteriaceae;g__Acetobacterium;s__Acetobacterium woodii
       ncbi_source_id: NCBITaxon:33952
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Recombinant lactate-producing A. woodii mutant used as the acetogenic CO2/H2-converting
@@ -84,6 +85,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_AM;s__Clostridium_AM drakei
       ncbi_source_id: NCBITaxon:332101
       majority_fraction: 1.0
+      support_genomes: 6
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Wild-type chain-elongating partner that converts lactate-derived intermediates toward

--- a/kb/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.yaml
+++ b/kb/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.yaml
@@ -54,7 +54,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Eubacteriales;f__Eubacteriaceae;g__Acetobacterium;s__Acetobacterium woodii
       ncbi_source_id: NCBITaxon:33952
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Recombinant lactate-producing A. woodii mutant used as the acetogenic CO2/H2-converting
@@ -85,7 +85,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_AM;s__Clostridium_AM drakei
       ncbi_source_id: NCBITaxon:332101
       majority_fraction: 1.0
-      support_genomes: 6
+      total_genomes: 6
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Wild-type chain-elongating partner that converts lactate-derived intermediates toward

--- a/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
+++ b/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
@@ -59,6 +59,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota
       ncbi_source_id: NCBITaxon:201174
       majority_fraction: 1.0
+      support_genomes: 91744
+      total_genomes: 91751
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: A novel anaerobic acetylenotroph in the phylum Actinobacteria was

--- a/kb/communities/Aerobic_Denitrification_Disturbance_SynCom.yaml
+++ b/kb/communities/Aerobic_Denitrification_Disturbance_SynCom.yaml
@@ -43,7 +43,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas;s__Pseudomonas aeruginosa
       ncbi_source_id: NCBITaxon:287
       majority_fraction: 0.99
-      support_genomes: 17191
+      total_genomes: 17191
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -61,7 +61,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Moraxellaceae;g__Acinetobacter;s__Acinetobacter baumannii
       ncbi_source_id: NCBITaxon:470
       majority_fraction: 1.0
-      support_genomes: 15884
+      total_genomes: 15884
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -79,7 +79,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Aeromonadaceae;g__Aeromonas;s__Aeromonas hydrophila
       ncbi_source_id: NCBITaxon:644
       majority_fraction: 0.96
-      support_genomes: 423
+      total_genomes: 423
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Aerobic_Denitrification_Disturbance_SynCom.yaml
+++ b/kb/communities/Aerobic_Denitrification_Disturbance_SynCom.yaml
@@ -43,6 +43,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas;s__Pseudomonas aeruginosa
       ncbi_source_id: NCBITaxon:287
       majority_fraction: 0.99
+      support_genomes: 17191
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -60,6 +61,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Moraxellaceae;g__Acinetobacter;s__Acinetobacter baumannii
       ncbi_source_id: NCBITaxon:470
       majority_fraction: 1.0
+      support_genomes: 15884
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -77,6 +79,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Aeromonadaceae;g__Aeromonas;s__Aeromonas hydrophila
       ncbi_source_id: NCBITaxon:644
       majority_fraction: 0.96
+      support_genomes: 423
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Aerobic_Denitrification_QQ_SynCom.yaml
+++ b/kb/communities/Aerobic_Denitrification_QQ_SynCom.yaml
@@ -42,6 +42,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Moraxellaceae;g__Acinetobacter;s__Acinetobacter baumannii
       ncbi_source_id: NCBITaxon:470
       majority_fraction: 1.0
+      support_genomes: 15884
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -59,6 +60,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas;s__Pseudomonas aeruginosa
       ncbi_source_id: NCBITaxon:287
       majority_fraction: 0.99
+      support_genomes: 17191
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -76,6 +78,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Aeromonadaceae;g__Aeromonas;s__Aeromonas hydrophila
       ncbi_source_id: NCBITaxon:644
       majority_fraction: 0.96
+      support_genomes: 423
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Aerobic_Denitrification_QQ_SynCom.yaml
+++ b/kb/communities/Aerobic_Denitrification_QQ_SynCom.yaml
@@ -42,7 +42,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Moraxellaceae;g__Acinetobacter;s__Acinetobacter baumannii
       ncbi_source_id: NCBITaxon:470
       majority_fraction: 1.0
-      support_genomes: 15884
+      total_genomes: 15884
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -60,7 +60,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas;s__Pseudomonas aeruginosa
       ncbi_source_id: NCBITaxon:287
       majority_fraction: 0.99
-      support_genomes: 17191
+      total_genomes: 17191
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -78,7 +78,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Aeromonadaceae;g__Aeromonas;s__Aeromonas hydrophila
       ncbi_source_id: NCBITaxon:644
       majority_fraction: 0.96
-      support_genomes: 423
+      total_genomes: 423
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Alaska_Tundra_Permafrost_Iron_Redox_Community.yaml
+++ b/kb/communities/Alaska_Tundra_Permafrost_Iron_Redox_Community.yaml
@@ -37,6 +37,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Rhodoferax
       ncbi_source_id: NCBITaxon:28065
       majority_fraction: 0.706
+      support_genomes: 24
+      total_genomes: 34
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Iron-cycling Gammaproteobacteria-lineage Rhodoferax sp. that
@@ -67,6 +69,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Gallionellaceae;g__Gallionella
       ncbi_source_id: NCBITaxon:96
       majority_fraction: 1.0
+      support_genomes: 6
+      total_genomes: 6
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Iron-cycling Gammaproteobacteria-lineage Gallionella sp. that, with
@@ -95,6 +99,8 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanosarcinia
       ncbi_source_id: NCBITaxon:224756
       majority_fraction: 0.709
+      support_genomes: 547
+      total_genomes: 771
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Co-resident acetoclastic methanogenic archaea whose CH4-metabolism

--- a/kb/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.yaml
+++ b/kb/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.yaml
@@ -42,6 +42,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A
       ncbi_source_id: NCBITaxon:1239
       majority_fraction: 0.501
+      support_genomes: 226306
+      total_genomes: 451729
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 12 GTDB taxa under the NCBI taxon]
     notes: Represents ASF356 Clostridium sp., ASF492 Eubacterium plexicaudatum, ASF500 Firmicutes bacterium,
@@ -72,6 +74,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactobacillus
       ncbi_source_id: NCBITaxon:1578
       majority_fraction: 0.998
+      support_genomes: 5369
+      total_genomes: 5379
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Represents ASF360 Lactobacillus sp. and ASF361 Lactobacillus murinus.
@@ -100,6 +104,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Deferribacterota;c__Deferribacteres;o__Deferribacterales;f__Mucispirillaceae;g__Mucispirillum;s__Mucispirillum schaedleri
       ncbi_source_id: NCBITaxon:1379858
       majority_fraction: 1.0
+      support_genomes: 73
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Spiral, mucus-associated member of the ASF.
@@ -123,6 +128,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Tannerellaceae;g__Parabacteroides
       ncbi_source_id: NCBITaxon:375288
       majority_fraction: 1.0
+      support_genomes: 15116
+      total_genomes: 15122
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Bacteroidetes/Tannerellaceae member of the ASF, represented at genus level because the genome

--- a/kb/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.yaml
+++ b/kb/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.yaml
@@ -104,7 +104,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Deferribacterota;c__Deferribacteres;o__Deferribacterales;f__Mucispirillaceae;g__Mucispirillum;s__Mucispirillum schaedleri
       ncbi_source_id: NCBITaxon:1379858
       majority_fraction: 1.0
-      support_genomes: 73
+      total_genomes: 73
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Spiral, mucus-associated member of the ASF.

--- a/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
+++ b/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
@@ -59,6 +59,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Planctomycetota
       ncbi_source_id: NCBITaxon:203682
       majority_fraction: 1.0
+      support_genomes: 519
+      total_genomes: 519
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Anaerobic ammonium-oxidizing bacterium that drives nitrogen removal

--- a/kb/communities/Anammox_Granule_Metabolic_Interaction_Community.yaml
+++ b/kb/communities/Anammox_Granule_Metabolic_Interaction_Community.yaml
@@ -45,6 +45,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Planctomycetota;c__Brocadiia;o__Brocadiales;f__Brocadiaceae;g__Brocadia;s__Brocadia sinica
       ncbi_source_id: NCBITaxon:795830
       majority_fraction: 1.0
+      support_genomes: 10
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: AMX1 was reported as a Brocadia-affiliated anammox MAG closely related to named Brocadia species.
@@ -75,6 +76,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota
       ncbi_source_id: NCBITaxon:1090
       majority_fraction: 1.0
+      support_genomes: 132
+      total_genomes: 132
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Chlorobi-affiliated MAGs, especially CHB1 and CHB2, were inferred as active protein and peptide

--- a/kb/communities/Anammox_Granule_Metabolic_Interaction_Community.yaml
+++ b/kb/communities/Anammox_Granule_Metabolic_Interaction_Community.yaml
@@ -45,7 +45,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Planctomycetota;c__Brocadiia;o__Brocadiales;f__Brocadiaceae;g__Brocadia;s__Brocadia sinica
       ncbi_source_id: NCBITaxon:795830
       majority_fraction: 1.0
-      support_genomes: 10
+      total_genomes: 10
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: AMX1 was reported as a Brocadia-affiliated anammox MAG closely related to named Brocadia species.

--- a/kb/communities/Angelarchaeales_Thermoplasmata_CuMMO_Soil_Sediment_Community.yaml
+++ b/kb/communities/Angelarchaeales_Thermoplasmata_CuMMO_Soil_Sediment_Community.yaml
@@ -35,6 +35,8 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Thermoplasmatota
       ncbi_source_id: NCBITaxon:2283796
       majority_fraction: 1.0
+      support_genomes: 605
+      total_genomes: 605
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Newly defined Thermoplasmatota archaeal order encoding divergent

--- a/kb/communities/At_RSPHERE_SynCom.yaml
+++ b/kb/communities/At_RSPHERE_SynCom.yaml
@@ -95,6 +95,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Rhodococcus
       ncbi_source_id: NCBITaxon:1827
       majority_fraction: 1.0
+      support_genomes: 514
+      total_genomes: 514
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON

--- a/kb/communities/Australian_Lead_Zinc_Polymetallic.yaml
+++ b/kb/communities/Australian_Lead_Zinc_Polymetallic.yaml
@@ -56,7 +56,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
-      support_genomes: 7
+      total_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Metabolically versatile chemolithoautotrophic γ-proteobacterium that dominates the upper oxidized
@@ -110,7 +110,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
-      support_genomes: 4
+      total_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Highly specialized chemolithoautotrophic iron-oxidizing bacterium (phylum Nitrospirae) that
@@ -158,7 +158,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales;f__Thermoplasmataceae;g__Ferroplasma;s__Ferroplasma acidarmanus
       ncbi_source_id: NCBITaxon:97393
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Extremely acidophilic archaeon (order Thermoplasmatales) that dominates the most acidic microhabitats
@@ -209,7 +209,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Obligately anaerobic δ-proteobacterium specialized for dissimilatory metal reduction, inhabiting
@@ -259,7 +259,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_E;c__Sulfobacillia;o__Sulfobacillales;f__Sulfobacillaceae;g__Sulfobacillus;s__Sulfobacillus thermosulfidooxidans
       ncbi_source_id: NCBITaxon:28034
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Moderately thermophilic facultatively chemolithoautotrophic bacterium (Firmicutes) present
@@ -306,7 +306,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acidiphilium;s__Acidiphilium multivorum
       ncbi_source_id: NCBITaxon:524
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Heterotrophic acidophilic α-proteobacterium that scavenges organic carbon in the acidic tailings

--- a/kb/communities/Australian_Lead_Zinc_Polymetallic.yaml
+++ b/kb/communities/Australian_Lead_Zinc_Polymetallic.yaml
@@ -56,6 +56,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
+      support_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Metabolically versatile chemolithoautotrophic γ-proteobacterium that dominates the upper oxidized
@@ -109,6 +110,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
+      support_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Highly specialized chemolithoautotrophic iron-oxidizing bacterium (phylum Nitrospirae) that
@@ -156,6 +158,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales;f__Thermoplasmataceae;g__Ferroplasma;s__Ferroplasma acidarmanus
       ncbi_source_id: NCBITaxon:97393
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Extremely acidophilic archaeon (order Thermoplasmatales) that dominates the most acidic microhabitats
@@ -206,6 +209,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Obligately anaerobic δ-proteobacterium specialized for dissimilatory metal reduction, inhabiting
@@ -255,6 +259,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_E;c__Sulfobacillia;o__Sulfobacillales;f__Sulfobacillaceae;g__Sulfobacillus;s__Sulfobacillus thermosulfidooxidans
       ncbi_source_id: NCBITaxon:28034
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Moderately thermophilic facultatively chemolithoautotrophic bacterium (Firmicutes) present
@@ -301,6 +306,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acidiphilium;s__Acidiphilium multivorum
       ncbi_source_id: NCBITaxon:524
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Heterotrophic acidophilic α-proteobacterium that scavenges organic carbon in the acidic tailings

--- a/kb/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.yaml
+++ b/kb/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.yaml
@@ -82,6 +82,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales
       ncbi_source_id: NCBITaxon:80840
       majority_fraction: 1.0
+      support_genomes: 29473
+      total_genomes: 29476
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
@@ -103,6 +105,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Streptomycetales;f__Catenulisporaceae;g__Catenulispora
       ncbi_source_id: NCBITaxon:414878
       majority_fraction: 1.0
+      support_genomes: 18
+      total_genomes: 18
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:

--- a/kb/communities/BSFL_Gut_SynCom_Bacillus_Lactobacillus_Issatchenkia.yaml
+++ b/kb/communities/BSFL_Gut_SynCom_Bacillus_Lactobacillus_Issatchenkia.yaml
@@ -31,6 +31,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
       majority_fraction: 0.57
+      support_genomes: 4981
+      total_genomes: 8737
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the source paper names the functionally relevant taxon only as
@@ -57,6 +59,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactobacillus
       ncbi_source_id: NCBITaxon:1578
       majority_fraction: 0.998
+      support_genomes: 5369
+      total_genomes: 5379
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the source paper names the functionally relevant taxon only as

--- a/kb/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.yaml
+++ b/kb/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.yaml
@@ -43,6 +43,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus siamensis
       ncbi_source_id: NCBITaxon:659243
       majority_fraction: 0.85
+      support_genomes: 26
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.yaml
+++ b/kb/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.yaml
@@ -43,7 +43,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus siamensis
       ncbi_source_id: NCBITaxon:659243
       majority_fraction: 0.85
-      support_genomes: 26
+      total_genomes: 26
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.yaml
+++ b/kb/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.yaml
@@ -48,7 +48,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides;s__Bacteroides thetaiotaomicron
       ncbi_source_id: NCBITaxon:226186
       majority_fraction: 1.0
-      support_genomes: 2039
+      total_genomes: 2039
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Human gut Bacteroidetes member used as the polysaccharide-foraging partner.
@@ -86,7 +86,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Agathobacter;s__Agathobacter rectalis
       ncbi_source_id: NCBITaxon:515619
       majority_fraction: 1.0
-      support_genomes: 13850
+      total_genomes: 13850
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Literature name retained in preferred_term; NCBI currently labels the strain as Agathobacter

--- a/kb/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.yaml
+++ b/kb/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.yaml
@@ -48,6 +48,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides;s__Bacteroides thetaiotaomicron
       ncbi_source_id: NCBITaxon:226186
       majority_fraction: 1.0
+      support_genomes: 2039
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Human gut Bacteroidetes member used as the polysaccharide-foraging partner.
@@ -85,6 +86,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Agathobacter;s__Agathobacter rectalis
       ncbi_source_id: NCBITaxon:515619
       majority_fraction: 1.0
+      support_genomes: 13850
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Literature name retained in preferred_term; NCBI currently labels the strain as Agathobacter

--- a/kb/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.yaml
+++ b/kb/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.yaml
@@ -45,7 +45,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides;s__Bacteroides thetaiotaomicron
       ncbi_source_id: NCBITaxon:818
       majority_fraction: 0.99
-      support_genomes: 1011
+      total_genomes: 1011
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Saccharolytic bacterial forager in the defined gnotobiotic community.
@@ -89,7 +89,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Desulfovibrio;s__Desulfovibrio piger
       ncbi_source_id: NCBITaxon:901
       majority_fraction: 1.0
-      support_genomes: 156
+      total_genomes: 156
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Sulfate-reducing comparator organism used to distinguish M. smithii-specific effects.

--- a/kb/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.yaml
+++ b/kb/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.yaml
@@ -45,6 +45,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides;s__Bacteroides thetaiotaomicron
       ncbi_source_id: NCBITaxon:818
       majority_fraction: 0.99
+      support_genomes: 1011
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Saccharolytic bacterial forager in the defined gnotobiotic community.
@@ -88,6 +89,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Desulfovibrio;s__Desulfovibrio piger
       ncbi_source_id: NCBITaxon:901
       majority_fraction: 1.0
+      support_genomes: 156
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Sulfate-reducing comparator organism used to distinguish M. smithii-specific effects.

--- a/kb/communities/Banana_Fusarium_Biocontrol_SynCom12.yaml
+++ b/kb/communities/Banana_Fusarium_Biocontrol_SynCom12.yaml
@@ -51,6 +51,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus velezensis
       ncbi_source_id: NCBITaxon:492670
       majority_fraction: 1.0
+      support_genomes: 1163
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Banana_Fusarium_Biocontrol_SynCom12.yaml
+++ b/kb/communities/Banana_Fusarium_Biocontrol_SynCom12.yaml
@@ -51,7 +51,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus velezensis
       ncbi_source_id: NCBITaxon:492670
       majority_fraction: 1.0
-      support_genomes: 1163
+      total_genomes: 1163
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Bayan_Obo_REE_Tailings_Consortium.yaml
+++ b/kb/communities/Bayan_Obo_REE_Tailings_Consortium.yaml
@@ -68,7 +68,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
-      support_genomes: 7
+      total_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Autotrophic chemolithotrophic acidophile that oxidizes ferrous iron and reduced sulfur compounds
@@ -117,7 +117,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acidiphilium;s__Acidiphilium multivorum
       ncbi_source_id: NCBITaxon:524
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Heterotrophic acidophilic bacterium that produces high concentrations of organic acids critical

--- a/kb/communities/Bayan_Obo_REE_Tailings_Consortium.yaml
+++ b/kb/communities/Bayan_Obo_REE_Tailings_Consortium.yaml
@@ -68,6 +68,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
+      support_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Autotrophic chemolithotrophic acidophile that oxidizes ferrous iron and reduced sulfur compounds
@@ -116,6 +117,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acidiphilium;s__Acidiphilium multivorum
       ncbi_source_id: NCBITaxon:524
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Heterotrophic acidophilic bacterium that produces high concentrations of organic acids critical
@@ -145,6 +147,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Streptomycetales;f__Streptomycetaceae;g__Streptomyces
       ncbi_source_id: NCBITaxon:1883
       majority_fraction: 0.99
+      support_genomes: 3010
+      total_genomes: 3040
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
     notes: 'Actinobacterial genus capable of bioleaching rare earth elements from bastnaesite-bearing

--- a/kb/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.yaml
+++ b/kb/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.yaml
@@ -59,6 +59,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium breve
       ncbi_source_id: NCBITaxon:1685
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: ABUNDANT
@@ -82,6 +83,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Ruminococcus_B;s__Ruminococcus_B gnavus
       ncbi_source_id: NCBITaxon:33038
       majority_fraction: 0.99
+      support_genomes: 311
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: ABUNDANT

--- a/kb/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.yaml
+++ b/kb/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.yaml
@@ -59,7 +59,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium breve
       ncbi_source_id: NCBITaxon:1685
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: ABUNDANT
@@ -83,7 +83,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Ruminococcus_B;s__Ruminococcus_B gnavus
       ncbi_source_id: NCBITaxon:33038
       majority_fraction: 0.99
-      support_genomes: 311
+      total_genomes: 311
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: ABUNDANT

--- a/kb/communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.yaml
+++ b/kb/communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.yaml
@@ -52,7 +52,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium breve
       ncbi_source_id: NCBITaxon:1685
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Vaginal commensal whose population is reduced in women infected with T. vaginalis, which

--- a/kb/communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.yaml
+++ b/kb/communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.yaml
@@ -52,6 +52,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium breve
       ncbi_source_id: NCBITaxon:1685
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Vaginal commensal whose population is reduced in women infected with T. vaginalis, which

--- a/kb/communities/BioAsteroid_ISS_Chondrite_Biomining_Consortium.yaml
+++ b/kb/communities/BioAsteroid_ISS_Chondrite_Biomining_Consortium.yaml
@@ -91,7 +91,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Sphingomonas;s__Sphingomonas desiccabilis
       ncbi_source_id: NCBITaxon:429134
       majority_fraction: 1.0
-      support_genomes: 6
+      total_genomes: 6
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >

--- a/kb/communities/BioAsteroid_ISS_Chondrite_Biomining_Consortium.yaml
+++ b/kb/communities/BioAsteroid_ISS_Chondrite_Biomining_Consortium.yaml
@@ -91,6 +91,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Sphingomonas;s__Sphingomonas desiccabilis
       ncbi_source_id: NCBITaxon:429134
       majority_fraction: 1.0
+      support_genomes: 6
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >

--- a/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
+++ b/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
@@ -43,7 +43,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactobacillus;s__Lactobacillus kefiranofaciens
       ncbi_source_id: NCBITaxon:267818
       majority_fraction: 1.0
-      support_genomes: 24
+      total_genomes: 24
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -66,7 +66,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Lactococcus;s__Lactococcus lactis
       ncbi_source_id: NCBITaxon:1358
       majority_fraction: 0.92
-      support_genomes: 893
+      total_genomes: 893
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -90,7 +90,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Leuconostoc;s__Leuconostoc mesenteroides
       ncbi_source_id: NCBITaxon:1245
       majority_fraction: 0.99
-      support_genomes: 301
+      total_genomes: 301
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -114,7 +114,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lentilactobacillus;s__Lentilactobacillus kefiri
       ncbi_source_id: NCBITaxon:33962
       majority_fraction: 1.0
-      support_genomes: 32
+      total_genomes: 32
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -138,7 +138,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acetobacter;s__Acetobacter fabarum
       ncbi_source_id: NCBITaxon:483199
       majority_fraction: 1.0
-      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
+++ b/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
@@ -43,6 +43,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactobacillus;s__Lactobacillus kefiranofaciens
       ncbi_source_id: NCBITaxon:267818
       majority_fraction: 1.0
+      support_genomes: 24
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -65,6 +66,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Lactococcus;s__Lactococcus lactis
       ncbi_source_id: NCBITaxon:1358
       majority_fraction: 0.92
+      support_genomes: 893
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -88,6 +90,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Leuconostoc;s__Leuconostoc mesenteroides
       ncbi_source_id: NCBITaxon:1245
       majority_fraction: 0.99
+      support_genomes: 301
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -111,6 +114,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lentilactobacillus;s__Lentilactobacillus kefiri
       ncbi_source_id: NCBITaxon:33962
       majority_fraction: 1.0
+      support_genomes: 32
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -134,6 +138,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acetobacter;s__Acetobacter fabarum
       ncbi_source_id: NCBITaxon:483199
       majority_fraction: 1.0
+      support_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/BioModels_MODEL2209060002_DPigrum_SAureus_Community.yaml
+++ b/kb/communities/BioModels_MODEL2209060002_DPigrum_SAureus_Community.yaml
@@ -38,7 +38,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Carnobacteriaceae;g__Dolosigranulum;s__Dolosigranulum pigrum
       ncbi_source_id: NCBITaxon:29394
       majority_fraction: 1.0
-      support_genomes: 84
+      total_genomes: 84
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -54,7 +54,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus;s__Staphylococcus aureus
       ncbi_source_id: NCBITaxon:1280
       majority_fraction: 1.0
-      support_genomes: 37403
+      total_genomes: 37403
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/BioModels_MODEL2209060002_DPigrum_SAureus_Community.yaml
+++ b/kb/communities/BioModels_MODEL2209060002_DPigrum_SAureus_Community.yaml
@@ -38,6 +38,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Carnobacteriaceae;g__Dolosigranulum;s__Dolosigranulum pigrum
       ncbi_source_id: NCBITaxon:29394
       majority_fraction: 1.0
+      support_genomes: 84
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -53,6 +54,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus;s__Staphylococcus aureus
       ncbi_source_id: NCBITaxon:1280
       majority_fraction: 1.0
+      support_genomes: 37403
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
+++ b/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
@@ -43,6 +43,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium infantis
       ncbi_source_id: NCBITaxon:1682
       majority_fraction: 0.94
+      support_genomes: 71
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -67,6 +68,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium bifidum
       ncbi_source_id: NCBITaxon:1681
       majority_fraction: 1.0
+      support_genomes: 472
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -90,6 +92,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium breve
       ncbi_source_id: NCBITaxon:1685
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:
@@ -116,6 +119,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Phocaeicola;s__Phocaeicola vulgatus
       ncbi_source_id: NCBITaxon:821
       majority_fraction: 0.86
+      support_genomes: 1446
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -142,6 +146,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_C;c__Negativicutes;o__Veillonellales;f__Veillonellaceae;g__Veillonella;s__Veillonella parvula_A
       ncbi_source_id: NCBITaxon:29466
       majority_fraction: 0.95
+      support_genomes: 1282
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -159,6 +164,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Ruminococcus_B;s__Ruminococcus_B gnavus
       ncbi_source_id: NCBITaxon:33038
       majority_fraction: 0.99
+      support_genomes: 311
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -176,6 +182,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:83333
       majority_fraction: 1.0
+      support_genomes: 50
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -193,6 +200,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lacticaseibacillus;s__Lacticaseibacillus rhamnosus
       ncbi_source_id: NCBITaxon:47715
       majority_fraction: 1.0
+      support_genomes: 1203
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -210,6 +218,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Enterococcaceae;g__Enterococcus;s__Enterococcus faecalis
       ncbi_source_id: NCBITaxon:1351
       majority_fraction: 1.0
+      support_genomes: 9081
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -227,6 +236,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Streptococcus;s__Streptococcus thermophilus
       ncbi_source_id: NCBITaxon:1308
       majority_fraction: 0.99
+      support_genomes: 2093
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -244,6 +254,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Blautia;s__Blautia coccoides
       ncbi_source_id: NCBITaxon:33035
       majority_fraction: 1.0
+      support_genomes: 7
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:

--- a/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
+++ b/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
@@ -43,7 +43,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium infantis
       ncbi_source_id: NCBITaxon:1682
       majority_fraction: 0.94
-      support_genomes: 71
+      total_genomes: 71
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -68,7 +68,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium bifidum
       ncbi_source_id: NCBITaxon:1681
       majority_fraction: 1.0
-      support_genomes: 472
+      total_genomes: 472
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -92,7 +92,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium breve
       ncbi_source_id: NCBITaxon:1685
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:
@@ -119,7 +119,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Phocaeicola;s__Phocaeicola vulgatus
       ncbi_source_id: NCBITaxon:821
       majority_fraction: 0.86
-      support_genomes: 1446
+      total_genomes: 1446
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -146,7 +146,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_C;c__Negativicutes;o__Veillonellales;f__Veillonellaceae;g__Veillonella;s__Veillonella parvula_A
       ncbi_source_id: NCBITaxon:29466
       majority_fraction: 0.95
-      support_genomes: 1282
+      total_genomes: 1282
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -164,7 +164,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Ruminococcus_B;s__Ruminococcus_B gnavus
       ncbi_source_id: NCBITaxon:33038
       majority_fraction: 0.99
-      support_genomes: 311
+      total_genomes: 311
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -182,7 +182,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:83333
       majority_fraction: 1.0
-      support_genomes: 50
+      total_genomes: 50
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -200,7 +200,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lacticaseibacillus;s__Lacticaseibacillus rhamnosus
       ncbi_source_id: NCBITaxon:47715
       majority_fraction: 1.0
-      support_genomes: 1203
+      total_genomes: 1203
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -218,7 +218,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Enterococcaceae;g__Enterococcus;s__Enterococcus faecalis
       ncbi_source_id: NCBITaxon:1351
       majority_fraction: 1.0
-      support_genomes: 9081
+      total_genomes: 9081
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -236,7 +236,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Streptococcus;s__Streptococcus thermophilus
       ncbi_source_id: NCBITaxon:1308
       majority_fraction: 0.99
-      support_genomes: 2093
+      total_genomes: 2093
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -254,7 +254,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Blautia;s__Blautia coccoides
       ncbi_source_id: NCBITaxon:33035
       majority_fraction: 1.0
-      support_genomes: 7
+      total_genomes: 7
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:

--- a/kb/communities/BioRock_ISS_Basalt_Biomining_Consortium.yaml
+++ b/kb/communities/BioRock_ISS_Basalt_Biomining_Consortium.yaml
@@ -83,7 +83,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Sphingomonas;s__Sphingomonas desiccabilis
       ncbi_source_id: NCBITaxon:429134
       majority_fraction: 1.0
-      support_genomes: 6
+      total_genomes: 6
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
@@ -120,7 +120,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
       ncbi_source_id: NCBITaxon:1423
       majority_fraction: 0.91
-      support_genomes: 1256
+      total_genomes: 1256
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
@@ -158,7 +158,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Cupriavidus;s__Cupriavidus metallidurans
       ncbi_source_id: NCBITaxon:119219
       majority_fraction: 1.0
-      support_genomes: 34
+      total_genomes: 34
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >

--- a/kb/communities/BioRock_ISS_Basalt_Biomining_Consortium.yaml
+++ b/kb/communities/BioRock_ISS_Basalt_Biomining_Consortium.yaml
@@ -83,6 +83,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Sphingomonas;s__Sphingomonas desiccabilis
       ncbi_source_id: NCBITaxon:429134
       majority_fraction: 1.0
+      support_genomes: 6
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
@@ -119,6 +120,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
       ncbi_source_id: NCBITaxon:1423
       majority_fraction: 0.91
+      support_genomes: 1256
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
@@ -156,6 +158,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Cupriavidus;s__Cupriavidus metallidurans
       ncbi_source_id: NCBITaxon:119219
       majority_fraction: 1.0
+      support_genomes: 34
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >

--- a/kb/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.yaml
+++ b/kb/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.yaml
@@ -35,6 +35,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota
       ncbi_source_id: NCBITaxon:201174
       majority_fraction: 1.0
+      support_genomes: 91744
+      total_genomes: 91751
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
   functional_role:
@@ -57,6 +59,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota
       ncbi_source_id: NCBITaxon:976
       majority_fraction: 0.999
+      support_genomes: 151365
+      total_genomes: 151454
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 5 GTDB taxa under the NCBI taxon]
   functional_role:
@@ -78,6 +82,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A
       ncbi_source_id: NCBITaxon:1239
       majority_fraction: 0.501
+      support_genomes: 226306
+      total_genomes: 451729
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 12 GTDB taxa under the NCBI taxon]
   functional_role:
@@ -99,6 +105,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota
       ncbi_source_id: NCBITaxon:1224
       majority_fraction: 1.0
+      support_genomes: 806030
+      total_genomes: 806033
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:

--- a/kb/communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.yaml
+++ b/kb/communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.yaml
@@ -28,6 +28,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae_A;g__Buchnera;s__Buchnera aphidicola_F
       ncbi_source_id: NCBITaxon:372461
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Reduced-genome primary aphid endosymbiont from Cinara cedri.

--- a/kb/communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.yaml
+++ b/kb/communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.yaml
@@ -28,7 +28,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae_A;g__Buchnera;s__Buchnera aphidicola_F
       ncbi_source_id: NCBITaxon:372461
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Reduced-genome primary aphid endosymbiont from Cinara cedri.

--- a/kb/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.yaml
+++ b/kb/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.yaml
@@ -27,6 +27,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfobulbia;o__Desulfobulbales;f__Desulfobulbaceae
       ncbi_source_id: NCBITaxon:213121
       majority_fraction: 0.852
+      support_genomes: 52
+      total_genomes: 61
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at f__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Long multicellular filamentous bacteria mediating electrogenic sulfur oxidation in sediment.

--- a/kb/communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.yaml
+++ b/kb/communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.yaml
@@ -56,6 +56,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__Acetivibrionaceae;g__Hungateiclostridium;s__Hungateiclostridium thermocellum
       ncbi_source_id: NCBITaxon:1515
       majority_fraction: 1.0
+      support_genomes: 18
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Cellulolytic anaerobic partner in the designed coculture.
@@ -79,6 +80,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales_B;f__Caldibacillaceae;g__Caldibacillus;s__Caldibacillus debilis
       ncbi_source_id: NCBITaxon:301148
       majority_fraction: 1.0
+      support_genomes: 13
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Noncellulolytic facultative anaerobe isolated from the air-tolerant cellulolytic enrichment

--- a/kb/communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.yaml
+++ b/kb/communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.yaml
@@ -56,7 +56,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__Acetivibrionaceae;g__Hungateiclostridium;s__Hungateiclostridium thermocellum
       ncbi_source_id: NCBITaxon:1515
       majority_fraction: 1.0
-      support_genomes: 18
+      total_genomes: 18
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Cellulolytic anaerobic partner in the designed coculture.
@@ -80,7 +80,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales_B;f__Caldibacillaceae;g__Caldibacillus;s__Caldibacillus debilis
       ncbi_source_id: NCBITaxon:301148
       majority_fraction: 1.0
-      support_genomes: 13
+      total_genomes: 13
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Noncellulolytic facultative anaerobe isolated from the air-tolerant cellulolytic enrichment

--- a/kb/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.yaml
+++ b/kb/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.yaml
@@ -58,7 +58,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Thermoanaerobacteria;o__Caldicellulosiruptorales;f__Caldicellulosiruptoraceae;g__Caldicellulosiruptor;s__Caldicellulosiruptor saccharolyticus
       ncbi_source_id: NCBITaxon:351627
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Extreme thermophilic anaerobe used as one hydrogen-producing member of the defined coculture.
@@ -91,7 +91,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Thermoanaerobacteria;o__Caldicellulosiruptorales;f__Caldicellulosiruptoraceae;g__Caldicellulosiruptor;s__Caldicellulosiruptor acetigenus
       ncbi_source_id: NCBITaxon:632335
       majority_fraction: 1.0
-      support_genomes: 4
+      total_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >

--- a/kb/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.yaml
+++ b/kb/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.yaml
@@ -58,6 +58,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Thermoanaerobacteria;o__Caldicellulosiruptorales;f__Caldicellulosiruptoraceae;g__Caldicellulosiruptor;s__Caldicellulosiruptor saccharolyticus
       ncbi_source_id: NCBITaxon:351627
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Extreme thermophilic anaerobe used as one hydrogen-producing member of the defined coculture.
@@ -90,6 +91,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Thermoanaerobacteria;o__Caldicellulosiruptorales;f__Caldicellulosiruptoraceae;g__Caldicellulosiruptor;s__Caldicellulosiruptor acetigenus
       ncbi_source_id: NCBITaxon:632335
       majority_fraction: 1.0
+      support_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >

--- a/kb/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.yaml
+++ b/kb/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.yaml
@@ -60,6 +60,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Cellulomonadaceae;g__Cellulomonas
       ncbi_source_id: NCBITaxon:1707
       majority_fraction: 0.888
+      support_genomes: 183
+      total_genomes: 206
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: >
@@ -92,6 +94,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhodobacterales;f__Rhodobacteraceae;g__Rhodobacter;s__Rhodobacter capsulatus_B
       ncbi_source_id: NCBITaxon:1061
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: >

--- a/kb/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.yaml
+++ b/kb/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.yaml
@@ -94,7 +94,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhodobacterales;f__Rhodobacteraceae;g__Rhodobacter;s__Rhodobacter capsulatus_B
       ncbi_source_id: NCBITaxon:1061
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: >

--- a/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
+++ b/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
@@ -44,7 +44,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__DSM-27016;g__Ruminiclostridium;s__Ruminiclostridium cellulolyticum
       ncbi_source_id: NCBITaxon:1521
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -62,7 +62,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanospirillum;s__Methanospirillum hungatei
       ncbi_source_id: NCBITaxon:323259
       majority_fraction: 1.0
-      support_genomes: 5
+      total_genomes: 5
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -80,7 +80,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanosarcinia;o__Methanotrichales;f__Methanotrichaceae;g__Methanothrix;s__Methanothrix soehngenii
       ncbi_source_id: NCBITaxon:2223
       majority_fraction: 1.0
-      support_genomes: 9
+      total_genomes: 9
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -98,7 +98,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Nitratidesulfovibrio;s__Nitratidesulfovibrio vulgaris
       ncbi_source_id: NCBITaxon:881
       majority_fraction: 1.0
-      support_genomes: 6
+      total_genomes: 6
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
+++ b/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
@@ -44,6 +44,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__DSM-27016;g__Ruminiclostridium;s__Ruminiclostridium cellulolyticum
       ncbi_source_id: NCBITaxon:1521
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -61,6 +62,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanospirillum;s__Methanospirillum hungatei
       ncbi_source_id: NCBITaxon:323259
       majority_fraction: 1.0
+      support_genomes: 5
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -78,6 +80,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanosarcinia;o__Methanotrichales;f__Methanotrichaceae;g__Methanothrix;s__Methanothrix soehngenii
       ncbi_source_id: NCBITaxon:2223
       majority_fraction: 1.0
+      support_genomes: 9
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -95,6 +98,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Nitratidesulfovibrio;s__Nitratidesulfovibrio vulgaris
       ncbi_source_id: NCBITaxon:881
       majority_fraction: 1.0
+      support_genomes: 6
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Cheese_Rind_InSitu_InVitro_Model_Community.yaml
+++ b/kb/communities/Cheese_Rind_InSitu_InVitro_Model_Community.yaml
@@ -52,6 +52,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus
       ncbi_source_id: NCBITaxon:1279
       majority_fraction: 1.0
+      support_genomes: 60202
+      total_genomes: 60204
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Genus-level taxon used because the source record reports community members primarily at genus
@@ -74,6 +76,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Brevibacteriaceae;g__Brevibacterium
       ncbi_source_id: NCBITaxon:1696
       majority_fraction: 1.0
+      support_genomes: 469
+      total_genomes: 469
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Genus-level taxon used because the source reports Brevibacterium as a mature-rind genus in

--- a/kb/communities/Chlamydomonas_Bacterial_H2_Consortium.yaml
+++ b/kb/communities/Chlamydomonas_Bacterial_H2_Consortium.yaml
@@ -88,6 +88,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Xanthomonadaceae;g__Stenotrophomonas
       ncbi_source_id: NCBITaxon:40323
       majority_fraction: 0.985
+      support_genomes: 398
+      total_genomes: 404
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON

--- a/kb/communities/Chlorella_Azospirillum_Synthetic_Mutualism.yaml
+++ b/kb/communities/Chlorella_Azospirillum_Synthetic_Mutualism.yaml
@@ -91,7 +91,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Azospirillales;f__Azospirillaceae;g__Azospirillum;s__Azospirillum brasilense
       ncbi_source_id: NCBITaxon:192
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: >

--- a/kb/communities/Chlorella_Azospirillum_Synthetic_Mutualism.yaml
+++ b/kb/communities/Chlorella_Azospirillum_Synthetic_Mutualism.yaml
@@ -91,6 +91,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Azospirillales;f__Azospirillaceae;g__Azospirillum;s__Azospirillum brasilense
       ncbi_source_id: NCBITaxon:192
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: >

--- a/kb/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.yaml
+++ b/kb/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.yaml
@@ -83,6 +83,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
+      support_genomes: 166397
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Bacterial partner in the mixotrophic algal-bacterial coculture.

--- a/kb/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.yaml
+++ b/kb/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.yaml
@@ -83,7 +83,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
-      support_genomes: 166397
+      total_genomes: 166397
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Bacterial partner in the mixotrophic algal-bacterial coculture.

--- a/kb/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.yaml
+++ b/kb/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.yaml
@@ -88,6 +88,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
       majority_fraction: 0.699
+      support_genomes: 17956
+      total_genomes: 25706
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: Keystone genus; the taxon enriched by 2% D-mannitol treatment. Resolved at genus level —
@@ -120,6 +122,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Duganella
       ncbi_source_id: NCBITaxon:75654
       majority_fraction: 1.0
+      support_genomes: 45
+      total_genomes: 45
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Keystone genus of the Chlorella phytomicrobiome; resolved at genus level.
@@ -141,6 +145,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Brevibacteriaceae;g__Brevibacterium
       ncbi_source_id: NCBITaxon:1696
       majority_fraction: 1.0
+      support_genomes: 469
+      total_genomes: 469
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Keystone genus of the Chlorella phytomicrobiome; resolved at genus level.

--- a/kb/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml
+++ b/kb/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml
@@ -60,6 +60,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Symbiobacter;s__Symbiobacter mobilis
       ncbi_source_id: NCBITaxon:1436290
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Central non-pigmented motile heterotroph in the barrel-shaped phototrophic consortium.

--- a/kb/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml
+++ b/kb/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml
@@ -60,7 +60,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Symbiobacter;s__Symbiobacter mobilis
       ncbi_source_id: NCBITaxon:1436290
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Central non-pigmented motile heterotroph in the barrel-shaped phototrophic consortium.

--- a/kb/communities/Chromium_Sulfur_Reduction_Enrichment.yaml
+++ b/kb/communities/Chromium_Sulfur_Reduction_Enrichment.yaml
@@ -70,6 +70,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Dermatophilaceae
       ncbi_source_id: NCBITaxon:85021
       majority_fraction: 0.996
+      support_genomes: 532
+      total_genomes: 534
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at f__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive actinobacterium of the Intrasporangiaceae family, isolated as the dominant chromium-reducing
@@ -124,6 +126,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
       majority_fraction: 0.699
+      support_genomes: 17956
+      total_genomes: 25706
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: 'Gram-negative gammaproteobacteria contributing to sulfur oxidation, chromium reduction, and
@@ -173,6 +177,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
       majority_fraction: 0.57
+      support_genomes: 4981
+      total_genomes: 8737
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive, spore-forming bacteria (Firmicutes phylum) performing Cr(VI) reduction, metal

--- a/kb/communities/Cinnamate_Degradation_Consortium.yaml
+++ b/kb/communities/Cinnamate_Degradation_Consortium.yaml
@@ -27,6 +27,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Oscillospirales;f__Oscillospiraceae;g__Papillibacter;s__Papillibacter cinnamivorans
       ncbi_source_id: NCBITaxon:100176
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT
@@ -51,6 +52,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Syntrophia;o__Syntrophales;f__Syntrophaceae;g__Syntrophus
       ncbi_source_id: NCBITaxon:43773
       majority_fraction: 1.0
+      support_genomes: 8
+      total_genomes: 8
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   abundance_level: ABUNDANT
@@ -75,6 +78,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Methanobacteriota;c__Methanobacteria;o__Methanobacteriales;f__Methanobacteriaceae;g__Methanobacterium;s__Methanobacterium formicicum
       ncbi_source_id: NCBITaxon:2162
       majority_fraction: 0.94
+      support_genomes: 17
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: ABUNDANT

--- a/kb/communities/Cinnamate_Degradation_Consortium.yaml
+++ b/kb/communities/Cinnamate_Degradation_Consortium.yaml
@@ -27,7 +27,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Oscillospirales;f__Oscillospiraceae;g__Papillibacter;s__Papillibacter cinnamivorans
       ncbi_source_id: NCBITaxon:100176
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT
@@ -78,7 +78,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Methanobacteriota;c__Methanobacteria;o__Methanobacteriales;f__Methanobacteriaceae;g__Methanobacterium;s__Methanobacterium formicicum
       ncbi_source_id: NCBITaxon:2162
       majority_fraction: 0.94
-      support_genomes: 17
+      total_genomes: 17
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: ABUNDANT

--- a/kb/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.yaml
+++ b/kb/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.yaml
@@ -55,7 +55,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_B;s__Clostridium_B ljungdahlii
       ncbi_source_id: NCBITaxon:84023
       majority_fraction: 1.0
-      support_genomes: 7
+      total_genomes: 7
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Acetogenic syngas-fermenting partner in the defined coculture.
@@ -84,7 +84,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_B;s__Clostridium_B kluyveri
       ncbi_source_id: NCBITaxon:1534
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Chain-elongating partner that consumes acetogen products in the defined coculture.

--- a/kb/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.yaml
+++ b/kb/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.yaml
@@ -55,6 +55,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_B;s__Clostridium_B ljungdahlii
       ncbi_source_id: NCBITaxon:84023
       majority_fraction: 1.0
+      support_genomes: 7
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Acetogenic syngas-fermenting partner in the defined coculture.
@@ -83,6 +84,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_B;s__Clostridium_B kluyveri
       ncbi_source_id: NCBITaxon:1534
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Chain-elongating partner that consumes acetogen products in the defined coculture.

--- a/kb/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.yaml
+++ b/kb/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.yaml
@@ -55,7 +55,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__Acetivibrionaceae;g__Hungateiclostridium;s__Hungateiclostridium thermocellum
       ncbi_source_id: NCBITaxon:203119
       majority_fraction: 0.93
-      support_genomes: 14
+      total_genomes: 14
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The primary publication uses Clostridium thermocellum ATCC 27405;
@@ -95,7 +95,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Thermoanaerobacteria;o__Caldicellulosiruptorales;f__Caldicellulosiruptoraceae;g__Caldicellulosiruptor;s__Caldicellulosiruptor bescii
       ncbi_source_id: NCBITaxon:521460
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Type strain DSM 6725 is also available as ATCC BAA-1888 and was

--- a/kb/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.yaml
+++ b/kb/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.yaml
@@ -55,6 +55,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__Acetivibrionaceae;g__Hungateiclostridium;s__Hungateiclostridium thermocellum
       ncbi_source_id: NCBITaxon:203119
       majority_fraction: 0.93
+      support_genomes: 14
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The primary publication uses Clostridium thermocellum ATCC 27405;
@@ -94,6 +95,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Thermoanaerobacteria;o__Caldicellulosiruptorales;f__Caldicellulosiruptoraceae;g__Caldicellulosiruptor;s__Caldicellulosiruptor bescii
       ncbi_source_id: NCBITaxon:521460
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Type strain DSM 6725 is also available as ATCC BAA-1888 and was

--- a/kb/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.yaml
+++ b/kb/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.yaml
@@ -61,6 +61,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_AM;s__Clostridium_AM carboxidivorans
       ncbi_source_id: NCBITaxon:217159
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Autotrophic acetogenic/solventogenic partner that reduces C. kluyveri-derived organic acids to alcohols.
@@ -90,6 +91,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_B;s__Clostridium_B kluyveri
       ncbi_source_id: NCBITaxon:1534
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Chain-elongating partner that generates organic acids from C2 substrates in the coculture.

--- a/kb/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.yaml
+++ b/kb/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.yaml
@@ -61,7 +61,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_AM;s__Clostridium_AM carboxidivorans
       ncbi_source_id: NCBITaxon:217159
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Autotrophic acetogenic/solventogenic partner that reduces C. kluyveri-derived organic acids to alcohols.
@@ -91,7 +91,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_B;s__Clostridium_B kluyveri
       ncbi_source_id: NCBITaxon:1534
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Chain-elongating partner that generates organic acids from C2 substrates in the coculture.

--- a/kb/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.yaml
+++ b/kb/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.yaml
@@ -59,7 +59,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__DSM-27016;g__Ruminiclostridium;s__Ruminiclostridium cellulolyticum
       ncbi_source_id: NCBITaxon:1521
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: NCBI Taxonomy treats Clostridium cellulolyticum as the basionym/synonym of Ruminiclostridium
@@ -90,7 +90,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter sulfurreducens
       ncbi_source_id: NCBITaxon:35554
       majority_fraction: 1.0
-      support_genomes: 19
+      total_genomes: 19
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Electrochemically active partner that occupies the anode-attached fraction in particulate

--- a/kb/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.yaml
+++ b/kb/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.yaml
@@ -59,6 +59,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__DSM-27016;g__Ruminiclostridium;s__Ruminiclostridium cellulolyticum
       ncbi_source_id: NCBITaxon:1521
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: NCBI Taxonomy treats Clostridium cellulolyticum as the basionym/synonym of Ruminiclostridium
@@ -89,6 +90,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter sulfurreducens
       ncbi_source_id: NCBITaxon:35554
       majority_fraction: 1.0
+      support_genomes: 19
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Electrochemically active partner that occupies the anode-attached fraction in particulate

--- a/kb/communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.yaml
+++ b/kb/communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.yaml
@@ -56,7 +56,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_K;s__Clostridium_K cellulovorans
       ncbi_source_id: NCBITaxon:573061
       majority_fraction: 1.0
-      support_genomes: 4
+      total_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: ATCC 35296 cellulolytic fermenter that supplies H2, formate, acetate, and other VFAs
@@ -87,7 +87,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanosarcinia;o__Methanosarcinales;f__Methanosarcinaceae;g__Methanosarcina;s__Methanosarcina barkeri_B
       ncbi_source_id: NCBITaxon:269797
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: DSM 804 methanogen able to use H2, formate, and acetate-linked metabolism in the

--- a/kb/communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.yaml
+++ b/kb/communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.yaml
@@ -56,6 +56,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_K;s__Clostridium_K cellulovorans
       ncbi_source_id: NCBITaxon:573061
       majority_fraction: 1.0
+      support_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: ATCC 35296 cellulolytic fermenter that supplies H2, formate, acetate, and other VFAs
@@ -86,6 +87,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanosarcinia;o__Methanosarcinales;f__Methanosarcinaceae;g__Methanosarcina;s__Methanosarcina barkeri_B
       ncbi_source_id: NCBITaxon:269797
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: DSM 804 methanogen able to use H2, formate, and acetate-linked metabolism in the

--- a/kb/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.yaml
+++ b/kb/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.yaml
@@ -64,7 +64,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_K;s__Clostridium_K cellulovorans
       ncbi_source_id: NCBITaxon:573061
       majority_fraction: 1.0
-      support_genomes: 4
+      total_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Cellulolytic dark-fermentative bacterium that degrades cellulose and produces volatile fatty acids.
@@ -94,7 +94,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Rhodopseudomonas;s__Rhodopseudomonas palustris_F
       ncbi_source_id: NCBITaxon:258594
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Purple nonsulfur phototroph that consumes fermentation products and contributes to hydrogen production.

--- a/kb/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.yaml
+++ b/kb/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.yaml
@@ -64,6 +64,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_K;s__Clostridium_K cellulovorans
       ncbi_source_id: NCBITaxon:573061
       majority_fraction: 1.0
+      support_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Cellulolytic dark-fermentative bacterium that degrades cellulose and produces volatile fatty acids.
@@ -93,6 +94,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Rhodopseudomonas;s__Rhodopseudomonas palustris_F
       ncbi_source_id: NCBITaxon:258594
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Purple nonsulfur phototroph that consumes fermentation products and contributes to hydrogen production.

--- a/kb/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.yaml
+++ b/kb/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.yaml
@@ -59,6 +59,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_B;s__Clostridium_B ljungdahlii
       ncbi_source_id: NCBITaxon:1538
       majority_fraction: 1.0
+      support_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Acetogenic carboxydotroph that produces ethanol and acetate from syngas in the coculture.
@@ -88,6 +89,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_B;s__Clostridium_B kluyveri
       ncbi_source_id: NCBITaxon:1534
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Chain-elongating partner that consumes ethanol and produces butyrate and caproate.

--- a/kb/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.yaml
+++ b/kb/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.yaml
@@ -59,7 +59,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_B;s__Clostridium_B ljungdahlii
       ncbi_source_id: NCBITaxon:1538
       majority_fraction: 1.0
-      support_genomes: 4
+      total_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Acetogenic carboxydotroph that produces ethanol and acetate from syngas in the coculture.
@@ -89,7 +89,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_B;s__Clostridium_B kluyveri
       ncbi_source_id: NCBITaxon:1534
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Chain-elongating partner that consumes ethanol and produces butyrate and caproate.

--- a/kb/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.yaml
+++ b/kb/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.yaml
@@ -65,7 +65,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Lachnoclostridium;s__Lachnoclostridium phytofermentans
       ncbi_source_id: NCBITaxon:357809
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The paper uses the name C. phytofermentans; NCBI currently places strain ISDg under
@@ -106,7 +106,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:511145
       majority_fraction: 1.0
-      support_genomes: 37
+      total_genomes: 37
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Facultative anaerobic secondary-resource specialist in the artificial consortium.

--- a/kb/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.yaml
+++ b/kb/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.yaml
@@ -65,6 +65,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Lachnoclostridium;s__Lachnoclostridium phytofermentans
       ncbi_source_id: NCBITaxon:357809
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The paper uses the name C. phytofermentans; NCBI currently places strain ISDg under
@@ -105,6 +106,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:511145
       majority_fraction: 1.0
+      support_genomes: 37
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Facultative anaerobic secondary-resource specialist in the artificial consortium.

--- a/kb/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.yaml
@@ -58,7 +58,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Lachnoclostridium;s__Lachnoclostridium phytofermentans
       ncbi_source_id: NCBITaxon:357809
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The source uses the name C. phytofermentans; NCBI currently represents

--- a/kb/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.yaml
@@ -58,6 +58,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Lachnoclostridium;s__Lachnoclostridium phytofermentans
       ncbi_source_id: NCBITaxon:357809
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The source uses the name C. phytofermentans; NCBI currently represents

--- a/kb/communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.yaml
@@ -52,7 +52,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__Acetivibrionaceae;g__Hungateiclostridium;s__Hungateiclostridium thermocellum
       ncbi_source_id: NCBITaxon:572545
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The publications use Clostridium thermocellum LQRI; NCBI and JGI records place DSM 2360/LQRI
@@ -88,7 +88,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Thermoanaerobacteria;o__Thermoanaerobacterales;f__Thermoanaerobacteraceae;g__Thermoanaerobacter;s__Thermoanaerobacter pseudethanolicus
       ncbi_source_id: NCBITaxon:399726
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The cyclic fed-batch paper names Thermoanaerobacter pseudethanolicus strain X514; NCBI records

--- a/kb/communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.yaml
@@ -52,6 +52,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__Acetivibrionaceae;g__Hungateiclostridium;s__Hungateiclostridium thermocellum
       ncbi_source_id: NCBITaxon:572545
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The publications use Clostridium thermocellum LQRI; NCBI and JGI records place DSM 2360/LQRI
@@ -87,6 +88,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Thermoanaerobacteria;o__Thermoanaerobacterales;f__Thermoanaerobacteraceae;g__Thermoanaerobacter;s__Thermoanaerobacter pseudethanolicus
       ncbi_source_id: NCBITaxon:399726
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The cyclic fed-batch paper names Thermoanaerobacter pseudethanolicus strain X514; NCBI records

--- a/kb/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.yaml
+++ b/kb/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.yaml
@@ -57,6 +57,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__Acetivibrionaceae;g__Hungateiclostridium;s__Hungateiclostridium thermocellum
       ncbi_source_id: NCBITaxon:1515
       majority_fraction: 1.0
+      support_genomes: 18
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Cellulolytic member that releases glucose or cellobiose from lignocellulosic substrates.
@@ -82,6 +83,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Thermoanaerobacteria;o__Thermoanaerobacterales;f__Thermoanaerobacteraceae;g__Thermoanaerobacterium;s__Thermoanaerobacterium thermosaccharolyticum
       ncbi_source_id: NCBITaxon:1517
       majority_fraction: 1.0
+      support_genomes: 18
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Non-cellulolytic fermentative partner with a competitive metabolic advantage in glucose

--- a/kb/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.yaml
+++ b/kb/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.yaml
@@ -57,7 +57,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__Acetivibrionaceae;g__Hungateiclostridium;s__Hungateiclostridium thermocellum
       ncbi_source_id: NCBITaxon:1515
       majority_fraction: 1.0
-      support_genomes: 18
+      total_genomes: 18
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Cellulolytic member that releases glucose or cellobiose from lignocellulosic substrates.
@@ -83,7 +83,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Thermoanaerobacteria;o__Thermoanaerobacterales;f__Thermoanaerobacteraceae;g__Thermoanaerobacterium;s__Thermoanaerobacterium thermosaccharolyticum
       ncbi_source_id: NCBITaxon:1517
       majority_fraction: 1.0
-      support_genomes: 18
+      total_genomes: 18
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Non-cellulolytic fermentative partner with a competitive metabolic advantage in glucose

--- a/kb/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.yaml
@@ -53,7 +53,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__Acetivibrionaceae;g__Hungateiclostridium;s__Hungateiclostridium thermocellum
       ncbi_source_id: NCBITaxon:203119
       majority_fraction: 0.93
-      support_genomes: 14
+      total_genomes: 14
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The primary paper uses Clostridium thermocellum; NCBI currently represents ATCC 27405 as

--- a/kb/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.yaml
@@ -53,6 +53,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__Acetivibrionaceae;g__Hungateiclostridium;s__Hungateiclostridium thermocellum
       ncbi_source_id: NCBITaxon:203119
       majority_fraction: 0.93
+      support_genomes: 14
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The primary paper uses Clostridium thermocellum; NCBI currently represents ATCC 27405 as

--- a/kb/communities/Composting_SynCom_Lignocellulose_Degradation_Humus.yaml
+++ b/kb/communities/Composting_SynCom_Lignocellulose_Degradation_Humus.yaml
@@ -28,6 +28,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Streptosporangiales;f__Streptosporangiaceae;g__Thermobifida
       ncbi_source_id: NCBITaxon:83677
       majority_fraction: 1.0
+      support_genomes: 37
+      total_genomes: 37
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Native lignocellulose-degrading actinobacterial genus enriched by SynCom inoculation. The five
@@ -54,6 +56,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Streptosporangiales;f__Streptosporangiaceae;g__Spirillospora
       ncbi_source_id: NCBITaxon:1988
       majority_fraction: 0.956
+      support_genomes: 197
+      total_genomes: 206
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Native lignocellulose-degrading actinobacterial genus enriched by SynCom inoculation.

--- a/kb/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.yaml
+++ b/kb/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.yaml
@@ -79,6 +79,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Sphingobacteriales;f__Sphingobacteriaceae;g__Sphingobacterium;s__Sphingobacterium paramultivorum
       ncbi_source_id: NCBITaxon:2886510
       majority_fraction: 0.88
+      support_genomes: 8
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The 2020 consortium paper reports this member as Sphingobacterium multivorum w15;

--- a/kb/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.yaml
+++ b/kb/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.yaml
@@ -79,7 +79,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Sphingobacteriales;f__Sphingobacteriaceae;g__Sphingobacterium;s__Sphingobacterium paramultivorum
       ncbi_source_id: NCBITaxon:2886510
       majority_fraction: 0.88
-      support_genomes: 8
+      total_genomes: 8
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The 2020 consortium paper reports this member as Sphingobacterium multivorum w15;

--- a/kb/communities/Copper_Biomining_Heap_Leach.yaml
+++ b/kb/communities/Copper_Biomining_Heap_Leach.yaml
@@ -62,7 +62,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
-      support_genomes: 7
+      total_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Gram-negative γ-proteobacterium that oxidizes both ferrous iron (Fe²⁺) and reduced sulfur
@@ -103,7 +103,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
-      support_genomes: 4
+      total_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Iron-oxidizing bacterium (Nitrospirae phylum) that becomes dominant in aged copper bioleaching
@@ -146,7 +146,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus thiooxidans
       ncbi_source_id: NCBITaxon:930
       majority_fraction: 1.0
-      support_genomes: 43
+      total_genomes: 43
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Gram-negative γ-proteobacterium specialized for oxidizing elemental sulfur (S⁰) and reduced
@@ -186,7 +186,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales;f__Thermoplasmataceae;g__Ferroplasma;s__Ferroplasma acidarmanus
       ncbi_source_id: NCBITaxon:74969
       majority_fraction: 0.91
-      support_genomes: 22
+      total_genomes: 22
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Cell wall-lacking archaeon (Thermoplasmatales) that oxidizes ferrous iron in extremely acidic
@@ -220,7 +220,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_E;c__Sulfobacillia;o__Sulfobacillales;f__Sulfobacillaceae;g__Sulfobacillus;s__Sulfobacillus thermosulfidooxidans
       ncbi_source_id: NCBITaxon:28034
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Gram-positive, spore-forming, moderately thermophilic bacterium (optimum 50-55°C) that oxidizes

--- a/kb/communities/Copper_Biomining_Heap_Leach.yaml
+++ b/kb/communities/Copper_Biomining_Heap_Leach.yaml
@@ -62,6 +62,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
+      support_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Gram-negative γ-proteobacterium that oxidizes both ferrous iron (Fe²⁺) and reduced sulfur
@@ -102,6 +103,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
+      support_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Iron-oxidizing bacterium (Nitrospirae phylum) that becomes dominant in aged copper bioleaching
@@ -144,6 +146,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus thiooxidans
       ncbi_source_id: NCBITaxon:930
       majority_fraction: 1.0
+      support_genomes: 43
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Gram-negative γ-proteobacterium specialized for oxidizing elemental sulfur (S⁰) and reduced
@@ -183,6 +186,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales;f__Thermoplasmataceae;g__Ferroplasma;s__Ferroplasma acidarmanus
       ncbi_source_id: NCBITaxon:74969
       majority_fraction: 0.91
+      support_genomes: 22
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Cell wall-lacking archaeon (Thermoplasmatales) that oxidizes ferrous iron in extremely acidic
@@ -216,6 +220,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_E;c__Sulfobacillia;o__Sulfobacillales;f__Sulfobacillaceae;g__Sulfobacillus;s__Sulfobacillus thermosulfidooxidans
       ncbi_source_id: NCBITaxon:28034
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Gram-positive, spore-forming, moderately thermophilic bacterium (optimum 50-55°C) that oxidizes

--- a/kb/communities/Corynebacterium_glutamicum_Shewanella_oneidensis_Succinic_Acid_Coculture.yaml
+++ b/kb/communities/Corynebacterium_glutamicum_Shewanella_oneidensis_Succinic_Acid_Coculture.yaml
@@ -31,7 +31,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Corynebacterium;s__Corynebacterium glutamicum
       ncbi_source_id: NCBITaxon:1718
       majority_fraction: 0.99
-      support_genomes: 159
+      total_genomes: 159
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -59,7 +59,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella oneidensis
       ncbi_source_id: NCBITaxon:70863
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   functional_role:

--- a/kb/communities/Corynebacterium_glutamicum_Shewanella_oneidensis_Succinic_Acid_Coculture.yaml
+++ b/kb/communities/Corynebacterium_glutamicum_Shewanella_oneidensis_Succinic_Acid_Coculture.yaml
@@ -31,6 +31,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Corynebacterium;s__Corynebacterium glutamicum
       ncbi_source_id: NCBITaxon:1718
       majority_fraction: 0.99
+      support_genomes: 159
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -58,6 +59,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella oneidensis
       ncbi_source_id: NCBITaxon:70863
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   functional_role:

--- a/kb/communities/Coscinodiscus_Synthetic_Community.yaml
+++ b/kb/communities/Coscinodiscus_Synthetic_Community.yaml
@@ -76,6 +76,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhodobacterales;f__Rhodobacteraceae;g__Mameliella
       ncbi_source_id: NCBITaxon:1434019
       majority_fraction: 1.0
+      support_genomes: 3
+      total_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Roseobacteraceae member that extended the diatom''s stationary phase and reduced dead algal
@@ -107,6 +109,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhodobacterales;f__Rhodobacteraceae;g__Roseovarius
       ncbi_source_id: NCBITaxon:74030
       majority_fraction: 1.0
+      support_genomes: 117
+      total_genomes: 117
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Roseobacteraceae member that promoted diatom survival during late growth phases. Rose1 showed
@@ -138,6 +142,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Flavobacteriales;f__Flavobacteriaceae;g__Croceibacter
       ncbi_source_id: NCBITaxon:216431
       majority_fraction: 1.0
+      support_genomes: 38
+      total_genomes: 38
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Flavobacterium that consistently inhibited C. radiatus throughout all growth phases. Crocei1
@@ -170,6 +176,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Oleiphilaceae;g__Marinobacter
       ncbi_source_id: NCBITaxon:2742
       majority_fraction: 0.974
+      support_genomes: 518
+      total_genomes: 532
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Gammaproteobacterium that initially suppressed algal growth but enabled recovery by day nine,

--- a/kb/communities/Crucian_Carp_Gut_Disease_Resistance_SynCom.yaml
+++ b/kb/communities/Crucian_Carp_Gut_Disease_Resistance_SynCom.yaml
@@ -29,6 +29,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Fusobacteriota;c__Fusobacteriia;o__Fusobacteriales;f__Fusobacteriaceae;g__Cetobacterium_A
       ncbi_source_id: NCBITaxon:180162
       majority_fraction: 1.0
+      support_genomes: 16
+      total_genomes: 16
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the source reports the genus Cetobacterium (no species/strain
@@ -51,6 +53,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Peptostreptococcales;f__Peptostreptococcaceae;g__Paraclostridium
       ncbi_source_id: NCBITaxon:1849822
       majority_fraction: 0.995
+      support_genomes: 204
+      total_genomes: 205
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the source reports the genus Paraclostridium (no species/strain
@@ -73,6 +77,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
       majority_fraction: 0.699
+      support_genomes: 17956
+      total_genomes: 25706
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the source reports the genus Pseudomonas (no species/strain

--- a/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
+++ b/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
@@ -69,6 +69,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus
       ncbi_source_id: NCBITaxon:119977
       majority_fraction: 0.745
+      support_genomes: 158
+      total_genomes: 212
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Acidithiobacillus species and strains dominated the enrichments on
@@ -109,6 +111,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__RF32
       ncbi_source_id: NCBITaxon:204441
       majority_fraction: 0.704
+      support_genomes: 1269
+      total_genomes: 1802
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 15 GTDB taxa under the NCBI taxon]
   abundance_level: ABUNDANT
@@ -129,6 +133,8 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales
       ncbi_source_id: NCBITaxon:2301
       majority_fraction: 1.0
+      support_genomes: 63
+      total_genomes: 63
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 1 GTDB taxa under the NCBI taxon]
   abundance_level: ABUNDANT

--- a/kb/communities/DIETsimp_Lignocellulose_to_Methane_DIET_Consortia.yaml
+++ b/kb/communities/DIETsimp_Lignocellulose_to_Methane_DIET_Consortia.yaml
@@ -33,7 +33,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanosarcinia;o__Methanosarcinales;f__Methanosarcinaceae;g__Methanosarcina;s__Methanosarcina mazei
       ncbi_source_id: NCBITaxon:2209
       majority_fraction: 1.0
-      support_genomes: 197
+      total_genomes: 197
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -61,7 +61,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Spirochaetota;c__Spirochaetia;o__Sphaerochaetales;f__Sphaerochaetaceae;g__Sphaerochaeta;s__Sphaerochaeta globosa
       ncbi_source_id: NCBITaxon:1131703
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -92,7 +92,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Peptostreptococcales;f__Natronincolaceae;g__Clostridium_W;s__Clostridium_W aceticum
       ncbi_source_id: NCBITaxon:84022
       majority_fraction: 1.0
-      support_genomes: 6
+      total_genomes: 6
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/DIETsimp_Lignocellulose_to_Methane_DIET_Consortia.yaml
+++ b/kb/communities/DIETsimp_Lignocellulose_to_Methane_DIET_Consortia.yaml
@@ -33,6 +33,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanosarcinia;o__Methanosarcinales;f__Methanosarcinaceae;g__Methanosarcina;s__Methanosarcina mazei
       ncbi_source_id: NCBITaxon:2209
       majority_fraction: 1.0
+      support_genomes: 197
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -60,6 +61,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Spirochaetota;c__Spirochaetia;o__Sphaerochaetales;f__Sphaerochaetaceae;g__Sphaerochaeta;s__Sphaerochaeta globosa
       ncbi_source_id: NCBITaxon:1131703
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -90,6 +92,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Peptostreptococcales;f__Natronincolaceae;g__Clostridium_W;s__Clostridium_W aceticum
       ncbi_source_id: NCBITaxon:84022
       majority_fraction: 1.0
+      support_genomes: 6
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/DVM_Triculture.yaml
+++ b/kb/communities/DVM_Triculture.yaml
@@ -39,6 +39,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Nitratidesulfovibrio;s__Nitratidesulfovibrio vulgaris
       ncbi_source_id: NCBITaxon:881
       majority_fraction: 1.0
+      support_genomes: 6
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Sulfate-reducing bacterium that serves as the keystone species in this tri-culture. D. vulgaris
@@ -73,6 +74,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Methanobacteriota_A;c__Methanococci;o__Methanococcales;f__Methanococcaceae;g__Methanococcus;s__Methanococcus maripaludis
       ncbi_source_id: NCBITaxon:39152
       majority_fraction: 0.93
+      support_genomes: 56
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Hydrogenotrophic methanogen that consumes H2 and CO2 to produce methane. M. maripaludis serves

--- a/kb/communities/DVM_Triculture.yaml
+++ b/kb/communities/DVM_Triculture.yaml
@@ -39,7 +39,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Nitratidesulfovibrio;s__Nitratidesulfovibrio vulgaris
       ncbi_source_id: NCBITaxon:881
       majority_fraction: 1.0
-      support_genomes: 6
+      total_genomes: 6
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Sulfate-reducing bacterium that serves as the keystone species in this tri-culture. D. vulgaris
@@ -74,7 +74,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Methanobacteriota_A;c__Methanococci;o__Methanococcales;f__Methanococcaceae;g__Methanococcus;s__Methanococcus maripaludis
       ncbi_source_id: NCBITaxon:39152
       majority_fraction: 0.93
-      support_genomes: 56
+      total_genomes: 56
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Hydrogenotrophic methanogen that consumes H2 and CO2 to produce methane. M. maripaludis serves

--- a/kb/communities/Dangl_SynComm_35.yaml
+++ b/kb/communities/Dangl_SynComm_35.yaml
@@ -68,7 +68,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Rhodanobacteraceae;g__Dyella;s__Dyella marensis
       ncbi_source_id: NCBITaxon:231455
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: COMMON
@@ -202,7 +202,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:668369
       majority_fraction: 1.0
-      support_genomes: 4
+      total_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: COMMON

--- a/kb/communities/Dangl_SynComm_35.yaml
+++ b/kb/communities/Dangl_SynComm_35.yaml
@@ -68,6 +68,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Rhodanobacteraceae;g__Dyella;s__Dyella marensis
       ncbi_source_id: NCBITaxon:231455
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: COMMON
@@ -91,6 +92,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales
       ncbi_source_id: NCBITaxon:135614
       majority_fraction: 1.0
+      support_genomes: 7047
+      total_genomes: 7047
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 1 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
@@ -114,6 +117,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
       majority_fraction: 0.699
+      support_genomes: 17956
+      total_genomes: 25706
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
@@ -136,6 +141,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Flavobacteriales;f__Flavobacteriaceae;g__Flavobacterium
       ncbi_source_id: NCBITaxon:237
       majority_fraction: 0.999
+      support_genomes: 859
+      total_genomes: 860
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
@@ -159,6 +166,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Xanthomonadaceae;g__Stenotrophomonas
       ncbi_source_id: NCBITaxon:40323
       majority_fraction: 0.985
+      support_genomes: 398
+      total_genomes: 404
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
@@ -175,6 +184,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Microbacteriaceae;g__Microbacterium
       ncbi_source_id: NCBITaxon:33882
       majority_fraction: 1.0
+      support_genomes: 591
+      total_genomes: 591
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
@@ -191,6 +202,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:668369
       majority_fraction: 1.0
+      support_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: COMMON

--- a/kb/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.yaml
+++ b/kb/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.yaml
@@ -28,6 +28,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales
       ncbi_source_id: NCBITaxon:135619
       majority_fraction: 0.974
+      support_genomes: 1617
+      total_genomes: 1660
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Early deep-plume bloom related to known petroleum-degrading Oceanospirillales.
@@ -76,6 +78,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Cycloclasticaceae;g__Cycloclasticus
       ncbi_source_id: NCBITaxon:34067
       majority_fraction: 1.0
+      support_genomes: 25
+      total_genomes: 25
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Aromatic-hydrocarbon-associated genus reported in DWH plume succession studies.
@@ -98,6 +102,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Nitrosococcales;f__Methylophagaceae;g__Methylophaga
       ncbi_source_id: NCBITaxon:40222
       majority_fraction: 1.0
+      support_genomes: 45
+      total_genomes: 45
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Methylotrophic bacteria implicated in later plume-water hydrocarbon processing.
@@ -120,6 +126,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Oleiphilaceae;g__Marinobacter
       ncbi_source_id: NCBITaxon:2742
       majority_fraction: 0.974
+      support_genomes: 518
+      total_genomes: 532
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Alkane-degrading genus enriched in stable-isotope probing experiments with DWH spill samples.

--- a/kb/communities/Defined_Multispecies_Enamel_Caries_Model.yaml
+++ b/kb/communities/Defined_Multispecies_Enamel_Caries_Model.yaml
@@ -55,6 +55,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lacticaseibacillus;s__Lacticaseibacillus paracasei
       ncbi_source_id: NCBITaxon:1582
       majority_fraction: 1.0
+      support_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Study uses the historical name Lactobacillus casei.
@@ -78,6 +79,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Streptococcus;s__Streptococcus mutans
       ncbi_source_id: NCBITaxon:1309
       majority_fraction: 1.0
+      support_genomes: 512
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   evidence:

--- a/kb/communities/Defined_Multispecies_Enamel_Caries_Model.yaml
+++ b/kb/communities/Defined_Multispecies_Enamel_Caries_Model.yaml
@@ -55,7 +55,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lacticaseibacillus;s__Lacticaseibacillus paracasei
       ncbi_source_id: NCBITaxon:1582
       majority_fraction: 1.0
-      support_genomes: 4
+      total_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Study uses the historical name Lactobacillus casei.
@@ -79,7 +79,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Streptococcus;s__Streptococcus mutans
       ncbi_source_id: NCBITaxon:1309
       majority_fraction: 1.0
-      support_genomes: 512
+      total_genomes: 512
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   evidence:

--- a/kb/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.yaml
+++ b/kb/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.yaml
@@ -57,6 +57,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Chloroflexota;c__Dehalococcoidia;o__Dehalococcoidales;f__Dehalococcoidaceae;g__Dehalococcoides;s__Dehalococcoides mccartyi
       ncbi_source_id: NCBITaxon:243164
       majority_fraction: 1.0
+      support_genomes: 5
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The main 2011 publication uses the historical name Dehalococcoides
@@ -97,6 +98,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Nitratidesulfovibrio;s__Nitratidesulfovibrio vulgaris
       ncbi_source_id: NCBITaxon:882
       majority_fraction: 1.0
+      support_genomes: 7
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The publications use Desulfovibrio vulgaris Hildenborough or DvH; NCBI

--- a/kb/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.yaml
+++ b/kb/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.yaml
@@ -57,7 +57,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Chloroflexota;c__Dehalococcoidia;o__Dehalococcoidales;f__Dehalococcoidaceae;g__Dehalococcoides;s__Dehalococcoides mccartyi
       ncbi_source_id: NCBITaxon:243164
       majority_fraction: 1.0
-      support_genomes: 5
+      total_genomes: 5
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The main 2011 publication uses the historical name Dehalococcoides
@@ -98,7 +98,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Nitratidesulfovibrio;s__Nitratidesulfovibrio vulgaris
       ncbi_source_id: NCBITaxon:882
       majority_fraction: 1.0
-      support_genomes: 7
+      total_genomes: 7
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The publications use Desulfovibrio vulgaris Hildenborough or DvH; NCBI

--- a/kb/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.yaml
+++ b/kb/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.yaml
@@ -59,6 +59,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Chloroflexota;c__Dehalococcoidia;o__Dehalococcoidales;f__Dehalococcoidaceae;g__Dehalococcoides;s__Dehalococcoides mccartyi
       ncbi_source_id: NCBITaxon:243164
       majority_fraction: 1.0
+      support_genomes: 5
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Organohalide-respiring strain that depends on partner-supplied hydrogen,
@@ -99,6 +100,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Nitratidesulfovibrio;s__Nitratidesulfovibrio vulgaris
       ncbi_source_id: NCBITaxon:882
       majority_fraction: 1.0
+      support_genomes: 7
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The source uses Desulfovibrio vulgaris Hildenborough or DvH; NCBI
@@ -138,6 +140,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_C;c__Negativicutes;o__DSM-13327;f__DSM-13327;g__Pelosinus;s__Pelosinus fermentans
       ncbi_source_id: NCBITaxon:1122947
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The source uses Pelosinus fermentans R7 or PfR7; NCBI represents the

--- a/kb/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.yaml
+++ b/kb/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.yaml
@@ -59,7 +59,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Chloroflexota;c__Dehalococcoidia;o__Dehalococcoidales;f__Dehalococcoidaceae;g__Dehalococcoides;s__Dehalococcoides mccartyi
       ncbi_source_id: NCBITaxon:243164
       majority_fraction: 1.0
-      support_genomes: 5
+      total_genomes: 5
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Organohalide-respiring strain that depends on partner-supplied hydrogen,
@@ -100,7 +100,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Nitratidesulfovibrio;s__Nitratidesulfovibrio vulgaris
       ncbi_source_id: NCBITaxon:882
       majority_fraction: 1.0
-      support_genomes: 7
+      total_genomes: 7
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The source uses Desulfovibrio vulgaris Hildenborough or DvH; NCBI
@@ -140,7 +140,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_C;c__Negativicutes;o__DSM-13327;f__DSM-13327;g__Pelosinus;s__Pelosinus fermentans
       ncbi_source_id: NCBITaxon:1122947
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The source uses Pelosinus fermentans R7 or PfR7; NCBI represents the

--- a/kb/communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.yaml
@@ -55,7 +55,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Chloroflexota;c__Dehalococcoidia;o__Dehalococcoidales;f__Dehalococcoidaceae;g__Dehalococcoides;s__Dehalococcoides mccartyi_B
       ncbi_source_id: NCBITaxon:216389
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Strain BAV1 is curated as the organohalide-respiring Dehalococcoides member.
@@ -85,7 +85,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanosarcinia;o__Methanosarcinales;f__Methanosarcinaceae;g__Methanosarcina;s__Methanosarcina barkeri_B
       ncbi_source_id: NCBITaxon:269797
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Methanogenic partner population tested for cobamide production and DMB-guided cobalamin support.

--- a/kb/communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.yaml
@@ -55,6 +55,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Chloroflexota;c__Dehalococcoidia;o__Dehalococcoidales;f__Dehalococcoidaceae;g__Dehalococcoides;s__Dehalococcoides mccartyi_B
       ncbi_source_id: NCBITaxon:216389
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Strain BAV1 is curated as the organohalide-respiring Dehalococcoides member.
@@ -84,6 +85,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanosarcinia;o__Methanosarcinales;f__Methanosarcinaceae;g__Methanosarcina;s__Methanosarcina barkeri_B
       ncbi_source_id: NCBITaxon:269797
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Methanogenic partner population tested for cobamide production and DMB-guided cobalamin support.

--- a/kb/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml
@@ -59,8 +59,9 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Chloroflexota;c__Dehalococcoidia;o__Dehalococcoidales;f__Dehalococcoidaceae;g__Dehalococcoides;s__Dehalococcoides mccartyi
       ncbi_source_id: NCBITaxon:243164
       majority_fraction: 1.0
+      total_genomes: 5
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19)
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Organohalide-respiring partner used for TCE reductive dechlorination in the defined
       SFB93 coculture.
   strain_designation:

--- a/kb/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.yaml
@@ -65,6 +65,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Chloroflexota;c__Dehalococcoidia;o__Dehalococcoidales;f__Dehalococcoidaceae;g__Dehalococcoides;s__Dehalococcoides mccartyi
       ncbi_source_id: NCBITaxon:243164
       majority_fraction: 1.0
+      support_genomes: 5
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Organohalide-respiring bacterium that uses hydrogen as the electron donor for reductive

--- a/kb/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.yaml
@@ -65,7 +65,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Chloroflexota;c__Dehalococcoidia;o__Dehalococcoidales;f__Dehalococcoidaceae;g__Dehalococcoides;s__Dehalococcoides mccartyi
       ncbi_source_id: NCBITaxon:243164
       majority_fraction: 1.0
-      support_genomes: 5
+      total_genomes: 5
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Organohalide-respiring bacterium that uses hydrogen as the electron donor for reductive

--- a/kb/communities/Desulfovibrio_Methanococcus_Syntrophy.yaml
+++ b/kb/communities/Desulfovibrio_Methanococcus_Syntrophy.yaml
@@ -37,6 +37,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Nitratidesulfovibrio;s__Nitratidesulfovibrio vulgaris
       ncbi_source_id: NCBITaxon:882
       majority_fraction: 1.0
+      support_genomes: 7
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Anaerobic sulfate-reducing bacterium that can also grow syntrophically in the absence of sulfate.
@@ -70,6 +71,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Methanobacteriota_A;c__Methanococci;o__Methanococcales;f__Methanococcaceae;g__Methanococcus;s__Methanococcus maripaludis
       ncbi_source_id: NCBITaxon:267377
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Hydrogenotrophic methanogen that consumes H2 and CO2 to produce methane. Essential syntrophic

--- a/kb/communities/Desulfovibrio_Methanococcus_Syntrophy.yaml
+++ b/kb/communities/Desulfovibrio_Methanococcus_Syntrophy.yaml
@@ -37,7 +37,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Nitratidesulfovibrio;s__Nitratidesulfovibrio vulgaris
       ncbi_source_id: NCBITaxon:882
       majority_fraction: 1.0
-      support_genomes: 7
+      total_genomes: 7
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Anaerobic sulfate-reducing bacterium that can also grow syntrophically in the absence of sulfate.
@@ -71,7 +71,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Methanobacteriota_A;c__Methanococci;o__Methanococcales;f__Methanococcaceae;g__Methanococcus;s__Methanococcus maripaludis
       ncbi_source_id: NCBITaxon:267377
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Hydrogenotrophic methanogen that consumes H2 and CO2 to produce methane. Essential syntrophic

--- a/kb/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.yaml
+++ b/kb/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.yaml
@@ -48,6 +48,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acetobacter
       ncbi_source_id: NCBITaxon:434
       majority_fraction: 1.0
+      support_genomes: 395
+      total_genomes: 395
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Represents Acetobacter pomorum DmelCS_004 and Acetobacter tropicalis DmelCS_006 in the defined
@@ -78,6 +80,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactobacillus
       ncbi_source_id: NCBITaxon:1578
       majority_fraction: 0.998
+      support_genomes: 5369
+      total_genomes: 5379
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Represents Lactobacillus brevis DmelCS_003, Lactobacillus fructivorans DmelCS_002, and

--- a/kb/communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.yaml
+++ b/kb/communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.yaml
@@ -34,6 +34,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota
       ncbi_source_id: NCBITaxon:201174
       majority_fraction: 1.0
+      support_genomes: 91744
+      total_genomes: 91751
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Drought-enriched Actinobacteria lineage whose abundance is amplified

--- a/kb/communities/ENIGMA_Denitrifying_SynCom.yaml
+++ b/kb/communities/ENIGMA_Denitrifying_SynCom.yaml
@@ -51,7 +51,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Rhodanobacteraceae;g__Rhodanobacter;s__Rhodanobacter thiooxydans
       ncbi_source_id: NCBITaxon:416169
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:

--- a/kb/communities/ENIGMA_Denitrifying_SynCom.yaml
+++ b/kb/communities/ENIGMA_Denitrifying_SynCom.yaml
@@ -51,6 +51,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Rhodanobacteraceae;g__Rhodanobacter;s__Rhodanobacter thiooxydans
       ncbi_source_id: NCBITaxon:416169
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:

--- a/kb/communities/Early_Dental_Biofilm_FiveSpecies.yaml
+++ b/kb/communities/Early_Dental_Biofilm_FiveSpecies.yaml
@@ -95,6 +95,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Streptococcus;s__Streptococcus downei
       ncbi_source_id: NCBITaxon:1317
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   evidence:
@@ -117,6 +118,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Actinomycetaceae;g__Actinomyces;s__Actinomyces naeslundii
       ncbi_source_id: NCBITaxon:1655
       majority_fraction: 0.96
+      support_genomes: 164
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   evidence:

--- a/kb/communities/Early_Dental_Biofilm_FiveSpecies.yaml
+++ b/kb/communities/Early_Dental_Biofilm_FiveSpecies.yaml
@@ -95,7 +95,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Streptococcus;s__Streptococcus downei
       ncbi_source_id: NCBITaxon:1317
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   evidence:
@@ -118,7 +118,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Actinomycetaceae;g__Actinomyces;s__Actinomyces naeslundii
       ncbi_source_id: NCBITaxon:1655
       majority_fraction: 0.96
-      support_genomes: 164
+      total_genomes: 164
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   evidence:

--- a/kb/communities/East_River_Floodplain_Core_Microbiome.yaml
+++ b/kb/communities/East_River_Floodplain_Core_Microbiome.yaml
@@ -28,6 +28,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria
       ncbi_source_id: NCBITaxon:28216
       majority_fraction: 1.0
+      support_genomes: 41937
+      total_genomes: 41937
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Betaproteobacteria had the highest number of representative genomes and dominated the operationally
@@ -77,6 +79,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Acidobacteriota
       ncbi_source_id: NCBITaxon:57723
       majority_fraction: 1.0
+      support_genomes: 203
+      total_genomes: 203
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Acidobacteriota were among the abundant representative genomes reconstructed across the three
@@ -101,6 +105,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Gemmatimonadota
       ncbi_source_id: NCBITaxon:142182
       majority_fraction: 1.0
+      support_genomes: 36
+      total_genomes: 36
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Gemmatimonadota were reported among abundant reconstructed taxa and among the lower-abundance

--- a/kb/communities/EcoFAB_Ring_Trial_SynCom17.yaml
+++ b/kb/communities/EcoFAB_Ring_Trial_SynCom17.yaml
@@ -59,6 +59,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Paraburkholderia
       ncbi_source_id: NCBITaxon:1822464
       majority_fraction: 0.993
+      support_genomes: 680
+      total_genomes: 685
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Dominant root colonizer in SynCom17 (~98% relative abundance across all 5 labs). Uniquely
@@ -95,6 +97,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Rhodococcus
       ncbi_source_id: NCBITaxon:1827
       majority_fraction: 1.0
+      support_genomes: 514
+      total_genomes: 514
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Dominant in SynCom16 (without Paraburkholderia) at ~68% relative abundance. Fast growth and
@@ -126,6 +130,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Mycobacterium
       ncbi_source_id: NCBITaxon:1763
       majority_fraction: 1.0
+      support_genomes: 18589
+      total_genomes: 18589
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: High relative abundance in SynCom16 roots (~14%).
@@ -152,6 +158,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Methylobacterium
       ncbi_source_id: NCBITaxon:407
       majority_fraction: 1.0
+      support_genomes: 279
+      total_genomes: 279
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: High relative abundance in SynCom16 roots (~15%).
@@ -178,6 +186,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -201,6 +211,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Rhizobium
       ncbi_source_id: NCBITaxon:379
       majority_fraction: 0.87
+      support_genomes: 694
+      total_genomes: 798
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 12 GTDB taxa under the NCBI taxon]
     notes: Most closely related to R. endophyticum.
@@ -225,6 +237,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Bosea
       ncbi_source_id: NCBITaxon:169215
       majority_fraction: 1.0
+      support_genomes: 34
+      total_genomes: 34
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -248,6 +262,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Bradyrhizobium
       ncbi_source_id: NCBITaxon:374
       majority_fraction: 0.995
+      support_genomes: 592
+      total_genomes: 595
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Grown in 1/10 R2A medium (unlike other members grown in R2A).
@@ -272,6 +288,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Xanthomonadaceae;g__Lysobacter
       ncbi_source_id: NCBITaxon:68
       majority_fraction: 0.758
+      support_genomes: 25
+      total_genomes: 33
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Enriched in rhizosphere at 21 DPI (order Xanthomonadales).
@@ -314,6 +332,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Propionibacteriales;f__Nocardioidaceae;g__Marmoricola
       ncbi_source_id: NCBITaxon:86795
       majority_fraction: 1.0
+      support_genomes: 3
+      total_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -337,6 +357,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Chitinophagales;f__Chitinophagaceae;g__Chitinophaga
       ncbi_source_id: NCBITaxon:79328
       majority_fraction: 1.0
+      support_genomes: 133
+      total_genomes: 133
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -360,6 +382,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Sphingobacteriales;f__Sphingobacteriaceae;g__Mucilaginibacter
       ncbi_source_id: NCBITaxon:423349
       majority_fraction: 1.0
+      support_genomes: 173
+      total_genomes: 173
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -383,6 +407,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Chitinophagales;f__Chitinophagaceae;g__Niastella
       ncbi_source_id: NCBITaxon:354354
       majority_fraction: 1.0
+      support_genomes: 21
+      total_genomes: 21
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -406,6 +432,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae_G;g__Gottfriedia
       ncbi_source_id: NCBITaxon:2837503
       majority_fraction: 1.0
+      support_genomes: 7
+      total_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Formerly classified as Bacillus sp. OAE603.
@@ -430,6 +458,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Brevibacillales;f__Brevibacillaceae;g__Brevibacillus
       ncbi_source_id: NCBITaxon:55080
       majority_fraction: 0.803
+      support_genomes: 151
+      total_genomes: 188
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
   strain_designation:

--- a/kb/communities/Ecoli_Bifidobacterium_bifidum_Infant_gut_HMO_Mutualism_Coculture.yaml
+++ b/kb/communities/Ecoli_Bifidobacterium_bifidum_Infant_gut_HMO_Mutualism_Coculture.yaml
@@ -29,7 +29,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
-      support_genomes: 166397
+      total_genomes: 166397
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -55,7 +55,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium bifidum
       ncbi_source_id: NCBITaxon:1681
       majority_fraction: 1.0
-      support_genomes: 472
+      total_genomes: 472
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Ecoli_Bifidobacterium_bifidum_Infant_gut_HMO_Mutualism_Coculture.yaml
+++ b/kb/communities/Ecoli_Bifidobacterium_bifidum_Infant_gut_HMO_Mutualism_Coculture.yaml
@@ -29,6 +29,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
+      support_genomes: 166397
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -54,6 +55,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium bifidum
       ncbi_source_id: NCBITaxon:1681
       majority_fraction: 1.0
+      support_genomes: 472
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Electrostimulated_Mixotrophic_VFA_Producing_Enrichment_Consortium.yaml
+++ b/kb/communities/Electrostimulated_Mixotrophic_VFA_Producing_Enrichment_Consortium.yaml
@@ -30,6 +30,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Enterococcaceae;g__Enterococcus_B
       ncbi_source_id: NCBITaxon:1350
       majority_fraction: 0.598
+      support_genomes: 17011
+      total_genomes: 28462
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the source reports the taxon only as "Enterococcus". Dominant in
@@ -74,6 +76,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Desulfovibrio
       ncbi_source_id: NCBITaxon:872
       majority_fraction: 0.931
+      support_genomes: 551
+      total_genomes: 592
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 9 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the source reports the taxon only as "Desulfovibrio". Enriched in

--- a/kb/communities/Electrosynthetic_Consortia_Shewanella_Clostridium_Acetobacterium_Acetate.yaml
+++ b/kb/communities/Electrosynthetic_Consortia_Shewanella_Clostridium_Acetobacterium_Acetate.yaml
@@ -31,7 +31,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella oneidensis
       ncbi_source_id: NCBITaxon:70863
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:
@@ -61,7 +61,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Peptostreptococcales;f__Natronincolaceae;g__Clostridium_W;s__Clostridium_W aceticum
       ncbi_source_id: NCBITaxon:84022
       majority_fraction: 1.0
-      support_genomes: 6
+      total_genomes: 6
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -88,7 +88,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Eubacteriales;f__Eubacteriaceae;g__Acetobacterium;s__Acetobacterium woodii
       ncbi_source_id: NCBITaxon:33952
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   functional_role:

--- a/kb/communities/Electrosynthetic_Consortia_Shewanella_Clostridium_Acetobacterium_Acetate.yaml
+++ b/kb/communities/Electrosynthetic_Consortia_Shewanella_Clostridium_Acetobacterium_Acetate.yaml
@@ -31,6 +31,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella oneidensis
       ncbi_source_id: NCBITaxon:70863
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:
@@ -60,6 +61,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Peptostreptococcales;f__Natronincolaceae;g__Clostridium_W;s__Clostridium_W aceticum
       ncbi_source_id: NCBITaxon:84022
       majority_fraction: 1.0
+      support_genomes: 6
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -86,6 +88,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Eubacteriales;f__Eubacteriaceae;g__Acetobacterium;s__Acetobacterium woodii
       ncbi_source_id: NCBITaxon:33952
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   functional_role:

--- a/kb/communities/Emiliania_Phaeobacter_Dynamic_Interaction.yaml
+++ b/kb/communities/Emiliania_Phaeobacter_Dynamic_Interaction.yaml
@@ -63,6 +63,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhodobacterales;f__Rhodobacteraceae;g__Phaeobacter;s__Phaeobacter inhibens
       ncbi_source_id: NCBITaxon:391619
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Heterotrophic Roseobacter-group bacterium that attaches to E. huxleyi and produces IAA.

--- a/kb/communities/Emiliania_Phaeobacter_Dynamic_Interaction.yaml
+++ b/kb/communities/Emiliania_Phaeobacter_Dynamic_Interaction.yaml
@@ -63,7 +63,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhodobacterales;f__Rhodobacteraceae;g__Phaeobacter;s__Phaeobacter inhibens
       ncbi_source_id: NCBITaxon:391619
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Heterotrophic Roseobacter-group bacterium that attaches to E. huxleyi and produces IAA.

--- a/kb/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.yaml
+++ b/kb/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.yaml
@@ -49,6 +49,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
+      support_genomes: 166397
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered gut-associated Enterobacteriaceae member in the four-species consortium.
@@ -71,6 +72,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Salmonella;s__Salmonella enterica
       ncbi_source_id: NCBITaxon:90371
       majority_fraction: 1.0
+      support_genomes: 21226
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered Salmonella member used as a genetically tractable gut-associated strain.
@@ -93,6 +95,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides;s__Bacteroides thetaiotaomicron
       ncbi_source_id: NCBITaxon:818
       majority_fraction: 0.99
+      support_genomes: 1011
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered Bacteroides member of the consortium; Bacteroides taxa were described as more

--- a/kb/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.yaml
+++ b/kb/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.yaml
@@ -49,7 +49,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
-      support_genomes: 166397
+      total_genomes: 166397
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered gut-associated Enterobacteriaceae member in the four-species consortium.
@@ -72,7 +72,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Salmonella;s__Salmonella enterica
       ncbi_source_id: NCBITaxon:90371
       majority_fraction: 1.0
-      support_genomes: 21226
+      total_genomes: 21226
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered Salmonella member used as a genetically tractable gut-associated strain.
@@ -95,7 +95,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides;s__Bacteroides thetaiotaomicron
       ncbi_source_id: NCBITaxon:818
       majority_fraction: 0.99
-      support_genomes: 1011
+      total_genomes: 1011
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered Bacteroides member of the consortium; Bacteroides taxa were described as more

--- a/kb/communities/Ensifer_YF2_Sphingobacterium_Y2_Polyethylene_Degrading_Consortium.yaml
+++ b/kb/communities/Ensifer_YF2_Sphingobacterium_Y2_Polyethylene_Degrading_Consortium.yaml
@@ -29,6 +29,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Ensifer
       ncbi_source_id: NCBITaxon:106591
       majority_fraction: 0.5
+      support_genomes: 19
+      total_genomes: 38
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Strain YF2 identified only to genus Ensifer in the source; grounded at genus rank.
@@ -55,6 +57,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Sphingobacteriales;f__Sphingobacteriaceae;g__Sphingobacterium
       ncbi_source_id: NCBITaxon:28453
       majority_fraction: 0.996
+      support_genomes: 232
+      total_genomes: 233
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Strain Y2 identified only to genus Sphingobacterium in the source; grounded at genus rank.
@@ -84,6 +88,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Flavobacteriales;f__Weeksellaceae;g__Chryseobacterium
       ncbi_source_id: NCBITaxon:59732
       majority_fraction: 0.828
+      support_genomes: 361
+      total_genomes: 436
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
   strain_designation:

--- a/kb/communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.yaml
+++ b/kb/communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.yaml
@@ -53,7 +53,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
       ncbi_source_id: NCBITaxon:1423
       majority_fraction: 0.91
-      support_genomes: 1256
+      total_genomes: 1256
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: One of the three consortium members identified to species.
@@ -75,7 +75,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Paraburkholderia;s__Paraburkholderia caribensis
       ncbi_source_id: NCBITaxon:75105
       majority_fraction: 0.92
-      support_genomes: 26
+      total_genomes: 26
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: One of the three consortium members identified to species.
@@ -97,7 +97,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Methylobacterium;s__Methylobacterium tardum
       ncbi_source_id: NCBITaxon:374432
       majority_fraction: 1.0
-      support_genomes: 6
+      total_genomes: 6
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: One of the three consortium members identified to species.

--- a/kb/communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.yaml
+++ b/kb/communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.yaml
@@ -53,6 +53,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
       ncbi_source_id: NCBITaxon:1423
       majority_fraction: 0.91
+      support_genomes: 1256
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: One of the three consortium members identified to species.
@@ -74,6 +75,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Paraburkholderia;s__Paraburkholderia caribensis
       ncbi_source_id: NCBITaxon:75105
       majority_fraction: 0.92
+      support_genomes: 26
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: One of the three consortium members identified to species.
@@ -95,6 +97,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Methylobacterium;s__Methylobacterium tardum
       ncbi_source_id: NCBITaxon:374432
       majority_fraction: 1.0
+      support_genomes: 6
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: One of the three consortium members identified to species.
@@ -131,6 +134,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Mesorhizobium
       ncbi_source_id: NCBITaxon:68287
       majority_fraction: 0.928
+      support_genomes: 167
+      total_genomes: 180
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus level because the paper describes this member as a putative novel

--- a/kb/communities/Ewaste_Bioleaching_Consortium.yaml
+++ b/kb/communities/Ewaste_Bioleaching_Consortium.yaml
@@ -62,7 +62,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
-      support_genomes: 4
+      total_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Dominant iron-oxidizing bacterium in the e-waste bioleaching consortium. Leptospirillum can
@@ -102,7 +102,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_E;c__Sulfobacillia;o__Sulfobacillales;f__Sulfobacillaceae;g__Sulfobacillus;s__Sulfobacillus benefaciens
       ncbi_source_id: NCBITaxon:453960
       majority_fraction: 0.96
-      support_genomes: 45
+      total_genomes: 45
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Gram-positive, moderately thermophilic, facultatively autotrophic bacterium co-occurring with
@@ -137,7 +137,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
-      support_genomes: 7
+      total_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Mesophilic γ-proteobacterium that oxidizes both ferrous iron and reduced sulfur compounds.
@@ -179,7 +179,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus thiooxidans
       ncbi_source_id: NCBITaxon:930
       majority_fraction: 1.0
-      support_genomes: 43
+      total_genomes: 43
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Sulfur-oxidizing bacterium that generates sulfuric acid from elemental sulfur and reduced
@@ -217,7 +217,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrivorans
       ncbi_source_id: NCBITaxon:160808
       majority_fraction: 0.95
-      support_genomes: 20
+      total_genomes: 20
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Facultatively anaerobic, psychrotolerant iron- and sulfur-oxidizing acidophile. Used in two-step

--- a/kb/communities/Ewaste_Bioleaching_Consortium.yaml
+++ b/kb/communities/Ewaste_Bioleaching_Consortium.yaml
@@ -62,6 +62,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
+      support_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Dominant iron-oxidizing bacterium in the e-waste bioleaching consortium. Leptospirillum can
@@ -101,6 +102,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_E;c__Sulfobacillia;o__Sulfobacillales;f__Sulfobacillaceae;g__Sulfobacillus;s__Sulfobacillus benefaciens
       ncbi_source_id: NCBITaxon:453960
       majority_fraction: 0.96
+      support_genomes: 45
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Gram-positive, moderately thermophilic, facultatively autotrophic bacterium co-occurring with
@@ -135,6 +137,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
+      support_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Mesophilic γ-proteobacterium that oxidizes both ferrous iron and reduced sulfur compounds.
@@ -176,6 +179,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus thiooxidans
       ncbi_source_id: NCBITaxon:930
       majority_fraction: 1.0
+      support_genomes: 43
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Sulfur-oxidizing bacterium that generates sulfuric acid from elemental sulfur and reduced
@@ -213,6 +217,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrivorans
       ncbi_source_id: NCBITaxon:160808
       majority_fraction: 0.95
+      support_genomes: 20
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Facultatively anaerobic, psychrotolerant iron- and sulfur-oxidizing acidophile. Used in two-step

--- a/kb/communities/Ferroplasma_Leptospirillum_Syntrophy.yaml
+++ b/kb/communities/Ferroplasma_Leptospirillum_Syntrophy.yaml
@@ -45,6 +45,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
+      support_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Chemolithoautotrophic iron-oxidizing bacterium (Nitrospirae phylum) that oxidizes Fe²⁺ to
@@ -93,6 +94,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales;f__Thermoplasmataceae;g__Ferroplasma;s__Ferroplasma acidarmanus
       ncbi_source_id: NCBITaxon:74969
       majority_fraction: 0.91
+      support_genomes: 22
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Cell wall-lacking archaeon (Thermoplasmatales) that grows chemomixotrophically, oxidizing

--- a/kb/communities/Ferroplasma_Leptospirillum_Syntrophy.yaml
+++ b/kb/communities/Ferroplasma_Leptospirillum_Syntrophy.yaml
@@ -45,7 +45,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
-      support_genomes: 4
+      total_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Chemolithoautotrophic iron-oxidizing bacterium (Nitrospirae phylum) that oxidizes Fe²⁺ to
@@ -94,7 +94,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales;f__Thermoplasmataceae;g__Ferroplasma;s__Ferroplasma acidarmanus
       ncbi_source_id: NCBITaxon:74969
       majority_fraction: 0.91
-      support_genomes: 22
+      total_genomes: 22
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Cell wall-lacking archaeon (Thermoplasmatales) that grows chemomixotrophically, oxidizing

--- a/kb/communities/GLBRC_Populus_Variovorax_SynCom28.yaml
+++ b/kb/communities/GLBRC_Populus_Variovorax_SynCom28.yaml
@@ -51,6 +51,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -82,6 +84,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -113,6 +117,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -144,6 +150,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -175,6 +183,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -206,6 +216,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -237,6 +249,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -268,6 +282,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -299,6 +315,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -330,6 +348,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -361,6 +381,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -392,6 +414,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -423,6 +447,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -454,6 +480,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -485,6 +513,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -516,6 +546,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -547,6 +579,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -578,6 +612,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -609,6 +645,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -640,6 +678,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -671,6 +711,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -702,6 +744,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -733,6 +777,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -764,6 +810,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -795,6 +843,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -826,6 +876,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -857,6 +909,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -888,6 +942,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:

--- a/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
+++ b/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
@@ -68,7 +68,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Coriobacteriia;o__Coriobacteriales;f__Atopobiaceae;g__Olsenella;s__Olsenella uli
       ncbi_source_id: NCBITaxon:133926
       majority_fraction: 1.0
-      support_genomes: 27
+      total_genomes: 27
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Dominant Actinobacteriota member (up to 61.5% relative abundance). Degrades lactose via the
@@ -304,7 +304,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Coriobacteriia;o__Coriobacteriales;f__Atopobiaceae;g__Olsenella;s__Olsenella uli
       ncbi_source_id: NCBITaxon:133926
       majority_fraction: 1.0
-      support_genomes: 27
+      total_genomes: 27
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Second Olsenella MAG (up to 13.9% relative abundance). Lactose degradation via Leloir pathway.
@@ -337,7 +337,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium thermacidophilum
       ncbi_source_id: NCBITaxon:33905
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Third Bifidobacterium MAG (up to 11.4% relative abundance). Lactose fermentation.

--- a/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
+++ b/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
@@ -68,6 +68,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Coriobacteriia;o__Coriobacteriales;f__Atopobiaceae;g__Olsenella;s__Olsenella uli
       ncbi_source_id: NCBITaxon:133926
       majority_fraction: 1.0
+      support_genomes: 27
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Dominant Actinobacteriota member (up to 61.5% relative abundance). Degrades lactose via the
@@ -127,6 +128,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Actinomycetaceae;g__Pauljensenia
       ncbi_source_id: NCBITaxon:2740557
       majority_fraction: 1.0
+      support_genomes: 113
+      total_genomes: 113
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Actinobacteriota member (up to 29.6% relative abundance). Produces succinic acid from lactose.
@@ -159,6 +162,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Agathobacter
       ncbi_source_id: NCBITaxon:1766253
       majority_fraction: 1.0
+      support_genomes: 14281
+      total_genomes: 14281
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Firmicutes member (up to 18.7% relative abundance). Performs lactose-based chain elongation
@@ -193,6 +198,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium
       ncbi_source_id: NCBITaxon:1678
       majority_fraction: 0.999
+      support_genomes: 25518
+      total_genomes: 25552
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Actinobacteriota member (up to 17.4% relative abundance). Ferments lactose via the bifid shunt
@@ -226,6 +233,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Spirochaetota
       ncbi_source_id: NCBITaxon:203691
       majority_fraction: 1.0
+      support_genomes: 6024
+      total_genomes: 6025
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Spirochaetota member (up to 16.1% relative abundance). Produces ethanol which serves as substrate
@@ -260,6 +269,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium
       ncbi_source_id: NCBITaxon:1678
       majority_fraction: 0.999
+      support_genomes: 25518
+      total_genomes: 25552
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Second Bifidobacterium MAG (up to 15.3% relative abundance). Lactose fermentation via bifid
@@ -293,6 +304,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Coriobacteriia;o__Coriobacteriales;f__Atopobiaceae;g__Olsenella;s__Olsenella uli
       ncbi_source_id: NCBITaxon:133926
       majority_fraction: 1.0
+      support_genomes: 27
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Second Olsenella MAG (up to 13.9% relative abundance). Lactose degradation via Leloir pathway.
@@ -325,6 +337,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium thermacidophilum
       ncbi_source_id: NCBITaxon:33905
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Third Bifidobacterium MAG (up to 11.4% relative abundance). Lactose fermentation.
@@ -357,6 +370,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_C;c__Negativicutes;o__Acidaminococcales;f__Acidaminococcaceae;g__Acidaminococcus
       ncbi_source_id: NCBITaxon:904
       majority_fraction: 1.0
+      support_genomes: 1625
+      total_genomes: 1625
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Firmicutes member (up to 10.2% relative abundance). Possible ethanol-based chain elongation.

--- a/kb/communities/GOM_Oil_Degrading_Consortium.yaml
+++ b/kb/communities/GOM_Oil_Degrading_Consortium.yaml
@@ -42,7 +42,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Halopseudomonas;s__Halopseudomonas aestusnigri
       ncbi_source_id: NCBITaxon:857252
       majority_fraction: 1.0
-      support_genomes: 47
+      total_genomes: 47
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT
@@ -65,7 +65,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Micrococcaceae;g__Arthrobacter;s__Arthrobacter sp018215265
       ncbi_source_id: NCBITaxon:2782567
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT

--- a/kb/communities/GOM_Oil_Degrading_Consortium.yaml
+++ b/kb/communities/GOM_Oil_Degrading_Consortium.yaml
@@ -42,6 +42,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Halopseudomonas;s__Halopseudomonas aestusnigri
       ncbi_source_id: NCBITaxon:857252
       majority_fraction: 1.0
+      support_genomes: 47
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT
@@ -64,6 +65,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Micrococcaceae;g__Arthrobacter;s__Arthrobacter sp018215265
       ncbi_source_id: NCBITaxon:2782567
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT

--- a/kb/communities/Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.yaml
+++ b/kb/communities/Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.yaml
@@ -49,7 +49,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter sulfurreducens
       ncbi_source_id: NCBITaxon:35554
       majority_fraction: 1.0
-      support_genomes: 19
+      total_genomes: 19
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Anaerobic bacterium serving as the exoelectrogen in this partnership.
@@ -97,7 +97,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_I;s__Clostridium_I pasteurianum
       ncbi_source_id: NCBITaxon:1501
       majority_fraction: 1.0
-      support_genomes: 19
+      total_genomes: 19
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Saccharolytic, nitrogen-fixing, spore-forming Gram-positive obligate anaerobe

--- a/kb/communities/Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.yaml
+++ b/kb/communities/Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.yaml
@@ -49,6 +49,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter sulfurreducens
       ncbi_source_id: NCBITaxon:35554
       majority_fraction: 1.0
+      support_genomes: 19
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Anaerobic bacterium serving as the exoelectrogen in this partnership.
@@ -96,6 +97,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_I;s__Clostridium_I pasteurianum
       ncbi_source_id: NCBITaxon:1501
       majority_fraction: 1.0
+      support_genomes: 19
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Saccharolytic, nitrogen-fixing, spore-forming Gram-positive obligate anaerobe

--- a/kb/communities/Geobacter_Methanosaeta_DIET.yaml
+++ b/kb/communities/Geobacter_Methanosaeta_DIET.yaml
@@ -40,7 +40,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Anaerobic bacterium capable of oxidizing organic compounds (including
@@ -76,7 +76,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanosarcinia;o__Methanotrichales;f__Methanotrichaceae;g__Methanocrinis;s__Methanocrinis harundinaceus
       ncbi_source_id: NCBITaxon:301375
       majority_fraction: 1.0
-      support_genomes: 20
+      total_genomes: 20
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Obligate acetoclastic methanogenic archaeon capable of accepting electrons

--- a/kb/communities/Geobacter_Methanosaeta_DIET.yaml
+++ b/kb/communities/Geobacter_Methanosaeta_DIET.yaml
@@ -40,6 +40,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Anaerobic bacterium capable of oxidizing organic compounds (including
@@ -75,6 +76,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanosarcinia;o__Methanotrichales;f__Methanotrichaceae;g__Methanocrinis;s__Methanocrinis harundinaceus
       ncbi_source_id: NCBITaxon:301375
       majority_fraction: 1.0
+      support_genomes: 20
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Obligate acetoclastic methanogenic archaeon capable of accepting electrons

--- a/kb/communities/Geobacter_Methanosarcina_DIET.yaml
+++ b/kb/communities/Geobacter_Methanosarcina_DIET.yaml
@@ -39,7 +39,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Anaerobic bacterium capable of oxidizing organic compounds (including

--- a/kb/communities/Geobacter_Methanosarcina_DIET.yaml
+++ b/kb/communities/Geobacter_Methanosarcina_DIET.yaml
@@ -39,6 +39,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Anaerobic bacterium capable of oxidizing organic compounds (including

--- a/kb/communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.yaml
+++ b/kb/communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.yaml
@@ -61,7 +61,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter sulfurreducens
       ncbi_source_id: NCBITaxon:35554
       majority_fraction: 1.0
-      support_genomes: 19
+      total_genomes: 19
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Species-level member of the defined Geobacter-Pseudomonas coculture.
@@ -92,7 +92,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas;s__Pseudomonas aeruginosa
       ncbi_source_id: NCBITaxon:287
       majority_fraction: 0.99
-      support_genomes: 17191
+      total_genomes: 17191
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Species-level member of the defined Geobacter-Pseudomonas coculture.

--- a/kb/communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.yaml
+++ b/kb/communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.yaml
@@ -61,6 +61,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter sulfurreducens
       ncbi_source_id: NCBITaxon:35554
       majority_fraction: 1.0
+      support_genomes: 19
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Species-level member of the defined Geobacter-Pseudomonas coculture.
@@ -91,6 +92,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas;s__Pseudomonas aeruginosa
       ncbi_source_id: NCBITaxon:287
       majority_fraction: 0.99
+      support_genomes: 17191
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Species-level member of the defined Geobacter-Pseudomonas coculture.

--- a/kb/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.yaml
+++ b/kb/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.yaml
@@ -38,6 +38,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Elusimicrobiota;c__Elusimicrobia
       ncbi_source_id: NCBITaxon:641853
       majority_fraction: 1.0
+      support_genomes: 423
+      total_genomes: 423
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Groundwater Elusimicrobia clades with diverse metabolic strategies
@@ -64,6 +66,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Elusimicrobiota;c__Elusimicrobia
       ncbi_source_id: NCBITaxon:641853
       majority_fraction: 1.0
+      support_genomes: 423
+      total_genomes: 423
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Animal-associated Elusimicrobia clades whose phylogenetic placement

--- a/kb/communities/Hanford_300_Area_Unconfined_Aquifer_Community.yaml
+++ b/kb/communities/Hanford_300_Area_Unconfined_Aquifer_Community.yaml
@@ -29,6 +29,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota
       ncbi_source_id: NCBITaxon:1224
       majority_fraction: 1.0
+      support_genomes: 806030
+      total_genomes: 806033
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Proteobacteria comprised half of the recovered sequences in the Hanford unconfined aquifer
@@ -55,6 +57,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota
       ncbi_source_id: NCBITaxon:976
       majority_fraction: 0.999
+      support_genomes: 151365
+      total_genomes: 151454
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 5 GTDB taxa under the NCBI taxon]
     notes: Bacteroidetes were the second most abundant phylum in the recovered 16S rRNA gene sequences.
@@ -80,6 +84,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota
       ncbi_source_id: NCBITaxon:201174
       majority_fraction: 1.0
+      support_genomes: 91744
+      total_genomes: 91751
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Actinobacterial ACK-M1 and CL500-29 groups appeared during river-water intrusion and became

--- a/kb/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.yaml
+++ b/kb/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.yaml
@@ -63,6 +63,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia
       ncbi_source_id: NCBITaxon:186801
       majority_fraction: 0.987
+      support_genomes: 224360
+      total_genomes: 227406
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 26 GTDB taxa under the NCBI taxon]
     notes: The source reports Clostridia within Firmicutes as dominant contributors of measured CAZymes.
@@ -87,6 +89,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli
       ncbi_source_id: NCBITaxon:91061
       majority_fraction: 0.999
+      support_genomes: 184322
+      total_genomes: 184474
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: The paper describes Bacillus/Bacilli-lineage Firmicutes among dominant CAZyme contributors.
@@ -111,6 +115,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Chloroflexota
       ncbi_source_id: NCBITaxon:200795
       majority_fraction: 0.997
+      support_genomes: 299
+      total_genomes: 300
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: The publication uses the historical phylum name Chloroflexi and reports fraction-specific
@@ -136,6 +142,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Thermotogota
       ncbi_source_id: NCBITaxon:200918
       majority_fraction: 1.0
+      support_genomes: 276
+      total_genomes: 276
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: The publication uses the historical phylum name Thermotogae and reports Thermotogae-derived

--- a/kb/communities/Human_Gut_FourMember_Proteome_Complementarity_Consortium.yaml
+++ b/kb/communities/Human_Gut_FourMember_Proteome_Complementarity_Consortium.yaml
@@ -58,6 +58,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Anaerobutyricum;s__Anaerobutyricum hallii
       ncbi_source_id: NCBITaxon:39488
       majority_fraction: 1.0
+      support_genomes: 156
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: The paper's "Eubacterium hallii" — NCBITaxon carries this organism under the current name
@@ -81,6 +82,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Roseburia;s__Roseburia intestinalis
       ncbi_source_id: NCBITaxon:166486
       majority_fraction: 1.0
+      support_genomes: 78
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Hemicellulose and starch degrader producing butyrate as a terminal metabolite.
@@ -103,6 +105,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Marvinbryantia;s__Marvinbryantia formatexigens
       ncbi_source_id: NCBITaxon:168384
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Amorphous-cellulose degrader producing formate and acetate.

--- a/kb/communities/Human_Gut_FourMember_Proteome_Complementarity_Consortium.yaml
+++ b/kb/communities/Human_Gut_FourMember_Proteome_Complementarity_Consortium.yaml
@@ -58,7 +58,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Anaerobutyricum;s__Anaerobutyricum hallii
       ncbi_source_id: NCBITaxon:39488
       majority_fraction: 1.0
-      support_genomes: 156
+      total_genomes: 156
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: The paper's "Eubacterium hallii" — NCBITaxon carries this organism under the current name
@@ -82,7 +82,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Roseburia;s__Roseburia intestinalis
       ncbi_source_id: NCBITaxon:166486
       majority_fraction: 1.0
-      support_genomes: 78
+      total_genomes: 78
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Hemicellulose and starch degrader producing butyrate as a terminal metabolite.
@@ -105,7 +105,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Marvinbryantia;s__Marvinbryantia formatexigens
       ncbi_source_id: NCBITaxon:168384
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Amorphous-cellulose degrader producing formate and acetate.

--- a/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
+++ b/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
@@ -93,7 +93,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
-      support_genomes: 7
+      total_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Metabolically versatile chemolithoautotroph capable of both iron and sulfur oxidation in the

--- a/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
+++ b/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
@@ -50,6 +50,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum
       ncbi_source_id: NCBITaxon:179
       majority_fraction: 0.742
+      support_genomes: 23
+      total_genomes: 31
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Iron-oxidizing chemolithoautotroph present in the chemocline and upper layers of stratified
@@ -91,6 +93,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
+      support_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Metabolically versatile chemolithoautotroph capable of both iron and sulfur oxidation in the
@@ -124,6 +127,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acidiphilium
       ncbi_source_id: NCBITaxon:522
       majority_fraction: 1.0
+      support_genomes: 27
+      total_genomes: 27
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Facultatively heterotrophic acidophilic bacterium that consumes algal-derived organic carbon
@@ -162,6 +167,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfomonilia;o__Desulfomonilales;f__Desulfomonilaceae;g__Desulfomonile
       ncbi_source_id: NCBITaxon:2357
       majority_fraction: 1.0
+      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Dominant sulfate-reducing bacterium in the chemocline (~11m depth), representing 43% of amplicon
@@ -236,6 +243,8 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales
       ncbi_source_id: NCBITaxon:2301
       majority_fraction: 1.0
+      support_genomes: 63
+      total_genomes: 63
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Dominant archaeal heterotrophs in the deep anoxic monimolimnion, representing 46% ± 2.5% of
@@ -283,6 +292,8 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Methanobacteriota;c__Methanobacteria;o__Methanobacteriales;f__Methanobacteriaceae;g__Methanobrevibacter_A
       ncbi_source_id: NCBITaxon:2172
       majority_fraction: 0.965
+      support_genomes: 2508
+      total_genomes: 2598
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 6 GTDB taxa under the NCBI taxon]
     notes: 'Hydrogenotrophic methanogen detected in the deep anoxic monimolimnion and subsurface sediments

--- a/kb/communities/Industrial_Bioreactor_Consortium.yaml
+++ b/kb/communities/Industrial_Bioreactor_Consortium.yaml
@@ -69,6 +69,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus_A;s__Acidithiobacillus_A caldus
       ncbi_source_id: NCBITaxon:33059
       majority_fraction: 1.0
+      support_genomes: 42
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Moderately thermophilic chemolithoautotrophic bacterium that oxidizes ferrous iron (Fe²⁺)
@@ -123,6 +124,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales;f__Thermoplasmataceae;g__Ferroplasma;s__Ferroplasma acidarmanus
       ncbi_source_id: NCBITaxon:74969
       majority_fraction: 0.91
+      support_genomes: 22
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Extremely acidophilic, cell wall-lacking archaeon (Thermoplasmatales, Ferroplasmaceae) that
@@ -310,6 +312,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_E;c__Sulfobacillia;o__Sulfobacillales;f__Sulfobacillaceae;g__Sulfobacillus;s__Sulfobacillus benefaciens
       ncbi_source_id: NCBITaxon:453960
       majority_fraction: 0.96
+      support_genomes: 45
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Gram-positive, moderately thermophilic (optimum 45-50°C), facultatively autotrophic bacterium
@@ -348,6 +351,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
+      support_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Obligate chemolithoautotrophic iron-oxidizing bacterium (Nitrospirae) specialized for extremely

--- a/kb/communities/Industrial_Bioreactor_Consortium.yaml
+++ b/kb/communities/Industrial_Bioreactor_Consortium.yaml
@@ -69,7 +69,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus_A;s__Acidithiobacillus_A caldus
       ncbi_source_id: NCBITaxon:33059
       majority_fraction: 1.0
-      support_genomes: 42
+      total_genomes: 42
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Moderately thermophilic chemolithoautotrophic bacterium that oxidizes ferrous iron (Fe²⁺)
@@ -124,7 +124,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales;f__Thermoplasmataceae;g__Ferroplasma;s__Ferroplasma acidarmanus
       ncbi_source_id: NCBITaxon:74969
       majority_fraction: 0.91
-      support_genomes: 22
+      total_genomes: 22
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Extremely acidophilic, cell wall-lacking archaeon (Thermoplasmatales, Ferroplasmaceae) that
@@ -312,7 +312,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_E;c__Sulfobacillia;o__Sulfobacillales;f__Sulfobacillaceae;g__Sulfobacillus;s__Sulfobacillus benefaciens
       ncbi_source_id: NCBITaxon:453960
       majority_fraction: 0.96
-      support_genomes: 45
+      total_genomes: 45
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Gram-positive, moderately thermophilic (optimum 45-50°C), facultatively autotrophic bacterium
@@ -351,7 +351,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
-      support_genomes: 4
+      total_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Obligate chemolithoautotrophic iron-oxidizing bacterium (Nitrospirae) specialized for extremely

--- a/kb/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.yaml
+++ b/kb/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.yaml
@@ -52,6 +52,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Rhodocyclaceae;g__Rhodocyclus
       ncbi_source_id: NCBITaxon:1064
       majority_fraction: 1.0
+      support_genomes: 6
+      total_genomes: 6
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Source strain CCL5 was identified to genus level as Rhodocyclus sp.; genus-level taxonomy is

--- a/kb/communities/Infant_Gut_DNA_Phage_Succession_Community.yaml
+++ b/kb/communities/Infant_Gut_DNA_Phage_Succession_Community.yaml
@@ -50,6 +50,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides
       ncbi_source_id: NCBITaxon:816
       majority_fraction: 0.997
+      support_genomes: 40426
+      total_genomes: 40544
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 6 GTDB taxa under the NCBI taxon]
   evidence:

--- a/kb/communities/Infant_Gut_Prebiotic_Response_SynCom.yaml
+++ b/kb/communities/Infant_Gut_Prebiotic_Response_SynCom.yaml
@@ -32,6 +32,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium
       ncbi_source_id: NCBITaxon:1678
       majority_fraction: 0.999
+      support_genomes: 25518
+      total_genomes: 25552
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the source reports HMO/GOS-driven bifidobacterial expansion without
@@ -58,6 +60,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides
       ncbi_source_id: NCBITaxon:816
       majority_fraction: 0.997
+      support_genomes: 40426
+      total_genomes: 40544
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 6 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank (Bacteroides); the source discusses the Bacteroides/Phocaeicola group,
@@ -84,6 +88,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Phocaeicola;s__Phocaeicola vulgatus
       ncbi_source_id: NCBITaxon:821
       majority_fraction: 0.86
+      support_genomes: 1446
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -108,6 +113,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
+      support_genomes: 166397
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Infant_Gut_Prebiotic_Response_SynCom.yaml
+++ b/kb/communities/Infant_Gut_Prebiotic_Response_SynCom.yaml
@@ -88,7 +88,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Phocaeicola;s__Phocaeicola vulgatus
       ncbi_source_id: NCBITaxon:821
       majority_fraction: 0.86
-      support_genomes: 1446
+      total_genomes: 1446
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -113,7 +113,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
-      support_genomes: 166397
+      total_genomes: 166397
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Infant_Gut_Strain_Persistence_Maternal_Community.yaml
+++ b/kb/communities/Infant_Gut_Strain_Persistence_Maternal_Community.yaml
@@ -32,6 +32,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides
       ncbi_source_id: NCBITaxon:816
       majority_fraction: 0.997
+      support_genomes: 40426
+      total_genomes: 40544
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 6 GTDB taxa under the NCBI taxon]
     notes: Bacteroides is one of the two main genera among ~11 percent of
@@ -58,6 +60,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium
       ncbi_source_id: NCBITaxon:1678
       majority_fraction: 0.999
+      support_genomes: 25518
+      total_genomes: 25552
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Bifidobacterium is the second main genus among ~11 percent of

--- a/kb/communities/Ion_Adsorption_REE_Indigenous_Community.yaml
+++ b/kb/communities/Ion_Adsorption_REE_Indigenous_Community.yaml
@@ -50,6 +50,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota
       ncbi_source_id: NCBITaxon:1224
       majority_fraction: 1.0
+      support_genomes: 806030
+      total_genomes: 806033
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Dominant bacterial phylum (46.9% average abundance) present along the entire weathering profile.
@@ -88,6 +90,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Acidobacteriota
       ncbi_source_id: NCBITaxon:57723
       majority_fraction: 1.0
+      support_genomes: 203
+      total_genomes: 203
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Second most abundant bacterial phylum (14.6%) exhibiting oligotrophic K-strategist lifestyle
@@ -129,6 +133,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota
       ncbi_source_id: NCBITaxon:201174
       majority_fraction: 1.0
+      support_genomes: 91744
+      total_genomes: 91751
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: 'Third most abundant bacterial phylum (9.0%) contributing to bioweathering and REE mobilization
@@ -161,6 +167,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
       majority_fraction: 0.57
+      support_genomes: 4981
+      total_genomes: 8737
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive Firmicutes genus demonstrating exceptional HREE selectivity through teichoic
@@ -208,6 +216,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Micrococcaceae;g__Micrococcus
       ncbi_source_id: NCBITaxon:1269
       majority_fraction: 1.0
+      support_genomes: 831
+      total_genomes: 831
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive Actinobacteria genus exhibiting the highest HREE selectivity among tested strains.

--- a/kb/communities/Jala_Maize_PGPB_SynCom.yaml
+++ b/kb/communities/Jala_Maize_PGPB_SynCom.yaml
@@ -41,7 +41,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas_E;s__Pseudomonas_E protegens
       ncbi_source_id: NCBITaxon:380021
       majority_fraction: 1.0
-      support_genomes: 57
+      total_genomes: 57
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   functional_role:
@@ -59,7 +59,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Pantoea;s__Pantoea ananatis
       ncbi_source_id: NCBITaxon:553
       majority_fraction: 0.99
-      support_genomes: 461
+      total_genomes: 461
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -77,7 +77,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Klebsiella;s__Klebsiella variicola
       ncbi_source_id: NCBITaxon:244366
       majority_fraction: 1.0
-      support_genomes: 1719
+      total_genomes: 1719
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Jala_Maize_PGPB_SynCom.yaml
+++ b/kb/communities/Jala_Maize_PGPB_SynCom.yaml
@@ -41,6 +41,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas_E;s__Pseudomonas_E protegens
       ncbi_source_id: NCBITaxon:380021
       majority_fraction: 1.0
+      support_genomes: 57
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   functional_role:
@@ -58,6 +59,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Pantoea;s__Pantoea ananatis
       ncbi_source_id: NCBITaxon:553
       majority_fraction: 0.99
+      support_genomes: 461
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -75,6 +77,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Klebsiella;s__Klebsiella variicola
       ncbi_source_id: NCBITaxon:244366
       majority_fraction: 1.0
+      support_genomes: 1719
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -92,6 +95,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Burkholderia
       ncbi_source_id: NCBITaxon:32008
       majority_fraction: 0.999
+      support_genomes: 8896
+      total_genomes: 8908
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:

--- a/kb/communities/KB1_Chlorinated_Ethene_Dechlorinating_Consortium.yaml
+++ b/kb/communities/KB1_Chlorinated_Ethene_Dechlorinating_Consortium.yaml
@@ -73,7 +73,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Eubacteriales;f__Eubacteriaceae;g__Acetobacterium;s__Acetobacterium woodii
       ncbi_source_id: NCBITaxon:33952
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Dominant acetogen in KB-1 low-pH and vitamin-perturbation experiments; supports cobamide availability.

--- a/kb/communities/KB1_Chlorinated_Ethene_Dechlorinating_Consortium.yaml
+++ b/kb/communities/KB1_Chlorinated_Ethene_Dechlorinating_Consortium.yaml
@@ -44,6 +44,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Chloroflexota;c__Dehalococcoidia;o__Dehalococcoidales;f__Dehalococcoidaceae;g__Dehalococcoides
       ncbi_source_id: NCBITaxon:61434
       majority_fraction: 1.0
+      support_genomes: 27
+      total_genomes: 27
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Organohalide-respiring bacteria responsible for dechlorination beyond cis-DCE to ethene.
@@ -71,6 +73,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Eubacteriales;f__Eubacteriaceae;g__Acetobacterium;s__Acetobacterium woodii
       ncbi_source_id: NCBITaxon:33952
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Dominant acetogen in KB-1 low-pH and vitamin-perturbation experiments; supports cobamide availability.
@@ -93,6 +96,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_C;c__Negativicutes;o__Sporomusales;f__Sporomusaceae;g__Sporomusa
       ncbi_source_id: NCBITaxon:2375
       majority_fraction: 1.0
+      support_genomes: 27
+      total_genomes: 27
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Acetogenic KB-1 member reported with Acetobacterium in cultures lacking exogenous vitamins.

--- a/kb/communities/KBase_Models_for_Zahmeeth_Original_PLOS.yaml
+++ b/kb/communities/KBase_Models_for_Zahmeeth_Original_PLOS.yaml
@@ -50,7 +50,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
-      support_genomes: 166397
+      total_genomes: 166397
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -85,7 +85,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides;s__Bacteroides thetaiotaomicron
       ncbi_source_id: NCBITaxon:818
       majority_fraction: 0.99
-      support_genomes: 1011
+      total_genomes: 1011
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/KBase_Models_for_Zahmeeth_Original_PLOS.yaml
+++ b/kb/communities/KBase_Models_for_Zahmeeth_Original_PLOS.yaml
@@ -50,6 +50,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
+      support_genomes: 166397
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -84,6 +85,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides;s__Bacteroides thetaiotaomicron
       ncbi_source_id: NCBITaxon:818
       majority_fraction: 0.99
+      support_genomes: 1011
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -105,6 +107,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Klebsiella
       ncbi_source_id: NCBITaxon:570
       majority_fraction: 1.0
+      support_genomes: 44527
+      total_genomes: 44529
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:

--- a/kb/communities/KBase_ORT_Workflow_Community_Model.yaml
+++ b/kb/communities/KBase_ORT_Workflow_Community_Model.yaml
@@ -83,6 +83,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria
       ncbi_source_id: NCBITaxon:1236
       majority_fraction: 1.0
+      support_genomes: 744655
+      total_genomes: 744658
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Gammaproteobacterial genome within family Steroidobacteraceae from Columbia River sediments.
@@ -106,6 +108,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria
       ncbi_source_id: NCBITaxon:1236
       majority_fraction: 1.0
+      support_genomes: 744655
+      total_genomes: 744658
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Second gammaproteobacterial genome within family Steroidobacteraceae from Columbia River sediments.

--- a/kb/communities/KBase_Synthetic_Bacterial_Community_R2A.yaml
+++ b/kb/communities/KBase_Synthetic_Bacterial_Community_R2A.yaml
@@ -39,6 +39,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Pantoea
       ncbi_source_id: NCBITaxon:53335
       majority_fraction: 0.982
+      support_genomes: 1455
+      total_genomes: 1482
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 6 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -66,6 +68,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:

--- a/kb/communities/Kombucha_KMC_IMBG1_Fermentation_Community.yaml
+++ b/kb/communities/Kombucha_KMC_IMBG1_Fermentation_Community.yaml
@@ -28,6 +28,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Komagataeibacter
       ncbi_source_id: NCBITaxon:1434011
       majority_fraction: 1.0
+      support_genomes: 141
+      total_genomes: 141
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Acetobacterial core member reported as the current genus name for former Gluconacetobacter
@@ -52,6 +54,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Gluconobacter
       ncbi_source_id: NCBITaxon:441
       majority_fraction: 0.744
+      support_genomes: 122
+      total_genomes: 164
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Acetobacterial core member of the KMC-IMBG1 kombucha culture.

--- a/kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml
+++ b/kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml
@@ -236,7 +236,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylomonadaceae;g__Methylosarcina;s__Methylosarcina fibrata
       ncbi_source_id: NCBITaxon:105972
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Higher-oxygen methanotrophic genus in Lake Washington methane-fed microcosms.

--- a/kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml
+++ b/kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml
@@ -87,6 +87,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylomonadaceae
       ncbi_source_id: NCBITaxon:403
       majority_fraction: 0.695
+      support_genomes: 107
+      total_genomes: 154
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at f__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: >
@@ -118,6 +120,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Methylophilaceae
       ncbi_source_id: NCBITaxon:32011
       majority_fraction: 1.0
+      support_genomes: 434
+      total_genomes: 434
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at f__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: >
@@ -176,6 +180,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Methylophilaceae;g__Methylotenera
       ncbi_source_id: NCBITaxon:359407
       majority_fraction: 0.818
+      support_genomes: 9
+      total_genomes: 11
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Low-oxygen non-methanotrophic methylotroph genus partnered with Methylobacter.
@@ -206,6 +212,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylomonadaceae;g__Methylomonas
       ncbi_source_id: NCBITaxon:416
       majority_fraction: 1.0
+      support_genomes: 42
+      total_genomes: 42
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Methanotrophic genus included in genome-scale modeling of the Lake Washington methane-cycling community.
@@ -228,6 +236,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylomonadaceae;g__Methylosarcina;s__Methylosarcina fibrata
       ncbi_source_id: NCBITaxon:105972
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Higher-oxygen methanotrophic genus in Lake Washington methane-fed microcosms.
@@ -250,6 +259,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Methylophilaceae;g__Methylophilus
       ncbi_source_id: NCBITaxon:16
       majority_fraction: 1.0
+      support_genomes: 17
+      total_genomes: 17
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Higher-oxygen non-methanotrophic methylotroph genus partnered with Methylosarcina.

--- a/kb/communities/Legume_Rhizobia_Mars_Simulant_Symbiosis.yaml
+++ b/kb/communities/Legume_Rhizobia_Mars_Simulant_Symbiosis.yaml
@@ -74,6 +74,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Sinorhizobium;s__Sinorhizobium meliloti
       ncbi_source_id: NCBITaxon:382
       majority_fraction: 0.97
+      support_genomes: 521
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
@@ -98,6 +99,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Sinorhizobium;s__Sinorhizobium medicae
       ncbi_source_id: NCBITaxon:110321
       majority_fraction: 1.0
+      support_genomes: 131
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >

--- a/kb/communities/Legume_Rhizobia_Mars_Simulant_Symbiosis.yaml
+++ b/kb/communities/Legume_Rhizobia_Mars_Simulant_Symbiosis.yaml
@@ -74,7 +74,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Sinorhizobium;s__Sinorhizobium meliloti
       ncbi_source_id: NCBITaxon:382
       majority_fraction: 0.97
-      support_genomes: 521
+      total_genomes: 521
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
@@ -99,7 +99,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Sinorhizobium;s__Sinorhizobium medicae
       ncbi_source_id: NCBITaxon:110321
       majority_fraction: 1.0
-      support_genomes: 131
+      total_genomes: 131
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >

--- a/kb/communities/Lotus_LjSC3.yaml
+++ b/kb/communities/Lotus_LjSC3.yaml
@@ -53,6 +53,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Mesorhizobium
       ncbi_source_id: NCBITaxon:68287
       majority_fraction: 0.928
+      support_genomes: 167
+      total_genomes: 180
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
   abundance_level: DOMINANT
@@ -76,6 +78,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Mesorhizobium
       ncbi_source_id: NCBITaxon:68287
       majority_fraction: 0.928
+      support_genomes: 167
+      total_genomes: 180
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
@@ -99,6 +103,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Mesorhizobium
       ncbi_source_id: NCBITaxon:68287
       majority_fraction: 0.928
+      support_genomes: 167
+      total_genomes: 180
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
@@ -170,6 +176,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae
       ncbi_source_id: NCBITaxon:75682
       majority_fraction: 0.995
+      support_genomes: 635
+      total_genomes: 638
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at f__ rank; 2 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON

--- a/kb/communities/Lunar_Martian_Simulant_PGPB_Lettuce_SynCom.yaml
+++ b/kb/communities/Lunar_Martian_Simulant_PGPB_Lettuce_SynCom.yaml
@@ -87,6 +87,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Azotobacter;s__Azotobacter chroococcum
       ncbi_source_id: NCBITaxon:353
       majority_fraction: 1.0
+      support_genomes: 25
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
@@ -148,6 +149,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Methylobacterium;s__Methylobacterium thiocyanatum
       ncbi_source_id: NCBITaxon:223967
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: >
@@ -185,6 +187,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Kosakonia;s__Kosakonia pseudosacchari
       ncbi_source_id: NCBITaxon:1646340
       majority_fraction: 1.0
+      support_genomes: 10
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >

--- a/kb/communities/Lunar_Martian_Simulant_PGPB_Lettuce_SynCom.yaml
+++ b/kb/communities/Lunar_Martian_Simulant_PGPB_Lettuce_SynCom.yaml
@@ -87,7 +87,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Azotobacter;s__Azotobacter chroococcum
       ncbi_source_id: NCBITaxon:353
       majority_fraction: 1.0
-      support_genomes: 25
+      total_genomes: 25
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
@@ -149,7 +149,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Methylobacterium;s__Methylobacterium thiocyanatum
       ncbi_source_id: NCBITaxon:223967
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: >
@@ -187,7 +187,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Kosakonia;s__Kosakonia pseudosacchari
       ncbi_source_id: NCBITaxon:1646340
       majority_fraction: 1.0
-      support_genomes: 10
+      total_genomes: 10
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >

--- a/kb/communities/Lunar_Simulant_Phosphate_Solubilizing_Bacteria_Nicotiana.yaml
+++ b/kb/communities/Lunar_Simulant_Phosphate_Solubilizing_Bacteria_Nicotiana.yaml
@@ -82,7 +82,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Paenibacillales;f__NBRC-103111;g__Paenibacillus_G;s__Paenibacillus_G mucilaginosus
       ncbi_source_id: NCBITaxon:61624
       majority_fraction: 0.88
-      support_genomes: 8
+      total_genomes: 8
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
@@ -170,7 +170,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
       ncbi_source_id: NCBITaxon:1423
       majority_fraction: 0.91
-      support_genomes: 1256
+      total_genomes: 1256
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
@@ -200,7 +200,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus licheniformis
       ncbi_source_id: NCBITaxon:1402
       majority_fraction: 0.98
-      support_genomes: 562
+      total_genomes: 562
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >

--- a/kb/communities/Lunar_Simulant_Phosphate_Solubilizing_Bacteria_Nicotiana.yaml
+++ b/kb/communities/Lunar_Simulant_Phosphate_Solubilizing_Bacteria_Nicotiana.yaml
@@ -82,6 +82,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Paenibacillales;f__NBRC-103111;g__Paenibacillus_G;s__Paenibacillus_G mucilaginosus
       ncbi_source_id: NCBITaxon:61624
       majority_fraction: 0.88
+      support_genomes: 8
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
@@ -169,6 +170,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
       ncbi_source_id: NCBITaxon:1423
       majority_fraction: 0.91
+      support_genomes: 1256
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
@@ -198,6 +200,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus licheniformis
       ncbi_source_id: NCBITaxon:1402
       majority_fraction: 0.98
+      support_genomes: 562
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >

--- a/kb/communities/MAMC_M48_Lignocellulose.yaml
+++ b/kb/communities/MAMC_M48_Lignocellulose.yaml
@@ -89,7 +89,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Flavobacteriales;f__Weeksellaceae;g__Chryseobacterium;s__Chryseobacterium taiwanense
       ncbi_source_id: NCBITaxon:363331
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT

--- a/kb/communities/MAMC_M48_Lignocellulose.yaml
+++ b/kb/communities/MAMC_M48_Lignocellulose.yaml
@@ -89,6 +89,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Flavobacteriales;f__Weeksellaceae;g__Chryseobacterium;s__Chryseobacterium taiwanense
       ncbi_source_id: NCBITaxon:363331
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT

--- a/kb/communities/MSC1_Dominant_Core.yaml
+++ b/kb/communities/MSC1_Dominant_Core.yaml
@@ -28,6 +28,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Rhodococcus
       ncbi_source_id: NCBITaxon:1827
       majority_fraction: 1.0
+      support_genomes: 514
+      total_genomes: 514
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   abundance_level: DOMINANT
@@ -64,6 +66,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Cytophagales;f__Spirosomataceae;g__Dyadobacter;s__Dyadobacter sp017744695
       ncbi_source_id: NCBITaxon:1914288
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT
@@ -100,6 +103,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Bosea
       ncbi_source_id: NCBITaxon:169215
       majority_fraction: 1.0
+      support_genomes: 34
+      total_genomes: 34
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
@@ -122,6 +127,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Neorhizobium;s__Neorhizobium sp028283725
       ncbi_source_id: NCBITaxon:1911909
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: COMMON
@@ -187,6 +193,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Sinorhizobium;s__Sinorhizobium sp031178305
       ncbi_source_id: NCBITaxon:42445
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: COMMON
@@ -223,6 +230,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota
       ncbi_source_id: NCBITaxon:201174
       majority_fraction: 1.0
+      support_genomes: 91744
+      total_genomes: 91751
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
   abundance_level: RARE
@@ -246,6 +255,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota
       ncbi_source_id: NCBITaxon:976
       majority_fraction: 0.999
+      support_genomes: 151365
+      total_genomes: 151454
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 5 GTDB taxa under the NCBI taxon]
   abundance_level: RARE

--- a/kb/communities/MSC1_Dominant_Core.yaml
+++ b/kb/communities/MSC1_Dominant_Core.yaml
@@ -66,7 +66,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Cytophagales;f__Spirosomataceae;g__Dyadobacter;s__Dyadobacter sp017744695
       ncbi_source_id: NCBITaxon:1914288
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT
@@ -127,7 +127,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Neorhizobium;s__Neorhizobium sp028283725
       ncbi_source_id: NCBITaxon:1911909
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: COMMON
@@ -193,7 +193,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Sinorhizobium;s__Sinorhizobium sp031178305
       ncbi_source_id: NCBITaxon:42445
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: COMMON

--- a/kb/communities/MSC2_Model_Soil_Consortium.yaml
+++ b/kb/communities/MSC2_Model_Soil_Consortium.yaml
@@ -64,7 +64,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Neorhizobium;s__Neorhizobium tomejilense
       ncbi_source_id: NCBITaxon:2093828
       majority_fraction: 0.9
-      support_genomes: 10
+      total_genomes: 10
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -84,7 +84,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Cytophagales;f__Spirosomataceae;g__Dyadobacter;s__Dyadobacter sp017744695
       ncbi_source_id: NCBITaxon:1914288
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -115,7 +115,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Ensifer;s__Ensifer canadensis
       ncbi_source_id: NCBITaxon:106592
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:
@@ -147,7 +147,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Sinorhizobium;s__Sinorhizobium meliloti
       ncbi_source_id: NCBITaxon:382
       majority_fraction: 0.97
-      support_genomes: 521
+      total_genomes: 521
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:

--- a/kb/communities/MSC2_Model_Soil_Consortium.yaml
+++ b/kb/communities/MSC2_Model_Soil_Consortium.yaml
@@ -64,6 +64,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Neorhizobium;s__Neorhizobium tomejilense
       ncbi_source_id: NCBITaxon:2093828
       majority_fraction: 0.9
+      support_genomes: 10
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -83,6 +84,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Cytophagales;f__Spirosomataceae;g__Dyadobacter;s__Dyadobacter sp017744695
       ncbi_source_id: NCBITaxon:1914288
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -113,6 +115,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Ensifer;s__Ensifer canadensis
       ncbi_source_id: NCBITaxon:106592
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:
@@ -144,6 +147,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Sinorhizobium;s__Sinorhizobium meliloti
       ncbi_source_id: NCBITaxon:382
       majority_fraction: 0.97
+      support_genomes: 521
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -163,6 +167,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Rhodococcus
       ncbi_source_id: NCBITaxon:1827
       majority_fraction: 1.0
+      support_genomes: 514
+      total_genomes: 514
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:

--- a/kb/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.yaml
+++ b/kb/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.yaml
@@ -80,6 +80,8 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanoregula
       ncbi_source_id: NCBITaxon:395331
       majority_fraction: 1.0
+      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Methanoregula is curated at genus level because the study reports it

--- a/kb/communities/Maize_Root_Simplified_Community.yaml
+++ b/kb/communities/Maize_Root_Simplified_Community.yaml
@@ -128,6 +128,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Herbaspirillum;s__Herbaspirillum frisingense
       ncbi_source_id: NCBITaxon:92645
       majority_fraction: 1.0
+      support_genomes: 4
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: COMMON
@@ -160,6 +161,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Flavobacteriales;f__Weeksellaceae;g__Chryseobacterium;s__Chryseobacterium indologenes
       ncbi_source_id: NCBITaxon:253
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: COMMON

--- a/kb/communities/Maize_Root_Simplified_Community.yaml
+++ b/kb/communities/Maize_Root_Simplified_Community.yaml
@@ -128,7 +128,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Herbaspirillum;s__Herbaspirillum frisingense
       ncbi_source_id: NCBITaxon:92645
       majority_fraction: 1.0
-      support_genomes: 4
+      total_genomes: 4
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: COMMON
@@ -161,7 +161,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Flavobacteriales;f__Weeksellaceae;g__Chryseobacterium;s__Chryseobacterium indologenes
       ncbi_source_id: NCBITaxon:253
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: COMMON

--- a/kb/communities/Mars_Meteorite_EETA79001_Growth_Panel.yaml
+++ b/kb/communities/Mars_Meteorite_EETA79001_Growth_Panel.yaml
@@ -73,7 +73,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
-      support_genomes: 166397
+      total_genomes: 166397
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
@@ -138,7 +138,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales_A;f__Planococcaceae;g__Planococcus;s__Planococcus halocryophilus
       ncbi_source_id: NCBITaxon:1215089
       majority_fraction: 1.0
-      support_genomes: 4
+      total_genomes: 4
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: >

--- a/kb/communities/Mars_Meteorite_EETA79001_Growth_Panel.yaml
+++ b/kb/communities/Mars_Meteorite_EETA79001_Growth_Panel.yaml
@@ -73,6 +73,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
+      support_genomes: 166397
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
@@ -111,6 +112,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Cyanobacteriales;f__Chroococcidiopsidaceae;g__Chroococcidiopsis
       ncbi_source_id: NCBITaxon:54298
       majority_fraction: 1.0
+      support_genomes: 8
+      total_genomes: 8
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: >
@@ -135,6 +138,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales_A;f__Planococcaceae;g__Planococcus;s__Planococcus halocryophilus
       ncbi_source_id: NCBITaxon:1215089
       majority_fraction: 1.0
+      support_genomes: 4
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: >

--- a/kb/communities/Medicago_Nodule_Biofertilizer_SynCom.yaml
+++ b/kb/communities/Medicago_Nodule_Biofertilizer_SynCom.yaml
@@ -44,6 +44,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Ensifer
       ncbi_source_id: NCBITaxon:106591
       majority_fraction: 0.5
+      support_genomes: 19
+      total_genomes: 38
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:

--- a/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
+++ b/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
@@ -247,7 +247,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanocorpusculaceae;g__Methanocorpusculum;s__Methanocorpusculum parvum
       ncbi_source_id: NCBITaxon:71518
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Confirmed hgcAB+ mercury methylator. Demonstrated methylmercury production in pure culture.
@@ -276,7 +276,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanofollaceae;g__Methanofollis;s__Methanofollis liminatans
       ncbi_source_id: NCBITaxon:2201
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Confirmed hgcAB+ mercury methylator. Demonstrated methylmercury production in pure culture.
@@ -305,7 +305,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanosphaerula;s__Methanosphaerula palustris
       ncbi_source_id: NCBITaxon:475088
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Confirmed hgcAB+ mercury methylator. Demonstrated methylmercury production in pure culture.

--- a/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
+++ b/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
@@ -38,6 +38,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota
       ncbi_source_id: NCBITaxon:1224
       majority_fraction: 1.0
+      support_genomes: 806030
+      total_genomes: 806033
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Multiple MAGs representing Proteobacteria were reconstructed from EFPC sediment metagenomes.
@@ -67,6 +69,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Acidobacteriota
       ncbi_source_id: NCBITaxon:57723
       majority_fraction: 1.0
+      support_genomes: 203
+      total_genomes: 203
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: MAGs from this phylum were recovered from EFPC sediment metagenomes.
@@ -93,6 +97,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota
       ncbi_source_id: NCBITaxon:201174
       majority_fraction: 1.0
+      support_genomes: 91744
+      total_genomes: 91751
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: MAGs from this phylum were recovered from EFPC sediment metagenomes.
@@ -119,6 +125,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Gemmatimonadota
       ncbi_source_id: NCBITaxon:142182
       majority_fraction: 1.0
+      support_genomes: 36
+      total_genomes: 36
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: MAGs from this phylum were recovered from EFPC sediment metagenomes.
@@ -162,6 +170,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Myxococcota
       ncbi_source_id: NCBITaxon:2818505
       majority_fraction: 0.836
+      support_genomes: 230
+      total_genomes: 275
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: MAGs from this phylum were recovered from EFPC sediment metagenomes.
@@ -188,6 +198,8 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Thermoproteota
       ncbi_source_id: NCBITaxon:28889
       majority_fraction: 1.0
+      support_genomes: 684
+      total_genomes: 684
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Archaeal MAGs recovered from EFPC sediment metagenomes.
@@ -235,6 +247,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanocorpusculaceae;g__Methanocorpusculum;s__Methanocorpusculum parvum
       ncbi_source_id: NCBITaxon:71518
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Confirmed hgcAB+ mercury methylator. Demonstrated methylmercury production in pure culture.
@@ -263,6 +276,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanofollaceae;g__Methanofollis;s__Methanofollis liminatans
       ncbi_source_id: NCBITaxon:2201
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Confirmed hgcAB+ mercury methylator. Demonstrated methylmercury production in pure culture.
@@ -291,6 +305,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanosphaerula;s__Methanosphaerula palustris
       ncbi_source_id: NCBITaxon:475088
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Confirmed hgcAB+ mercury methylator. Demonstrated methylmercury production in pure culture.

--- a/kb/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.yaml
+++ b/kb/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.yaml
@@ -58,6 +58,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Cyanobacteriales;f__MRBY01;g__Limnothrix;s__Limnothrix sp001693275
       ncbi_source_id: NCBITaxon:32049
       majority_fraction: 1.0
+      support_genomes: 6
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The paper's "Synechococcus sp. PCC 7002" — NCBITaxon carries this strain under the
@@ -85,6 +86,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Mesorhizobium
       ncbi_source_id: NCBITaxon:68287
       majority_fraction: 0.928
+      support_genomes: 167
+      total_genomes: 180
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
     notes: The persistent partner and the proposed vitamin B12 source. Grounded at genus level —
@@ -108,6 +111,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
       majority_fraction: 0.699
+      support_genomes: 17956
+      total_genomes: 25706
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: A third member of the early community that declined once the community stabilised, so it
@@ -133,6 +138,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Cyanobacteriales;f__Microcystaceae;g__Microcystis
       ncbi_source_id: NCBITaxon:1125
       majority_fraction: 0.986
+      support_genomes: 276
+      total_genomes: 280
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: The bloom-forming community co-cultured with Syn7002 to seed the consortium. Grounded at

--- a/kb/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.yaml
+++ b/kb/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.yaml
@@ -58,7 +58,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Cyanobacteriales;f__MRBY01;g__Limnothrix;s__Limnothrix sp001693275
       ncbi_source_id: NCBITaxon:32049
       majority_fraction: 1.0
-      support_genomes: 6
+      total_genomes: 6
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The paper's "Synechococcus sp. PCC 7002" — NCBITaxon carries this strain under the

--- a/kb/communities/Methane_Oxidation_CrVI_Reduction_SynCom.yaml
+++ b/kb/communities/Methane_Oxidation_CrVI_Reduction_SynCom.yaml
@@ -41,6 +41,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Methylocystis
       ncbi_source_id: NCBITaxon:133
       majority_fraction: 1.0
+      support_genomes: 25
+      total_genomes: 25
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
@@ -67,6 +69,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Thiobacillaceae;g__Thiobacillus
       ncbi_source_id: NCBITaxon:919
       majority_fraction: 1.0
+      support_genomes: 6
+      total_genomes: 6
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:

--- a/kb/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.yaml
+++ b/kb/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.yaml
@@ -54,6 +54,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Verrucomicrobiota;c__Verrucomicrobiae;o__Methylacidiphilales;f__Methylacidiphilaceae;g__Methylacidiphilum;s__Methylacidiphilum infernorum
       ncbi_source_id: NCBITaxon:511746
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: NCBI Taxonomy lists Methylacidiphilum sp. RTK17.1 under Candidatus Methylacidiphilum

--- a/kb/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.yaml
+++ b/kb/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.yaml
@@ -54,7 +54,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Verrucomicrobiota;c__Verrucomicrobiae;o__Methylacidiphilales;f__Methylacidiphilaceae;g__Methylacidiphilum;s__Methylacidiphilum infernorum
       ncbi_source_id: NCBITaxon:511746
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: NCBI Taxonomy lists Methylacidiphilum sp. RTK17.1 under Candidatus Methylacidiphilum

--- a/kb/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.yaml
+++ b/kb/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.yaml
@@ -54,6 +54,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylococcaceae;g__Methylocaldum;s__Methylocaldum marinum
       ncbi_source_id: NCBITaxon:1432792
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Marine methanotroph S8 that excretes acetate under both microaerobic and aerobic conditions.
@@ -90,6 +91,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Cupriavidus;s__Cupriavidus necator_D
       ncbi_source_id: NCBITaxon:1218105
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Non-methylotrophic acetate-utilizing partner selected for bioproduction relevance.

--- a/kb/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.yaml
+++ b/kb/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.yaml
@@ -54,7 +54,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylococcaceae;g__Methylocaldum;s__Methylocaldum marinum
       ncbi_source_id: NCBITaxon:1432792
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Marine methanotroph S8 that excretes acetate under both microaerobic and aerobic conditions.
@@ -91,7 +91,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Cupriavidus;s__Cupriavidus necator_D
       ncbi_source_id: NCBITaxon:1218105
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Non-methylotrophic acetate-utilizing partner selected for bioproduction relevance.

--- a/kb/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.yaml
+++ b/kb/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.yaml
@@ -51,6 +51,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylococcaceae;g__Methylocaldum;s__Methylocaldum marinum
       ncbi_source_id: NCBITaxon:1432792
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Marine thermotolerant methane-oxidizing bacterium; type strain S8 is also listed by DSM and
@@ -87,6 +88,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Methyloligellaceae;g__Methyloceanibacter;s__Methyloceanibacter caenitepidi
       ncbi_source_id: NCBITaxon:1384459
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Facultative methylotroph isolated from marine sediment near a hydrothermal vent.

--- a/kb/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.yaml
+++ b/kb/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.yaml
@@ -51,7 +51,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylococcaceae;g__Methylocaldum;s__Methylocaldum marinum
       ncbi_source_id: NCBITaxon:1432792
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Marine thermotolerant methane-oxidizing bacterium; type strain S8 is also listed by DSM and
@@ -88,7 +88,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Methyloligellaceae;g__Methyloceanibacter;s__Methyloceanibacter caenitepidi
       ncbi_source_id: NCBITaxon:1384459
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Facultative methylotroph isolated from marine sediment near a hydrothermal vent.

--- a/kb/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.yaml
+++ b/kb/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.yaml
@@ -49,7 +49,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Methylocystis;s__Methylocystis parva
       ncbi_source_id: NCBITaxon:134
       majority_fraction: 1.0
-      support_genomes: 5
+      total_genomes: 5
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: NCBI Taxonomy lists Methylocystis parvus at taxon 134; the PHBV study used

--- a/kb/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.yaml
+++ b/kb/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.yaml
@@ -49,6 +49,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Methylocystis;s__Methylocystis parva
       ncbi_source_id: NCBITaxon:134
       majority_fraction: 1.0
+      support_genomes: 5
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: NCBI Taxonomy lists Methylocystis parvus at taxon 134; the PHBV study used

--- a/kb/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.yaml
+++ b/kb/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.yaml
@@ -62,6 +62,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylomonadaceae;g__Methylotuvimicrobium;s__Methylotuvimicrobium alcaliphilum
       ncbi_source_id: NCBITaxon:1091494
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >

--- a/kb/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.yaml
+++ b/kb/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.yaml
@@ -62,7 +62,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylomonadaceae;g__Methylotuvimicrobium;s__Methylotuvimicrobium alcaliphilum
       ncbi_source_id: NCBITaxon:1091494
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >

--- a/kb/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.yaml
+++ b/kb/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.yaml
@@ -53,6 +53,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylomonadaceae;g__Methylotuvimicrobium;s__Methylotuvimicrobium alcaliphilum
       ncbi_source_id: NCBITaxon:1091494
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Source publications use Methylomicrobium alcaliphilum 20z or 20ZR; NCBI Taxonomy
@@ -91,6 +92,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Cyanobacteriales;f__MRBY01;g__Limnothrix;s__Limnothrix sp001693275
       ncbi_source_id: NCBITaxon:32049
       majority_fraction: 1.0
+      support_genomes: 6
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Source publications use Synechococcus PCC 7002 or Synechococcus sp. PCC7002; NCBI

--- a/kb/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.yaml
+++ b/kb/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.yaml
@@ -53,7 +53,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylomonadaceae;g__Methylotuvimicrobium;s__Methylotuvimicrobium alcaliphilum
       ncbi_source_id: NCBITaxon:1091494
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Source publications use Methylomicrobium alcaliphilum 20z or 20ZR; NCBI Taxonomy
@@ -92,7 +92,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Cyanobacteriales;f__MRBY01;g__Limnothrix;s__Limnothrix sp001693275
       ncbi_source_id: NCBITaxon:32049
       majority_fraction: 1.0
-      support_genomes: 6
+      total_genomes: 6
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Source publications use Synechococcus PCC 7002 or Synechococcus sp. PCC7002; NCBI

--- a/kb/communities/Microcoleus_Massilia_Cyanosphere_Urea_Mutualism.yaml
+++ b/kb/communities/Microcoleus_Massilia_Cyanosphere_Urea_Mutualism.yaml
@@ -75,6 +75,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Telluria
       ncbi_source_id: NCBITaxon:149698
       majority_fraction: 1.0
+      support_genomes: 140
+      total_genomes: 140
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Heterotrophic cyanosphere isolate METH4; curated at genus level because the papers report the

--- a/kb/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.yaml
+++ b/kb/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.yaml
@@ -43,6 +43,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Burkholderia
       ncbi_source_id: NCBITaxon:32008
       majority_fraction: 0.999
+      support_genomes: 8896
+      total_genomes: 8908
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
@@ -60,6 +62,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Paraburkholderia
       ncbi_source_id: NCBITaxon:1822464
       majority_fraction: 0.993
+      support_genomes: 680
+      total_genomes: 685
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
@@ -77,6 +81,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Microbacteriaceae;g__Curtobacterium
       ncbi_source_id: NCBITaxon:2034
       majority_fraction: 1.0
+      support_genomes: 35
+      total_genomes: 35
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
@@ -94,6 +100,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Microbacteriaceae;g__Leifsonia
       ncbi_source_id: NCBITaxon:110932
       majority_fraction: 0.958
+      support_genomes: 23
+      total_genomes: 24
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:

--- a/kb/communities/Mixed_Gallium_LED_Recovery_Consortium.yaml
+++ b/kb/communities/Mixed_Gallium_LED_Recovery_Consortium.yaml
@@ -68,7 +68,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus thiooxidans
       ncbi_source_id: NCBITaxon:930
       majority_fraction: 1.0
-      support_genomes: 43
+      total_genomes: 43
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Gram-negative γ-proteobacterium specialized for oxidizing elemental sulfur (S⁰) and reduced
@@ -116,7 +116,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
-      support_genomes: 7
+      total_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Mesophilic γ-proteobacterium that oxidizes both ferrous iron (Fe²⁺) and reduced sulfur compounds.
@@ -164,7 +164,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum;s__Leptospirillum ferrooxidans
       ncbi_source_id: NCBITaxon:180
       majority_fraction: 1.0
-      support_genomes: 16
+      total_genomes: 16
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Obligate iron-oxidizing bacterium (Nitrospirae phylum) specialized for Fe²⁺ oxidation at extremely

--- a/kb/communities/Mixed_Gallium_LED_Recovery_Consortium.yaml
+++ b/kb/communities/Mixed_Gallium_LED_Recovery_Consortium.yaml
@@ -68,6 +68,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus thiooxidans
       ncbi_source_id: NCBITaxon:930
       majority_fraction: 1.0
+      support_genomes: 43
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Gram-negative γ-proteobacterium specialized for oxidizing elemental sulfur (S⁰) and reduced
@@ -115,6 +116,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
+      support_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Mesophilic γ-proteobacterium that oxidizes both ferrous iron (Fe²⁺) and reduced sulfur compounds.
@@ -162,6 +164,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum;s__Leptospirillum ferrooxidans
       ncbi_source_id: NCBITaxon:180
       majority_fraction: 1.0
+      support_genomes: 16
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Obligate iron-oxidizing bacterium (Nitrospirae phylum) specialized for Fe²⁺ oxidation at extremely

--- a/kb/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.yaml
+++ b/kb/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.yaml
@@ -62,6 +62,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota
       ncbi_source_id: NCBITaxon:1117
       majority_fraction: 1.0
+      support_genomes: 2189
+      total_genomes: 2190
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Five well-characterized model cyanobacterial strains served as the

--- a/kb/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.yaml
+++ b/kb/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.yaml
@@ -73,6 +73,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Cellulomonadaceae;g__Cellulomonas;s__Cellulomonas fimi
       ncbi_source_id: NCBITaxon:1708
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Source describes C. fimi as the cellulose degrader and formaldehyde-sensitive member.
@@ -101,6 +102,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Methylobacterium;s__Methylobacterium extorquens
       ncbi_source_id: NCBITaxon:408
       majority_fraction: 0.88
+      support_genomes: 42
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Methylotrophic partner included to consume formaldehyde generated during aromatic-substrate

--- a/kb/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.yaml
+++ b/kb/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.yaml
@@ -73,7 +73,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Cellulomonadaceae;g__Cellulomonas;s__Cellulomonas fimi
       ncbi_source_id: NCBITaxon:1708
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Source describes C. fimi as the cellulose degrader and formaldehyde-sensitive member.
@@ -102,7 +102,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Methylobacterium;s__Methylobacterium extorquens
       ncbi_source_id: NCBITaxon:408
       majority_fraction: 0.88
-      support_genomes: 42
+      total_genomes: 42
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Methylotrophic partner included to consume formaldehyde generated during aromatic-substrate

--- a/kb/communities/Moss_Microbe_Complex_Regolith_Biofertilizer.yaml
+++ b/kb/communities/Moss_Microbe_Complex_Regolith_Biofertilizer.yaml
@@ -108,6 +108,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Devosiaceae;g__Devosia
       ncbi_source_id: NCBITaxon:46913
       majority_fraction: 0.963
+      support_genomes: 79
+      total_genomes: 82
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: >

--- a/kb/communities/Mushroom_Spring_Hot_Spring_Phototrophic_Mat_Community.yaml
+++ b/kb/communities/Mushroom_Spring_Hot_Spring_Phototrophic_Mat_Community.yaml
@@ -54,6 +54,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Chloroflexota;c__Chloroflexia;o__Chloroflexales;f__Roseiflexaceae;g__Roseiflexus
       ncbi_source_id: NCBITaxon:120961
       majority_fraction: 1.0
+      support_genomes: 5
+      total_genomes: 5
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: >
@@ -86,6 +88,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Chloroflexota;c__Chloroflexia;o__Chloroflexales;f__Chloroflexaceae;g__Chloroflexus
       ncbi_source_id: NCBITaxon:1107
       majority_fraction: 1.0
+      support_genomes: 14
+      total_genomes: 14
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Filamentous anoxygenic phototrophs in the Mushroom Spring phototrophic mat.
@@ -114,6 +118,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota;c__Thermodesulfovibrionia;o__Thermodesulfovibrionales;f__Thermodesulfovibrionaceae;g__Thermodesulfovibrio
       ncbi_source_id: NCBITaxon:28261
       majority_fraction: 1.0
+      support_genomes: 30
+      total_genomes: 30
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: >

--- a/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
+++ b/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
@@ -48,6 +48,8 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Thermoproteota
       ncbi_source_id: NCBITaxon:651137
       majority_fraction: 1.0
+      support_genomes: 631
+      total_genomes: 631
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Dominant archaeal lineage representing basal Thaumarchaeota clades adapted to deep subsurface
@@ -94,6 +96,8 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales
       ncbi_source_id: NCBITaxon:2301
       majority_fraction: 1.0
+      support_genomes: 63
+      total_genomes: 63
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Euryarchaeota belonging to a large clade of environmental sequences branching as a sister
@@ -163,6 +167,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A
       ncbi_source_id: NCBITaxon:1239
       majority_fraction: 0.501
+      support_genomes: 226306
+      total_genomes: 451729
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 12 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive bacteria detected in Naica subsurface waters, likely representing thermophilic
@@ -196,6 +202,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria
       ncbi_source_id: NCBITaxon:28211
       majority_fraction: 1.0
+      support_genomes: 19132
+      total_genomes: 19134
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Alpha-proteobacteria detected in Naica representing oligotrophic heterotrophs or mixotrophs
@@ -228,6 +236,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria
       ncbi_source_id: NCBITaxon:28216
       majority_fraction: 1.0
+      support_genomes: 41937
+      total_genomes: 41937
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Beta-proteobacteria present in Naica subsurface waters, potentially representing autotrophic

--- a/kb/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.yaml
+++ b/kb/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.yaml
@@ -59,6 +59,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__DSM-27016;g__Ruminiclostridium;s__Ruminiclostridium cellulolyticum
       ncbi_source_id: NCBITaxon:1521
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The primary abstract identifies C. cellulolyticum as the fermentative member.
@@ -89,6 +90,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Nitratidesulfovibrio;s__Nitratidesulfovibrio vulgaris
       ncbi_source_id: NCBITaxon:882
       majority_fraction: 1.0
+      support_genomes: 7
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The source uses the historical Desulfovibrio vulgaris Hildenborough name; NCBI
@@ -120,6 +122,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter sulfurreducens
       ncbi_source_id: NCBITaxon:35554
       majority_fraction: 1.0
+      support_genomes: 19
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The primary abstract identifies G. sulfurreducens as the partner supplied with fumarate

--- a/kb/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.yaml
+++ b/kb/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.yaml
@@ -59,7 +59,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__DSM-27016;g__Ruminiclostridium;s__Ruminiclostridium cellulolyticum
       ncbi_source_id: NCBITaxon:1521
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The primary abstract identifies C. cellulolyticum as the fermentative member.
@@ -90,7 +90,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Nitratidesulfovibrio;s__Nitratidesulfovibrio vulgaris
       ncbi_source_id: NCBITaxon:882
       majority_fraction: 1.0
-      support_genomes: 7
+      total_genomes: 7
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The source uses the historical Desulfovibrio vulgaris Hildenborough name; NCBI
@@ -122,7 +122,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter sulfurreducens
       ncbi_source_id: NCBITaxon:35554
       majority_fraction: 1.0
-      support_genomes: 19
+      total_genomes: 19
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The primary abstract identifies G. sulfurreducens as the partner supplied with fumarate

--- a/kb/communities/ORNL_PMI_Populus_PD10_SynCom.yaml
+++ b/kb/communities/ORNL_PMI_Populus_PD10_SynCom.yaml
@@ -53,6 +53,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Pantoea
       ncbi_source_id: NCBITaxon:53335
       majority_fraction: 0.982
+      support_genomes: 1455
+      total_genomes: 1482
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 6 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -101,6 +103,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Sphingobium
       ncbi_source_id: NCBITaxon:165695
       majority_fraction: 0.987
+      support_genomes: 222
+      total_genomes: 225
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -126,6 +130,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Rhizobium
       ncbi_source_id: NCBITaxon:379
       majority_fraction: 0.87
+      support_genomes: 694
+      total_genomes: 798
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 12 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -151,6 +157,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -176,6 +184,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
       majority_fraction: 0.57
+      support_genomes: 4981
+      total_genomes: 8737
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -201,6 +211,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Caulobacterales;f__Caulobacteraceae;g__Caulobacter
       ncbi_source_id: NCBITaxon:75
       majority_fraction: 1.0
+      support_genomes: 32
+      total_genomes: 32
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -226,6 +238,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Duganella
       ncbi_source_id: NCBITaxon:75654
       majority_fraction: 1.0
+      support_genomes: 45
+      total_genomes: 45
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -268,6 +282,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Paraburkholderia
       ncbi_source_id: NCBITaxon:1822464
       majority_fraction: 0.993
+      support_genomes: 680
+      total_genomes: 685
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   strain_designation:

--- a/kb/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.yaml
+++ b/kb/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.yaml
@@ -52,6 +52,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
       majority_fraction: 0.699
+      support_genomes: 17956
+      total_genomes: 25706
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: Pseudomonas was reported among organisms stimulated in the highly contaminated well FW113-47
@@ -77,6 +79,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella
       ncbi_source_id: NCBITaxon:22
       majority_fraction: 1.0
+      support_genomes: 827
+      total_genomes: 827
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Shewanella was reported as a uranium-reducing organism stimulated in the highly contaminated
@@ -102,6 +106,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Xanthomonadaceae;g__Stenotrophomonas
       ncbi_source_id: NCBITaxon:40323
       majority_fraction: 0.985
+      support_genomes: 398
+      total_genomes: 404
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Stenotrophomonas was reported among organisms stimulated in the highly contaminated well FW113-47

--- a/kb/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.yaml
+++ b/kb/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.yaml
@@ -67,6 +67,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhodobacterales;f__Rhodobacteraceae;g__Dinoroseobacter;s__Dinoroseobacter shibae
       ncbi_source_id: NCBITaxon:215813
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: DF-12 strain used as the heterotrophic bacterial partner.

--- a/kb/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.yaml
+++ b/kb/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.yaml
@@ -67,7 +67,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhodobacterales;f__Rhodobacteraceae;g__Dinoroseobacter;s__Dinoroseobacter shibae
       ncbi_source_id: NCBITaxon:215813
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: DF-12 strain used as the heterotrophic bacterial partner.

--- a/kb/communities/PET_Artificial_FourSpecies_Degradation_Consortium.yaml
+++ b/kb/communities/PET_Artificial_FourSpecies_Degradation_Consortium.yaml
@@ -53,6 +53,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
       ncbi_source_id: NCBITaxon:1423
       majority_fraction: 0.91
+      support_genomes: 1256
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered B. subtilis 168 strain carrying pHP13-P43-LipB-PETase; represented at species level
@@ -82,6 +83,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
       ncbi_source_id: NCBITaxon:1423
       majority_fraction: 0.91
+      support_genomes: 1256
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered B. subtilis 168 strain carrying pHP13-P43-LipB-MHETase; represented at species level
@@ -111,6 +113,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Rhodococcus;s__Rhodococcus jostii_A
       ncbi_source_id: NCBITaxon:101510
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Wild-type R. jostii RHA1 added as the terephthalic-acid utilization module.
@@ -140,6 +143,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas_E;s__Pseudomonas_E alloputida
       ncbi_source_id: NCBITaxon:160488
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Wild-type P. putida KT2440 added as the ethylene-glycol utilization module.

--- a/kb/communities/PET_Artificial_FourSpecies_Degradation_Consortium.yaml
+++ b/kb/communities/PET_Artificial_FourSpecies_Degradation_Consortium.yaml
@@ -53,7 +53,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
       ncbi_source_id: NCBITaxon:1423
       majority_fraction: 0.91
-      support_genomes: 1256
+      total_genomes: 1256
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered B. subtilis 168 strain carrying pHP13-P43-LipB-PETase; represented at species level
@@ -83,7 +83,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
       ncbi_source_id: NCBITaxon:1423
       majority_fraction: 0.91
-      support_genomes: 1256
+      total_genomes: 1256
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered B. subtilis 168 strain carrying pHP13-P43-LipB-MHETase; represented at species level
@@ -113,7 +113,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Rhodococcus;s__Rhodococcus jostii_A
       ncbi_source_id: NCBITaxon:101510
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Wild-type R. jostii RHA1 added as the terephthalic-acid utilization module.
@@ -143,7 +143,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas_E;s__Pseudomonas_E alloputida
       ncbi_source_id: NCBITaxon:160488
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Wild-type P. putida KT2440 added as the ethylene-glycol utilization module.

--- a/kb/communities/PGM_Spent_Catalyst_Bioleaching.yaml
+++ b/kb/communities/PGM_Spent_Catalyst_Bioleaching.yaml
@@ -68,6 +68,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus thiooxidans
       ncbi_source_id: NCBITaxon:930
       majority_fraction: 1.0
+      support_genomes: 43
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Primary sulfur-oxidizing bacterium responsible for both alumina dissolution and thiosulfate
@@ -131,6 +132,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
+      support_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Supporting acidophilic bacterium that contributes to bioleaching through dual iron and sulfur
@@ -174,6 +176,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_E;c__Sulfobacillia;o__Sulfobacillales;f__Sulfobacillaceae;g__Sulfobacillus;s__Sulfobacillus thermosulfidooxidans
       ncbi_source_id: NCBITaxon:28034
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Moderately thermophilic, facultatively autotrophic bacterium contributing to sulfur and iron
@@ -218,6 +221,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Thiobacillaceae;g__Thiobacillus;s__Thiobacillus thioparus
       ncbi_source_id: NCBITaxon:931
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Neutrophilic to slightly acidophilic sulfur-oxidizing bacterium that produces thiosulfate

--- a/kb/communities/PGM_Spent_Catalyst_Bioleaching.yaml
+++ b/kb/communities/PGM_Spent_Catalyst_Bioleaching.yaml
@@ -68,7 +68,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus thiooxidans
       ncbi_source_id: NCBITaxon:930
       majority_fraction: 1.0
-      support_genomes: 43
+      total_genomes: 43
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Primary sulfur-oxidizing bacterium responsible for both alumina dissolution and thiosulfate
@@ -132,7 +132,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
-      support_genomes: 7
+      total_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Supporting acidophilic bacterium that contributes to bioleaching through dual iron and sulfur
@@ -176,7 +176,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_E;c__Sulfobacillia;o__Sulfobacillales;f__Sulfobacillaceae;g__Sulfobacillus;s__Sulfobacillus thermosulfidooxidans
       ncbi_source_id: NCBITaxon:28034
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Moderately thermophilic, facultatively autotrophic bacterium contributing to sulfur and iron
@@ -221,7 +221,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Thiobacillaceae;g__Thiobacillus;s__Thiobacillus thioparus
       ncbi_source_id: NCBITaxon:931
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Neutrophilic to slightly acidophilic sulfur-oxidizing bacterium that produces thiosulfate

--- a/kb/communities/PMI_Variovorax_Thermotolerance_Collection.yaml
+++ b/kb/communities/PMI_Variovorax_Thermotolerance_Collection.yaml
@@ -51,6 +51,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -78,6 +80,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -103,6 +107,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -128,6 +134,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -153,6 +161,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
@@ -178,6 +188,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:

--- a/kb/communities/Panzhihua_Vanadium_Titanium_Tailings.yaml
+++ b/kb/communities/Panzhihua_Vanadium_Titanium_Tailings.yaml
@@ -158,6 +158,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
       majority_fraction: 0.57
+      support_genomes: 4981
+      total_genomes: 8737
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive spore-forming bacteria representing the most abundant genus (79 of 136 isolates,
@@ -203,6 +205,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Ochrobactrum;s__Ochrobactrum intermedium
       ncbi_source_id: NCBITaxon:94625
       majority_fraction: 0.99
+      support_genomes: 67
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Alphaproteobacterium (13 isolates) with exceptional heavy metal tolerance and plant growth-promoting
@@ -248,6 +251,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Polaromonas
       ncbi_source_id: NCBITaxon:52972
       majority_fraction: 1.0
+      support_genomes: 12
+      total_genomes: 12
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Betaproteobacteria capable of dissimilatory vanadium reduction in contaminated mine environments.

--- a/kb/communities/Panzhihua_Vanadium_Titanium_Tailings.yaml
+++ b/kb/communities/Panzhihua_Vanadium_Titanium_Tailings.yaml
@@ -205,7 +205,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Ochrobactrum;s__Ochrobactrum intermedium
       ncbi_source_id: NCBITaxon:94625
       majority_fraction: 0.99
-      support_genomes: 67
+      total_genomes: 67
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Alphaproteobacterium (13 isolates) with exceptional heavy metal tolerance and plant growth-promoting

--- a/kb/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.yaml
+++ b/kb/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.yaml
@@ -61,6 +61,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_B;c__Desulfotomaculia;o__Desulfotomaculales;f__Pelotomaculaceae;g__Pelotomaculum;s__Pelotomaculum thermopropionicum
       ncbi_source_id: NCBITaxon:110500
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Propionate-oxidizing bacterial syntroph in the two-member RNA-seq coculture.
@@ -89,6 +90,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanocellia;o__Methanocellales;f__Methanocellaceae;g__Methanocella;s__Methanocella conradii
       ncbi_source_id: NCBITaxon:1175444
       majority_fraction: 1.0
+      support_genomes: 4
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Hydrogenotrophic methanogenic archaeal partner in the two-member RNA-seq coculture.

--- a/kb/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.yaml
+++ b/kb/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.yaml
@@ -61,7 +61,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_B;c__Desulfotomaculia;o__Desulfotomaculales;f__Pelotomaculaceae;g__Pelotomaculum;s__Pelotomaculum thermopropionicum
       ncbi_source_id: NCBITaxon:110500
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Propionate-oxidizing bacterial syntroph in the two-member RNA-seq coculture.
@@ -90,7 +90,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanocellia;o__Methanocellales;f__Methanocellaceae;g__Methanocella;s__Methanocella conradii
       ncbi_source_id: NCBITaxon:1175444
       majority_fraction: 1.0
-      support_genomes: 4
+      total_genomes: 4
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Hydrogenotrophic methanogenic archaeal partner in the two-member RNA-seq coculture.

--- a/kb/communities/Pelotomaculum_Methanothermobacter_Syntrophy.yaml
+++ b/kb/communities/Pelotomaculum_Methanothermobacter_Syntrophy.yaml
@@ -37,7 +37,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_B;c__Desulfotomaculia;o__Desulfotomaculales;f__Pelotomaculaceae;g__Pelotomaculum;s__Pelotomaculum thermopropionicum
       ncbi_source_id: NCBITaxon:110500
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Thermophilic, anaerobic, syntrophic, propionate-oxidizing bacterium that oxidizes propionate,
@@ -72,7 +72,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Methanobacteriota;c__Methanobacteria;o__Methanobacteriales;f__Methanothermobacteraceae;g__Methanothermobacter;s__Methanothermobacter thermautotrophicus
       ncbi_source_id: NCBITaxon:145262
       majority_fraction: 1.0
-      support_genomes: 24
+      total_genomes: 24
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Thermophilic hydrogen-utilizing methanogen that consumes H2 and CO2 to produce methane. Essential

--- a/kb/communities/Pelotomaculum_Methanothermobacter_Syntrophy.yaml
+++ b/kb/communities/Pelotomaculum_Methanothermobacter_Syntrophy.yaml
@@ -37,6 +37,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_B;c__Desulfotomaculia;o__Desulfotomaculales;f__Pelotomaculaceae;g__Pelotomaculum;s__Pelotomaculum thermopropionicum
       ncbi_source_id: NCBITaxon:110500
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Thermophilic, anaerobic, syntrophic, propionate-oxidizing bacterium that oxidizes propionate,
@@ -71,6 +72,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Methanobacteriota;c__Methanobacteria;o__Methanobacteriales;f__Methanothermobacteraceae;g__Methanothermobacter;s__Methanothermobacter thermautotrophicus
       ncbi_source_id: NCBITaxon:145262
       majority_fraction: 1.0
+      support_genomes: 24
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Thermophilic hydrogen-utilizing methanogen that consumes H2 and CO2 to produce methane. Essential

--- a/kb/communities/Pepper_Phytophthora_SynCom5.yaml
+++ b/kb/communities/Pepper_Phytophthora_SynCom5.yaml
@@ -43,6 +43,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
       majority_fraction: 0.57
+      support_genomes: 4981
+      total_genomes: 8737
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
   functional_role:
@@ -60,6 +62,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Flavobacteriales;f__Flavobacteriaceae;g__Flavobacterium
       ncbi_source_id: NCBITaxon:237
       majority_fraction: 0.999
+      support_genomes: 859
+      total_genomes: 860
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:

--- a/kb/communities/Phormidium_Alkaline_Consortium.yaml
+++ b/kb/communities/Phormidium_Alkaline_Consortium.yaml
@@ -85,6 +85,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota
       ncbi_source_id: NCBITaxon:976
       majority_fraction: 0.999
+      support_genomes: 151365
+      total_genomes: 151454
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 5 GTDB taxa under the NCBI taxon]
     notes: 'Multiple heterotrophic Bacteroidota species present in the consortium. These organisms contribute
@@ -115,6 +117,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria
       ncbi_source_id: NCBITaxon:28211
       majority_fraction: 1.0
+      support_genomes: 19132
+      total_genomes: 19134
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Diverse alphaproteobacterial species in the consortium that likely contribute to vitamin production,
@@ -144,6 +148,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Verrucomicrobiota
       ncbi_source_id: NCBITaxon:74201
       majority_fraction: 1.0
+      support_genomes: 7012
+      total_genomes: 7012
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Verrucomicrobial species equipped with glycoside hydrolases for degradation of sulfated polysaccharides
@@ -172,6 +178,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Planctomycetota
       ncbi_source_id: NCBITaxon:203682
       majority_fraction: 1.0
+      support_genomes: 519
+      total_genomes: 519
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Planctomycete species with glycoside hydrolases capable of degrading cyanobacterial cell wall

--- a/kb/communities/Phosphitivorax_Methanoculleus_Lithosyntrophy_Phosphite_Coculture.yaml
+++ b/kb/communities/Phosphitivorax_Methanoculleus_Lithosyntrophy_Phosphite_Coculture.yaml
@@ -30,7 +30,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfomonilia;o__UBA1062;f__UBA1062;g__UBA1062;s__UBA1062 sp001896555
       ncbi_source_id: NCBITaxon:1918507
       majority_fraction: 1.0
-      support_genomes: 9
+      total_genomes: 9
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:

--- a/kb/communities/Phosphitivorax_Methanoculleus_Lithosyntrophy_Phosphite_Coculture.yaml
+++ b/kb/communities/Phosphitivorax_Methanoculleus_Lithosyntrophy_Phosphite_Coculture.yaml
@@ -30,6 +30,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfomonilia;o__UBA1062;f__UBA1062;g__UBA1062;s__UBA1062 sp001896555
       ncbi_source_id: NCBITaxon:1918507
       majority_fraction: 1.0
+      support_genomes: 9
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -57,6 +58,8 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanoculleaceae;g__Methanoculleus
       ncbi_source_id: NCBITaxon:45989
       majority_fraction: 0.951
+      support_genomes: 78
+      total_genomes: 82
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the paper reports only "Methanoculleus sp." with no species assignment.

--- a/kb/communities/Phylogenetically_Diverse_Denitrifying_SynCom.yaml
+++ b/kb/communities/Phylogenetically_Diverse_Denitrifying_SynCom.yaml
@@ -42,6 +42,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella
       ncbi_source_id: NCBITaxon:22
       majority_fraction: 1.0
+      support_genomes: 827
+      total_genomes: 827
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:

--- a/kb/communities/Pinus_armandii_Endophytic_Biocontrol_SynCom.yaml
+++ b/kb/communities/Pinus_armandii_Endophytic_Biocontrol_SynCom.yaml
@@ -66,6 +66,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus velezensis
       ncbi_source_id: NCBITaxon:492670
       majority_fraction: 1.0
+      support_genomes: 1163
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -92,6 +93,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus velezensis
       ncbi_source_id: NCBITaxon:492670
       majority_fraction: 1.0
+      support_genomes: 1163
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -117,6 +119,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
       ncbi_source_id: NCBITaxon:1423
       majority_fraction: 0.91
+      support_genomes: 1256
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:

--- a/kb/communities/Pinus_armandii_Endophytic_Biocontrol_SynCom.yaml
+++ b/kb/communities/Pinus_armandii_Endophytic_Biocontrol_SynCom.yaml
@@ -66,7 +66,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus velezensis
       ncbi_source_id: NCBITaxon:492670
       majority_fraction: 1.0
-      support_genomes: 1163
+      total_genomes: 1163
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -93,7 +93,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus velezensis
       ncbi_source_id: NCBITaxon:492670
       majority_fraction: 1.0
-      support_genomes: 1163
+      total_genomes: 1163
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -119,7 +119,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
       ncbi_source_id: NCBITaxon:1423
       majority_fraction: 0.91
-      support_genomes: 1256
+      total_genomes: 1256
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:

--- a/kb/communities/Pleuromutilin_Degrading_Artificial_Consortium_5_Strain.yaml
+++ b/kb/communities/Pleuromutilin_Degrading_Artificial_Consortium_5_Strain.yaml
@@ -34,6 +34,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Xanthomonadaceae;g__Stenotrophomonas;s__Stenotrophomonas pavanii
       ncbi_source_id: NCBITaxon:487698
       majority_fraction: 1.0
+      support_genomes: 25
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -90,6 +91,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales_A;f__Planococcaceae;g__Lysinibacillus;s__Lysinibacillus mangiferihumi
       ncbi_source_id: NCBITaxon:1130819
       majority_fraction: 1.0
+      support_genomes: 6
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -115,6 +117,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Stutzerimonas;s__Stutzerimonas songnenensis
       ncbi_source_id: NCBITaxon:1176259
       majority_fraction: 1.0
+      support_genomes: 6
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Pleuromutilin_Degrading_Artificial_Consortium_5_Strain.yaml
+++ b/kb/communities/Pleuromutilin_Degrading_Artificial_Consortium_5_Strain.yaml
@@ -34,7 +34,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Xanthomonadaceae;g__Stenotrophomonas;s__Stenotrophomonas pavanii
       ncbi_source_id: NCBITaxon:487698
       majority_fraction: 1.0
-      support_genomes: 25
+      total_genomes: 25
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -91,7 +91,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales_A;f__Planococcaceae;g__Lysinibacillus;s__Lysinibacillus mangiferihumi
       ncbi_source_id: NCBITaxon:1130819
       majority_fraction: 1.0
-      support_genomes: 6
+      total_genomes: 6
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -117,7 +117,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Stutzerimonas;s__Stutzerimonas songnenensis
       ncbi_source_id: NCBITaxon:1176259
       majority_fraction: 1.0
-      support_genomes: 6
+      total_genomes: 6
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Polaromonas_Vanadium_Reduction_Community.yaml
+++ b/kb/communities/Polaromonas_Vanadium_Reduction_Community.yaml
@@ -49,6 +49,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Polaromonas
       ncbi_source_id: NCBITaxon:52972
       majority_fraction: 1.0
+      support_genomes: 12
+      total_genomes: 12
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Gram-negative betaproteobacteria (Burkholderiaceae family) dominating the vanadium-contaminated
@@ -93,6 +95,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Desulfovibrio
       ncbi_source_id: NCBITaxon:872
       majority_fraction: 0.931
+      support_genomes: 551
+      total_genomes: 592
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 9 GTDB taxa under the NCBI taxon]
     notes: 'Gram-negative deltaproteobacteria performing dissimilatory sulfate reduction in the vanadium
@@ -140,6 +144,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Deltaproteobacteria specialized in dissimilatory metal reduction, present at 5-8% relative
@@ -188,6 +193,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_B;c__Desulfitobacteriia;o__Desulfitobacteriales;f__Desulfitobacteriaceae;g__Desulfitobacterium
       ncbi_source_id: NCBITaxon:36853
       majority_fraction: 0.939
+      support_genomes: 46
+      total_genomes: 49
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive, spore-forming bacteria (Firmicutes phylum) capable of organohalide respiration

--- a/kb/communities/Polaromonas_Vanadium_Reduction_Community.yaml
+++ b/kb/communities/Polaromonas_Vanadium_Reduction_Community.yaml
@@ -144,7 +144,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Deltaproteobacteria specialized in dissimilatory metal reduction, present at 5-8% relative

--- a/kb/communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.yaml
+++ b/kb/communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.yaml
@@ -36,6 +36,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia
       ncbi_source_id: NCBITaxon:561
       majority_fraction: 1.0
+      support_genomes: 185621
+      total_genomes: 185625
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Escherichia spp. whose in situ physiological conditions were

--- a/kb/communities/Prochlorococcus_Alteromonas_Helper_Coculture.yaml
+++ b/kb/communities/Prochlorococcus_Alteromonas_Helper_Coculture.yaml
@@ -67,6 +67,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Alteromonadaceae;g__Alteromonas;s__Alteromonas macleodii
       ncbi_source_id: NCBITaxon:28108
       majority_fraction: 0.9
+      support_genomes: 135
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Heterotrophic helper bacterium that removes hydrogen peroxide and modifies Prochlorococcus oxidative

--- a/kb/communities/Prochlorococcus_Alteromonas_Helper_Coculture.yaml
+++ b/kb/communities/Prochlorococcus_Alteromonas_Helper_Coculture.yaml
@@ -67,7 +67,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Alteromonadaceae;g__Alteromonas;s__Alteromonas macleodii
       ncbi_source_id: NCBITaxon:28108
       majority_fraction: 0.9
-      support_genomes: 135
+      total_genomes: 135
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Heterotrophic helper bacterium that removes hydrogen peroxide and modifies Prochlorococcus oxidative

--- a/kb/communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.yaml
+++ b/kb/communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.yaml
@@ -114,6 +114,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Mycobacterium
       ncbi_source_id: NCBITaxon:1866885
       majority_fraction: 0.998
+      support_genomes: 852
+      total_genomes: 854
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Dominant genus across all four cDCE-amended enrichments and the
@@ -144,6 +146,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Mycobacterium
       ncbi_source_id: NCBITaxon:1763
       majority_fraction: 1.0
+      support_genomes: 18589
+      total_genomes: 18589
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Second dominant genus in cDCE-amended enrichments after
@@ -171,6 +175,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Pseudonocardiaceae;g__Pseudonocardia
       ncbi_source_id: NCBITaxon:1847
       majority_fraction: 1.0
+      support_genomes: 122
+      total_genomes: 122
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Dominant genus in 1,1-DCE-degrading enrichments after re-selection
@@ -201,6 +207,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Pseudonocardiaceae;g__Pseudonocardia;s__Pseudonocardia broussonetiae
       ncbi_source_id: NCBITaxon:2736640
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Species-level MAGs recovered from the impacted-site (Site 1)
@@ -227,6 +234,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Methylibium
       ncbi_source_id: NCBITaxon:316612
       majority_fraction: 0.625
+      support_genomes: 5
+      total_genomes: 8
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: One of two non-actinobacterial MAGs containing the propane
@@ -253,6 +262,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae
       ncbi_source_id: NCBITaxon:119060
       majority_fraction: 1.0
+      support_genomes: 12271
+      total_genomes: 12271
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at f__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: One of two non-actinobacterial MAGs containing the propane

--- a/kb/communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.yaml
+++ b/kb/communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.yaml
@@ -207,7 +207,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Pseudonocardiaceae;g__Pseudonocardia;s__Pseudonocardia broussonetiae
       ncbi_source_id: NCBITaxon:2736640
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Species-level MAGs recovered from the impacted-site (Site 1)

--- a/kb/communities/Pseudomonas_Pedobacter_Social_Spreading_Coculture.yaml
+++ b/kb/communities/Pseudomonas_Pedobacter_Social_Spreading_Coculture.yaml
@@ -66,6 +66,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Sphingobacteriales;f__Sphingobacteriaceae;g__Pedobacter
       ncbi_source_id: NCBITaxon:84567
       majority_fraction: 0.902
+      support_genomes: 212
+      total_genomes: 235
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Soil-associated Pedobacter isolate V48; represented at genus level because the publication names

--- a/kb/communities/Pseudomonas_Rhodococcus_Chloronitrobenzene_Coculture.yaml
+++ b/kb/communities/Pseudomonas_Rhodococcus_Chloronitrobenzene_Coculture.yaml
@@ -79,6 +79,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Rhodococcus
       ncbi_source_id: NCBITaxon:1827
       majority_fraction: 1.0
+      support_genomes: 514
+      total_genomes: 514
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Chlorohydroxyacetanilide-degrading partner paired with P. putida HS12 for complete

--- a/kb/communities/Pseudomonas_putida_PpTE_Rhodococcus_RDK17_Terephthalic_Acid_Consortium.yaml
+++ b/kb/communities/Pseudomonas_putida_PpTE_Rhodococcus_RDK17_Terephthalic_Acid_Consortium.yaml
@@ -50,6 +50,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Rhodococcus
       ncbi_source_id: NCBITaxon:1827
       majority_fraction: 1.0
+      support_genomes: 514
+      total_genomes: 514
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Native TPA degrader, strain RDK17. Grounded at genus rank (Rhodococcus sp.) because the

--- a/kb/communities/Pseudomonas_stutzeri_Rhodococcus_Naphthalene_Biochar_Engineered_Consortium.yaml
+++ b/kb/communities/Pseudomonas_stutzeri_Rhodococcus_Naphthalene_Biochar_Engineered_Consortium.yaml
@@ -52,6 +52,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Mycobacteriales;f__Mycobacteriaceae;g__Rhodococcus
       ncbi_source_id: NCBITaxon:1827
       majority_fraction: 1.0
+      support_genomes: 514
+      total_genomes: 514
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Source paper names the strain "Rhodococcus rhodococcus", which is not a valid NCBITaxon

--- a/kb/communities/Rammelsberg_Cobalt_Nickel_Tailings.yaml
+++ b/kb/communities/Rammelsberg_Cobalt_Nickel_Tailings.yaml
@@ -65,7 +65,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
-      support_genomes: 7
+      total_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Mesophilic chemolithoautotrophic iron-oxidizing bacterium that obtains energy from oxidation
@@ -110,7 +110,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus thiooxidans
       ncbi_source_id: NCBITaxon:930
       majority_fraction: 1.0
-      support_genomes: 43
+      total_genomes: 43
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Mesophilic chemolithoautotrophic sulfur-oxidizing bacterium that derives energy from oxidation

--- a/kb/communities/Rammelsberg_Cobalt_Nickel_Tailings.yaml
+++ b/kb/communities/Rammelsberg_Cobalt_Nickel_Tailings.yaml
@@ -65,6 +65,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
+      support_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Mesophilic chemolithoautotrophic iron-oxidizing bacterium that obtains energy from oxidation
@@ -109,6 +110,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus thiooxidans
       ncbi_source_id: NCBITaxon:930
       majority_fraction: 1.0
+      support_genomes: 43
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Mesophilic chemolithoautotrophic sulfur-oxidizing bacterium that derives energy from oxidation

--- a/kb/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.yaml
+++ b/kb/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.yaml
@@ -51,7 +51,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
-      support_genomes: 166397
+      total_genomes: 166397
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.yaml
+++ b/kb/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.yaml
@@ -51,6 +51,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
+      support_genomes: 166397
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.yaml
+++ b/kb/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.yaml
@@ -60,7 +60,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Rhodopseudomonas;s__Rhodopseudomonas palustris_F
       ncbi_source_id: NCBITaxon:395960
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Phototrophic Fe(II)-oxidizing member of the coculture.
@@ -90,7 +90,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter sulfurreducens
       ncbi_source_id: NCBITaxon:35554
       majority_fraction: 1.0
-      support_genomes: 19
+      total_genomes: 19
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Anaerobic Fe(III)-reducing member of the coculture.

--- a/kb/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.yaml
+++ b/kb/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.yaml
@@ -60,6 +60,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Rhodopseudomonas;s__Rhodopseudomonas palustris_F
       ncbi_source_id: NCBITaxon:395960
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Phototrophic Fe(II)-oxidizing member of the coculture.
@@ -89,6 +90,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter sulfurreducens
       ncbi_source_id: NCBITaxon:35554
       majority_fraction: 1.0
+      support_genomes: 19
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Anaerobic Fe(III)-reducing member of the coculture.

--- a/kb/communities/Rice_Duckweed_Bacillus_SynCom.yaml
+++ b/kb/communities/Rice_Duckweed_Bacillus_SynCom.yaml
@@ -51,6 +51,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
       majority_fraction: 0.57
+      support_genomes: 4981
+      total_genomes: 8737
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
     notes: Auxin (IAA)-producing specialist within the 8-member SynCom. Division-of-labor member contributing
@@ -76,6 +78,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
       majority_fraction: 0.57
+      support_genomes: 4981
+      total_genomes: 8737
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
     notes: Siderophore-producing specialist within the 8-member SynCom. Contributes to rice growth promotion
@@ -100,6 +104,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
       majority_fraction: 0.57
+      support_genomes: 4981
+      total_genomes: 8737
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
     notes: Lipopeptide-producing antagonist within the 8-member SynCom. Produces surfactin, bacillomycin,
@@ -124,6 +130,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
       majority_fraction: 0.57
+      support_genomes: 4981
+      total_genomes: 8737
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
     notes: Polyketide-producing antagonist within the 8-member SynCom. Produces difficidin for biocontrol

--- a/kb/communities/Rice_P_Uptake_Intercropping_SynCom4.yaml
+++ b/kb/communities/Rice_P_Uptake_Intercropping_SynCom4.yaml
@@ -52,7 +52,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Novosphingobium;s__Novosphingobium subterraneum
       ncbi_source_id: NCBITaxon:48936
       majority_fraction: 1.0
-      support_genomes: 4
+      total_genomes: 4
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -70,7 +70,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Hydrogenophaga;s__Hydrogenophaga pseudoflava
       ncbi_source_id: NCBITaxon:47421
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   functional_role:

--- a/kb/communities/Rice_P_Uptake_Intercropping_SynCom4.yaml
+++ b/kb/communities/Rice_P_Uptake_Intercropping_SynCom4.yaml
@@ -52,6 +52,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Novosphingobium;s__Novosphingobium subterraneum
       ncbi_source_id: NCBITaxon:48936
       majority_fraction: 1.0
+      support_genomes: 4
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -69,6 +70,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Hydrogenophaga;s__Hydrogenophaga pseudoflava
       ncbi_source_id: NCBITaxon:47421
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   functional_role:
@@ -86,6 +88,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Acidovorax
       ncbi_source_id: NCBITaxon:12916
       majority_fraction: 0.997
+      support_genomes: 323
+      total_genomes: 324
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:

--- a/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
+++ b/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
@@ -75,6 +75,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales;f__Thermoplasmataceae;g__Ferroplasma;s__Ferroplasma acidarmanus
       ncbi_source_id: NCBITaxon:97393
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Cell wall-lacking archaeon (Thermoplasmatales order) adapted to extremely
@@ -150,6 +151,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
+      support_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Gram-negative γ-proteobacterium that oxidizes both iron and reduced sulfur

--- a/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
+++ b/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
@@ -75,7 +75,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Thermoplasmatota;c__Thermoplasmata;o__Thermoplasmatales;f__Thermoplasmataceae;g__Ferroplasma;s__Ferroplasma acidarmanus
       ncbi_source_id: NCBITaxon:97393
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Cell wall-lacking archaeon (Thermoplasmatales order) adapted to extremely
@@ -151,7 +151,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
-      support_genomes: 7
+      total_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Gram-negative γ-proteobacterium that oxidizes both iron and reduced sulfur

--- a/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
+++ b/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
@@ -79,6 +79,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota
       ncbi_source_id: NCBITaxon:201174
       majority_fraction: 1.0
+      support_genomes: 91744
+      total_genomes: 91751
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
   functional_role:
@@ -102,6 +104,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota
       ncbi_source_id: NCBITaxon:1134404
       majority_fraction: 1.0
+      support_genomes: 7
+      total_genomes: 7
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
@@ -123,6 +127,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Chloroflexota
       ncbi_source_id: NCBITaxon:200795
       majority_fraction: 0.997
+      support_genomes: 299
+      total_genomes: 300
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:
@@ -144,6 +150,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Acidobacteriota
       ncbi_source_id: NCBITaxon:57723
       majority_fraction: 1.0
+      support_genomes: 203
+      total_genomes: 203
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
@@ -165,6 +173,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A
       ncbi_source_id: NCBITaxon:1239
       majority_fraction: 0.501
+      support_genomes: 226306
+      total_genomes: 451729
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 12 GTDB taxa under the NCBI taxon]
   functional_role:
@@ -186,6 +196,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota
       ncbi_source_id: NCBITaxon:1224
       majority_fraction: 1.0
+      support_genomes: 806030
+      total_genomes: 806033
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:

--- a/kb/communities/Rifle_Uranium_Reducing_Community.yaml
+++ b/kb/communities/Rifle_Uranium_Reducing_Community.yaml
@@ -43,6 +43,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Geobacter species, primarily G. metallireducens, dominate Phase I of uranium bioremediation
@@ -114,6 +115,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Nitratidesulfovibrio;s__Nitratidesulfovibrio vulgaris
       ncbi_source_id: NCBITaxon:881
       majority_fraction: 1.0
+      support_genomes: 6
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Sulfate-reducing bacterium that contributes to uranium reduction through enzymatic pathways
@@ -147,6 +149,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_B;c__Desulfitobacteriia;o__Desulfitobacteriales;f__Desulfitobacteriaceae;g__Desulfosporosinus
       ncbi_source_id: NCBITaxon:79206
       majority_fraction: 1.0
+      support_genomes: 32
+      total_genomes: 32
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Gram-positive, spore-forming, sulfate-reducing bacteria detected during later phases of uranium
@@ -191,6 +195,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfobacteria;o__Desulfobacterales
       ncbi_source_id: NCBITaxon:213118
       majority_fraction: 1.0
+      support_genomes: 109
+      total_genomes: 109
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Family of sulfate-reducing bacteria that becomes dominant during Phase II of uranium biostimulation

--- a/kb/communities/Rifle_Uranium_Reducing_Community.yaml
+++ b/kb/communities/Rifle_Uranium_Reducing_Community.yaml
@@ -43,7 +43,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Geobacter species, primarily G. metallireducens, dominate Phase I of uranium bioremediation
@@ -115,7 +115,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfovibrionia;o__Desulfovibrionales;f__Desulfovibrionaceae;g__Nitratidesulfovibrio;s__Nitratidesulfovibrio vulgaris
       ncbi_source_id: NCBITaxon:881
       majority_fraction: 1.0
-      support_genomes: 6
+      total_genomes: 6
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Sulfate-reducing bacterium that contributes to uranium reduction through enzymatic pathways

--- a/kb/communities/SF356_Cellulose_Degrader.yaml
+++ b/kb/communities/SF356_Cellulose_Degrader.yaml
@@ -29,7 +29,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__Acetivibrionaceae;g__Hungateiclostridium;s__Hungateiclostridium straminisolvens
       ncbi_source_id: NCBITaxon:253314
       majority_fraction: 1.0
-      support_genomes: 4
+      total_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT

--- a/kb/communities/SF356_Cellulose_Degrader.yaml
+++ b/kb/communities/SF356_Cellulose_Degrader.yaml
@@ -29,6 +29,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Acetivibrionales;f__Acetivibrionaceae;g__Hungateiclostridium;s__Hungateiclostridium straminisolvens
       ncbi_source_id: NCBITaxon:253314
       majority_fraction: 1.0
+      support_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT
@@ -88,6 +89,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Brevibacillales;f__Brevibacillaceae;g__Brevibacillus
       ncbi_source_id: NCBITaxon:55080
       majority_fraction: 0.803
+      support_genomes: 151
+      total_genomes: 188
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 5 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON

--- a/kb/communities/SIHUMIx_Human_Intestinal_Model_Community.yaml
+++ b/kb/communities/SIHUMIx_Human_Intestinal_Model_Community.yaml
@@ -47,7 +47,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Anaerostipes;s__Anaerostipes caccae
       ncbi_source_id: NCBITaxon:105841
       majority_fraction: 1.0
-      support_genomes: 35
+      total_genomes: 35
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Human intestinal anaerobe included in SIHUMIx.
@@ -76,7 +76,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides;s__Bacteroides thetaiotaomicron
       ncbi_source_id: NCBITaxon:818
       majority_fraction: 0.99
-      support_genomes: 1011
+      total_genomes: 1011
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Gut Bacteroides member and dominant SIHUMIx constituent in bioreactor studies.
@@ -122,7 +122,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Blautia;s__Blautia coccoides
       ncbi_source_id: NCBITaxon:33035
       majority_fraction: 1.0
-      support_genomes: 7
+      total_genomes: 7
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Anaerobic gut member included in SIHUMIx.
@@ -151,7 +151,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium;s__Clostridium butyricum
       ncbi_source_id: NCBITaxon:1492
       majority_fraction: 0.97
-      support_genomes: 327
+      total_genomes: 327
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Butyrate-associated clostridial member added in the extended SIHUMIx community.
@@ -180,7 +180,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_I;c__Bacilli_A;o__Erysipelotrichales;f__Coprobacillaceae;g__Thomasclavelia;s__Thomasclavelia ramosa
       ncbi_source_id: NCBITaxon:1547
       majority_fraction: 0.99
-      support_genomes: 183
+      total_genomes: 183
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Literature name retained as preferred term; this organism is also encountered under updated
@@ -210,7 +210,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:511145
       majority_fraction: 1.0
-      support_genomes: 37
+      total_genomes: 37
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Facultative anaerobic Proteobacteria member of SIHUMIx.
@@ -236,7 +236,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactiplantibacillus;s__Lactiplantibacillus plantarum
       ncbi_source_id: NCBITaxon:1590
       majority_fraction: 1.0
-      support_genomes: 2061
+      total_genomes: 2061
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Literature name retained in preferred_term; current NCBI label reflects Lactobacillus

--- a/kb/communities/SIHUMIx_Human_Intestinal_Model_Community.yaml
+++ b/kb/communities/SIHUMIx_Human_Intestinal_Model_Community.yaml
@@ -47,6 +47,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Anaerostipes;s__Anaerostipes caccae
       ncbi_source_id: NCBITaxon:105841
       majority_fraction: 1.0
+      support_genomes: 35
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Human intestinal anaerobe included in SIHUMIx.
@@ -75,6 +76,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides;s__Bacteroides thetaiotaomicron
       ncbi_source_id: NCBITaxon:818
       majority_fraction: 0.99
+      support_genomes: 1011
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Gut Bacteroides member and dominant SIHUMIx constituent in bioreactor studies.
@@ -120,6 +122,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Blautia;s__Blautia coccoides
       ncbi_source_id: NCBITaxon:33035
       majority_fraction: 1.0
+      support_genomes: 7
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Anaerobic gut member included in SIHUMIx.
@@ -148,6 +151,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium;s__Clostridium butyricum
       ncbi_source_id: NCBITaxon:1492
       majority_fraction: 0.97
+      support_genomes: 327
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Butyrate-associated clostridial member added in the extended SIHUMIx community.
@@ -176,6 +180,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_I;c__Bacilli_A;o__Erysipelotrichales;f__Coprobacillaceae;g__Thomasclavelia;s__Thomasclavelia ramosa
       ncbi_source_id: NCBITaxon:1547
       majority_fraction: 0.99
+      support_genomes: 183
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Literature name retained as preferred term; this organism is also encountered under updated
@@ -205,6 +210,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:511145
       majority_fraction: 1.0
+      support_genomes: 37
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Facultative anaerobic Proteobacteria member of SIHUMIx.
@@ -230,6 +236,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactiplantibacillus;s__Lactiplantibacillus plantarum
       ncbi_source_id: NCBITaxon:1590
       majority_fraction: 1.0
+      support_genomes: 2061
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Literature name retained in preferred_term; current NCBI label reflects Lactobacillus

--- a/kb/communities/SMutans_CAlbicans_ECC_Biofilm.yaml
+++ b/kb/communities/SMutans_CAlbicans_ECC_Biofilm.yaml
@@ -54,7 +54,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Streptococcus;s__Streptococcus mutans
       ncbi_source_id: NCBITaxon:1309
       majority_fraction: 1.0
-      support_genomes: 512
+      total_genomes: 512
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   evidence:

--- a/kb/communities/SMutans_CAlbicans_ECC_Biofilm.yaml
+++ b/kb/communities/SMutans_CAlbicans_ECC_Biofilm.yaml
@@ -54,6 +54,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Streptococcus;s__Streptococcus mutans
       ncbi_source_id: NCBITaxon:1309
       majority_fraction: 1.0
+      support_genomes: 512
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   evidence:

--- a/kb/communities/SMutans_SSputigena_ECC_Pathobiont.yaml
+++ b/kb/communities/SMutans_SSputigena_ECC_Pathobiont.yaml
@@ -58,7 +58,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Streptococcus;s__Streptococcus mutans
       ncbi_source_id: NCBITaxon:1309
       majority_fraction: 1.0
-      support_genomes: 512
+      total_genomes: 512
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   evidence:
@@ -80,7 +80,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_C;c__Negativicutes;o__Selenomonadales;f__Selenomonadaceae;g__Selenomonas;s__Selenomonas sp905372355
       ncbi_source_id: NCBITaxon:69823
       majority_fraction: 0.86
-      support_genomes: 64
+      total_genomes: 64
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   evidence:

--- a/kb/communities/SMutans_SSputigena_ECC_Pathobiont.yaml
+++ b/kb/communities/SMutans_SSputigena_ECC_Pathobiont.yaml
@@ -58,6 +58,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Streptococcus;s__Streptococcus mutans
       ncbi_source_id: NCBITaxon:1309
       majority_fraction: 1.0
+      support_genomes: 512
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   evidence:
@@ -79,6 +80,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_C;c__Negativicutes;o__Selenomonadales;f__Selenomonadaceae;g__Selenomonas;s__Selenomonas sp905372355
       ncbi_source_id: NCBITaxon:69823
       majority_fraction: 0.86
+      support_genomes: 64
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   evidence:

--- a/kb/communities/SMutans_VParvula_ASC_Biofilm.yaml
+++ b/kb/communities/SMutans_VParvula_ASC_Biofilm.yaml
@@ -58,6 +58,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Streptococcus;s__Streptococcus mutans
       ncbi_source_id: NCBITaxon:1309
       majority_fraction: 1.0
+      support_genomes: 512
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   evidence:
@@ -80,6 +81,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_C;c__Negativicutes;o__Veillonellales;f__Veillonellaceae;g__Veillonella;s__Veillonella parvula_A
       ncbi_source_id: NCBITaxon:29466
       majority_fraction: 0.95
+      support_genomes: 1282
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT

--- a/kb/communities/SMutans_VParvula_ASC_Biofilm.yaml
+++ b/kb/communities/SMutans_VParvula_ASC_Biofilm.yaml
@@ -58,7 +58,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Streptococcus;s__Streptococcus mutans
       ncbi_source_id: NCBITaxon:1309
       majority_fraction: 1.0
-      support_genomes: 512
+      total_genomes: 512
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   evidence:
@@ -81,7 +81,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_C;c__Negativicutes;o__Veillonellales;f__Veillonellaceae;g__Veillonella;s__Veillonella parvula_A
       ncbi_source_id: NCBITaxon:29466
       majority_fraction: 0.95
-      support_genomes: 1282
+      total_genomes: 1282
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT

--- a/kb/communities/SPRUCE_Peatland_Methane_Cycling_Community.yaml
+++ b/kb/communities/SPRUCE_Peatland_Methane_Cycling_Community.yaml
@@ -46,6 +46,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Acidobacteriota
       ncbi_source_id: NCBITaxon:57723
       majority_fraction: 1.0
+      support_genomes: 203
+      total_genomes: 203
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Acidobacteriota MAGs contribute to anaerobic peat carbon turnover and sulfur-linked respiratory

--- a/kb/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.yaml
+++ b/kb/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.yaml
@@ -98,6 +98,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria
       ncbi_source_id: NCBITaxon:1236
       majority_fraction: 1.0
+      support_genomes: 744655
+      total_genomes: 744658
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: SUP05 Gammaproteobacteria are represented at class level and described as the dominant denitrifier

--- a/kb/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.yaml
+++ b/kb/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.yaml
@@ -76,6 +76,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Moraxellaceae;g__Acinetobacter;s__Acinetobacter baylyi
       ncbi_source_id: NCBITaxon:202950
       majority_fraction: 0.96
+      support_genomes: 28
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered ADP1 strain that bioconverts furan aldehyde inhibitors and

--- a/kb/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.yaml
+++ b/kb/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.yaml
@@ -76,7 +76,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Moraxellaceae;g__Acinetobacter;s__Acinetobacter baylyi
       ncbi_source_id: NCBITaxon:202950
       majority_fraction: 0.96
-      support_genomes: 28
+      total_genomes: 28
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered ADP1 strain that bioconverts furan aldehyde inhibitors and

--- a/kb/communities/Salar_Atacama_Lithium_Brine_Community.yaml
+++ b/kb/communities/Salar_Atacama_Lithium_Brine_Community.yaml
@@ -43,6 +43,8 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Halobacteria;o__Halobacteriales;f__Haloarculaceae;g__Halovenus
       ncbi_source_id: NCBITaxon:1377992
       majority_fraction: 1.0
+      support_genomes: 10
+      total_genomes: 10
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Extremely halophilic archaeon of the family Halobacteriaceae. This genus is the most abundant
@@ -80,6 +82,8 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Halobacteria;o__Halobacteriales;f__Haloarculaceae;g__Natronomonas
       ncbi_source_id: NCBITaxon:63743
       majority_fraction: 1.0
+      support_genomes: 16
+      total_genomes: 16
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Alkaliphilic and extremely halophilic archaeon that thrives in hypersaline soda lake environments
@@ -112,6 +116,8 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Halobacteria;o__Halobacteriales;f__Haloarculaceae;g__Haloarcula
       ncbi_source_id: NCBITaxon:2237
       majority_fraction: 1.0
+      support_genomes: 116
+      total_genomes: 116
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Extremely halophilic archaeon with metabolic versatility including aerobic respiration, nitrate
@@ -143,6 +149,8 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Halobacteria;o__Halobacteriales;f__Halobacteriaceae;g__Halobacterium
       ncbi_source_id: NCBITaxon:2239
       majority_fraction: 1.0
+      support_genomes: 61
+      total_genomes: 61
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Model extremely halophilic archaeon with well-characterized physiology including bacteriorhodopsin-mediated
@@ -174,6 +182,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Rhodothermia;o__Rhodothermales;f__Salinibacteraceae;g__Salinibacter
       ncbi_source_id: NCBITaxon:146918
       majority_fraction: 1.0
+      support_genomes: 342
+      total_genomes: 342
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Extremely halophilic bacterium of the family Rhodothermaceae, representing the dominant bacterial
@@ -207,6 +217,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae
       ncbi_source_id: NCBITaxon:90964
       majority_fraction: 0.997
+      support_genomes: 60649
+      total_genomes: 60835
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at f__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Halotolerant bacterial family present in the Atacama brine community. Members of Staphylococcaceae

--- a/kb/communities/Shewanella_Denitrifying_Richness_SynComs.yaml
+++ b/kb/communities/Shewanella_Denitrifying_Richness_SynComs.yaml
@@ -41,6 +41,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella
       ncbi_source_id: NCBITaxon:22
       majority_fraction: 1.0
+      support_genomes: 827
+      total_genomes: 827
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:

--- a/kb/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.yaml
+++ b/kb/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.yaml
@@ -65,7 +65,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella oneidensis
       ncbi_source_id: NCBITaxon:70863
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Exoelectrogenic proteobacterium in the defined anode biofilm community.
@@ -96,7 +96,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter sulfurreducens
       ncbi_source_id: NCBITaxon:35554
       majority_fraction: 1.0
-      support_genomes: 19
+      total_genomes: 19
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Exoelectrogenic Geobacter member that was detected in the planktonic phase of mixed-culture
@@ -128,7 +128,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Exoelectrogenic Geobacter member of the defined biofilm community.

--- a/kb/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.yaml
+++ b/kb/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.yaml
@@ -65,6 +65,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella oneidensis
       ncbi_source_id: NCBITaxon:70863
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Exoelectrogenic proteobacterium in the defined anode biofilm community.
@@ -95,6 +96,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter sulfurreducens
       ncbi_source_id: NCBITaxon:35554
       majority_fraction: 1.0
+      support_genomes: 19
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Exoelectrogenic Geobacter member that was detected in the planktonic phase of mixed-culture
@@ -126,6 +128,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Exoelectrogenic Geobacter member of the defined biofilm community.

--- a/kb/communities/Shewanella_Pseudomonas_Fe0_Electrosyntrophic_Denitrifying_Consortium.yaml
+++ b/kb/communities/Shewanella_Pseudomonas_Fe0_Electrosyntrophic_Denitrifying_Consortium.yaml
@@ -32,6 +32,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella oneidensis
       ncbi_source_id: NCBITaxon:70863
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   functional_role:
@@ -63,6 +64,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas;s__Pseudomonas aeruginosa
       ncbi_source_id: NCBITaxon:287
       majority_fraction: 0.99
+      support_genomes: 17191
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Shewanella_Pseudomonas_Fe0_Electrosyntrophic_Denitrifying_Consortium.yaml
+++ b/kb/communities/Shewanella_Pseudomonas_Fe0_Electrosyntrophic_Denitrifying_Consortium.yaml
@@ -32,7 +32,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella oneidensis
       ncbi_source_id: NCBITaxon:70863
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   functional_role:
@@ -64,7 +64,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas;s__Pseudomonas aeruginosa
       ncbi_source_id: NCBITaxon:287
       majority_fraction: 0.99
-      support_genomes: 17191
+      total_genomes: 17191
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.yaml
+++ b/kb/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.yaml
@@ -57,7 +57,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella oneidensis
       ncbi_source_id: NCBITaxon:211586
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Exoelectrogenic strain that generates electricity from lactic acid in the MFC.

--- a/kb/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.yaml
+++ b/kb/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.yaml
@@ -57,6 +57,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella oneidensis
       ncbi_source_id: NCBITaxon:211586
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Exoelectrogenic strain that generates electricity from lactic acid in the MFC.

--- a/kb/communities/Shewanella_oneidensis_Rhodopseudomonas_palustris_Electrosyntrophic_Coculture.yaml
+++ b/kb/communities/Shewanella_oneidensis_Rhodopseudomonas_palustris_Electrosyntrophic_Coculture.yaml
@@ -31,6 +31,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella oneidensis
       ncbi_source_id: NCBITaxon:70863
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:

--- a/kb/communities/Shewanella_oneidensis_Rhodopseudomonas_palustris_Electrosyntrophic_Coculture.yaml
+++ b/kb/communities/Shewanella_oneidensis_Rhodopseudomonas_palustris_Electrosyntrophic_Coculture.yaml
@@ -31,7 +31,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella oneidensis
       ncbi_source_id: NCBITaxon:70863
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:

--- a/kb/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.yaml
+++ b/kb/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.yaml
@@ -34,6 +34,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota
       ncbi_source_id: NCBITaxon:201174
       majority_fraction: 1.0
+      support_genomes: 91744
+      total_genomes: 91751
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
   functional_role:
@@ -56,6 +58,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Chloroflexota
       ncbi_source_id: NCBITaxon:200795
       majority_fraction: 0.997
+      support_genomes: 299
+      total_genomes: 300
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:

--- a/kb/communities/Soil_Corrinoid_B12_Reservoir_Community.yaml
+++ b/kb/communities/Soil_Corrinoid_B12_Reservoir_Community.yaml
@@ -34,6 +34,8 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Thermoproteota
       ncbi_source_id: NCBITaxon:28889
       majority_fraction: 1.0
+      support_genomes: 684
+      total_genomes: 684
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
@@ -56,6 +58,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota
       ncbi_source_id: NCBITaxon:201174
       majority_fraction: 1.0
+      support_genomes: 91744
+      total_genomes: 91751
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 3 GTDB taxa under the NCBI taxon]
   functional_role:
@@ -78,6 +82,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota
       ncbi_source_id: NCBITaxon:1224
       majority_fraction: 1.0
+      support_genomes: 806030
+      total_genomes: 806033
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:

--- a/kb/communities/Sorghum_SRC1_Subset.yaml
+++ b/kb/communities/Sorghum_SRC1_Subset.yaml
@@ -102,7 +102,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Streptomycetales;f__Streptomycetaceae;g__Streptomyces;s__Streptomyces ambofaciens
       ncbi_source_id: NCBITaxon:1889
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: COMMON
@@ -126,7 +126,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Paenibacillales;f__Paenibacillaceae;g__Paenibacillus;s__Paenibacillus lautus
       ncbi_source_id: NCBITaxon:1401
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: COMMON
@@ -150,7 +150,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas_E;s__Pseudomonas_E pudica
       ncbi_source_id: NCBITaxon:272772
       majority_fraction: 1.0
-      support_genomes: 8
+      total_genomes: 8
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: COMMON

--- a/kb/communities/Sorghum_SRC1_Subset.yaml
+++ b/kb/communities/Sorghum_SRC1_Subset.yaml
@@ -63,6 +63,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
       majority_fraction: 0.57
+      support_genomes: 4981
+      total_genomes: 8737
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
   abundance_level: ABUNDANT
@@ -100,6 +102,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Streptomycetales;f__Streptomycetaceae;g__Streptomyces;s__Streptomyces ambofaciens
       ncbi_source_id: NCBITaxon:1889
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: COMMON
@@ -123,6 +126,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Paenibacillales;f__Paenibacillaceae;g__Paenibacillus;s__Paenibacillus lautus
       ncbi_source_id: NCBITaxon:1401
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: COMMON
@@ -146,6 +150,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas_E;s__Pseudomonas_E pudica
       ncbi_source_id: NCBITaxon:272772
       majority_fraction: 1.0
+      support_genomes: 8
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: COMMON

--- a/kb/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.yaml
+++ b/kb/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.yaml
@@ -52,6 +52,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Bradyrhizobium
       ncbi_source_id: NCBITaxon:374
       majority_fraction: 0.995
+      support_genomes: 592
+      total_genomes: 595
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
   functional_role:

--- a/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
+++ b/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
@@ -49,7 +49,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Bradyrhizobium;s__Bradyrhizobium elkanii
       ncbi_source_id: NCBITaxon:29448
       majority_fraction: 0.89
-      support_genomes: 166
+      total_genomes: 166
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT

--- a/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
+++ b/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
@@ -49,6 +49,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Bradyrhizobium;s__Bradyrhizobium elkanii
       ncbi_source_id: NCBITaxon:29448
       majority_fraction: 0.89
+      support_genomes: 166
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT
@@ -73,6 +74,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Pantoea
       ncbi_source_id: NCBITaxon:53335
       majority_fraction: 0.982
+      support_genomes: 1455
+      total_genomes: 1482
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 6 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
@@ -98,6 +101,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Pantoea
       ncbi_source_id: NCBITaxon:53335
       majority_fraction: 0.982
+      support_genomes: 1455
+      total_genomes: 1482
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 6 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON

--- a/kb/communities/Sphingobium_Rhodococcus_Lignin_Dimer_Valorization_Coculture.yaml
+++ b/kb/communities/Sphingobium_Rhodococcus_Lignin_Dimer_Valorization_Coculture.yaml
@@ -60,6 +60,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Sphingobium
       ncbi_source_id: NCBITaxon:165695
       majority_fraction: 0.987
+      support_genomes: 222
+      total_genomes: 225
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: >

--- a/kb/communities/Subsurface_Carboxydocella_CO_Aquifer_Community.yaml
+++ b/kb/communities/Subsurface_Carboxydocella_CO_Aquifer_Community.yaml
@@ -32,6 +32,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_B;c__GCA-003054495;o__Carboxydocellales;f__Carboxydocellaceae;g__Carboxydocella
       ncbi_source_id: NCBITaxon:178898
       majority_fraction: 1.0
+      support_genomes: 8
+      total_genomes: 8
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Native carboxydotrophic Carboxydocella whose relative abundance

--- a/kb/communities/Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom.yaml
+++ b/kb/communities/Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom.yaml
@@ -79,7 +79,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus altitudinis
       ncbi_source_id: NCBITaxon:293387
       majority_fraction: 1.0
-      support_genomes: 257
+      total_genomes: 257
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Hyphae-associated bacterium recruited to the fungal mycelial surface; produces and

--- a/kb/communities/Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom.yaml
+++ b/kb/communities/Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom.yaml
@@ -79,6 +79,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus altitudinis
       ncbi_source_id: NCBITaxon:293387
       majority_fraction: 1.0
+      support_genomes: 257
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Hyphae-associated bacterium recruited to the fungal mycelial surface; produces and

--- a/kb/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.yaml
+++ b/kb/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.yaml
@@ -35,7 +35,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Thiotrichales;f__Thiotrichaceae;g__Thiothrix;s__Thiothrix nivea
       ncbi_source_id: NCBITaxon:1031
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: DOMINANT

--- a/kb/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.yaml
+++ b/kb/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.yaml
@@ -35,6 +35,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Thiotrichales;f__Thiotrichaceae;g__Thiothrix;s__Thiothrix nivea
       ncbi_source_id: NCBITaxon:1031
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: DOMINANT
@@ -60,6 +61,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Beggiatoales;f__Beggiatoaceae;g__Beggiatoa
       ncbi_source_id: NCBITaxon:1021
       majority_fraction: 1.0
+      support_genomes: 9
+      total_genomes: 9
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   abundance_level: DOMINANT

--- a/kb/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.yaml
+++ b/kb/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.yaml
@@ -73,6 +73,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
       majority_fraction: 0.57
+      support_genomes: 4981
+      total_genomes: 8737
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
     notes: Three of the four ARC members. The paper gives isolate codes but no species assignment
@@ -98,6 +100,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Enterobacter
       ncbi_source_id: NCBITaxon:547
       majority_fraction: 0.999
+      support_genomes: 2761
+      total_genomes: 2763
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: The fourth ARC member. Isolate code given without a species assignment, so grounded at
@@ -122,6 +126,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Bradyrhizobium
       ncbi_source_id: NCBITaxon:374
       majority_fraction: 0.995
+      support_genomes: 592
+      total_genomes: 595
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: The nitrogen-fixing symbiont whose compatibility constrained community assembly, and

--- a/kb/communities/SynCom_BsBv_Cigar_Tobacco_Leaf_Fermentation.yaml
+++ b/kb/communities/SynCom_BsBv_Cigar_Tobacco_Leaf_Fermentation.yaml
@@ -30,6 +30,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus safensis
       ncbi_source_id: NCBITaxon:561879
       majority_fraction: 1.0
+      support_genomes: 257
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: One of two SynCom members, screened for high extracellular cellulase, amylase and protease
@@ -55,6 +56,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus velezensis
       ncbi_source_id: NCBITaxon:492670
       majority_fraction: 1.0
+      support_genomes: 1163
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: One of two SynCom members, screened for high extracellular cellulase, amylase and protease

--- a/kb/communities/SynCom_BsBv_Cigar_Tobacco_Leaf_Fermentation.yaml
+++ b/kb/communities/SynCom_BsBv_Cigar_Tobacco_Leaf_Fermentation.yaml
@@ -30,7 +30,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus safensis
       ncbi_source_id: NCBITaxon:561879
       majority_fraction: 1.0
-      support_genomes: 257
+      total_genomes: 257
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: One of two SynCom members, screened for high extracellular cellulase, amylase and protease
@@ -56,7 +56,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus velezensis
       ncbi_source_id: NCBITaxon:492670
       majority_fraction: 1.0
-      support_genomes: 1163
+      total_genomes: 1163
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: One of two SynCom members, screened for high extracellular cellulase, amylase and protease

--- a/kb/communities/SynCom_MetG2_Rhizobacteria_Sugarcane_Stress_Resilience.yaml
+++ b/kb/communities/SynCom_MetG2_Rhizobacteria_Sugarcane_Stress_Resilience.yaml
@@ -48,6 +48,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota
       ncbi_source_id: NCBITaxon:1224
       majority_fraction: 1.0
+      support_genomes: 806030
+      total_genomes: 806033
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: The abstract names no individual SynCom member species; it reports that flagellar assembly,

--- a/kb/communities/SynCom_Pseudomonas_Rahnella_Artemisia_Phytoremediation.yaml
+++ b/kb/communities/SynCom_Pseudomonas_Rahnella_Artemisia_Phytoremediation.yaml
@@ -31,6 +31,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
       majority_fraction: 0.699
+      support_genomes: 17956
+      total_genomes: 25706
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the abstract names the SynCom member only as "Pseudomonas" (no
@@ -58,6 +60,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Rahnella
       ncbi_source_id: NCBITaxon:34037
       majority_fraction: 1.0
+      support_genomes: 135
+      total_genomes: 135
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Grounded at genus rank; the abstract names the SynCom member only as "Rahnella" (no

--- a/kb/communities/SynCom_Sesame_Flavor_Baijiu_Fuqu_13Genus.yaml
+++ b/kb/communities/SynCom_Sesame_Flavor_Baijiu_Fuqu_13Genus.yaml
@@ -48,6 +48,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
       majority_fraction: 0.57
+      support_genomes: 4981
+      total_genomes: 8737
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
     notes: Genus-level identification (core Fuqu microbiota). NCBITaxon canonical label carries a
@@ -74,6 +76,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactobacillus
       ncbi_source_id: NCBITaxon:1578
       majority_fraction: 0.998
+      support_genomes: 5369
+      total_genomes: 5379
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Genus-level identification (core Fuqu microbiota); lactic acid bacterium.
@@ -99,6 +103,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Leuconostoc
       ncbi_source_id: NCBITaxon:1243
       majority_fraction: 0.99
+      support_genomes: 972
+      total_genomes: 982
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Genus-level identification (core Fuqu microbiota); lactic acid bacterium.
@@ -124,6 +130,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Pediococcus
       ncbi_source_id: NCBITaxon:1253
       majority_fraction: 1.0
+      support_genomes: 847
+      total_genomes: 847
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Genus-level identification (core Fuqu microbiota); lactic acid bacterium.
@@ -200,6 +208,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Weissella
       ncbi_source_id: NCBITaxon:46255
       majority_fraction: 1.0
+      support_genomes: 802
+      total_genomes: 802
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Genus-level identification (core Fuqu microbiota); lactic acid bacterium.

--- a/kb/communities/SynCom_Y_Agrobacterium_Bacillus_Biofilm_Biocontrol_Coculture.yaml
+++ b/kb/communities/SynCom_Y_Agrobacterium_Bacillus_Biofilm_Biocontrol_Coculture.yaml
@@ -30,7 +30,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Agrobacterium;s__Agrobacterium leguminum
       ncbi_source_id: NCBITaxon:1183412
       majority_fraction: 1.0
-      support_genomes: 10
+      total_genomes: 10
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -57,7 +57,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus velezensis
       ncbi_source_id: NCBITaxon:492670
       majority_fraction: 1.0
-      support_genomes: 1163
+      total_genomes: 1163
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:

--- a/kb/communities/SynCom_Y_Agrobacterium_Bacillus_Biofilm_Biocontrol_Coculture.yaml
+++ b/kb/communities/SynCom_Y_Agrobacterium_Bacillus_Biofilm_Biocontrol_Coculture.yaml
@@ -30,6 +30,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Agrobacterium;s__Agrobacterium leguminum
       ncbi_source_id: NCBITaxon:1183412
       majority_fraction: 1.0
+      support_genomes: 10
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
@@ -56,6 +57,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus velezensis
       ncbi_source_id: NCBITaxon:492670
       majority_fraction: 1.0
+      support_genomes: 1163
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:

--- a/kb/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.yaml
+++ b/kb/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.yaml
@@ -54,6 +54,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
       ncbi_source_id: NCBITaxon:1140
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered PCC 7942 derivative expressing cscB for sucrose export.
@@ -90,6 +91,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Azotobacter;s__Azotobacter vinelandii
       ncbi_source_id: NCBITaxon:354
       majority_fraction: 1.0
+      support_genomes: 10
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The primary publication specifies strain AV3; NCBI Taxonomy resolves the organism at species

--- a/kb/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.yaml
+++ b/kb/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.yaml
@@ -54,7 +54,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
       ncbi_source_id: NCBITaxon:1140
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered PCC 7942 derivative expressing cscB for sucrose export.
@@ -91,7 +91,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Azotobacter;s__Azotobacter vinelandii
       ncbi_source_id: NCBITaxon:354
       majority_fraction: 1.0
-      support_genomes: 10
+      total_genomes: 10
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The primary publication specifies strain AV3; NCBI Taxonomy resolves the organism at species

--- a/kb/communities/Synechococcus_Bacillus_SPC.yaml
+++ b/kb/communities/Synechococcus_Bacillus_SPC.yaml
@@ -42,7 +42,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
       ncbi_source_id: NCBITaxon:32046
       majority_fraction: 0.85
-      support_genomes: 13
+      total_genomes: 13
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT
@@ -71,7 +71,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
       ncbi_source_id: NCBITaxon:1423
       majority_fraction: 0.91
-      support_genomes: 1256
+      total_genomes: 1256
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: ABUNDANT

--- a/kb/communities/Synechococcus_Bacillus_SPC.yaml
+++ b/kb/communities/Synechococcus_Bacillus_SPC.yaml
@@ -42,6 +42,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
       ncbi_source_id: NCBITaxon:32046
       majority_fraction: 0.85
+      support_genomes: 13
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT
@@ -70,6 +71,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
       ncbi_source_id: NCBITaxon:1423
       majority_fraction: 0.91
+      support_genomes: 1256
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: ABUNDANT

--- a/kb/communities/Synechococcus_Ecoli_SPC.yaml
+++ b/kb/communities/Synechococcus_Ecoli_SPC.yaml
@@ -49,6 +49,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
       ncbi_source_id: NCBITaxon:32046
       majority_fraction: 0.85
+      support_genomes: 13
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Engineered strain expressing E. coli H+/sucrose symporter CscB to enable sucrose export. Wild-type
@@ -82,6 +83,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:83333
       majority_fraction: 1.0
+      support_genomes: 50
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Heterotrophic partner that utilizes secreted sucrose from the cyanobacterium.

--- a/kb/communities/Synechococcus_Ecoli_SPC.yaml
+++ b/kb/communities/Synechococcus_Ecoli_SPC.yaml
@@ -49,7 +49,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
       ncbi_source_id: NCBITaxon:32046
       majority_fraction: 0.85
-      support_genomes: 13
+      total_genomes: 13
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Engineered strain expressing E. coli H+/sucrose symporter CscB to enable sucrose export. Wild-type
@@ -83,7 +83,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:83333
       majority_fraction: 1.0
-      support_genomes: 50
+      total_genomes: 50
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Heterotrophic partner that utilizes secreted sucrose from the cyanobacterium.

--- a/kb/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.yaml
+++ b/kb/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.yaml
@@ -54,6 +54,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
       ncbi_source_id: NCBITaxon:32046
       majority_fraction: 0.85
+      support_genomes: 13
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered PCC 7942 derivative expressing cscB for sucrose export.
@@ -90,6 +91,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Halomonadaceae;g__Vreelandella;s__Vreelandella boliviensis
       ncbi_source_id: NCBITaxon:1072583
       majority_fraction: 1.0
+      support_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The publication and culture collections use Halomonas boliviensis LC1; NCBI Taxonomy currently

--- a/kb/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.yaml
+++ b/kb/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.yaml
@@ -54,7 +54,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
       ncbi_source_id: NCBITaxon:32046
       majority_fraction: 0.85
-      support_genomes: 13
+      total_genomes: 13
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered PCC 7942 derivative expressing cscB for sucrose export.
@@ -91,7 +91,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Halomonadaceae;g__Vreelandella;s__Vreelandella boliviensis
       ncbi_source_id: NCBITaxon:1072583
       majority_fraction: 1.0
-      support_genomes: 4
+      total_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The publication and culture collections use Halomonas boliviensis LC1; NCBI Taxonomy currently

--- a/kb/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.yaml
+++ b/kb/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.yaml
@@ -59,6 +59,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
       ncbi_source_id: NCBITaxon:32046
       majority_fraction: 0.85
+      support_genomes: 13
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered PCC 7942 derivative expressing the heterologous CscB sucrose permease to export

--- a/kb/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.yaml
+++ b/kb/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.yaml
@@ -59,7 +59,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
       ncbi_source_id: NCBITaxon:32046
       majority_fraction: 0.85
-      support_genomes: 13
+      total_genomes: 13
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered PCC 7942 derivative expressing the heterologous CscB sucrose permease to export

--- a/kb/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.yaml
+++ b/kb/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.yaml
@@ -60,6 +60,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
       ncbi_source_id: NCBITaxon:1350461
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered Syn2973-omcS-ldh cyanobacterial charging unit that produces D-lactate.
@@ -90,6 +91,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella oneidensis
       ncbi_source_id: NCBITaxon:211586
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered napA deletion discharging unit used for D-lactate oxidation and anode electron transfer.

--- a/kb/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.yaml
+++ b/kb/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.yaml
@@ -60,7 +60,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
       ncbi_source_id: NCBITaxon:1350461
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered Syn2973-omcS-ldh cyanobacterial charging unit that produces D-lactate.
@@ -91,7 +91,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Shewanellaceae;g__Shewanella;s__Shewanella oneidensis
       ncbi_source_id: NCBITaxon:211586
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered napA deletion discharging unit used for D-lactate oxidation and anode electron transfer.

--- a/kb/communities/Synechococcus_Yarrowia_SPC.yaml
+++ b/kb/communities/Synechococcus_Yarrowia_SPC.yaml
@@ -44,6 +44,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
       ncbi_source_id: NCBITaxon:32046
       majority_fraction: 0.85
+      support_genomes: 13
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT

--- a/kb/communities/Synechococcus_Yarrowia_SPC.yaml
+++ b/kb/communities/Synechococcus_Yarrowia_SPC.yaml
@@ -44,7 +44,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
       ncbi_source_id: NCBITaxon:32046
       majority_fraction: 0.85
-      support_genomes: 13
+      total_genomes: 13
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT

--- a/kb/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.yaml
+++ b/kb/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.yaml
@@ -44,6 +44,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
       ncbi_source_id: NCBITaxon:32046
       majority_fraction: 0.85
+      support_genomes: 13
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered cyanobacterial phototroph expressing cscB to secrete sucrose.

--- a/kb/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.yaml
+++ b/kb/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.yaml
@@ -44,7 +44,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Synechococcales;f__Synechococcaceae;g__Synechococcus;s__Synechococcus elongatus
       ncbi_source_id: NCBITaxon:32046
       majority_fraction: 0.85
-      support_genomes: 13
+      total_genomes: 13
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered cyanobacterial phototroph expressing cscB to secrete sucrose.

--- a/kb/communities/Synthetic_Periphyton_Freshwater_Biofilm.yaml
+++ b/kb/communities/Synthetic_Periphyton_Freshwater_Biofilm.yaml
@@ -61,6 +61,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota
       ncbi_source_id: NCBITaxon:1117
       majority_fraction: 1.0
+      support_genomes: 2189
+      total_genomes: 2190
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 2 GTDB taxa under the NCBI taxon]
   functional_role:

--- a/kb/communities/Syntrophobacter_Methanobacterium_Syntrophy.yaml
+++ b/kb/communities/Syntrophobacter_Methanobacterium_Syntrophy.yaml
@@ -36,6 +36,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Syntrophobacteria;o__Syntrophobacterales;f__Syntrophobacteraceae;g__Syntrophobacter;s__Syntrophobacter fumaroxidans
       ncbi_source_id: NCBITaxon:119484
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Anaerobic, syntrophic, propionate-oxidizing bacterium that degrades propionate to acetate
@@ -68,6 +69,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Methanobacteriota;c__Methanobacteria;o__Methanobacteriales;f__Methanobacteriaceae;g__Methanobacterium;s__Methanobacterium formicicum
       ncbi_source_id: NCBITaxon:2162
       majority_fraction: 0.94
+      support_genomes: 17
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Hydrogen and formate-utilizing methanogen that consumes H2/formate and CO2 to produce methane

--- a/kb/communities/Syntrophobacter_Methanobacterium_Syntrophy.yaml
+++ b/kb/communities/Syntrophobacter_Methanobacterium_Syntrophy.yaml
@@ -36,7 +36,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Syntrophobacteria;o__Syntrophobacterales;f__Syntrophobacteraceae;g__Syntrophobacter;s__Syntrophobacter fumaroxidans
       ncbi_source_id: NCBITaxon:119484
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Anaerobic, syntrophic, propionate-oxidizing bacterium that degrades propionate to acetate
@@ -69,7 +69,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Methanobacteriota;c__Methanobacteria;o__Methanobacteriales;f__Methanobacteriaceae;g__Methanobacterium;s__Methanobacterium formicicum
       ncbi_source_id: NCBITaxon:2162
       majority_fraction: 0.94
-      support_genomes: 17
+      total_genomes: 17
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Hydrogen and formate-utilizing methanogen that consumes H2/formate and CO2 to produce methane

--- a/kb/communities/Syntrophobacter_Methanospirillum_Syntrophy.yaml
+++ b/kb/communities/Syntrophobacter_Methanospirillum_Syntrophy.yaml
@@ -36,7 +36,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Syntrophobacteria;o__Syntrophobacterales;f__Syntrophobacteraceae;g__Syntrophobacter;s__Syntrophobacter fumaroxidans
       ncbi_source_id: NCBITaxon:119484
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Anaerobic, syntrophic, propionate-oxidizing bacterium that degrades propionate to acetate
@@ -69,7 +69,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanospirillum;s__Methanospirillum hungatei
       ncbi_source_id: NCBITaxon:2203
       majority_fraction: 1.0
-      support_genomes: 5
+      total_genomes: 5
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Hydrogen and formate-utilizing methanogen that consumes H2/formate and CO2 to produce methane

--- a/kb/communities/Syntrophobacter_Methanospirillum_Syntrophy.yaml
+++ b/kb/communities/Syntrophobacter_Methanospirillum_Syntrophy.yaml
@@ -36,6 +36,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Syntrophobacteria;o__Syntrophobacterales;f__Syntrophobacteraceae;g__Syntrophobacter;s__Syntrophobacter fumaroxidans
       ncbi_source_id: NCBITaxon:119484
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Anaerobic, syntrophic, propionate-oxidizing bacterium that degrades propionate to acetate
@@ -68,6 +69,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanospirillum;s__Methanospirillum hungatei
       ncbi_source_id: NCBITaxon:2203
       majority_fraction: 1.0
+      support_genomes: 5
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Hydrogen and formate-utilizing methanogen that consumes H2/formate and CO2 to produce methane

--- a/kb/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.yaml
+++ b/kb/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.yaml
@@ -81,7 +81,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Methanobacteriota_A;c__Methanococci;o__Methanococcales;f__Methanococcaceae;g__Methanococcus;s__Methanococcus maripaludis
       ncbi_source_id: NCBITaxon:39152
       majority_fraction: 0.93
-      support_genomes: 56
+      total_genomes: 56
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Hydrogenotrophic methanogen paired with S. wolfei in the mesophilic coculture.

--- a/kb/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.yaml
+++ b/kb/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.yaml
@@ -81,6 +81,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Methanobacteriota_A;c__Methanococci;o__Methanococcales;f__Methanococcaceae;g__Methanococcus;s__Methanococcus maripaludis
       ncbi_source_id: NCBITaxon:39152
       majority_fraction: 0.93
+      support_genomes: 56
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Hydrogenotrophic methanogen paired with S. wolfei in the mesophilic coculture.

--- a/kb/communities/Syntrophomonas_Methanospirillum_Syntrophy.yaml
+++ b/kb/communities/Syntrophomonas_Methanospirillum_Syntrophy.yaml
@@ -56,7 +56,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanospirillum;s__Methanospirillum hungatei
       ncbi_source_id: NCBITaxon:2203
       majority_fraction: 1.0
-      support_genomes: 5
+      total_genomes: 5
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Hydrogen-utilizing methanogen that consumes H2 and CO2 to produce methane. Essential syntrophic

--- a/kb/communities/Syntrophomonas_Methanospirillum_Syntrophy.yaml
+++ b/kb/communities/Syntrophomonas_Methanospirillum_Syntrophy.yaml
@@ -56,6 +56,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanospirillum;s__Methanospirillum hungatei
       ncbi_source_id: NCBITaxon:2203
       majority_fraction: 1.0
+      support_genomes: 5
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Hydrogen-utilizing methanogen that consumes H2 and CO2 to produce methane. Essential syntrophic

--- a/kb/communities/Syntrophus_Benzoate_Degrader.yaml
+++ b/kb/communities/Syntrophus_Benzoate_Degrader.yaml
@@ -36,6 +36,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Syntrophia;o__Syntrophales;f__Syntrophaceae;g__Syntrophus;s__Syntrophus aciditrophicus
       ncbi_source_id: NCBITaxon:56780
       majority_fraction: 1.0
+      support_genomes: 5
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Anaerobic, syntrophic bacterium that degrades benzoate and other aromatic compounds to acetate,
@@ -67,6 +68,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanospirillum;s__Methanospirillum hungatei
       ncbi_source_id: NCBITaxon:2203
       majority_fraction: 1.0
+      support_genomes: 5
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Hydrogen-utilizing methanogen that consumes H2 and CO2 to produce methane. Essential syntrophic

--- a/kb/communities/Syntrophus_Benzoate_Degrader.yaml
+++ b/kb/communities/Syntrophus_Benzoate_Degrader.yaml
@@ -36,7 +36,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Syntrophia;o__Syntrophales;f__Syntrophaceae;g__Syntrophus;s__Syntrophus aciditrophicus
       ncbi_source_id: NCBITaxon:56780
       majority_fraction: 1.0
-      support_genomes: 5
+      total_genomes: 5
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Anaerobic, syntrophic bacterium that degrades benzoate and other aromatic compounds to acetate,
@@ -68,7 +68,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanospirillum;s__Methanospirillum hungatei
       ncbi_source_id: NCBITaxon:2203
       majority_fraction: 1.0
-      support_genomes: 5
+      total_genomes: 5
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Hydrogen-utilizing methanogen that consumes H2 and CO2 to produce methane. Essential syntrophic

--- a/kb/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.yaml
+++ b/kb/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.yaml
@@ -53,6 +53,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Syntrophia;o__Syntrophales;f__Syntrophaceae;g__Syntrophus;s__Syntrophus gentianae
       ncbi_source_id: NCBITaxon:43775
       majority_fraction: 1.0
+      support_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Anaerobic syntrophic benzoate-fermenting bacterium in the methanogenic coculture.
@@ -91,6 +92,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanospirillum;s__Methanospirillum hungatei
       ncbi_source_id: NCBITaxon:2203
       majority_fraction: 1.0
+      support_genomes: 5
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Methanogenic archaeal partner in the S. gentianae benzoate-degrading coculture.

--- a/kb/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.yaml
+++ b/kb/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.yaml
@@ -53,7 +53,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Syntrophia;o__Syntrophales;f__Syntrophaceae;g__Syntrophus;s__Syntrophus gentianae
       ncbi_source_id: NCBITaxon:43775
       majority_fraction: 1.0
-      support_genomes: 3
+      total_genomes: 3
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Anaerobic syntrophic benzoate-fermenting bacterium in the methanogenic coculture.
@@ -92,7 +92,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanospirillum;s__Methanospirillum hungatei
       ncbi_source_id: NCBITaxon:2203
       majority_fraction: 1.0
-      support_genomes: 5
+      total_genomes: 5
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Methanogenic archaeal partner in the S. gentianae benzoate-degrading coculture.

--- a/kb/communities/THOR_Rhizosphere_Model_Community.yaml
+++ b/kb/communities/THOR_Rhizosphere_Model_Community.yaml
@@ -86,7 +86,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Flavobacteriales;f__Flavobacteriaceae;g__Flavobacterium;s__Flavobacterium johnsoniae
       ncbi_source_id: NCBITaxon:986
       majority_fraction: 1.0
-      support_genomes: 10
+      total_genomes: 10
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Bacteroidetes/Flavobacteriia member whose abundance and transcriptional state are sensitive

--- a/kb/communities/THOR_Rhizosphere_Model_Community.yaml
+++ b/kb/communities/THOR_Rhizosphere_Model_Community.yaml
@@ -86,6 +86,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Flavobacteriales;f__Flavobacteriaceae;g__Flavobacterium;s__Flavobacterium johnsoniae
       ncbi_source_id: NCBITaxon:986
       majority_fraction: 1.0
+      support_genomes: 10
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Bacteroidetes/Flavobacteriia member whose abundance and transcriptional state are sensitive

--- a/kb/communities/TYQ1_Nematode_Biocontrol_SynCom.yaml
+++ b/kb/communities/TYQ1_Nematode_Biocontrol_SynCom.yaml
@@ -52,6 +52,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Agrobacterium;s__Agrobacterium pusense
       ncbi_source_id: NCBITaxon:648995
       majority_fraction: 1.0
+      support_genomes: 93
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Keystone species and central metabolic hub. Directly inhibits root-knot nematodes and coordinates
@@ -84,6 +85,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Sphingomonas;s__Sphingomonas panni
       ncbi_source_id: NCBITaxon:237612
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Biomarker species recruited by TYQ1 enrichment (OTU2477).
@@ -110,6 +112,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Sphingomonas
       ncbi_source_id: NCBITaxon:13687
       majority_fraction: 0.736
+      support_genomes: 449
+      total_genomes: 610
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 19 GTDB taxa under the NCBI taxon]
     notes: 'Biomarker species recruited by TYQ1 enrichment (OTU1716). Genus-level NCBITaxon used as species-level
@@ -159,6 +163,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Acidovorax
       ncbi_source_id: NCBITaxon:12916
       majority_fraction: 0.997
+      support_genomes: 323
+      total_genomes: 324
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Biomarker species with significant nematicidal activity (OTU2649).
@@ -184,6 +190,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Novosphingobium;s__Novosphingobium subterraneum
       ncbi_source_id: NCBITaxon:48936
       majority_fraction: 1.0
+      support_genomes: 4
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Biomarker species recruited by TYQ1 enrichment (OTU613).

--- a/kb/communities/TYQ1_Nematode_Biocontrol_SynCom.yaml
+++ b/kb/communities/TYQ1_Nematode_Biocontrol_SynCom.yaml
@@ -52,7 +52,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Agrobacterium;s__Agrobacterium pusense
       ncbi_source_id: NCBITaxon:648995
       majority_fraction: 1.0
-      support_genomes: 93
+      total_genomes: 93
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Keystone species and central metabolic hub. Directly inhibits root-knot nematodes and coordinates
@@ -85,7 +85,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Sphingomonas;s__Sphingomonas panni
       ncbi_source_id: NCBITaxon:237612
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Biomarker species recruited by TYQ1 enrichment (OTU2477).
@@ -190,7 +190,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Novosphingobium;s__Novosphingobium subterraneum
       ncbi_source_id: NCBITaxon:48936
       majority_fraction: 1.0
-      support_genomes: 4
+      total_genomes: 4
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Biomarker species recruited by TYQ1 enrichment (OTU613).

--- a/kb/communities/Teosinte_Maize_Biofertilizer_SynCom7.yaml
+++ b/kb/communities/Teosinte_Maize_Biofertilizer_SynCom7.yaml
@@ -60,6 +60,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Klebsiella;s__Klebsiella variicola
       ncbi_source_id: NCBITaxon:244366
       majority_fraction: 1.0
+      support_genomes: 1719
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -86,6 +87,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Pantoea;s__Pantoea agglomerans
       ncbi_source_id: NCBITaxon:549
       majority_fraction: 0.9
+      support_genomes: 280
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Teosinte_Maize_Biofertilizer_SynCom7.yaml
+++ b/kb/communities/Teosinte_Maize_Biofertilizer_SynCom7.yaml
@@ -60,7 +60,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Klebsiella;s__Klebsiella variicola
       ncbi_source_id: NCBITaxon:244366
       majority_fraction: 1.0
-      support_genomes: 1719
+      total_genomes: 1719
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -87,7 +87,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Pantoea;s__Pantoea agglomerans
       ncbi_source_id: NCBITaxon:549
       majority_fraction: 0.9
-      support_genomes: 280
+      total_genomes: 280
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.yaml
+++ b/kb/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.yaml
@@ -81,6 +81,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Oleiphilaceae;g__Marinobacter;s__Marinobacter adhaerens
       ncbi_source_id: NCBITaxon:225937
       majority_fraction: 1.0
+      support_genomes: 5
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >

--- a/kb/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.yaml
+++ b/kb/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.yaml
@@ -81,7 +81,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Oleiphilaceae;g__Marinobacter;s__Marinobacter adhaerens
       ncbi_source_id: NCBITaxon:225937
       majority_fraction: 1.0
-      support_genomes: 5
+      total_genomes: 5
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >

--- a/kb/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.yaml
+++ b/kb/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.yaml
@@ -77,7 +77,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhodobacterales;f__Rhodobacteraceae;g__Ruegeria_B;s__Ruegeria_B pomeroyi
       ncbi_source_id: NCBITaxon:246200
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Heterotrophic roseobacter strain DSS-3, inoculated into the diatom culture in pairwise coculture.

--- a/kb/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.yaml
+++ b/kb/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.yaml
@@ -77,6 +77,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhodobacterales;f__Rhodobacteraceae;g__Ruegeria_B;s__Ruegeria_B pomeroyi
       ncbi_source_id: NCBITaxon:246200
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Heterotrophic roseobacter strain DSS-3, inoculated into the diatom culture in pairwise coculture.

--- a/kb/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.yaml
+++ b/kb/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.yaml
@@ -59,6 +59,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_B;c__DSM-12270;o__Thermacetogeniales;f__Thermacetogeniaceae;g__Thermacetogenium;s__Thermacetogenium phaeum
       ncbi_source_id: NCBITaxon:1089553
       majority_fraction: 1.0
+      support_genomes: 5
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Type strain PB/DSM 12270; acetate-oxidizing syntrophic bacterium in the defined coculture.
@@ -98,6 +99,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Methanobacteriota;c__Methanobacteria;o__Methanobacteriales;f__Methanothermobacteraceae;g__Methanothermobacter;s__Methanothermobacter thermautotrophicus
       ncbi_source_id: NCBITaxon:145262
       majority_fraction: 1.0
+      support_genomes: 24
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Source literature also uses the spelling Methanothermobacter thermoautotrophicus;

--- a/kb/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.yaml
+++ b/kb/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.yaml
@@ -59,7 +59,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_B;c__DSM-12270;o__Thermacetogeniales;f__Thermacetogeniaceae;g__Thermacetogenium;s__Thermacetogenium phaeum
       ncbi_source_id: NCBITaxon:1089553
       majority_fraction: 1.0
-      support_genomes: 5
+      total_genomes: 5
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Type strain PB/DSM 12270; acetate-oxidizing syntrophic bacterium in the defined coculture.
@@ -99,7 +99,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Methanobacteriota;c__Methanobacteria;o__Methanobacteriales;f__Methanothermobacteraceae;g__Methanothermobacter;s__Methanothermobacter thermautotrophicus
       ncbi_source_id: NCBITaxon:145262
       majority_fraction: 1.0
-      support_genomes: 24
+      total_genomes: 24
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Source literature also uses the spelling Methanothermobacter thermoautotrophicus;

--- a/kb/communities/Thermophilic_Lignocellulose_Composting_SynCom_Biosanitization.yaml
+++ b/kb/communities/Thermophilic_Lignocellulose_Composting_SynCom_Biosanitization.yaml
@@ -47,6 +47,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Achromobacter
       ncbi_source_id: NCBITaxon:222
       majority_fraction: 0.991
+      support_genomes: 325
+      total_genomes: 328
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Species not specified in the source; grounded at the genus rank confirmed by OAK.
@@ -71,6 +73,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
       majority_fraction: 0.699
+      support_genomes: 17956
+      total_genomes: 25706
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: Species not specified in the source; grounded at the genus rank confirmed by OAK.

--- a/kb/communities/Thermophilic_Pyrite_QS_Consortium.yaml
+++ b/kb/communities/Thermophilic_Pyrite_QS_Consortium.yaml
@@ -65,7 +65,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
-      support_genomes: 4
+      total_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Chemolithoautotrophic iron-oxidizing bacterium (Nitrospirae phylum) representing a dominant
@@ -117,7 +117,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus_A;s__Acidithiobacillus_A caldus
       ncbi_source_id: NCBITaxon:33059
       majority_fraction: 1.0
-      support_genomes: 42
+      total_genomes: 42
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Gram-negative γ-proteobacterium specialized for oxidizing reduced inorganic sulfur compounds
@@ -180,7 +180,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_E;c__Sulfobacillia;o__Sulfobacillales;f__Sulfobacillaceae;g__Sulfobacillus;s__Sulfobacillus thermosulfidooxidans
       ncbi_source_id: NCBITaxon:28034
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Gram-positive, spore-forming, moderately thermophilic bacterium (Firmicutes) that oxidizes

--- a/kb/communities/Thermophilic_Pyrite_QS_Consortium.yaml
+++ b/kb/communities/Thermophilic_Pyrite_QS_Consortium.yaml
@@ -65,6 +65,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
+      support_genomes: 4
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Chemolithoautotrophic iron-oxidizing bacterium (Nitrospirae phylum) representing a dominant
@@ -116,6 +117,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus_A;s__Acidithiobacillus_A caldus
       ncbi_source_id: NCBITaxon:33059
       majority_fraction: 1.0
+      support_genomes: 42
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Gram-negative γ-proteobacterium specialized for oxidizing reduced inorganic sulfur compounds
@@ -178,6 +180,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_E;c__Sulfobacillia;o__Sulfobacillales;f__Sulfobacillaceae;g__Sulfobacillus;s__Sulfobacillus thermosulfidooxidans
       ncbi_source_id: NCBITaxon:28034
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Gram-positive, spore-forming, moderately thermophilic bacterium (Firmicutes) that oxidizes

--- a/kb/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.yaml
+++ b/kb/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.yaml
@@ -59,7 +59,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Thermotogota;c__Thermotogae;o__Thermotogales;f__Thermotogaceae;g__Thermotoga;s__Thermotoga maritima
       ncbi_source_id: NCBITaxon:243274
       majority_fraction: 1.0
-      support_genomes: 8
+      total_genomes: 8
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Hyperthermophilic anaerobic heterotroph and hydrogen-producing fermentative member.
@@ -98,7 +98,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Methanobacteriota_A;c__Methanococci;o__Methanococcales;f__Methanocaldococcaceae;g__Methanocaldococcus;s__Methanocaldococcus jannaschii
       ncbi_source_id: NCBITaxon:243232
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >

--- a/kb/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.yaml
+++ b/kb/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.yaml
@@ -59,6 +59,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Thermotogota;c__Thermotogae;o__Thermotogales;f__Thermotogaceae;g__Thermotoga;s__Thermotoga maritima
       ncbi_source_id: NCBITaxon:243274
       majority_fraction: 1.0
+      support_genomes: 8
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Hyperthermophilic anaerobic heterotroph and hydrogen-producing fermentative member.
@@ -97,6 +98,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Methanobacteriota_A;c__Methanococci;o__Methanococcales;f__Methanocaldococcaceae;g__Methanocaldococcus;s__Methanocaldococcus jannaschii
       ncbi_source_id: NCBITaxon:243232
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >

--- a/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
+++ b/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
@@ -65,6 +65,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Thiobacillaceae;g__Thiobacillus
       ncbi_source_id: NCBITaxon:919
       majority_fraction: 1.0
+      support_genomes: 6
+      total_genomes: 6
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: A single Thiobacillus strain proliferated in all reactors at high
@@ -91,6 +93,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Afipia
       ncbi_source_id: NCBITaxon:1033
       majority_fraction: 1.0
+      support_genomes: 103
+      total_genomes: 103
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: A single Afipia variant dominated the molasses-free reactor at
@@ -117,6 +121,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales
       ncbi_source_id: NCBITaxon:356
       majority_fraction: 0.994
+      support_genomes: 8427
+      total_genomes: 8480
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 5 GTDB taxa under the NCBI taxon]
     notes: Many Rhizobiales strains were present but did not dominate; Afipia

--- a/kb/communities/Tinto_River_Iron_Cycling_Community.yaml
+++ b/kb/communities/Tinto_River_Iron_Cycling_Community.yaml
@@ -45,6 +45,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum;s__Leptospirillum ferrooxidans
       ncbi_source_id: NCBITaxon:180
       majority_fraction: 1.0
+      support_genomes: 16
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Dominant iron-oxidizing bacterium (approximately 40% of prokaryotic community) in Rio Tinto
@@ -80,6 +81,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
+      support_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Second dominant iron-oxidizing bacterium (~25% of prokaryotic community) with metabolic versatility
@@ -110,6 +112,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Acetobacterales;f__Acetobacteraceae;g__Acidiphilium
       ncbi_source_id: NCBITaxon:522
       majority_fraction: 1.0
+      support_genomes: 27
+      total_genomes: 27
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Heterotrophic acidophile (~15% of prokaryotic community) forming the critical link between

--- a/kb/communities/Tinto_River_Iron_Cycling_Community.yaml
+++ b/kb/communities/Tinto_River_Iron_Cycling_Community.yaml
@@ -45,7 +45,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum;s__Leptospirillum ferrooxidans
       ncbi_source_id: NCBITaxon:180
       majority_fraction: 1.0
-      support_genomes: 16
+      total_genomes: 16
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Dominant iron-oxidizing bacterium (approximately 40% of prokaryotic community) in Rio Tinto
@@ -81,7 +81,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
-      support_genomes: 7
+      total_genomes: 7
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Second dominant iron-oxidizing bacterium (~25% of prokaryotic community) with metabolic versatility

--- a/kb/communities/Tobacco_Chemotactic_Biocontrol_SynCom.yaml
+++ b/kb/communities/Tobacco_Chemotactic_Biocontrol_SynCom.yaml
@@ -51,6 +51,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus
       ncbi_source_id: NCBITaxon:1386
       majority_fraction: 0.57
+      support_genomes: 4981
+      total_genomes: 8737
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 44 GTDB taxa under the NCBI taxon]
   functional_role:

--- a/kb/communities/Tomato_Oxylipin_SynCom3.yaml
+++ b/kb/communities/Tomato_Oxylipin_SynCom3.yaml
@@ -42,6 +42,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Caulobacterales;f__Caulobacteraceae;g__Asticcacaulis
       ncbi_source_id: NCBITaxon:76890
       majority_fraction: 1.0
+      support_genomes: 28
+      total_genomes: 28
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
@@ -59,6 +61,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Chitinophagales;f__Chitinophagaceae;g__Arachidicoccus
       ncbi_source_id: NCBITaxon:1769012
       majority_fraction: 1.0
+      support_genomes: 9
+      total_genomes: 9
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
@@ -76,6 +80,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Caulobacterales;f__Caulobacteraceae;g__Phenylobacterium
       ncbi_source_id: NCBITaxon:20
       majority_fraction: 1.0
+      support_genomes: 22
+      total_genomes: 22
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:

--- a/kb/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.yaml
+++ b/kb/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.yaml
@@ -45,6 +45,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_B;c__Desulfitobacteriia;o__Desulfitobacteriales;f__Syntrophobotulaceae;g__Dehalobacter
       ncbi_source_id: NCBITaxon:56112
       majority_fraction: 1.0
+      support_genomes: 5
+      total_genomes: 5
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:

--- a/kb/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.yaml
+++ b/kb/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.yaml
@@ -57,7 +57,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Aerococcaceae;g__Trichococcus;s__Trichococcus flocculiformis
       ncbi_source_id: NCBITaxon:82803
       majority_fraction: 1.0
-      support_genomes: 256
+      total_genomes: 256
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
@@ -116,7 +116,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanospirillum;s__Methanospirillum hungatei
       ncbi_source_id: NCBITaxon:2203
       majority_fraction: 1.0
-      support_genomes: 5
+      total_genomes: 5
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Hydrogen/formate-scavenging methanogenic archaeal partner in the three-member coculture.

--- a/kb/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.yaml
+++ b/kb/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.yaml
@@ -57,6 +57,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Aerococcaceae;g__Trichococcus;s__Trichococcus flocculiformis
       ncbi_source_id: NCBITaxon:82803
       majority_fraction: 1.0
+      support_genomes: 256
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
@@ -115,6 +116,7 @@ taxonomy:
       gtdb_lineage: d__Archaea;p__Halobacteriota;c__Methanomicrobia;o__Methanomicrobiales;f__Methanospirillaceae;g__Methanospirillum;s__Methanospirillum hungatei
       ncbi_source_id: NCBITaxon:2203
       majority_fraction: 1.0
+      support_genomes: 5
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Hydrogen/formate-scavenging methanogenic archaeal partner in the three-member coculture.

--- a/kb/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.yaml
+++ b/kb/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.yaml
@@ -74,6 +74,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
+      support_genomes: 166397
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Bacterial fermentation specialist; source abstract supports species-level identity.

--- a/kb/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.yaml
+++ b/kb/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.yaml
@@ -74,7 +74,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
-      support_genomes: 166397
+      total_genomes: 166397
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Bacterial fermentation specialist; source abstract supports species-level identity.

--- a/kb/communities/Trichoderma_Lactate_Platform.yaml
+++ b/kb/communities/Trichoderma_Lactate_Platform.yaml
@@ -60,6 +60,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactiplantibacillus;s__Lactiplantibacillus pentosus
       ncbi_source_id: NCBITaxon:1589
       majority_fraction: 0.99
+      support_genomes: 190
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: ABUNDANT
@@ -82,6 +83,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_B;s__Clostridium_B tyrobutyricum
       ncbi_source_id: NCBITaxon:1519
       majority_fraction: 0.97
+      support_genomes: 73
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: ABUNDANT

--- a/kb/communities/Trichoderma_Lactate_Platform.yaml
+++ b/kb/communities/Trichoderma_Lactate_Platform.yaml
@@ -60,7 +60,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactiplantibacillus;s__Lactiplantibacillus pentosus
       ncbi_source_id: NCBITaxon:1589
       majority_fraction: 0.99
-      support_genomes: 190
+      total_genomes: 190
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: ABUNDANT
@@ -83,7 +83,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_B;s__Clostridium_B tyrobutyricum
       ncbi_source_id: NCBITaxon:1519
       majority_fraction: 0.97
-      support_genomes: 73
+      total_genomes: 73
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: ABUNDANT

--- a/kb/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.yaml
+++ b/kb/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.yaml
@@ -81,6 +81,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Streptomycetales;f__Streptomycetaceae;g__Streptomyces;s__Streptomyces anthocyanicus
       ncbi_source_id: NCBITaxon:100226
       majority_fraction: 1.0
+      support_genomes: 5
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Noncellulolytic bacterial member dependent on cellulase-derived hydrolysate sugars.

--- a/kb/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.yaml
+++ b/kb/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.yaml
@@ -81,7 +81,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Streptomycetales;f__Streptomycetaceae;g__Streptomyces;s__Streptomyces anthocyanicus
       ncbi_source_id: NCBITaxon:100226
       majority_fraction: 1.0
-      support_genomes: 5
+      total_genomes: 5
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Noncellulolytic bacterial member dependent on cellulase-derived hydrolysate sugars.

--- a/kb/communities/Trichodesmium_Alteromonas_Marine_Consortium.yaml
+++ b/kb/communities/Trichodesmium_Alteromonas_Marine_Consortium.yaml
@@ -29,7 +29,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Cyanobacteriales;f__Microcoleaceae;g__Trichodesmium;s__Trichodesmium erythraeum
       ncbi_source_id: NCBITaxon:203124
       majority_fraction: 1.0
-      support_genomes: 1
+      total_genomes: 1
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Nitrogen-fixing cyanobacterial colony former and photoautotrophic host of the consortium.
@@ -52,7 +52,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Alteromonadaceae;g__Alteromonas;s__Alteromonas macleodii
       ncbi_source_id: NCBITaxon:28108
       majority_fraction: 0.9
-      support_genomes: 135
+      total_genomes: 135
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Conserved gammaproteobacterial heterotroph associated with Trichodesmium colonies and cultures.

--- a/kb/communities/Trichodesmium_Alteromonas_Marine_Consortium.yaml
+++ b/kb/communities/Trichodesmium_Alteromonas_Marine_Consortium.yaml
@@ -29,6 +29,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Cyanobacteriota;c__Cyanobacteriia;o__Cyanobacteriales;f__Microcoleaceae;g__Trichodesmium;s__Trichodesmium erythraeum
       ncbi_source_id: NCBITaxon:203124
       majority_fraction: 1.0
+      support_genomes: 1
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Nitrogen-fixing cyanobacterial colony former and photoautotrophic host of the consortium.
@@ -51,6 +52,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Alteromonadaceae;g__Alteromonas;s__Alteromonas macleodii
       ncbi_source_id: NCBITaxon:28108
       majority_fraction: 0.9
+      support_genomes: 135
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Conserved gammaproteobacterial heterotroph associated with Trichodesmium colonies and cultures.

--- a/kb/communities/Urine_Nitrification_SynCom.yaml
+++ b/kb/communities/Urine_Nitrification_SynCom.yaml
@@ -42,6 +42,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Nitrosomonadaceae;g__Nitrosomonas;s__Nitrosomonas europaea
       ncbi_source_id: NCBITaxon:915
       majority_fraction: 1.0
+      support_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   functional_role:
@@ -59,6 +60,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Nitrobacter;s__Nitrobacter winogradskyi_A
       ncbi_source_id: NCBITaxon:913
       majority_fraction: 0.88
+      support_genomes: 8
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Urine_Nitrification_SynCom.yaml
+++ b/kb/communities/Urine_Nitrification_SynCom.yaml
@@ -42,7 +42,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Nitrosomonadaceae;g__Nitrosomonas;s__Nitrosomonas europaea
       ncbi_source_id: NCBITaxon:915
       majority_fraction: 1.0
-      support_genomes: 2
+      total_genomes: 2
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   functional_role:
@@ -60,7 +60,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Nitrobacter;s__Nitrobacter winogradskyi_A
       ncbi_source_id: NCBITaxon:913
       majority_fraction: 0.88
-      support_genomes: 8
+      total_genomes: 8
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.yaml
+++ b/kb/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.yaml
@@ -91,6 +91,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Variovorax
       ncbi_source_id: NCBITaxon:34072
       majority_fraction: 1.0
+      support_genomes: 40
+      total_genomes: 40
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: The study identifies a Variovorax species as a thiamine-producing hub

--- a/kb/communities/Wheat_Consortium_C1.yaml
+++ b/kb/communities/Wheat_Consortium_C1.yaml
@@ -44,7 +44,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Cupriavidus;s__Cupriavidus campinensis
       ncbi_source_id: NCBITaxon:151783
       majority_fraction: 1.0
-      support_genomes: 13
+      total_genomes: 13
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT

--- a/kb/communities/Wheat_Consortium_C1.yaml
+++ b/kb/communities/Wheat_Consortium_C1.yaml
@@ -44,6 +44,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Cupriavidus;s__Cupriavidus campinensis
       ncbi_source_id: NCBITaxon:151783
       majority_fraction: 1.0
+      support_genomes: 13
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT

--- a/kb/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.yaml
+++ b/kb/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.yaml
@@ -50,6 +50,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
       ncbi_source_id: NCBITaxon:1423
       majority_fraction: 0.91
+      support_genomes: 1256
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -67,6 +68,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Moraxellaceae;g__Acinetobacter;s__Acinetobacter johnsonii
       ncbi_source_id: NCBITaxon:40214
       majority_fraction: 0.97
+      support_genomes: 153
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.yaml
+++ b/kb/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.yaml
@@ -50,7 +50,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Bacillales;f__Bacillaceae;g__Bacillus;s__Bacillus subtilis
       ncbi_source_id: NCBITaxon:1423
       majority_fraction: 0.91
-      support_genomes: 1256
+      total_genomes: 1256
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
@@ -68,7 +68,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Moraxellaceae;g__Acinetobacter;s__Acinetobacter johnsonii
       ncbi_source_id: NCBITaxon:40214
       majority_fraction: 0.97
-      support_genomes: 153
+      total_genomes: 153
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:

--- a/kb/communities/Yogurt_TwoSpecies_Starter_Culture.yaml
+++ b/kb/communities/Yogurt_TwoSpecies_Starter_Culture.yaml
@@ -59,6 +59,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Streptococcus;s__Streptococcus thermophilus
       ncbi_source_id: NCBITaxon:1308
       majority_fraction: 0.99
+      support_genomes: 2093
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Thermophilic dairy starter species represented at species level because the curated community
@@ -89,6 +90,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactobacillus;s__Lactobacillus delbrueckii
       ncbi_source_id: NCBITaxon:1585
       majority_fraction: 1.0
+      support_genomes: 220
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Literature often uses Lactobacillus bulgaricus; NCBI taxon captures the accepted subspecies.

--- a/kb/communities/Yogurt_TwoSpecies_Starter_Culture.yaml
+++ b/kb/communities/Yogurt_TwoSpecies_Starter_Culture.yaml
@@ -59,7 +59,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Streptococcaceae;g__Streptococcus;s__Streptococcus thermophilus
       ncbi_source_id: NCBITaxon:1308
       majority_fraction: 0.99
-      support_genomes: 2093
+      total_genomes: 2093
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Thermophilic dairy starter species represented at species level because the curated community
@@ -90,7 +90,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lactobacillus;s__Lactobacillus delbrueckii
       ncbi_source_id: NCBITaxon:1585
       majority_fraction: 1.0
-      support_genomes: 220
+      total_genomes: 220
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Literature often uses Lactobacillus bulgaricus; NCBI taxon captures the accepted subspecies.

--- a/kb/communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.yaml
+++ b/kb/communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.yaml
@@ -57,6 +57,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Zymomonas;s__Zymomonas mobilis
       ncbi_source_id: NCBITaxon:542
       majority_fraction: 0.89
+      support_genomes: 56
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Curated at species level because the abstract supports Z. mobilis but does not specify a strain
@@ -85,6 +86,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
+      support_genomes: 166397
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Curated at species level; the paper tested E. coli proA, pheA, and ilvA auxotroph partners.

--- a/kb/communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.yaml
+++ b/kb/communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.yaml
@@ -57,7 +57,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Zymomonas;s__Zymomonas mobilis
       ncbi_source_id: NCBITaxon:542
       majority_fraction: 0.89
-      support_genomes: 56
+      total_genomes: 56
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Curated at species level because the abstract supports Z. mobilis but does not specify a strain
@@ -86,7 +86,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
       ncbi_source_id: NCBITaxon:562
       majority_fraction: 1.0
-      support_genomes: 166397
+      total_genomes: 166397
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Curated at species level; the paper tested E. coli proA, pheA, and ilvA auxotroph partners.

--- a/kb/communities/mCAFEs_Brachypodium_RCC.yaml
+++ b/kb/communities/mCAFEs_Brachypodium_RCC.yaml
@@ -48,6 +48,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Methylobacterium
       ncbi_source_id: NCBITaxon:407
       majority_fraction: 1.0
+      support_genomes: 279
+      total_genomes: 279
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Keystone taxon in fast-growing consortia (3-day transfer). Member of Methylobacterium-Methylorubrum
@@ -72,6 +74,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Xanthomonadales;f__Xanthomonadaceae;g__Stenotrophomonas
       ncbi_source_id: NCBITaxon:40323
       majority_fraction: 0.985
+      support_genomes: 398
+      total_genomes: 404
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Keystone taxon in fast-growing consortia (3-day transfer).
@@ -95,6 +99,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas
       ncbi_source_id: NCBITaxon:286
       majority_fraction: 0.699
+      support_genomes: 17956
+      total_genomes: 25706
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 11 GTDB taxa under the NCBI taxon]
     notes: Keystone taxon in fast-growing consortia (3-day transfer).
@@ -118,6 +124,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Acidobacteriota;c__Terriglobia;o__Terriglobales;f__Acidobacteriaceae;g__Terriglobus
       ncbi_source_id: NCBITaxon:392733
       majority_fraction: 0.778
+      support_genomes: 7
+      total_genomes: 9
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Keystone taxon in slow-growing consortia (7-day transfer). Enriched in 1/10 R2A medium. Member
@@ -157,6 +165,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Burkholderiaceae;g__Burkholderia
       ncbi_source_id: NCBITaxon:32008
       majority_fraction: 0.999
+      support_genomes: 8896
+      total_genomes: 8908
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Keystone taxon in glycerol stock revivals.
@@ -195,6 +205,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Sphingomonadales;f__Sphingomonadaceae;g__Sphingomonas
       ncbi_source_id: NCBITaxon:13687
       majority_fraction: 0.736
+      support_genomes: 449
+      total_genomes: 610
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 19 GTDB taxa under the NCBI taxon]
     notes: Persistent keystone taxon across multiple enrichment conditions.
@@ -218,6 +230,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Sphingobacteriales;f__Sphingobacteriaceae;g__Mucilaginibacter
       ncbi_source_id: NCBITaxon:423349
       majority_fraction: 1.0
+      support_genomes: 173
+      total_genomes: 173
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Persistent keystone taxon across multiple enrichment conditions.
@@ -241,6 +255,8 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Xanthobacteraceae;g__Bradyrhizobium
       ncbi_source_id: NCBITaxon:374
       majority_fraction: 0.995
+      support_genomes: 592
+      total_genomes: 595
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Enriched in asparagine enrichment conditions.

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -160,17 +160,34 @@ def collect_rows(mapping_path: Path, want_ids, want_species_lc, want_higher_lc):
     return by_id, by_name, by_higher
 
 
+def _genomes(row) -> int:
+    """The row's genome count, or 0 if the cell is missing or unparseable."""
+    try:
+        return int(float(row[COL_TOTAL_GENOMES]))
+    except (ValueError, IndexError, TypeError):
+        return 0
+
+
 def _ground_species(rows, source_id, label, via):
     rows = sorted(rows, key=_maj, reverse=True)
     top = rows[0]
     sp = top[COL_GTDB_SPECIES].strip()
     ref = _clean_label(label) or top[COL_NCBI_SPECIES].strip()
+    # `majority_fraction` here is the crosswalk's own column, not something this
+    # script computes. So this path records `support_genomes` — how many genomes
+    # sat behind the row that was chosen — but deliberately **no**
+    # `total_genomes`: summing the matched rows would publish a ratio that
+    # contradicts the stored fraction. `Bacillus velezensis` is the worked case,
+    # 1163 genomes on the top row against 1196 across all rows, while the
+    # crosswalk calls it 1.0. A denominator is only emitted where this script
+    # computes the majority itself, which is the higher-rank path (#383).
     return {
         "ncbi_source_id": source_id,
         "gtdb_id": _curie(sp, "s") if sp else None,
         "gtdb_taxon": sp or None,
         "gtdb_lineage": _lineage(top, COL_GTDB_SPECIES),
         "majority_fraction": _maj(top),
+        "support_genomes": _genomes(top),
         "is_reclassified": bool(sp and ref and sp != ref),
         "via": via,
     }
@@ -318,7 +335,10 @@ def resolve_higher(clean_lc, source_id, label, by_higher, denominator="aggregate
                 continue
             try:
                 w = float(r[COL_TOTAL_GENOMES])
-            except (ValueError, IndexError):
+            except (ValueError, IndexError, TypeError):
+                # TypeError guards a None cell. Rows come from splitting a TSV so
+                # every cell is a string today, but this fell over in testing and
+                # a crash mid-sweep is a worse failure than a weight of 1.
                 w = 1.0
             weights[gv] += w
             rep.setdefault(gv, r)
@@ -339,6 +359,11 @@ def resolve_higher(clean_lc, source_id, label, by_higher, denominator="aggregate
                 "gtdb_taxon": top,
                 "gtdb_lineage": _lineage(rep[top], gtdb_col),
                 "majority_fraction": round(frac, 3),
+                # The numerator and denominator the fraction came from (#383).
+                # `frac` is rounded to 3 places, so these cannot be recovered
+                # from it — 4/7 and 4000/7000 both store as 0.571.
+                "support_genomes": int(tw),
+                "total_genomes": int(total),
                 "is_reclassified": top != _clean_label(label),
                 "via": f"ncbi_rank_{prefix}",
                 "n_alt": len(weights),
@@ -398,15 +423,27 @@ def _block(g: dict, mapping_source: str) -> dict:
         src += f" [grounded at {rank}__ rank; {g.get('n_alt', 1)} GTDB taxa under the NCBI taxon]"
     elif g.get("via") == "ncbi_name":
         src += " [mapped via NCBI species name — no species-level NCBI id in table]"
-    return {
+    block = {
         "gtdb_id": g["gtdb_id"],
         "gtdb_taxon": g["gtdb_taxon"],
         "gtdb_lineage": g["gtdb_lineage"],
         "ncbi_source_id": g["ncbi_source_id"],
         "majority_fraction": g["majority_fraction"],
+        "support_genomes": g.get("support_genomes"),
+        "total_genomes": g.get("total_genomes"),
         "is_reclassified": g["is_reclassified"],
         "mapping_source": src,
     }
+    # Omit the counts when absent rather than writing `total_genomes: null`. The
+    # species path computes no denominator, so a null would appear on 335 blocks
+    # as pure noise — and it hides from a naive diff, since `.get()` returns None
+    # for both an absent key and a null one. Only these two are dropped: the
+    # older fields have always been written even when empty, and silently
+    # changing that would be a second, unrelated migration.
+    for key in ("support_genomes", "total_genomes"):
+        if block[key] is None:
+            del block[key]
+    return block
 
 
 def emit_block(g: dict, mapping_source: str) -> str:
@@ -779,7 +816,12 @@ def main(argv: list[str] | None = None) -> int:
         print(f"  GTDB taxon   : {g['gtdb_taxon']}{flag}")
         print(f"  GTDB CURIE   : {g['gtdb_id']}")
         print(f"  GTDB lineage : {g['gtdb_lineage']}")
-        print(f"  majority     : {g['majority_fraction']}{via}")
+        support, total = g.get("support_genomes"), g.get("total_genomes")
+        # Say what the fraction is a fraction *of*. A bare 0.571 reads the same
+        # at 4 genomes as at 4000 (#383).
+        of = f"  [{support}/{total} genomes]" if total else (f"  [{support} genomes]" if support else "")
+        thin = "  ⚠ THIN" if total and total < 10 else ""
+        print(f"  majority     : {g['majority_fraction']}{via}{of}{thin}")
         if args.emit_yaml:
             print("  --- gtdb_classification block ---")
             for line in emit_block(g, mapping_source).splitlines():

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -169,25 +169,41 @@ def _genomes(row) -> int:
 
 
 def _ground_species(rows, source_id, label, via):
-    rows = sorted(rows, key=_maj, reverse=True)
+    # Deterministic order. A plain `sorted(key=_maj)` is stable, so among rows
+    # tied on majority the winner was whichever the crosswalk listed first —
+    # reversing the file moved *Anaerobutyricum hallii* from 156 genomes to 1,
+    # with the same gtdb_id and the same 1.0. That is the tie-break bug fixed for
+    # the higher-rank path in #382, reappearing here (#385 review). Prefer the
+    # best-supported row, then break by name.
+    rows = sorted(rows, key=lambda r: (-_maj(r), -_genomes(r), r[COL_GTDB_SPECIES].strip()))
     top = rows[0]
     sp = top[COL_GTDB_SPECIES].strip()
     ref = _clean_label(label) or top[COL_NCBI_SPECIES].strip()
-    # `majority_fraction` here is the crosswalk's own column, not something this
-    # script computes. So this path records `support_genomes` — how many genomes
-    # sat behind the row that was chosen — but deliberately **no**
-    # `total_genomes`: summing the matched rows would publish a ratio that
-    # contradicts the stored fraction. `Bacillus velezensis` is the worked case,
-    # 1163 genomes on the top row against 1196 across all rows, while the
-    # crosswalk calls it 1.0. A denominator is only emitted where this script
-    # computes the majority itself, which is the higher-rank path (#383).
+    # Column 2 is the chosen row's *total* genomes; `majority_fraction` is the
+    # share of them reaching this GTDB taxon. So this path can state the
+    # denominator exactly, and cannot state the numerator at all.
+    #
+    # Two wrong answers were tried before this one. Storing the column straight
+    # into `support_genomes` labelled the denominator as the numerator and
+    # overstated 74 of 335 species blocks — *P. aeruginosa* read 17191 against a
+    # true ~17019 — hidden by a worked example where `majority_fraction: 1.0`
+    # makes the two identical (#385 review). Deriving it as `round(total * maj)`
+    # is no better: the crosswalk's majority column carries **two decimal
+    # places**, so at 17191 genomes and 0.99 the true numerator spans ~170
+    # genomes, and a 5-digit `support_genomes` would assert a precision the
+    # source does not have.
+    #
+    # So species blocks carry `total_genomes` only. That is what #383 asked for —
+    # what the fraction is a fraction *of* — and `support_genomes` keeps one
+    # meaning everywhere: an exact count this script computed itself.
+    total = _genomes(top)
     return {
         "ncbi_source_id": source_id,
         "gtdb_id": _curie(sp, "s") if sp else None,
         "gtdb_taxon": sp or None,
         "gtdb_lineage": _lineage(top, COL_GTDB_SPECIES),
         "majority_fraction": _maj(top),
-        "support_genomes": _genomes(top),
+        "total_genomes": total,
         "is_reclassified": bool(sp and ref and sp != ref),
         "via": via,
     }
@@ -416,6 +432,25 @@ def resolve_target(ncbi_id, label, by_id, by_name, by_higher, denominator="aggre
     return resolve_higher(clean.lower(), source_id, label, by_higher, denominator, exclude_unnamed)
 
 
+# Groundings a curator chose against the majority vote, keyed by
+# (record filename, NCBITaxon id). `--refresh` recomputes an existing block, so
+# without this the tool silently replaces a right answer with a confidently wrong
+# one and only `tests/test_gtdb_withheld_groundings.py::CURATED` notices, after
+# the fact. Mirrors WITHHELD, which keeps taxa *ungrounded* (#292/#293).
+#
+# This is the narrow half of #384 — a hard-coded list, not the `curated:` flag on
+# the block that the issue asks for. It exists so the record stays tool-
+# maintainable: excluding the whole *file* instead stranded its other taxon.
+CURATED_GROUNDINGS = {
+    ("Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml", "NCBITaxon:18"): (
+        "GTDB:g__Syntrophotalea — SFB93 is an acetylene fermenter and the entry's "
+        "notes tie it to Syntrophotalea acetylenivorans, but every Pelobacter row "
+        "naming Syntrophotalea is an `sp.` row, so the named-species filter hands "
+        "the vote to g__Seleniibacterium at 0.571 (#384)."
+    ),
+}
+
+
 def _block(g: dict, mapping_source: str) -> dict:
     src = mapping_source
     if (g.get("via") or "").startswith("ncbi_rank"):
@@ -530,6 +565,14 @@ def apply_to_community(
         term = tt.get("term", {}) or {}
         tid = str(term.get("id", ""))
         grounded = "gtdb_classification" in tt
+        if (path.name, tid) in CURATED_GROUNDINGS:
+            print(
+                f"[gtdb] skipping curated {tid} in {path.name}: "
+                f"{CURATED_GROUNDINGS[(path.name, tid)]}",
+                file=sys.stderr,
+            )
+            wanted.append(None)
+            continue
         if not tid.startswith("NCBITaxon:") or (grounded != refresh):
             # normal: act on ungrounded only. refresh: act on grounded only.
             wanted.append(None)
@@ -819,7 +862,12 @@ def main(argv: list[str] | None = None) -> int:
         support, total = g.get("support_genomes"), g.get("total_genomes")
         # Say what the fraction is a fraction *of*. A bare 0.571 reads the same
         # at 4 genomes as at 4000 (#383).
-        of = f"  [{support}/{total} genomes]" if total else (f"  [{support} genomes]" if support else "")
+        if total and support is not None:
+            of = f"  [{support}/{total} genomes]"
+        elif total:
+            of = f"  [{total} genomes under the NCBI taxon]"
+        else:
+            of = ""
         thin = "  ⚠ THIN" if total and total < 10 else ""
         print(f"  majority     : {g['majority_fraction']}{via}{of}{thin}")
         if args.emit_yaml:

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-07-20T15:22:57
+# Generation date: 2026-08-04T14:47:44
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech
@@ -306,6 +306,8 @@ class GtdbClassification(YAMLRoot):
     gtdb_lineage: Optional[str] = None
     ncbi_source_id: Optional[str] = None
     majority_fraction: Optional[float] = None
+    support_genomes: Optional[int] = None
+    total_genomes: Optional[int] = None
     is_reclassified: Optional[Union[bool, Bool]] = None
     mapping_source: Optional[str] = None
 
@@ -324,6 +326,12 @@ class GtdbClassification(YAMLRoot):
 
         if self.majority_fraction is not None and not isinstance(self.majority_fraction, float):
             self.majority_fraction = float(self.majority_fraction)
+
+        if self.support_genomes is not None and not isinstance(self.support_genomes, int):
+            self.support_genomes = int(self.support_genomes)
+
+        if self.total_genomes is not None and not isinstance(self.total_genomes, int):
+            self.total_genomes = int(self.total_genomes)
 
         if self.is_reclassified is not None and not isinstance(self.is_reclassified, Bool):
             self.is_reclassified = Bool(self.is_reclassified)
@@ -3214,6 +3222,24 @@ slots.gtdbClassification__majority_fraction = Slot(
     model_uri=COMMUNITYMECH.gtdbClassification__majority_fraction,
     domain=None,
     range=Optional[float],
+)
+
+slots.gtdbClassification__support_genomes = Slot(
+    uri=COMMUNITYMECH.support_genomes,
+    name="gtdbClassification__support_genomes",
+    curie=COMMUNITYMECH.curie("support_genomes"),
+    model_uri=COMMUNITYMECH.gtdbClassification__support_genomes,
+    domain=None,
+    range=Optional[int],
+)
+
+slots.gtdbClassification__total_genomes = Slot(
+    uri=COMMUNITYMECH.total_genomes,
+    name="gtdbClassification__total_genomes",
+    curie=COMMUNITYMECH.curie("total_genomes"),
+    model_uri=COMMUNITYMECH.gtdbClassification__total_genomes,
+    domain=None,
+    range=Optional[int],
 )
 
 slots.gtdbClassification__is_reclassified = Slot(

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-08-04T14:47:44
+# Generation date: 2026-08-04T15:25:44
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -713,6 +713,23 @@ classes:
         range: float
         minimum_value: 0.0
         maximum_value: 1.0
+      support_genomes:
+        description: >-
+          Number of genomes supporting the chosen GTDB taxon — the numerator
+          behind majority_fraction. Without it a fraction is unreadable: 0.571
+          means one thing at 4 genomes and another at 4000, and 1.0 can rest on
+          a single row. Note majority_fraction is rounded to 3 places, so it
+          cannot be used to recover this.
+        range: integer
+        minimum_value: 0
+      total_genomes:
+        description: >-
+          Number of genomes counted across every candidate GTDB taxon at this
+          rank — the denominator behind majority_fraction. Excludes rows dropped
+          by the named-species filter (sp./uncultured/informal), so it is the
+          evidence actually considered, not every genome under the NCBI taxon.
+        range: integer
+        minimum_value: 0
       is_reclassified:
         description: >-
           True when the GTDB species name differs from the NCBITaxon species

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -716,18 +716,24 @@ classes:
       support_genomes:
         description: >-
           Number of genomes supporting the chosen GTDB taxon — the numerator
-          behind majority_fraction. Without it a fraction is unreadable: 0.571
-          means one thing at 4 genomes and another at 4000, and 1.0 can rest on
-          a single row. Note majority_fraction is rounded to 3 places, so it
-          cannot be used to recover this.
+          behind majority_fraction. Present only on genus-and-higher groundings,
+          where this majority is computed from the mapping rows directly. Absent
+          on species-level groundings: there majority_fraction comes from the
+          crosswalk's own column, which carries two decimal places, so any
+          numerator derived from it would assert a precision the source lacks
+          (~170 genomes of slack on a 17191-genome taxon).
         range: integer
         minimum_value: 0
       total_genomes:
         description: >-
-          Number of genomes counted across every candidate GTDB taxon at this
-          rank — the denominator behind majority_fraction. Excludes rows dropped
-          by the named-species filter (sp./uncultured/informal), so it is the
-          evidence actually considered, not every genome under the NCBI taxon.
+          Number of genomes the majority was computed over — the denominator
+          behind majority_fraction, and the answer to "0.571 of what?". For
+          genus-and-higher, the genomes across every candidate GTDB taxon at that
+          rank, excluding rows dropped by the named-species filter
+          (sp./uncultured/informal), so it is the evidence actually considered
+          rather than every genome under the NCBI taxon. For species, the genomes
+          under the chosen mapping row. Note majority_fraction is rounded, so
+          neither count can be recovered from it.
         range: integer
         minimum_value: 0
       is_reclassified:

--- a/tests/test_gtdb_grounding_freshness.py
+++ b/tests/test_gtdb_grounding_freshness.py
@@ -151,6 +151,26 @@ def test_grounding_is_internally_coherent(grounded):
         if fraction is not None and not (0.5 <= fraction <= 1.0):
             problems.append(f"{where}\n      majority_fraction={fraction} outside (0.5, 1]")
 
+        # The evidence counts (#383). `linkml-validate` checks their type and
+        # non-negativity but nothing relates them to each other or to the
+        # fraction, so a block claiming 99 supporting genomes out of 3 validates.
+        support, total = g.get("support_genomes"), g.get("total_genomes")
+        if total is not None and total <= 0:
+            problems.append(f"{where}\n      total_genomes={total} — a majority over no genomes")
+        if support is not None and total is not None:
+            if support > total:
+                problems.append(f"{where}\n      support_genomes={support} > total_genomes={total}")
+            elif total > 0 and fraction is not None and round(support / total, 3) != fraction:
+                problems.append(
+                    f"{where}\n      {support}/{total} = {round(support / total, 3)} but "
+                    f"majority_fraction={fraction}"
+                )
+        if support is not None and total is None:
+            problems.append(
+                f"{where}\n      support_genomes={support} with no total_genomes — a "
+                f"numerator without its denominator says nothing"
+            )
+
     assert not problems, "internally inconsistent gtdb_classification:\n" + "\n".join(
         f"  {p}" for p in problems
     )

--- a/tests/test_gtdb_support_counts.py
+++ b/tests/test_gtdb_support_counts.py
@@ -1,27 +1,29 @@
 """A `majority_fraction` must say what it is a fraction *of* (#383).
 
 `0.571` reads identically whether it came from 4 genomes or 4000, and `1.0` can
-rest on a single row. That is not hypothetical: across the KB, **19 higher-rank
-groundings rest on fewer than 10 genomes and every one of them reads 1.0** — a
-phylum grounded on 7 genomes is indistinguishable, in the stored block, from one
-grounded on 7000. The named-species filter (#375) made this sharper, because it
-shrinks the evidence without recording that it did.
+rest on a single row. Across the KB, **197 groundings rest on fewer than 10
+genomes, 192 of them reading `1.0`, and 25 rest on a single genome** — in the
+stored block those were indistinguishable from groundings drawn from thousands.
+The named-species filter (#375) sharpened it, because it shrinks the evidence
+without recording that it did.
 
-So the block now carries the numerator and the denominator:
+* ``total_genomes``   — genomes the majority was computed over. On **every**
+  grounding, because it is the number #383 actually asked for.
+* ``support_genomes`` — genomes behind the chosen taxon. Only on genus-and-higher
+  groundings, where this script computes the majority itself.
 
-* ``support_genomes`` — genomes behind the chosen GTDB taxon.
-* ``total_genomes``   — genomes across every candidate at that rank.
-
-Rounding is why they cannot be inferred: `majority_fraction` is rounded to 3
+Rounding is why neither can be inferred: `majority_fraction` is rounded to 3
 places, so 4/7 and 4000/7000 both store as 0.571.
 
-**`total_genomes` is deliberately absent on the species path.** There the
-fraction is the crosswalk's own column rather than something this script
-computes, so a locally-summed denominator would contradict it — *Bacillus
-velezensis* is 1163 genomes on the chosen row against 1196 across all its rows,
-while the crosswalk calls it 1.0. Publishing 1163/1196 next to `1.0` would be
-worse than publishing no denominator at all, so only `support_genomes` is
-emitted there.
+**Why species blocks carry no numerator.** Two wrong answers came first. Storing
+the crosswalk's `total genomes` column into `support_genomes` labelled the
+denominator as the numerator, overstating 74 of 335 species blocks — *P.
+aeruginosa* read 17191 against a true ~17019 — and hid behind a worked example
+where `majority_fraction: 1.0` makes the two identical. Deriving it as
+``round(total * majority)`` is no better: that column carries **two decimal
+places**, so at 17191 genomes and 0.99 the true numerator spans ~170 genomes. A
+5-digit count from a 2-digit fraction asserts precision the source lacks. So the
+species path states the denominator, which it knows exactly, and no numerator.
 """
 
 from __future__ import annotations
@@ -143,20 +145,24 @@ def test_an_unparseable_genome_count_does_not_crash_the_grounding(gtdb, cell):
     bad[2] = cell
     result = gtdb.resolve_higher("testgenus", "NCBITaxon:1", "Testgenus", {"testgenus": [row, bad]})
     assert result["support_genomes"] == 10
+    # The denominator is the only place the `w = 1.0` fallback is observable —
+    # without this, changing it to 0.0 passed every test (#385 review).
+    assert result["total_genomes"] == 11, "the unparseable row must still count as 1"
 
 
-def test_the_species_path_reports_support_but_no_denominator(gtdb, mapping):
-    """A locally-summed denominator would contradict the crosswalk's own fraction."""
+def test_the_species_path_reports_the_denominator_but_no_numerator(gtdb, mapping):
+    """The crosswalk gives the row total exactly and the share only to 2 places."""
     by_id, by_name, by_higher = gtdb.collect_rows(
         mapping, {"492670"}, {"bacillus velezensis"}, set()
     )
     result = gtdb.resolve_target("492670", "Bacillus velezensis", by_id, by_name, by_higher)
 
     assert result["gtdb_id"] == "GTDB:s__Bacillus_velezensis"
-    assert result["support_genomes"] > 0, "the species path must still say how much evidence"
-    assert "total_genomes" not in result, (
-        "the species path must not publish a denominator — its majority_fraction "
-        "comes from the crosswalk, not from this script"
+    assert result["total_genomes"] == 1163, "the chosen row's own genome count"
+    assert "support_genomes" not in result, (
+        "the species path must publish no numerator — majority_fraction comes "
+        "from the crosswalk's 2-decimal column, so any numerator derived from it "
+        "would assert precision the source lacks"
     )
 
 
@@ -187,29 +193,52 @@ def test_support_never_exceeds_the_total(grounded):
 
 
 def test_the_kb_carries_the_counts(grounded):
-    """Without this, shipping the schema change but not the sweep would pass."""
+    """Shipping the schema change without the sweep, or half of it, must fail.
+
+    `total_genomes` is the field every grounding gets, so it is the one that
+    detects a partial sweep. Only the four blocks the tool cannot recompute may
+    lack it: the curated Pelobacter pin (#384), the curated Chlorobium block, and
+    the two taxa that are now AMBIGUOUS (#376).
+    """
+    without = [
+        f"{record}: {name}" for record, name, b in grounded if b.get("total_genomes") is None
+    ]
+    assert len(without) <= 4, (
+        f"{len(without)} of {len(grounded)} blocks carry no total_genomes — the KB "
+        f"was not fully re-swept after the schema change (#383):\n"
+        + "\n".join(f"  {w}" for w in without[:10])
+    )
     with_support = [b for _, _, b in grounded if b.get("support_genomes") is not None]
-    assert len(with_support) > 600, (
-        f"only {len(with_support)} of {len(grounded)} blocks carry support_genomes — "
-        f"the KB was not re-swept after the schema change (#383)"
+    assert len(with_support) > 250, (
+        f"only {len(with_support)} blocks carry support_genomes — the higher-rank "
+        f"path should populate it on roughly 307"
     )
 
 
 def test_the_thin_groundings_are_visible(grounded):
     """The population this issue exists for, now findable by reading the KB.
 
-    Every one of these reads `majority_fraction: 1.0`. Before the counts landed,
-    nothing in the record distinguished them from a grounding drawn from
-    thousands of genomes. This asserts they are *visible*, not that they are
-    wrong — a small genus is legitimately small.
+    These are *visible*, not wrong — a small genus is legitimately small. What
+    was wrong is that nothing distinguished them from a grounding drawn from
+    thousands. An earlier revision of this docstring claimed every one reads
+    `1.0`; 5 do not, and asserting the claim rather than narrating it is what
+    caught that.
     """
     thin = [
-        (record, name, b["gtdb_id"], b["support_genomes"], b["total_genomes"])
+        (record, name, b["gtdb_id"], b.get("support_genomes"), b["total_genomes"])
         for record, name, b in grounded
         if b.get("total_genomes") is not None and b["total_genomes"] < 10
     ]
-    assert thin, "expected to find low-evidence groundings; has the mapping changed?"
+    assert len(thin) > 100, (
+        f"only {len(thin)} low-evidence groundings — this population is the "
+        f"reason #383 exists; has the mapping changed?"
+    )
     assert all(t[4] > 0 for t in thin), "a zero denominator would be a division bug"
+    assert any(t[1] != 1.0 for t in thin), (
+        "every thin grounding reads 1.0 — the earlier narrative said exactly "
+        "this and it was false, so it is asserted rather than assumed"
+    )
+    assert any(t[4] == 1 for t in thin), "expected groundings resting on a single genome"
 
 
 def test_the_emitted_block_carries_the_counts(gtdb):
@@ -233,8 +262,8 @@ def test_the_emitted_block_carries_the_counts(gtdb):
     assert "support_genomes" in gtdb.emit_block(grounding, "test-source")
 
 
-def test_an_emitted_species_block_omits_the_denominator(gtdb, mapping):
-    """`_block` must not invent a `total_genomes` the species path did not compute."""
+def test_an_emitted_species_block_omits_the_numerator(gtdb, mapping):
+    """`_block` must not invent a `support_genomes` the species path cannot know."""
     by_id, by_name, by_higher = gtdb.collect_rows(
         mapping, {"492670"}, {"bacillus velezensis"}, set()
     )
@@ -242,10 +271,127 @@ def test_an_emitted_species_block_omits_the_denominator(gtdb, mapping):
 
     block = gtdb._block(grounding, "test-source")
 
-    assert block["support_genomes"] > 0
-    assert "total_genomes" not in block, (
-        "a species block must omit the denominator entirely — writing "
-        "`total_genomes: null` puts noise on 335 records and hides from a "
+    assert block["total_genomes"] == 1163
+    assert "support_genomes" not in block, (
+        "a species block must omit the numerator entirely — writing "
+        "`support_genomes: null` puts noise on 336 records and hides from a "
         "`.get()`-based diff, which is how it survived the first sweep"
     )
-    assert "total_genomes" not in gtdb.emit_block(grounding, "test-source")
+    assert "support_genomes" not in gtdb.emit_block(grounding, "test-source")
+
+
+def test_species_counts_match_the_crosswalk(gtdb, mapping):
+    """Nothing compared a species-path count to the source, so two bugs hid here.
+
+    `support_genomes` was the crosswalk's *total* column mislabelled as the
+    numerator, and the chosen row was whichever the file listed first. Both
+    passed a `> 0` assertion. This reads the table directly.
+    """
+    import gzip
+
+    wanted = {"492670": "Bacillus velezensis", "1423": "Bacillus subtilis"}
+    expected = {}
+    with gzip.open(mapping, "rt") as handle:
+        next(handle)
+        for line in handle:
+            cells = line.rstrip("\n").split("\t")
+            if len(cells) > gtdb.COL_NCBI_SPECIES and cells[0] in wanted:
+                best = expected.get(cells[0])
+                key = (gtdb._maj(cells), gtdb._genomes(cells))
+                if best is None or key > best[0]:
+                    expected[cells[0]] = (key, gtdb._genomes(cells))
+
+    for ncbi_id, label in wanted.items():
+        by_id, by_name, by_higher = gtdb.collect_rows(mapping, {ncbi_id}, {label.lower()}, set())
+        result = gtdb.resolve_target(ncbi_id, label, by_id, by_name, by_higher)
+        assert result["total_genomes"] == expected[ncbi_id][1], (
+            f"{label}: stored {result['total_genomes']} but the best crosswalk row "
+            f"carries {expected[ncbi_id][1]} genomes"
+        )
+
+
+def test_the_chosen_species_row_does_not_depend_on_file_order(gtdb, mapping):
+    """The #382 tie-break bug, which reappeared on this path (#385 review).
+
+    `sorted(key=_maj)` is stable, so among rows tied on majority the winner was
+    whichever came first: reversing the input moved *Anaerobutyricum hallii* from
+    156 genomes to 1, with an unchanged gtdb_id and an unchanged 1.0.
+    """
+    _, by_name, _ = gtdb.collect_rows(mapping, set(), {"anaerobutyricum hallii"}, set())
+    rows = by_name["anaerobutyricum hallii"]
+    assert len(rows) > 1, "this taxon no longer has the tied rows the test needs"
+
+    forward = gtdb.resolve_target(
+        "", "Anaerobutyricum hallii", {}, {"anaerobutyricum hallii": rows}, {}
+    )
+    reverse = gtdb.resolve_target(
+        "", "Anaerobutyricum hallii", {}, {"anaerobutyricum hallii": list(reversed(rows))}, {}
+    )
+
+    assert (
+        forward["total_genomes"] == reverse["total_genomes"]
+    ), "reversing the crosswalk row order changed the stored evidence count"
+    # Deterministic is not enough — it must be the *best-supported* row. Both
+    # rows here sit at majority 1.0, carrying 156 genomes and 1, so consistently
+    # picking either end would satisfy the assertion above.
+    assert forward["total_genomes"] == 156, (
+        f"chose a {forward['total_genomes']}-genome row over the 156-genome one; "
+        f"a tie must break toward the better-supported row"
+    )
+
+
+def test_the_cli_prints_the_counts_and_flags_thin_evidence(gtdb, mapping, capsys):
+    """Nothing covered the CLI, so deleting the annotation or the marker passed."""
+    assert gtdb.main(["--name", "Pelobacter"]) == 0
+    thin = capsys.readouterr().out
+    assert "[4/7 genomes]" in thin, "the CLI must say what the fraction is a fraction of"
+    assert "THIN" in thin, "a 7-genome grounding must be flagged"
+
+    assert gtdb.main(["--name", "Acetobacter"]) == 0
+    thick = capsys.readouterr().out
+    assert "[395/395 genomes]" in thick
+    assert "THIN" not in thick, "395 genomes is not thin"
+
+
+def test_a_curated_grounding_is_skipped_by_refresh(gtdb, tmp_path, mapping):
+    """The tool must refuse to recompute a block a curator pinned (#384).
+
+    Excluding the whole *file* from the sweep instead — the first attempt — left
+    its other taxon ungrounded-by-counts and the record maintainable only by hand.
+    """
+    assert gtdb.CURATED_GROUNDINGS, "the curated map is empty; nothing is protected"
+    record, ncbi_id = next(iter(gtdb.CURATED_GROUNDINGS))
+
+    source = REPO / "kb/communities" / record
+    assert source.exists(), f"{record} no longer exists; update CURATED_GROUNDINGS"
+    destination = tmp_path / record
+    destination.write_text(source.read_text())
+
+    pairs = [
+        (
+            (e["taxon_term"].get("term") or {}).get("id", ""),
+            (e["taxon_term"].get("term") or {}).get("label", ""),
+        )
+        for e in yaml.safe_load(destination.read_text())["taxonomy"]
+    ]
+    cleaned = [gtdb._clean_label(label) for _, label in pairs]
+    rows = gtdb.collect_rows(
+        mapping,
+        {i.split(":")[1] for i, _ in pairs if i},
+        {c.lower() for c in cleaned if " " in c},
+        {c.lower() for c in cleaned if " " not in c},
+    )
+    gtdb.apply_to_community(destination, *rows, "test-source", refresh=True)
+
+    after = yaml.safe_load(destination.read_text())
+    pinned = next(
+        e["taxon_term"]
+        for e in after["taxonomy"]
+        if (e["taxon_term"].get("term") or {}).get("id") == ncbi_id
+    )
+    assert (
+        pinned["gtdb_classification"]["gtdb_id"] == "GTDB:g__Syntrophotalea"
+    ), "refresh overwrote a curated grounding"
+    assert "test-source" not in (
+        pinned["gtdb_classification"].get("mapping_source") or ""
+    ), "the curated block was rewritten even though its value survived"

--- a/tests/test_gtdb_support_counts.py
+++ b/tests/test_gtdb_support_counts.py
@@ -1,0 +1,251 @@
+"""A `majority_fraction` must say what it is a fraction *of* (#383).
+
+`0.571` reads identically whether it came from 4 genomes or 4000, and `1.0` can
+rest on a single row. That is not hypothetical: across the KB, **19 higher-rank
+groundings rest on fewer than 10 genomes and every one of them reads 1.0** — a
+phylum grounded on 7 genomes is indistinguishable, in the stored block, from one
+grounded on 7000. The named-species filter (#375) made this sharper, because it
+shrinks the evidence without recording that it did.
+
+So the block now carries the numerator and the denominator:
+
+* ``support_genomes`` — genomes behind the chosen GTDB taxon.
+* ``total_genomes``   — genomes across every candidate at that rank.
+
+Rounding is why they cannot be inferred: `majority_fraction` is rounded to 3
+places, so 4/7 and 4000/7000 both store as 0.571.
+
+**`total_genomes` is deliberately absent on the species path.** There the
+fraction is the crosswalk's own column rather than something this script
+computes, so a locally-summed denominator would contradict it — *Bacillus
+velezensis* is 1163 genomes on the chosen row against 1196 across all its rows,
+while the crosswalk calls it 1.0. Publishing 1163/1196 next to `1.0` would be
+worse than publishing no denominator at all, so only `support_genomes` is
+emitted there.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).parent.parent
+RECORD_DIRS = ("kb/communities", "data/isolates")
+
+
+@pytest.fixture(scope="module")
+def gtdb():
+    spec = importlib.util.spec_from_file_location("gtdb_ground", REPO / "scripts/gtdb_ground.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def mapping(gtdb):
+    try:
+        path = gtdb.resolve_kg_microbe_dir(None) / "data/raw/NCBI2GTDB.tsv.gz"
+    except SystemExit as exc:
+        pytest.skip(f"kg-microbe mapping unavailable: {str(exc).splitlines()[0]}")
+    if not path.exists():
+        pytest.skip(f"kg-microbe NCBI2GTDB mapping not available at {path}")
+    return path
+
+
+@pytest.fixture(scope="module")
+def grounded():
+    """Every stored gtdb_classification block in the KB."""
+    found = []
+    for directory in RECORD_DIRS:
+        for path in sorted((REPO / directory).glob("*.yaml")):
+            data = yaml.safe_load(path.read_text()) or {}
+            for entry in data.get("taxonomy") or []:
+                if not isinstance(entry, dict):
+                    continue
+                term = entry.get("taxon_term") or {}
+                block = term.get("gtdb_classification")
+                if block:
+                    found.append((path.name, term.get("preferred_term"), block))
+    assert len(found) > 500, f"expected the grounded KB, swept only {len(found)}"
+    return found
+
+
+def _higher_rank_row(gtdb_genus, genomes, species="Testgenus namedspecies"):
+    """A crosswalk row matching NCBI genus `Testgenus`."""
+    cells = [""] * 20
+    cells[2], cells[9], cells[17], cells[10] = genomes, "Testgenus", gtdb_genus, species
+    return cells
+
+
+def test_the_denominator_is_recorded_for_a_computed_majority(gtdb):
+    by_higher = {
+        "testgenus": [
+            _higher_rank_row("g__Alpha", "40"),
+            _higher_rank_row("g__Beta", "60"),
+        ]
+    }
+    result = gtdb.resolve_higher("testgenus", "NCBITaxon:1", "Testgenus", by_higher)
+
+    assert result["gtdb_taxon"] == "g__Beta"
+    assert result["support_genomes"] == 60
+    assert result["total_genomes"] == 100
+    assert result["majority_fraction"] == 0.6
+
+
+def test_the_counts_distinguish_two_groundings_that_share_a_fraction(gtdb):
+    """The whole point: 4/7 and 4000/7000 both round to 0.571."""
+    thin = gtdb.resolve_higher(
+        "testgenus",
+        "NCBITaxon:1",
+        "Testgenus",
+        {"testgenus": [_higher_rank_row("g__Alpha", "4"), _higher_rank_row("g__Beta", "3")]},
+    )
+    thick = gtdb.resolve_higher(
+        "testgenus",
+        "NCBITaxon:1",
+        "Testgenus",
+        {"testgenus": [_higher_rank_row("g__Alpha", "4000"), _higher_rank_row("g__Beta", "3000")]},
+    )
+
+    assert thin["majority_fraction"] == thick["majority_fraction"] == 0.571
+    assert (thin["support_genomes"], thin["total_genomes"]) == (4, 7)
+    assert (thick["support_genomes"], thick["total_genomes"]) == (4000, 7000)
+
+
+def test_the_filter_shrinks_the_denominator_it_reports(gtdb):
+    """The counts must describe what was *counted*, not what was available.
+
+    A denominator that included the dropped MAG rows would overstate the evidence
+    by exactly the amount the filter removed, which is the opposite of the point.
+    """
+    rows = [
+        _higher_rank_row("g__Alpha", "4"),
+        _higher_rank_row("g__Beta", "3"),
+        _higher_rank_row("g__Beta", "500", species="Testgenus sp. MAG-1"),
+    ]
+    filtered = gtdb.resolve_higher("testgenus", "NCBITaxon:1", "Testgenus", {"testgenus": rows})
+    unfiltered = gtdb.resolve_higher(
+        "testgenus", "NCBITaxon:1", "Testgenus", {"testgenus": rows}, exclude_unnamed=False
+    )
+
+    assert filtered["total_genomes"] == 7, "the dropped MAG row must not be counted"
+    assert unfiltered["total_genomes"] == 507
+    assert filtered["gtdb_taxon"] != unfiltered["gtdb_taxon"], "expected the filter to decide this"
+
+
+@pytest.mark.parametrize("cell", ["", "not-a-number", None])
+def test_an_unparseable_genome_count_does_not_crash_the_grounding(gtdb, cell):
+    row = _higher_rank_row("g__Alpha", "10")
+    bad = _higher_rank_row("g__Beta", "1")
+    bad[2] = cell
+    result = gtdb.resolve_higher("testgenus", "NCBITaxon:1", "Testgenus", {"testgenus": [row, bad]})
+    assert result["support_genomes"] == 10
+
+
+def test_the_species_path_reports_support_but_no_denominator(gtdb, mapping):
+    """A locally-summed denominator would contradict the crosswalk's own fraction."""
+    by_id, by_name, by_higher = gtdb.collect_rows(
+        mapping, {"492670"}, {"bacillus velezensis"}, set()
+    )
+    result = gtdb.resolve_target("492670", "Bacillus velezensis", by_id, by_name, by_higher)
+
+    assert result["gtdb_id"] == "GTDB:s__Bacillus_velezensis"
+    assert result["support_genomes"] > 0, "the species path must still say how much evidence"
+    assert "total_genomes" not in result, (
+        "the species path must not publish a denominator — its majority_fraction "
+        "comes from the crosswalk, not from this script"
+    )
+
+
+def test_every_stored_fraction_agrees_with_its_counts(grounded):
+    """The stored block must be internally consistent, or the counts mislead."""
+    wrong = []
+    for record, name, block in grounded:
+        support, total = block.get("support_genomes"), block.get("total_genomes")
+        fraction = block.get("majority_fraction")
+        if total is None or support is None or fraction is None:
+            continue
+        if total <= 0 or round(support / total, 3) != fraction:
+            wrong.append(f"{record}: {name} — {support}/{total} != {fraction}")
+    assert not wrong, "majority_fraction disagrees with its own counts:\n" + "\n".join(
+        f"  {w}" for w in wrong
+    )
+
+
+def test_support_never_exceeds_the_total(grounded):
+    bad = [
+        f"{record}: {name} — support {block['support_genomes']} > total {block['total_genomes']}"
+        for record, name, block in grounded
+        if block.get("total_genomes") is not None
+        and block.get("support_genomes") is not None
+        and block["support_genomes"] > block["total_genomes"]
+    ]
+    assert not bad, "\n".join(bad)
+
+
+def test_the_kb_carries_the_counts(grounded):
+    """Without this, shipping the schema change but not the sweep would pass."""
+    with_support = [b for _, _, b in grounded if b.get("support_genomes") is not None]
+    assert len(with_support) > 600, (
+        f"only {len(with_support)} of {len(grounded)} blocks carry support_genomes — "
+        f"the KB was not re-swept after the schema change (#383)"
+    )
+
+
+def test_the_thin_groundings_are_visible(grounded):
+    """The population this issue exists for, now findable by reading the KB.
+
+    Every one of these reads `majority_fraction: 1.0`. Before the counts landed,
+    nothing in the record distinguished them from a grounding drawn from
+    thousands of genomes. This asserts they are *visible*, not that they are
+    wrong — a small genus is legitimately small.
+    """
+    thin = [
+        (record, name, b["gtdb_id"], b["support_genomes"], b["total_genomes"])
+        for record, name, b in grounded
+        if b.get("total_genomes") is not None and b["total_genomes"] < 10
+    ]
+    assert thin, "expected to find low-evidence groundings; has the mapping changed?"
+    assert all(t[4] > 0 for t in thin), "a zero denominator would be a division bug"
+
+
+def test_the_emitted_block_carries_the_counts(gtdb):
+    """`_block` is what actually reaches the YAML, and nothing covered it.
+
+    The KB-level assertions above read files that were already swept, so deleting
+    the counts from `_block` left every one of them green — a regression would
+    ship and only surface on the next re-grounding.
+    """
+    grounding = gtdb.resolve_higher(
+        "testgenus",
+        "NCBITaxon:1",
+        "Testgenus",
+        {"testgenus": [_higher_rank_row("g__Alpha", "4"), _higher_rank_row("g__Beta", "3")]},
+    )
+
+    block = gtdb._block(grounding, "test-source")
+
+    assert block["support_genomes"] == 4
+    assert block["total_genomes"] == 7
+    assert "support_genomes" in gtdb.emit_block(grounding, "test-source")
+
+
+def test_an_emitted_species_block_omits_the_denominator(gtdb, mapping):
+    """`_block` must not invent a `total_genomes` the species path did not compute."""
+    by_id, by_name, by_higher = gtdb.collect_rows(
+        mapping, {"492670"}, {"bacillus velezensis"}, set()
+    )
+    grounding = gtdb.resolve_target("492670", "Bacillus velezensis", by_id, by_name, by_higher)
+
+    block = gtdb._block(grounding, "test-source")
+
+    assert block["support_genomes"] > 0
+    assert "total_genomes" not in block, (
+        "a species block must omit the denominator entirely — writing "
+        "`total_genomes: null` puts noise on 335 records and hides from a "
+        "`.get()`-based diff, which is how it survived the first sweep"
+    )
+    assert "total_genomes" not in gtdb.emit_block(grounding, "test-source")


### PR DESCRIPTION
Closes #383.

`majority_fraction: 0.571` reads identically whether it came from 4 genomes or 4000, and `1.0` can rest on a single row. Across the KB, **197 groundings rest on fewer than 10 genomes and 25 rest on a single genome**, almost all reading `1.0`. In the stored block those were indistinguishable from groundings drawn from thousands. The named-species filter (#375) sharpened it, because it shrinks the evidence without recording that it did.

## The change

| field | on | meaning |
|---|---|---|
| `total_genomes` | every grounding | genomes the majority was computed over — what the fraction is a fraction *of* |
| `support_genomes` | genus-and-higher only | the numerator, where this script computes the majority itself |

Rounding is why neither can be inferred: `majority_fraction` is rounded, so 4/7 and 4000/7000 both store as `0.571`.

For genus-and-higher, `total_genomes` counts only what was *counted* — rows the named-species filter drops are excluded, so it shrinks when the filter bites. For species it is the chosen mapping row's own genome count.

### Why species blocks carry no numerator

Two wrong answers came first, both caught in review.

Storing the crosswalk's `total genomes` column into `support_genomes` **labelled the denominator as the numerator**, overstating 74 of 335 species blocks — *P. aeruginosa* read `17191` against a true ~17019, *B. subtilis* `1256` against `1143`. It hid behind a worked example where `majority_fraction: 1.0` makes the two identical.

Deriving it as `round(total * majority)` is no better: that column carries **two decimal places**, so at 17191 genomes and `0.99` the true numerator spans ~170 genomes. A 5-digit count from a 2-digit fraction asserts precision the source lacks.

So the species path states the denominator, which it knows exactly, and no numerator.

This inverts the asymmetry argued in the first revision of this PR. That version claimed a species denominator would contradict the stored fraction — true only of the denominator it had picked (summing every matched row: 1196 for *B. velezensis*). The row'"'"'s own total, 1163, agrees with `1.0` exactly. The asymmetry was real; the explanation was not.

### CLI

```
majority : 0.571  (at g__ rank)  [4/7 genomes]  ⚠ THIN
majority : 1.0    (at g__ rank)  [395/395 genomes]
majority : 1.0    (via species name)  [1163 genomes under the NCBI taxon]
```

## The KB re-grounding

`--refresh --apply` over all 312 records, no exclusions. Measured against `main`:

| | |
|---|---|
| grounded blocks before / after | **647 / 647** |
| records changed outside `gtdb_classification` | **0** |
| pre-existing field values altered | **0** |
| gained `total_genomes` only (species) | 335 |
| gained both | 307 |
| legitimately unswept | 4 |

The 4: the curated Pelobacter pin (#384), the curated Chlorobium block (blocked by the `usable` gate), and the two taxa now AMBIGUOUS (#376).

## Review findings addressed

**A tie-break bug reappeared on a new path.** `sorted(key=_maj)` is stable, so among rows tied on majority the winner was whichever the crosswalk listed first — reversing the file moved *Anaerobutyricum hallii* from 156 genomes to 1, with an unchanged `gtdb_id` and an unchanged `1.0`. Rows now sort by `(-majority, -genomes, name)`. Same defect as #382, one level down.

**Excluding the curated record excluded the whole file.** Its other taxon, *Dehalococcoides mccartyi 195*, grounds cleanly and was skipped as collateral, stranded on the old mapping vintage — and the record became hand-maintainable with nothing recording that. Replaced with a taxon-level `CURATED_GROUNDINGS` skip inside the tool (the narrow half of #384): the sweep now covers every record, prints why it skips the pin, and leaves it byte-unchanged.

**Two false numbers, both mine.** "Every one reads 1.0" was 17 of 19, not 19 — `g__Methylibium` is 0.625 and `g__Terriglobus` 0.778. And the "5 unchanged" breakdown said 1 curated + 3 AMBIGUOUS, which is 4, and miscategorised: only 2 are AMBIGUOUS. The thin-grounding test now *asserts* the claim instead of narrating it, which is what would have caught it.

**8 of 11 mutants survived.** Nothing compared a species count to the crosswalk — precisely why the two bugs above were invisible to CI. Added tests that read the table directly, pin which row wins among ties, cover the CLI annotation and `⚠ THIN` marker, and assert `total_genomes == 11` for the unparseable-cell fallback (the denominator is the only place `w = 1.0` is observable). All nine mutants now fail.

**The schema accepts incoherent counts** — `support_genomes: 99, total_genomes: 3` validates. Extended `test_grounding_is_internally_coherent` to relate the counts to each other and to the fraction; schema-level enforcement filed as #387.

## Issues filed

**#386** — a species grounding uses one crosswalk row and ignores others that agree with it (*B. breve* stores 3 genomes where 25 rows totalling 1593 map to the same GTDB species). Not fixed here because it changes groundings rather than reporting them, and belongs with #371.
**#387** — schema-level coherence constraints.

`just validate-all` clean, 1065 passed, lint clean.
