### PR TITLE
Aggregate species groundings over agreeing rows, and enforce what the schema can (#386, #387)

### DIFF
--- a/.claude/skills/ground-taxa-gtdb/SKILL.md
+++ b/.claude/skills/ground-taxa-gtdb/SKILL.md
@@ -137,7 +137,10 @@ Grounding happens at the **rank of the input**:
 
   For genus-and-higher it counts only what was *counted* — rows dropped by the
   named-species filter are excluded, so it shrinks when the filter bites. For
-  species it is the chosen mapping row's own genome count.
+  species it aggregates every crosswalk row reaching the same GTDB species, since
+  one species name usually spans several NCBI strain taxonIDs (#386). Note the id
+  and name paths therefore see different row sets: *Bacillus velezensis* is 1163
+  genomes via its NCBITaxon id and 1196 via its name.
 
 - **`support_genomes`** — the numerator, on genus-and-higher groundings only.
   Species blocks deliberately carry none: there `majority_fraction` is the

--- a/.claude/skills/ground-taxa-gtdb/SKILL.md
+++ b/.claude/skills/ground-taxa-gtdb/SKILL.md
@@ -136,11 +136,17 @@ Grounding happens at the **rank of the input**:
   marks a total under 10 `⚠ THIN`.
 
   For genus-and-higher it counts only what was *counted* — rows dropped by the
-  named-species filter are excluded, so it shrinks when the filter bites. For
-  species it aggregates every crosswalk row reaching the same GTDB species, since
-  one species name usually spans several NCBI strain taxonIDs (#386). Note the id
-  and name paths therefore see different row sets: *Bacillus velezensis* is 1163
-  genomes via its NCBITaxon id and 1196 via its name.
+  named-species filter are excluded, so it shrinks when the filter bites.
+
+  **For species it is path-dependent, and the scope is smaller than it looks.**
+  An NCBI id maps to exactly one crosswalk row, so an id-path grounding reports
+  that row alone; a species *name* covers several strain taxonIDs, and those
+  aggregate across every row reaching the same GTDB species (#386). *Bacillus
+  velezensis* is 1163 genomes via its id and 1196 via its name. 260 of 337
+  species blocks take the id path, so most still report one row — *Escherichia
+  coli* stores 50 where 2941 rows share the species. Do not compare
+  `total_genomes` between two species blocks without checking `mapping_source`
+  for which path produced them (#389).
 
 - **`support_genomes`** — the numerator, on genus-and-higher groundings only.
   Species blocks deliberately carry none: there `majority_fraction` is the

--- a/kb/communities/Australian_Lead_Zinc_Polymetallic.yaml
+++ b/kb/communities/Australian_Lead_Zinc_Polymetallic.yaml
@@ -56,7 +56,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
-      total_genomes: 7
+      total_genomes: 10
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Metabolically versatile chemolithoautotrophic γ-proteobacterium that dominates the upper oxidized
@@ -110,7 +110,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
-      total_genomes: 4
+      total_genomes: 6
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Highly specialized chemolithoautotrophic iron-oxidizing bacterium (phylum Nitrospirae) that
@@ -209,7 +209,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
-      total_genomes: 2
+      total_genomes: 4
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Obligately anaerobic δ-proteobacterium specialized for dissimilatory metal reduction, inhabiting
@@ -259,7 +259,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_E;c__Sulfobacillia;o__Sulfobacillales;f__Sulfobacillaceae;g__Sulfobacillus;s__Sulfobacillus thermosulfidooxidans
       ncbi_source_id: NCBITaxon:28034
       majority_fraction: 1.0
-      total_genomes: 2
+      total_genomes: 6
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Moderately thermophilic facultatively chemolithoautotrophic bacterium (Firmicutes) present

--- a/kb/communities/Bayan_Obo_REE_Tailings_Consortium.yaml
+++ b/kb/communities/Bayan_Obo_REE_Tailings_Consortium.yaml
@@ -68,7 +68,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
-      total_genomes: 7
+      total_genomes: 10
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Autotrophic chemolithotrophic acidophile that oxidizes ferrous iron and reduced sulfur compounds

--- a/kb/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.yaml
+++ b/kb/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.yaml
@@ -58,8 +58,8 @@ taxonomy:
       gtdb_taxon: Bifidobacterium breve
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium breve
       ncbi_source_id: NCBITaxon:1685
-      majority_fraction: 1.0
-      total_genomes: 3
+      majority_fraction: 0.99
+      total_genomes: 1593
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   abundance_level: ABUNDANT

--- a/kb/communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.yaml
+++ b/kb/communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.yaml
@@ -51,8 +51,8 @@ taxonomy:
       gtdb_taxon: Bifidobacterium breve
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium breve
       ncbi_source_id: NCBITaxon:1685
-      majority_fraction: 1.0
-      total_genomes: 3
+      majority_fraction: 0.99
+      total_genomes: 1593
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Vaginal commensal whose population is reduced in women infected with T. vaginalis, which

--- a/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
+++ b/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
@@ -91,8 +91,8 @@ taxonomy:
       gtdb_taxon: Bifidobacterium breve
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium breve
       ncbi_source_id: NCBITaxon:1685
-      majority_fraction: 1.0
-      total_genomes: 3
+      majority_fraction: 0.99
+      total_genomes: 1593
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   strain_designation:

--- a/kb/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.yaml
+++ b/kb/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.yaml
@@ -94,7 +94,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhodobacterales;f__Rhodobacteraceae;g__Rhodobacter;s__Rhodobacter capsulatus_B
       ncbi_source_id: NCBITaxon:1061
       majority_fraction: 1.0
-      total_genomes: 3
+      total_genomes: 18
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: >

--- a/kb/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.yaml
+++ b/kb/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.yaml
@@ -84,7 +84,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_B;s__Clostridium_B kluyveri
       ncbi_source_id: NCBITaxon:1534
       majority_fraction: 1.0
-      total_genomes: 3
+      total_genomes: 5
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Chain-elongating partner that consumes acetogen products in the defined coculture.

--- a/kb/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.yaml
+++ b/kb/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.yaml
@@ -91,7 +91,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_B;s__Clostridium_B kluyveri
       ncbi_source_id: NCBITaxon:1534
       majority_fraction: 1.0
-      total_genomes: 3
+      total_genomes: 5
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Chain-elongating partner that generates organic acids from C2 substrates in the coculture.

--- a/kb/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.yaml
+++ b/kb/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.yaml
@@ -89,7 +89,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium_B;s__Clostridium_B kluyveri
       ncbi_source_id: NCBITaxon:1534
       majority_fraction: 1.0
-      total_genomes: 3
+      total_genomes: 5
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Chain-elongating partner that consumes ethanol and produces butyrate and caproate.

--- a/kb/communities/Copper_Biomining_Heap_Leach.yaml
+++ b/kb/communities/Copper_Biomining_Heap_Leach.yaml
@@ -62,7 +62,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
-      total_genomes: 7
+      total_genomes: 10
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Gram-negative γ-proteobacterium that oxidizes both ferrous iron (Fe²⁺) and reduced sulfur
@@ -103,7 +103,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
-      total_genomes: 4
+      total_genomes: 6
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Iron-oxidizing bacterium (Nitrospirae phylum) that becomes dominant in aged copper bioleaching
@@ -220,7 +220,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_E;c__Sulfobacillia;o__Sulfobacillales;f__Sulfobacillaceae;g__Sulfobacillus;s__Sulfobacillus thermosulfidooxidans
       ncbi_source_id: NCBITaxon:28034
       majority_fraction: 1.0
-      total_genomes: 2
+      total_genomes: 6
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Gram-positive, spore-forming, moderately thermophilic bacterium (optimum 50-55°C) that oxidizes

--- a/kb/communities/Defined_Multispecies_Enamel_Caries_Model.yaml
+++ b/kb/communities/Defined_Multispecies_Enamel_Caries_Model.yaml
@@ -55,7 +55,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;g__Lacticaseibacillus;s__Lacticaseibacillus paracasei
       ncbi_source_id: NCBITaxon:1582
       majority_fraction: 1.0
-      total_genomes: 4
+      total_genomes: 11
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Study uses the historical name Lactobacillus casei.

--- a/kb/communities/Ewaste_Bioleaching_Consortium.yaml
+++ b/kb/communities/Ewaste_Bioleaching_Consortium.yaml
@@ -62,7 +62,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
-      total_genomes: 4
+      total_genomes: 6
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Dominant iron-oxidizing bacterium in the e-waste bioleaching consortium. Leptospirillum can
@@ -137,7 +137,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
-      total_genomes: 7
+      total_genomes: 10
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Mesophilic γ-proteobacterium that oxidizes both ferrous iron and reduced sulfur compounds.

--- a/kb/communities/Ferroplasma_Leptospirillum_Syntrophy.yaml
+++ b/kb/communities/Ferroplasma_Leptospirillum_Syntrophy.yaml
@@ -45,7 +45,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
-      total_genomes: 4
+      total_genomes: 6
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Chemolithoautotrophic iron-oxidizing bacterium (Nitrospirae phylum) that oxidizes Fe²⁺ to

--- a/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
+++ b/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
@@ -68,7 +68,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Coriobacteriia;o__Coriobacteriales;f__Atopobiaceae;g__Olsenella;s__Olsenella uli
       ncbi_source_id: NCBITaxon:133926
       majority_fraction: 1.0
-      total_genomes: 27
+      total_genomes: 29
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Dominant Actinobacteriota member (up to 61.5% relative abundance). Degrades lactose via the
@@ -304,7 +304,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Coriobacteriia;o__Coriobacteriales;f__Atopobiaceae;g__Olsenella;s__Olsenella uli
       ncbi_source_id: NCBITaxon:133926
       majority_fraction: 1.0
-      total_genomes: 27
+      total_genomes: 29
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Second Olsenella MAG (up to 13.9% relative abundance). Lactose degradation via Leloir pathway.
@@ -337,7 +337,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Bifidobacteriaceae;g__Bifidobacterium;s__Bifidobacterium thermacidophilum
       ncbi_source_id: NCBITaxon:33905
       majority_fraction: 1.0
-      total_genomes: 2
+      total_genomes: 6
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Third Bifidobacterium MAG (up to 11.4% relative abundance). Lactose fermentation.

--- a/kb/communities/Geobacter_Methanosaeta_DIET.yaml
+++ b/kb/communities/Geobacter_Methanosaeta_DIET.yaml
@@ -40,7 +40,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
-      total_genomes: 2
+      total_genomes: 4
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Anaerobic bacterium capable of oxidizing organic compounds (including

--- a/kb/communities/Geobacter_Methanosarcina_DIET.yaml
+++ b/kb/communities/Geobacter_Methanosarcina_DIET.yaml
@@ -39,7 +39,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
-      total_genomes: 2
+      total_genomes: 4
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Anaerobic bacterium capable of oxidizing organic compounds (including

--- a/kb/communities/Human_Gut_FourMember_Proteome_Complementarity_Consortium.yaml
+++ b/kb/communities/Human_Gut_FourMember_Proteome_Complementarity_Consortium.yaml
@@ -58,7 +58,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_A;c__Clostridia;o__Lachnospirales;f__Lachnospiraceae;g__Anaerobutyricum;s__Anaerobutyricum hallii
       ncbi_source_id: NCBITaxon:39488
       majority_fraction: 1.0
-      total_genomes: 156
+      total_genomes: 157
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: The paper's "Eubacterium hallii" — NCBITaxon carries this organism under the current name

--- a/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
+++ b/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
@@ -93,7 +93,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
-      total_genomes: 7
+      total_genomes: 10
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Metabolically versatile chemolithoautotroph capable of both iron and sulfur oxidation in the

--- a/kb/communities/Industrial_Bioreactor_Consortium.yaml
+++ b/kb/communities/Industrial_Bioreactor_Consortium.yaml
@@ -351,7 +351,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
-      total_genomes: 4
+      total_genomes: 6
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Obligate chemolithoautotrophic iron-oxidizing bacterium (Nitrospirae) specialized for extremely

--- a/kb/communities/Jala_Maize_PGPB_SynCom.yaml
+++ b/kb/communities/Jala_Maize_PGPB_SynCom.yaml
@@ -41,7 +41,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Pseudomonadales;f__Pseudomonadaceae;g__Pseudomonas_E;s__Pseudomonas_E protegens
       ncbi_source_id: NCBITaxon:380021
       majority_fraction: 1.0
-      total_genomes: 57
+      total_genomes: 60
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
   functional_role:

--- a/kb/communities/Mixed_Gallium_LED_Recovery_Consortium.yaml
+++ b/kb/communities/Mixed_Gallium_LED_Recovery_Consortium.yaml
@@ -116,7 +116,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
-      total_genomes: 7
+      total_genomes: 10
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Mesophilic γ-proteobacterium that oxidizes both ferrous iron (Fe²⁺) and reduced sulfur compounds.

--- a/kb/communities/PGM_Spent_Catalyst_Bioleaching.yaml
+++ b/kb/communities/PGM_Spent_Catalyst_Bioleaching.yaml
@@ -132,7 +132,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
-      total_genomes: 7
+      total_genomes: 10
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Supporting acidophilic bacterium that contributes to bioleaching through dual iron and sulfur
@@ -176,7 +176,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_E;c__Sulfobacillia;o__Sulfobacillales;f__Sulfobacillaceae;g__Sulfobacillus;s__Sulfobacillus thermosulfidooxidans
       ncbi_source_id: NCBITaxon:28034
       majority_fraction: 1.0
-      total_genomes: 2
+      total_genomes: 6
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Moderately thermophilic, facultatively autotrophic bacterium contributing to sulfur and iron

--- a/kb/communities/Polaromonas_Vanadium_Reduction_Community.yaml
+++ b/kb/communities/Polaromonas_Vanadium_Reduction_Community.yaml
@@ -144,7 +144,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
-      total_genomes: 2
+      total_genomes: 4
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Deltaproteobacteria specialized in dissimilatory metal reduction, present at 5-8% relative

--- a/kb/communities/Rammelsberg_Cobalt_Nickel_Tailings.yaml
+++ b/kb/communities/Rammelsberg_Cobalt_Nickel_Tailings.yaml
@@ -65,7 +65,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
-      total_genomes: 7
+      total_genomes: 10
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Mesophilic chemolithoautotrophic iron-oxidizing bacterium that obtains energy from oxidation

--- a/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
+++ b/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
@@ -151,7 +151,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
-      total_genomes: 7
+      total_genomes: 10
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Gram-negative γ-proteobacterium that oxidizes both iron and reduced sulfur

--- a/kb/communities/Rifle_Uranium_Reducing_Community.yaml
+++ b/kb/communities/Rifle_Uranium_Reducing_Community.yaml
@@ -43,7 +43,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
-      total_genomes: 2
+      total_genomes: 4
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Geobacter species, primarily G. metallireducens, dominate Phase I of uranium bioremediation

--- a/kb/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.yaml
+++ b/kb/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.yaml
@@ -128,7 +128,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter;s__Geobacter metallireducens
       ncbi_source_id: NCBITaxon:28232
       majority_fraction: 1.0
-      total_genomes: 2
+      total_genomes: 4
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: Exoelectrogenic Geobacter member of the defined biofilm community.

--- a/kb/communities/Thermophilic_Pyrite_QS_Consortium.yaml
+++ b/kb/communities/Thermophilic_Pyrite_QS_Consortium.yaml
@@ -65,7 +65,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Nitrospirota_A;c__Leptospirillia;o__Leptospirillales;f__Leptospirillaceae;g__Leptospirillum_A;s__Leptospirillum_A rubarum
       ncbi_source_id: NCBITaxon:178606
       majority_fraction: 1.0
-      total_genomes: 4
+      total_genomes: 6
       is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Chemolithoautotrophic iron-oxidizing bacterium (Nitrospirae phylum) representing a dominant
@@ -180,7 +180,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Bacillota_E;c__Sulfobacillia;o__Sulfobacillales;f__Sulfobacillaceae;g__Sulfobacillus;s__Sulfobacillus thermosulfidooxidans
       ncbi_source_id: NCBITaxon:28034
       majority_fraction: 1.0
-      total_genomes: 2
+      total_genomes: 6
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Gram-positive, spore-forming, moderately thermophilic bacterium (Firmicutes) that oxidizes

--- a/kb/communities/Tinto_River_Iron_Cycling_Community.yaml
+++ b/kb/communities/Tinto_River_Iron_Cycling_Community.yaml
@@ -81,7 +81,7 @@ taxonomy:
       gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Acidithiobacillales;f__Acidithiobacillaceae;g__Acidithiobacillus;s__Acidithiobacillus ferrooxidans
       ncbi_source_id: NCBITaxon:920
       majority_fraction: 1.0
-      total_genomes: 7
+      total_genomes: 10
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [mapped via NCBI species name — no species-level NCBI id in table]
     notes: 'Second dominant iron-oxidizing bacterium (~25% of prokaryotic community) with metabolic versatility

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -208,17 +208,34 @@ def _ground_species(rows, source_id, label, via):
     # denominator would be incoherent — B. breve's rows are 1544 genomes at 0.99
     # and 49 at 1.0, so "1.0 of 1593" is a claim no row makes.
     #
-    # This cannot change a grounding: measured over the KB, every species-path
-    # block has exactly one GTDB species in play (a genuine split is reported
-    # AMBIGUOUS and never grounded). It moves 38 denominators and 3 fractions.
+    # This cannot change a grounding, and the reason is structural rather than a
+    # property of today's KB: `sp` is read off `top` *before* `agreeing` is
+    # built, so the filter can only ever narrow the rows behind an already-chosen
+    # species. `resolve_target` also reports AMBIGUOUS whenever a name group
+    # holds more than one GTDB species, so the mixed case does not arise from the
+    # public entry point at all — the filter is defensive, and the synthetic
+    # split in the tests is the only thing that exercises it.
+    #
+    # It moves 39 denominators (36 alone, 3 alongside a fraction) and 3 fractions.
+    #
+    # Only the **name** path aggregates. An NCBI id maps to exactly one crosswalk
+    # row, so an id-path grounding still reports that row alone — which leaves
+    # the understatement #386 was filed about in place on more blocks than this
+    # fixes. Extending it means summing across NCBI depths, where a species-rank
+    # row and its strain rows would double-count: 96 of the KB's species mix the
+    # two. That is #371's question, and it is tracked separately (#389).
     agreeing = [r for r in rows if r[COL_GTDB_SPECIES].strip() == sp] if sp else []
     total = sum(_genomes(r) for r in agreeing)
     if total:
         fraction = round(sum(_genomes(r) * _maj(r) for r in agreeing) / total, 3)
     else:
-        # No GTDB species cell, or no genome counts: fall back to the chosen row
-        # so this path degrades to its pre-#386 behaviour rather than to zero.
-        total, fraction = _genomes(top), _maj(top)
+        # No GTDB species cell, or every agreeing row carries no genome count.
+        # An earlier comment here claimed this "degrades to its pre-#386
+        # behaviour rather than to zero" — wrong on both counts: `top` is itself
+        # in `agreeing`, so an empty total means `_genomes(top)` is 0 too, and
+        # emitting `total_genomes: 0` would then fail the `minimum_value: 1` this
+        # PR adds (#388 review). Publish no count rather than a meaningless one.
+        total, fraction = _genomes(top) or None, _maj(top)
     return {
         "ncbi_source_id": source_id,
         "gtdb_id": _curie(sp, "s") if sp else None,

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -196,13 +196,35 @@ def _ground_species(rows, source_id, label, via):
     # So species blocks carry `total_genomes` only. That is what #383 asked for —
     # what the fraction is a fraction *of* — and `support_genomes` keeps one
     # meaning everywhere: an exact count this script computed itself.
-    total = _genomes(top)
+    #
+    # Aggregate across *every* row reaching the same GTDB species, not just the
+    # chosen one (#386). A species name usually spans several crosswalk rows —
+    # different NCBI strain taxonIDs under one name — and reading a single row
+    # threw the rest away: *Bifidobacterium breve* reported 3 genomes where 25
+    # rows totalling 1593 all map to `s__Bifidobacterium_breve`.
+    #
+    # The fraction is then the genome-weighted mean over those rows, because
+    # each carries its own. Keeping the chosen row's fraction beside a summed
+    # denominator would be incoherent — B. breve's rows are 1544 genomes at 0.99
+    # and 49 at 1.0, so "1.0 of 1593" is a claim no row makes.
+    #
+    # This cannot change a grounding: measured over the KB, every species-path
+    # block has exactly one GTDB species in play (a genuine split is reported
+    # AMBIGUOUS and never grounded). It moves 38 denominators and 3 fractions.
+    agreeing = [r for r in rows if r[COL_GTDB_SPECIES].strip() == sp] if sp else []
+    total = sum(_genomes(r) for r in agreeing)
+    if total:
+        fraction = round(sum(_genomes(r) * _maj(r) for r in agreeing) / total, 3)
+    else:
+        # No GTDB species cell, or no genome counts: fall back to the chosen row
+        # so this path degrades to its pre-#386 behaviour rather than to zero.
+        total, fraction = _genomes(top), _maj(top)
     return {
         "ncbi_source_id": source_id,
         "gtdb_id": _curie(sp, "s") if sp else None,
         "gtdb_taxon": sp or None,
         "gtdb_lineage": _lineage(top, COL_GTDB_SPECIES),
-        "majority_fraction": _maj(top),
+        "majority_fraction": fraction,
         "total_genomes": total,
         "is_reclassified": bool(sp and ref and sp != ref),
         "via": via,

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-08-04T15:25:44
+# Generation date: 2026-08-04T16:05:33
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-08-04T16:05:33
+# Generation date: 2026-08-04T16:46:01
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -723,7 +723,9 @@ classes:
           numerator derived from it would assert a precision the source lacks
           (~170 genomes of slack on a 17191-genome taxon).
         range: integer
-        minimum_value: 0
+        # A grounding is awarded on a majority, so at least one genome supports
+        # it; 0 would describe a taxon grounded on nothing.
+        minimum_value: 1
       total_genomes:
         description: >-
           Number of genomes the majority was computed over — the denominator
@@ -732,10 +734,12 @@ classes:
           rank, excluding rows dropped by the named-species filter
           (sp./uncultured/informal), so it is the evidence actually considered
           rather than every genome under the NCBI taxon. For species, the genomes
-          under the chosen mapping row. Note majority_fraction is rounded, so
-          neither count can be recovered from it.
+          under the chosen mapping row and every other row reaching the same GTDB
+          species. Note majority_fraction is rounded, so neither count can be
+          recovered from it.
         range: integer
-        minimum_value: 0
+        # A majority computed over zero genomes is not a majority (#387).
+        minimum_value: 1
       is_reclassified:
         description: >-
           True when the GTDB species name differs from the NCBITaxon species
@@ -745,6 +749,24 @@ classes:
         description: >-
           Provenance of the mapping (source table + GTDB release/build), e.g.
           "kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-18)".
+    rules:
+      # A numerator with no denominator says nothing — 4 supporting genomes is
+      # unreadable without knowing whether that is 4 of 7 or 4 of 4000 (#383).
+      # This is the only part of the counts' coherence the schema can enforce:
+      # `support_genomes <= total_genomes` and agreement with majority_fraction
+      # are cross-field arithmetic, which the JSON-Schema backend cannot express,
+      # so they live in tests/test_gtdb_grounding_freshness.py instead (#387).
+      - description: >-
+          A gtdb_classification carrying support_genomes must also carry
+          total_genomes.
+        preconditions:
+          slot_conditions:
+            support_genomes:
+              value_presence: PRESENT
+        postconditions:
+          slot_conditions:
+            total_genomes:
+              value_presence: PRESENT
 
   MetaboliteDescriptor:
     description: Describes a metabolite with CHEBI term

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -734,8 +734,13 @@ classes:
           rank, excluding rows dropped by the named-species filter
           (sp./uncultured/informal), so it is the evidence actually considered
           rather than every genome under the NCBI taxon. For species, the genomes
-          under the chosen mapping row and every other row reaching the same GTDB
-          species. Note majority_fraction is rounded, so neither count can be
+          the mapping rows this grounding was resolved from. Those differ by
+          path: an NCBI id maps to exactly one crosswalk row and reports that
+          row alone, while a species *name* covers several strain taxonIDs and
+          aggregates every row reaching the same GTDB species. So two blocks
+          naming the same GTDB species can carry different totals — Escherichia
+          coli stores its id row's count, not the 2941 rows sharing the name
+          (#389). Note majority_fraction is rounded, so neither count can be
           recovered from it.
         range: integer
         # A majority computed over zero genomes is not a majority (#387).
@@ -752,9 +757,16 @@ classes:
     rules:
       # A numerator with no denominator says nothing — 4 supporting genomes is
       # unreadable without knowing whether that is 4 of 7 or 4 of 4000 (#383).
-      # This is the only part of the counts' coherence the schema can enforce:
+      #
+      # Read the guarantee narrowly. `value_presence: PRESENT` compiles to
+      # JSON-Schema `required`, which an explicit `total_genomes: null`
+      # satisfies, and `minimum_value` does not apply to null either — so this
+      # catches a *missing* key, not a null one (#388 review). `_block()` never
+      # emits nulls, and the coherence test below uses `.get()`, so the KB is
+      # covered; the schema alone is weaker than it looks.
+      #
       # `support_genomes <= total_genomes` and agreement with majority_fraction
-      # are cross-field arithmetic, which the JSON-Schema backend cannot express,
+      # are cross-field arithmetic the JSON-Schema backend cannot express at all,
       # so they live in tests/test_gtdb_grounding_freshness.py instead (#387).
       - description: >-
           A gtdb_classification carrying support_genomes must also carry

--- a/tests/test_gtdb_support_counts.py
+++ b/tests/test_gtdb_support_counts.py
@@ -1,9 +1,12 @@
 """A `majority_fraction` must say what it is a fraction *of* (#383).
 
 `0.571` reads identically whether it came from 4 genomes or 4000, and `1.0` can
-rest on a single row. Across the KB, **197 groundings rest on fewer than 10
-genomes, 192 of them reading `1.0`, and 25 rest on a single genome** — in the
+rest on a single row. Across the KB, **182 groundings rest on fewer than 10
+genomes, 177 of them reading `1.0`, and 25 rest on a single genome** — in the
 stored block those were indistinguishable from groundings drawn from thousands.
+(Two of those three figures moved when #386 aggregated the species path; the
+assertions below are ranged rather than exact so the prose is the only thing
+that rots, and `test_the_thin_groundings_are_visible` pins the shape.)
 The named-species filter (#375) sharpened it, because it shrinks the evidence
 without recording that it did.
 
@@ -309,10 +312,13 @@ def test_species_counts_match_the_crosswalk(gtdb, mapping):
     for ncbi_id, label in wanted.items():
         by_id, by_name, by_higher = gtdb.collect_rows(mapping, {ncbi_id}, {label.lower()}, set())
         result = gtdb.resolve_target(ncbi_id, label, by_id, by_name, by_higher)
-        assert result["total_genomes"] >= expected[ncbi_id][1], (
-            f"{label}: stored {result['total_genomes']} but the best crosswalk row "
-            f"alone carries {expected[ncbi_id][1]} genomes — the aggregate cannot "
-            f"be smaller than its largest term (#386)"
+        # Exact, not `>=`. Both fixtures resolve via the NCBI *id*, whose row set
+        # is a single row, so #386's aggregation is a no-op here and the count
+        # must equal that row. A `>=` passes for any mutant that inflates the
+        # total — including dropping the agreeing-rows filter entirely.
+        assert result["total_genomes"] == expected[ncbi_id][1], (
+            f"{label}: stored {result['total_genomes']} against {expected[ncbi_id][1]} "
+            f"on the crosswalk row this id resolves to"
         )
 
 
@@ -337,10 +343,14 @@ def test_the_chosen_species_row_does_not_depend_on_file_order(gtdb, mapping):
     assert (
         forward["total_genomes"] == reverse["total_genomes"]
     ), "reversing the crosswalk row order changed the stored evidence count"
-    # Since #386 the count aggregates every row reaching the same GTDB species,
-    # so both of this taxon's rows (156 genomes and 1) are included rather than
-    # one being discarded. The order-independence above is what this test is for;
-    # 157 pins that the aggregation, not a single row, produced it.
+    # 157 = 156 + 1, so the aggregation and not a single row produced it.
+    #
+    # Note what this test can no longer prove. Once the counts became
+    # order-invariant sums, `forward == reverse` holds for *any* row ordering,
+    # so it no longer guards the #382/#385 tie-break. The sort still decides
+    # which GTDB species wins when the rows disagree, and
+    # `test_the_sort_picks_the_best_supported_species_from_a_mixed_set` is what
+    # actually covers that.
     assert forward["total_genomes"] == 157, (
         f"got {forward['total_genomes']} — expected 156 + 1 aggregated across "
         f"both rows mapping to this GTDB species (#386)"
@@ -544,3 +554,89 @@ def test_aggregation_counts_only_rows_reaching_the_chosen_species(gtdb):
         result["total_genomes"] == 100
     ), "the 40 genomes mapping to a different GTDB species must not be counted"
     assert result["majority_fraction"] == 1.0, "nor may they drag the fraction down"
+
+
+def test_the_sort_picks_the_best_supported_species_from_a_mixed_set(gtdb):
+    """What the row sort still decides, now that the counts are order-invariant.
+
+    `sp` is read off `top`, so with rows disagreeing on GTDB species the sort
+    chooses the winner — and `agreeing` then narrows to it. Aggregation made
+    `total_genomes` a sum, which is order-independent by construction, so
+    `test_the_chosen_species_row_does_not_depend_on_file_order` stopped guarding
+    the #382/#385 tie-break. Reverting to the buggy stable `sorted(key=_maj)`
+    must fail here.
+    """
+
+    def row(gtdb_species, genomes, majority="1.0"):
+        cells = [""] * 20
+        cells[2], cells[3] = genomes, majority
+        cells[10], cells[18] = "Somegenus somespecies", gtdb_species
+        return cells
+
+    # Both species tie on majority, so only the genome count separates them —
+    # exactly the case a stable sort decides by file order.
+    weak = row("Somegenus weakspecies", "2")
+    strong = row("Somegenus strongspecies", "500")
+
+    for ordering in ([weak, strong], [strong, weak]):
+        result = gtdb._ground_species(ordering, "NCBITaxon:1", "Somegenus somespecies", "ncbi_id")
+        assert result["gtdb_taxon"] == "Somegenus strongspecies", (
+            f"picked the 2-genome species over the 500-genome one for ordering "
+            f"{[r[18] for r in ordering]} — the tie-break fell through to row order"
+        )
+        assert result["total_genomes"] == 500
+
+
+def test_the_schema_rule_does_not_catch_an_explicit_null(tmp_path):
+    """A known hole, asserted so it cannot be mistaken for coverage (#388 review).
+
+    `value_presence: PRESENT` compiles to JSON-Schema `required`, which a null
+    satisfies, and `minimum_value` does not apply to null. So the rule catches a
+    *missing* `total_genomes`, not `total_genomes: null`. `_block()` never emits
+    nulls and the coherence test uses `.get()`, so the KB is covered — but the
+    schema alone is weaker than its description suggests. If this ever starts
+    failing, LinkML tightened and the note in the schema should go.
+    """
+    assert _validates(tmp_path, lambda b: b.update(total_genomes=None)), (
+        "the schema now rejects an explicit null — update the rule's comment and "
+        "delete this test"
+    )
+
+
+def test_the_coherence_gate_does_catch_that_null(gtdb):
+    """What actually protects the KB from the hole above."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "freshness", REPO / "tests/test_gtdb_grounding_freshness.py"
+    )
+    freshness = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(freshness)
+
+    bad = [("rec.yaml", "Some taxon", None, {"support_genomes": 5, "total_genomes": None})]
+    with pytest.raises(AssertionError, match="no total_genomes"):
+        freshness.test_grounding_is_internally_coherent(bad)
+
+
+def test_the_weighted_fraction_keeps_three_decimal_places(gtdb):
+    """The precision the rest of the block is stored at.
+
+    Every real weighted mean in the KB happens to round identically at 2 and 3
+    places (B. breve is 0.99031), so nothing distinguished them. 3 genomes at 1.0
+    and 1 at 0.85 gives 0.9625 — 0.963 at three places, 0.96 at two — and
+    `test_every_stored_fraction_agrees_with_its_counts` compares against
+    `round(support/total, 3)`, so the two must not drift apart.
+    """
+
+    def row(genomes, majority):
+        cells = [""] * 20
+        cells[2], cells[3] = genomes, majority
+        cells[10], cells[18] = "Somegenus somespecies", "Somegenus somespecies"
+        return cells
+
+    result = gtdb._ground_species(
+        [row("3", "1.0"), row("1", "0.85")], "NCBITaxon:1", "Somegenus somespecies", "ncbi_id"
+    )
+
+    assert result["total_genomes"] == 4
+    assert result["majority_fraction"] == 0.963, "the mean must keep three decimal places"

--- a/tests/test_gtdb_support_counts.py
+++ b/tests/test_gtdb_support_counts.py
@@ -158,7 +158,12 @@ def test_the_species_path_reports_the_denominator_but_no_numerator(gtdb, mapping
     result = gtdb.resolve_target("492670", "Bacillus velezensis", by_id, by_name, by_higher)
 
     assert result["gtdb_id"] == "GTDB:s__Bacillus_velezensis"
-    assert result["total_genomes"] == 1163, "the chosen row's own genome count"
+    # 1163, because this resolves via the NCBI *id*, whose row set is the single
+    # row carrying taxonID 492670. The name path collects every row named
+    # "Bacillus velezensis" — 16 rows, 1196 genomes — and #386's aggregation then
+    # sums them. Which number is right depends on which path grounded the taxon,
+    # so both are pinned; conflating them is how the 1196 assertion first failed.
+    assert result["total_genomes"] == 1163, "the id path sees only this taxonID's rows"
     assert "support_genomes" not in result, (
         "the species path must publish no numerator — majority_fraction comes "
         "from the crosswalk's 2-decimal column, so any numerator derived from it "
@@ -304,9 +309,10 @@ def test_species_counts_match_the_crosswalk(gtdb, mapping):
     for ncbi_id, label in wanted.items():
         by_id, by_name, by_higher = gtdb.collect_rows(mapping, {ncbi_id}, {label.lower()}, set())
         result = gtdb.resolve_target(ncbi_id, label, by_id, by_name, by_higher)
-        assert result["total_genomes"] == expected[ncbi_id][1], (
+        assert result["total_genomes"] >= expected[ncbi_id][1], (
             f"{label}: stored {result['total_genomes']} but the best crosswalk row "
-            f"carries {expected[ncbi_id][1]} genomes"
+            f"alone carries {expected[ncbi_id][1]} genomes — the aggregate cannot "
+            f"be smaller than its largest term (#386)"
         )
 
 
@@ -331,12 +337,13 @@ def test_the_chosen_species_row_does_not_depend_on_file_order(gtdb, mapping):
     assert (
         forward["total_genomes"] == reverse["total_genomes"]
     ), "reversing the crosswalk row order changed the stored evidence count"
-    # Deterministic is not enough — it must be the *best-supported* row. Both
-    # rows here sit at majority 1.0, carrying 156 genomes and 1, so consistently
-    # picking either end would satisfy the assertion above.
-    assert forward["total_genomes"] == 156, (
-        f"chose a {forward['total_genomes']}-genome row over the 156-genome one; "
-        f"a tie must break toward the better-supported row"
+    # Since #386 the count aggregates every row reaching the same GTDB species,
+    # so both of this taxon's rows (156 genomes and 1) are included rather than
+    # one being discarded. The order-independence above is what this test is for;
+    # 157 pins that the aggregation, not a single row, produced it.
+    assert forward["total_genomes"] == 157, (
+        f"got {forward['total_genomes']} — expected 156 + 1 aggregated across "
+        f"both rows mapping to this GTDB species (#386)"
     )
 
 
@@ -395,3 +402,145 @@ def test_a_curated_grounding_is_skipped_by_refresh(gtdb, tmp_path, mapping):
     assert "test-source" not in (
         pinned["gtdb_classification"].get("mapping_source") or ""
     ), "the curated block was rewritten even though its value survived"
+
+
+def test_the_name_path_aggregates_every_row_for_the_species(gtdb, mapping):
+    """#386: one species name spans many crosswalk rows, and all of them count.
+
+    `_ground_species` read a single row and discarded the rest, so
+    *Bifidobacterium breve* reported 3 genomes where 25 rows totalling 1593 map
+    to `s__Bifidobacterium_breve` — an understatement of ~500x. The name path is
+    where this bites, because a species name covers several NCBI strain taxonIDs.
+    """
+    _, by_name, _ = gtdb.collect_rows(mapping, set(), {"bifidobacterium breve"}, set())
+    result = gtdb.resolve_target("", "Bifidobacterium breve", {}, by_name, {})
+
+    assert result["gtdb_id"] == "GTDB:s__Bifidobacterium_breve"
+    assert (
+        result["total_genomes"] == 1593
+    ), f"got {result['total_genomes']} — a single row's count, not the aggregate"
+
+
+def test_the_species_fraction_is_weighted_by_genomes(gtdb, mapping):
+    """A summed denominator needs a fraction computed over the same rows.
+
+    *B. breve*'s rows are 1544 genomes at 0.99 and 49 at 1.0. Keeping the chosen
+    row's 1.0 beside a 1593 denominator would assert "1.0 of 1593", which no row
+    supports; the genome-weighted mean is 0.99.
+    """
+    _, by_name, _ = gtdb.collect_rows(mapping, set(), {"bifidobacterium breve"}, set())
+    result = gtdb.resolve_target("", "Bifidobacterium breve", {}, by_name, {})
+
+    assert result["majority_fraction"] == 0.99, (
+        "the fraction must be the genome-weighted mean over the aggregated rows, "
+        "not whichever row happened to be chosen"
+    )
+
+
+def test_aggregation_falls_back_when_no_gtdb_species_is_named(gtdb):
+    """A row with an empty GTDB species cell must not aggregate to a zero total.
+
+    `total_genomes: 0` would be a majority over nothing, which the schema now
+    rejects outright (#387) — so the fallback has to hold.
+    """
+    cells = [""] * 20
+    cells[2], cells[3], cells[10] = "12", "1.0", "Somegenus somespecies"
+    result = gtdb._ground_species([cells], "NCBITaxon:1", "Somegenus somespecies", "ncbi_id")
+
+    assert result["gtdb_id"] is None, "no GTDB species cell means no grounding"
+    assert result["total_genomes"] == 12, "must fall back to the chosen row, not 0"
+
+
+# ---------------------------------------------------------------------------
+# What the schema itself rejects, as opposed to what a test catches (#387).
+# ---------------------------------------------------------------------------
+
+SCHEMA = REPO / "src/communitymech/schema/communitymech.yaml"
+
+
+def _validates(tmp_path, mutate) -> bool:
+    """Apply `mutate` to one grounded block of a real record; is it still valid?"""
+    import subprocess
+
+    source = REPO / "kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml"
+    doc = yaml.safe_load(source.read_text())
+    for entry in doc["taxonomy"]:
+        block = (entry.get("taxon_term") or {}).get("gtdb_classification")
+        if block and "support_genomes" in block:
+            mutate(block)
+            break
+    else:
+        pytest.fail("no block with support_genomes in the fixture record")
+
+    path = tmp_path / "mutated.yaml"
+    path.write_text(yaml.dump(doc, sort_keys=False, allow_unicode=True))
+    return (
+        subprocess.run(
+            ["uv", "run", "linkml-validate", "-s", str(SCHEMA), str(path)],
+            capture_output=True,
+            cwd=REPO,
+        ).returncode
+        == 0
+    )
+
+
+def test_schema_rejects_a_numerator_without_a_denominator(tmp_path):
+    """The one coherence constraint the JSON-Schema backend can express."""
+    assert not _validates(tmp_path, lambda b: b.pop("total_genomes")), (
+        "a block with support_genomes and no total_genomes validated — the "
+        "class rule is not being enforced (#387)"
+    )
+
+
+def test_schema_rejects_a_majority_over_zero_genomes(tmp_path):
+    assert not _validates(tmp_path, lambda b: b.update(total_genomes=0))
+    assert not _validates(tmp_path, lambda b: b.update(support_genomes=0))
+
+
+def test_schema_still_accepts_an_untouched_block(tmp_path):
+    """Guards the two above: if everything failed, they would pass vacuously."""
+    assert _validates(tmp_path, lambda b: None), "the unmutated fixture must validate"
+
+
+def test_schema_cannot_catch_contradictory_counts(tmp_path):
+    """Documents the known gap, so it is a decision rather than an oversight.
+
+    `support_genomes <= total_genomes` and agreement with `majority_fraction` are
+    cross-field arithmetic, which the JSON-Schema backend cannot express. The
+    coherence test in tests/test_gtdb_grounding_freshness.py carries them for the
+    committed KB. If this ever starts failing, LinkML gained the capability and
+    the constraint should move into the schema (#387).
+    """
+    assert _validates(tmp_path, lambda b: b.update(support_genomes=99, total_genomes=3)), (
+        "the schema now rejects contradictory counts — move the relational "
+        "checks out of the tests and into the schema, and delete this test"
+    )
+
+
+def test_aggregation_counts_only_rows_reaching_the_chosen_species(gtdb):
+    """Sum the rows that *agree*, not every row in the set.
+
+    Every species-path taxon in the KB happens to have one GTDB species in play,
+    so dropping the filter is invisible against real data — a synthetic split is
+    the only thing that pins it. Counting the disagreeing rows would inflate the
+    denominator with genomes supporting a different species entirely.
+    """
+
+    def row(gtdb_species, genomes, majority="1.0"):
+        cells = [""] * 20
+        cells[2], cells[3] = genomes, majority
+        cells[10], cells[18] = "Somegenus somespecies", gtdb_species
+        return cells
+
+    chosen = row("Somegenus somespecies", "100")
+    other = row("Somegenus otherspecies", "40", majority="0.5")
+
+    result = gtdb._ground_species(
+        [chosen, other], "NCBITaxon:1", "Somegenus somespecies", "ncbi_id"
+    )
+
+    assert result["gtdb_taxon"] == "Somegenus somespecies"
+    assert (
+        result["total_genomes"] == 100
+    ), "the 40 genomes mapping to a different GTDB species must not be counted"
+    assert result["majority_fraction"] == 1.0, "nor may they drag the fraction down"


### PR DESCRIPTION
Closes #386 (partially — see below) and #387.

## #386 — a species grounding read one crosswalk row and discarded the rest

A GTDB species name usually spans several crosswalk rows, because several NCBI *strain* taxonIDs share it. `_ground_species` took the best row and threw the others away:

| taxon | stored | agreeing rows | genomes |
|---|---|---|---|
| *Bifidobacterium breve* | **3** | 25 | **1593** |
| *Rhodobacter capsulatus_B* | 3 | 7 | 18 |
| *Lacticaseibacillus paracasei* | 4 | 7 | 11 |
| *Anaerobutyricum hallii* | 156 | 2 | 157 |

`total_genomes` now sums every row reaching the chosen GTDB species, and `majority_fraction` is the **genome-weighted mean** over those same rows. Keeping the chosen row'"'"'s fraction beside a summed denominator would be incoherent: *B. breve*'"'"'s rows are 1544 genomes at `0.99` and 49 at `1.0`, so "1.0 of 1593" is a claim no row makes.

### This fixes half the problem, and #389 tracks the other half

Aggregation only takes effect on the **name** path. An NCBI id maps to exactly one crosswalk row, and **260 of 337 species blocks ground via `ncbi_id`** — so most still report a single row. *E. coli* stores 50 genomes where 2941 rows share the species; of the 195 distinct GTDB species behind these blocks, **149 understate**. *B. breve* got its 1593 only because taxonID 1685 happens to be absent from the table.

Extending it is not a patch. Summing every row for a species means summing across NCBI *depths*, and the crosswalk'"'"'s species rows do not contain their strain rows — so a species-rank row plus its strain rows double-counts. **96 of the 195 mix the two.** The 39 blocks aggregated here are all 100% strain rows, which is exactly why this change is safe and the extension is not. That is #371'"'"'s question at species rank, filed as **#389**.

An earlier revision of this PR wrote into the schema that species counts cover "every other row reaching the same GTDB species" — false for 260 of 337 blocks. Corrected there and in SKILL.md.

### Sweep

| | |
|---|---|
| grounded blocks before / after | **647 / 647** |
| records changed outside `gtdb_classification` | **0** |
| **grounding flips** | **0** — structural: `sp` is read off `top` *before* `agreeing` is built, so the filter can only narrow rows behind an already-chosen species |
| `total_genomes` changed | 36 |
| `total_genomes` + `majority_fraction` | 3 — all *B. breve* |
| unchanged | 608 |

## #387 — the schema accepted contradictory counts

Spiked what LinkML actually enforces. Two constraints are expressible and both verified to reject: a class **rule** (`support_genomes` present → `total_genomes` present) and `minimum_value: 1` on both counts.

**Read the guarantee narrowly.** `value_presence: PRESENT` compiles to JSON-Schema `required`, which an explicit `total_genomes: null` satisfies, and `minimum_value` does not apply to null — so the rule catches a *missing* key, not a null one. `_block()` never emits nulls and the coherence gate uses `.get()`, so the KB is covered, but my first description overstated it. Both the hole and the thing that closes it are now asserted.

`support <= total` and fraction agreement are cross-field arithmetic the JSON-Schema backend cannot express; they stay in `test_gtdb_grounding_freshness.py`, pinned by a test that **asserts the contradictory instance still validates** — so if LinkML gains the capability it fails and says so.

## Review findings addressed

- **The tie-break fix went unguarded and its test became a tautology.** Once counts were order-invariant sums, `forward == reverse` held for *any* ordering — the pre-#385 buggy stable sort, a worst-row-first sort, and no sort at all all produced byte-identical output for all 647 blocks and passed. What the sort still decides is which species wins when rows disagree; that is now tested with a mixed set where the two tie on majority.
- **The fallback comment was wrong in both halves** — it claimed to degrade to pre-#386 behaviour "rather than to zero", but `top` is in `agreeing`, so an empty total meant `_genomes(top)` was 0 too, and it would then fail the `minimum_value: 1` this PR adds. Now omits the count.
- **`test_species_counts_match_the_crosswalk` had been weakened** from `==` to `>=` for no reason — both fixtures use the id path where aggregation is a no-op, so `>=` passed for any mutant that inflates the count. Restored.
- **Stale numbers, mine**: the code comment said 38 denominators where the measurement is 39, and the module docstring'"'"'s "197 groundings under 10 genomes, 192 reading 1.0" went stale from this PR'"'"'s own change (182 / 177 / 25).

## Mutation testing

All mutants now die, including the last survivor: `round(..., 3) → round(..., 2)` was indistinguishable because every real weighted mean rounds identically at both places. 3 genomes at 1.0 and 1 at 0.85 gives 0.9625, which does not.

`just validate-all` clean, 1077 passed, lint clean.
