### PR TITLE
Enforce gtdb_classification count coherence outside the schema (#387)

### DIFF
--- a/justfile
+++ b/justfile
@@ -143,6 +143,19 @@ validate-cross-repo-ids FILE:
 validate-cross-repo-ids-all:
     PYTHONPATH=src uv run python scripts/validate_cross_repo_ids.py kb/communities/*.yaml
 
+# Check gtdb_classification evidence counts against each other (#387).
+#
+# The schema bounds support_genomes/total_genomes individually but cannot relate
+# them — LinkML's JSON-Schema backend has no cross-field arithmetic — so
+# `just validate` accepts 99 supporting genomes out of 3, and accepts
+# `total_genomes: null` (a null satisfies `required`). These same checks run
+# inside `just validate-strict`; this is the fast single-file form.
+validate-gtdb FILE:
+    PYTHONPATH=src uv run python scripts/validate_gtdb_coherence.py {{FILE}}
+
+validate-gtdb-all:
+    PYTHONPATH=src uv run python scripts/validate_gtdb_coherence.py kb/communities/*.yaml data/isolates/*.yaml
+
 # Environmental coverage dashboard: per-ENVO counts of communities vs CultureMech
 # media vs MediaIngredientMech ingredients (issue #30). Reads sibling repos from
 # COMMUNITYMECH_SIBLING_REPOS env (Name=path,Name=path); pass --tsv to also write

--- a/scripts/validate_gtdb_coherence.py
+++ b/scripts/validate_gtdb_coherence.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Report `gtdb_classification` blocks whose evidence counts contradict each other.
+
+The schema types and bounds the counts individually but cannot relate two slots
+to each other — the JSON-Schema backend has no cross-field arithmetic — so
+`linkml-validate` accepts a block claiming 99 supporting genomes out of 3, and
+accepts `total_genomes: null` because a null satisfies `required` (#387).
+
+The same checks run inside `just validate-strict`, which is the CI gate. This
+script exists for the single-file case, where booting the full closed-schema
+validator to ask one question is slow and its output buries the answer.
+
+    just validate-gtdb kb/communities/Foo.yaml
+    just validate-gtdb-all
+
+Exits 1 if any issue is found, so it can be used as a gate on its own.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from communitymech.validators.gtdb_coherence import validate_gtdb_coherence  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("files", nargs="+", type=Path, help="community YAML file(s)")
+    args = parser.parse_args(argv)
+
+    issues = []
+    for path in args.files:
+        if not path.exists():
+            print(f"[gtdb-coherence] no such file: {path}", file=sys.stderr)
+            return 2
+        issues.extend(validate_gtdb_coherence(path))
+
+    by_category: dict[str, int] = {}
+    for issue in issues:
+        by_category[issue.category] = by_category.get(issue.category, 0) + 1
+        print(f"{issue.file}: {issue.taxon}\n  [{issue.category}] {issue.message}")
+
+    print(f"\nfiles checked: {len(args.files)}", file=sys.stderr)
+    print(f"incoherent blocks: {len(issues)}", file=sys.stderr)
+    for category, count in sorted(by_category.items(), key=lambda kv: -kv[1]):
+        print(f"  {category:34s} {count:>6d}", file=sys.stderr)
+    return 1 if issues else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_strict.py
+++ b/scripts/validate_strict.py
@@ -44,7 +44,10 @@ from communitymech.validators.gtdb_coherence import validate_gtdb_coherence
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 SCHEMA_PATH = _REPO_ROOT / "src" / "communitymech" / "schema" / "communitymech.yaml"
-DEFAULT_ROOTS = [_REPO_ROOT / "kb" / "communities"]
+# `data/isolates` uses the same taxon_term shape and was outside this gate
+# while the comment below claimed "the same gate as everything else"
+# (#390 review). It has been outside a gate once before (#310).
+DEFAULT_ROOTS = [_REPO_ROOT / "kb" / "communities", _REPO_ROOT / "data" / "isolates"]
 TARGET_CLASS = "MicrobialCommunity"
 
 

--- a/scripts/validate_strict.py
+++ b/scripts/validate_strict.py
@@ -40,6 +40,8 @@ from linkml.validator import Validator
 from linkml.validator.plugins import JsonschemaValidationPlugin
 from linkml.validator.report import Severity
 
+from communitymech.validators.gtdb_coherence import validate_gtdb_coherence
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 SCHEMA_PATH = _REPO_ROOT / "src" / "communitymech" / "schema" / "communitymech.yaml"
 DEFAULT_ROOTS = [_REPO_ROOT / "kb" / "communities"]
@@ -142,6 +144,21 @@ def validate_one(path: Path) -> list[dict]:
             "detail": detail,
             "path": result.instance_index or "",
             "message": result.message[:300],
+        })
+
+    # Relational checks the schema cannot express (#387). LinkML has no
+    # cross-field arithmetic, so `support_genomes: 99` beside `total_genomes: 3`
+    # is valid to it, as is an explicit `total_genomes: null` — a null satisfies
+    # JSON-Schema `required`, which is what `value_presence: PRESENT` compiles
+    # to. Running them here rather than only in pytest means a hand-authored
+    # record is checked by the same gate as everything else.
+    for issue in validate_gtdb_coherence(path):
+        rows.append({
+            "file": str(path),
+            "category": f"gtdb_{issue.category}",
+            "detail": issue.taxon,
+            "path": "",
+            "message": issue.message[:300],
         })
     return rows
 

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-08-04T16:46:01
+# Generation date: 2026-08-04T17:21:08
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -733,7 +733,7 @@ classes:
           genus-and-higher, the genomes across every candidate GTDB taxon at that
           rank, excluding rows dropped by the named-species filter
           (sp./uncultured/informal), so it is the evidence actually considered
-          rather than every genome under the NCBI taxon. For species, the genomes
+          rather than every genome under the NCBI taxon. For species, the genomes in
           the mapping rows this grounding was resolved from. Those differ by
           path: an NCBI id maps to exactly one crosswalk row and reports that
           row alone, while a species *name* covers several strain taxonIDs and

--- a/src/communitymech/validators/gtdb_coherence.py
+++ b/src/communitymech/validators/gtdb_coherence.py
@@ -52,6 +52,25 @@ FRACTION_TOLERANCE = 0.001
 MIN_FRACTION = 0.5
 
 
+def _as_number(value: Any) -> float | None:
+    """The value as a number, or None if it is not one.
+
+    `isinstance(x, int)` was the original guard and it was a regression: it is
+    False for `3.0`, and JSON-Schema `type: integer` accepts `3.0`, so
+    `total_genomes: 3.0` slipped past every comparison below while the inline
+    logic this module replaced caught it (#390 review). It is also True for
+    `True`, which would read `total_genomes: true` as 1.
+
+    Anything non-numeric returns None and is reported separately rather than
+    silently skipped — silently skipping is what made the float case invisible.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
 @dataclass(frozen=True)
 class CoherenceIssue:
     """One problem with one `gtdb_classification` block."""
@@ -73,16 +92,28 @@ def _blocks(doc: Any) -> Iterator[tuple[str, dict]]:
     has 28 isolates on one id — and an id-keyed message would point at the wrong
     entry.
     """
-    for index, entry in enumerate((doc or {}).get("taxonomy") or []):
+    # Every level is type-guarded, not just truth-tested. `validate_one` in
+    # scripts/validate_strict.py calls this outside its try/except, so an
+    # AttributeError here does not fail one file — it kills the run and the TSV
+    # report is never written, losing every other file's errors (#390 review).
+    if not isinstance(doc, dict):
+        return
+    taxonomy = doc.get("taxonomy")
+    if not isinstance(taxonomy, list):
+        return
+    for index, entry in enumerate(taxonomy):
         if not isinstance(entry, dict):
             continue
-        term_block = entry.get("taxon_term") or {}
+        term_block = entry.get("taxon_term")
         if not isinstance(term_block, dict):
             continue
         grounding = term_block.get("gtdb_classification")
         if isinstance(grounding, dict):
+            term = term_block.get("term")
             name = (
-                term_block.get("preferred_term") or (term_block.get("term") or {}).get("id") or "?"
+                term_block.get("preferred_term")
+                or (term.get("id") if isinstance(term, dict) else None)
+                or "?"
             )
             yield f"taxonomy[{index}] {name}", grounding
 
@@ -94,46 +125,73 @@ def check_block(block: dict) -> list[tuple[str, str]]:
     memory — the tests use it, and so does anything validating before a write.
     """
     problems: list[tuple[str, str]] = []
-    support = block.get("support_genomes")
-    total = block.get("total_genomes")
-    fraction = block.get("majority_fraction")
+    raw_support = block.get("support_genomes")
+    raw_total = block.get("total_genomes")
+    raw_fraction = block.get("majority_fraction")
 
-    # An explicitly-null count is the case the schema's class rule misses.
-    for slot, value in (("support_genomes", support), ("total_genomes", total)):
-        if slot in block and value is None:
+    for slot, value in (
+        ("support_genomes", raw_support),
+        ("total_genomes", raw_total),
+        ("majority_fraction", raw_fraction),
+    ):
+        if slot not in block:
+            continue
+        # An explicitly-null count is the case the schema's class rule misses.
+        if value is None:
+            if slot != "majority_fraction":
+                problems.append(
+                    (
+                        "null_count",
+                        f"{slot} is present but null; `linkml-validate` accepts this "
+                        f"because a null satisfies JSON-Schema `required` (#387). Omit "
+                        f"the key instead.",
+                    )
+                )
+            continue
+        if _as_number(value) is None:
             problems.append(
                 (
-                    "null_count",
-                    f"{slot} is present but null; `linkml-validate` accepts this "
-                    f"because a null satisfies JSON-Schema `required` (#387). Omit "
-                    f"the key instead.",
+                    "non_numeric_count",
+                    f"{slot}={value!r} is not a number, so none of the relational "
+                    f"checks below can run on it.",
+                )
+            )
+        elif slot != "majority_fraction" and float(value) != int(float(value)):
+            problems.append(
+                (
+                    "non_integral_count",
+                    f"{slot}={value!r} is a genome count and must be a whole number.",
                 )
             )
 
-    if support is not None and total is None:
+    support = _as_number(raw_support)
+    total = _as_number(raw_total)
+    fraction = _as_number(raw_fraction)
+
+    if raw_support is not None and "total_genomes" not in block:
         problems.append(
             (
                 "numerator_without_denominator",
-                f"support_genomes={support} with no total_genomes — a numerator "
+                f"support_genomes={raw_support} with no total_genomes — a numerator "
                 f"says nothing without what it is out of (#383).",
             )
         )
 
-    if isinstance(total, int) and total <= 0:
+    if total is not None and total <= 0:
         problems.append(
-            ("nonpositive_total", f"total_genomes={total} — a majority over no genomes.")
+            ("nonpositive_total", f"total_genomes={raw_total} — a majority over no genomes.")
         )
 
-    if isinstance(support, int) and isinstance(total, int):
+    if support is not None and total is not None:
         if support > total:
             problems.append(
                 (
                     "support_exceeds_total",
-                    f"support_genomes={support} > total_genomes={total} — more "
+                    f"support_genomes={raw_support} > total_genomes={raw_total} — more "
                     f"supporting genomes than genomes counted.",
                 )
             )
-        elif total > 0 and isinstance(fraction, (int, float)):
+        elif total > 0 and fraction is not None:
             computed = round(support / total, 3)
             if abs(computed - fraction) > FRACTION_TOLERANCE:
                 problems.append(
@@ -145,12 +203,14 @@ def check_block(block: dict) -> list[tuple[str, str]]:
                     )
                 )
 
-    if isinstance(fraction, (int, float)) and not (MIN_FRACTION <= fraction <= 1.0):
+    if fraction is not None and not (MIN_FRACTION <= fraction <= 1.0):
         problems.append(
             (
                 "fraction_out_of_range",
-                f"majority_fraction={fraction} outside ({MIN_FRACTION}, 1.0] — the "
-                f"tool grounds on a majority, so this cannot be one.",
+                f"majority_fraction={raw_fraction} outside [{MIN_FRACTION}, 1.0]. "
+                f"The bound is inclusive because one KB block sits at exactly 0.5 "
+                f"— an unresolved two-way tie, tracked in #382 — not because a tie "
+                f"is a majority.",
             )
         )
 

--- a/src/communitymech/validators/gtdb_coherence.py
+++ b/src/communitymech/validators/gtdb_coherence.py
@@ -1,0 +1,178 @@
+"""Relational checks on `gtdb_classification` that LinkML cannot express (#387).
+
+The schema types the evidence counts and bounds them individually — `range:
+integer`, `minimum_value: 1`, and a class rule requiring `total_genomes` whenever
+`support_genomes` is present. What it cannot do is relate two slots to each
+other, because the JSON-Schema backend has no cross-field arithmetic. So
+`linkml-validate` accepts all of these:
+
+    support_genomes: 99   total_genomes: 3      # more supporters than genomes
+    support_genomes: 2    total_genomes: 9999   majority_fraction: 1.0
+    support_genomes: 5    total_genomes: null   # a null satisfies `required`
+
+The last is the sharpest, and is why this module exists rather than a note in the
+schema. `value_presence: PRESENT` compiles to JSON-Schema `required`, which an
+explicit null satisfies, and `minimum` does not apply to null either — so the
+class rule guards a *missing* key only. LinkML emits `type: ["integer", "null"]`
+for every optional slot, so this is not something the schema can be coaxed into.
+
+These checks previously lived only in `tests/test_gtdb_grounding_freshness.py`,
+which covers the committed KB on every CI run but does nothing for a
+hand-authored record someone validates with `just validate` alone. Here they run
+wherever schema validation runs — `just validate-gtdb`, and folded into
+`just validate-strict`, which is a CI gate.
+
+Usage:
+
+    from pathlib import Path
+    from communitymech.validators.gtdb_coherence import validate_gtdb_coherence
+
+    for issue in validate_gtdb_coherence(Path("kb/communities/Foo.yaml")):
+        print(issue.category, issue.message)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# `majority_fraction` is stored rounded to 3 places, so an exact comparison
+# against support/total would fail on legitimate blocks. One unit in the last
+# place is the whole tolerance — anything looser stops catching real drift.
+FRACTION_TOLERANCE = 0.001
+
+# The tool grounds on a majority, so a fraction at or below 0.5 is not one. This
+# duplicates the schema's 0.0–1.0 bound deliberately: the schema cannot express
+# the lower half, and a 0.4 "majority" is the kind of thing that survives a
+# hand-edit.
+MIN_FRACTION = 0.5
+
+
+@dataclass(frozen=True)
+class CoherenceIssue:
+    """One problem with one `gtdb_classification` block."""
+
+    file: str
+    taxon: str
+    category: str
+    message: str
+
+    def __str__(self) -> str:  # pragma: no cover - display only
+        return f"{self.file}: {self.taxon} [{self.category}] {self.message}"
+
+
+def _blocks(doc: Any) -> Iterator[tuple[str, dict]]:
+    """Yield (label, gtdb_classification) for each taxonomy entry that has one.
+
+    Positional index is included in the label because a record may legitimately
+    list the same NCBITaxon id many times — `GLBRC_Populus_Variovorax_SynCom28`
+    has 28 isolates on one id — and an id-keyed message would point at the wrong
+    entry.
+    """
+    for index, entry in enumerate((doc or {}).get("taxonomy") or []):
+        if not isinstance(entry, dict):
+            continue
+        term_block = entry.get("taxon_term") or {}
+        if not isinstance(term_block, dict):
+            continue
+        grounding = term_block.get("gtdb_classification")
+        if isinstance(grounding, dict):
+            name = (
+                term_block.get("preferred_term") or (term_block.get("term") or {}).get("id") or "?"
+            )
+            yield f"taxonomy[{index}] {name}", grounding
+
+
+def check_block(block: dict) -> list[tuple[str, str]]:
+    """Return (category, message) for each incoherence in one block.
+
+    Split out from the file walk so callers can check a block they hold in
+    memory — the tests use it, and so does anything validating before a write.
+    """
+    problems: list[tuple[str, str]] = []
+    support = block.get("support_genomes")
+    total = block.get("total_genomes")
+    fraction = block.get("majority_fraction")
+
+    # An explicitly-null count is the case the schema's class rule misses.
+    for slot, value in (("support_genomes", support), ("total_genomes", total)):
+        if slot in block and value is None:
+            problems.append(
+                (
+                    "null_count",
+                    f"{slot} is present but null; `linkml-validate` accepts this "
+                    f"because a null satisfies JSON-Schema `required` (#387). Omit "
+                    f"the key instead.",
+                )
+            )
+
+    if support is not None and total is None:
+        problems.append(
+            (
+                "numerator_without_denominator",
+                f"support_genomes={support} with no total_genomes — a numerator "
+                f"says nothing without what it is out of (#383).",
+            )
+        )
+
+    if isinstance(total, int) and total <= 0:
+        problems.append(
+            ("nonpositive_total", f"total_genomes={total} — a majority over no genomes.")
+        )
+
+    if isinstance(support, int) and isinstance(total, int):
+        if support > total:
+            problems.append(
+                (
+                    "support_exceeds_total",
+                    f"support_genomes={support} > total_genomes={total} — more "
+                    f"supporting genomes than genomes counted.",
+                )
+            )
+        elif total > 0 and isinstance(fraction, (int, float)):
+            computed = round(support / total, 3)
+            if abs(computed - fraction) > FRACTION_TOLERANCE:
+                problems.append(
+                    (
+                        "fraction_disagrees_with_counts",
+                        f"{support}/{total} = {computed} but majority_fraction="
+                        f"{fraction}. One of the three is stale — re-run "
+                        f"`gtdb_ground.py --refresh --apply` on this record.",
+                    )
+                )
+
+    if isinstance(fraction, (int, float)) and not (MIN_FRACTION <= fraction <= 1.0):
+        problems.append(
+            (
+                "fraction_out_of_range",
+                f"majority_fraction={fraction} outside ({MIN_FRACTION}, 1.0] — the "
+                f"tool grounds on a majority, so this cannot be one.",
+            )
+        )
+
+    return problems
+
+
+def validate_gtdb_coherence(path: Path) -> list[CoherenceIssue]:
+    """Check every `gtdb_classification` in one record."""
+    try:
+        doc = yaml.safe_load(path.read_text())
+    except yaml.YAMLError as exc:
+        return [
+            CoherenceIssue(
+                file=str(path),
+                taxon="-",
+                category="yaml_parse_error",
+                message=str(exc).splitlines()[0][:300],
+            )
+        ]
+
+    return [
+        CoherenceIssue(file=str(path), taxon=label, category=category, message=message)
+        for label, block in _blocks(doc)
+        for category, message in check_block(block)
+    ]

--- a/tests/test_gtdb_coherence_validator.py
+++ b/tests/test_gtdb_coherence_validator.py
@@ -28,6 +28,7 @@ import pytest
 import yaml
 
 from communitymech.validators.gtdb_coherence import (
+    _blocks,
     check_block,
     validate_gtdb_coherence,
 )
@@ -62,14 +63,22 @@ def _linkml_accepts(tmp_path: Path, block: dict) -> bool:
 
     path = tmp_path / "probe.yaml"
     path.write_text(yaml.dump(doc, sort_keys=False, allow_unicode=True))
-    return (
-        subprocess.run(
-            ["uv", "run", "linkml-validate", "-s", str(SCHEMA), str(path)],
-            capture_output=True,
-            cwd=REPO,
-        ).returncode
-        == 0
+    result = subprocess.run(
+        ["uv", "run", "linkml-validate", "-s", str(SCHEMA), str(path)],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
     )
+    if result.returncode != 0:
+        # Distinguish "linkml rejected the instance" from "the subprocess never
+        # ran". Without this the negative assertions pass whenever `uv` errors —
+        # and that is exactly the test whose job is to prove False is reachable.
+        output = result.stdout + result.stderr
+        assert "[ERROR]" in output, (
+            f"linkml-validate failed without reporting a validation error, so this "
+            f"says nothing about the schema:\n{output[-1500:]}"
+        )
+    return result.returncode == 0
 
 
 def test_a_correct_block_is_clean():
@@ -119,6 +128,15 @@ def test_rounding_slack_is_tolerated_but_drift_is_not():
     drifted = _valid_block()
     drifted["majority_fraction"] = 0.71
     assert "fraction_disagrees_with_counts" in {c for c, _ in check_block(drifted)}
+
+    # 0.71 is 0.015 away, so it survives any tolerance below ~0.0149 — loosening
+    # 0.001 to 0.01 passed the whole suite (#390 review). This sits two units in
+    # the last place out, the smallest drift that must still be caught.
+    just_outside = _valid_block()
+    just_outside["majority_fraction"] = 0.697
+    assert "fraction_disagrees_with_counts" in {
+        c for c, _ in check_block(just_outside)
+    }, "a two-in-the-last-place drift went unreported — the tolerance is too loose"
 
 
 @pytest.mark.parametrize("total", [0, -5])
@@ -170,10 +188,16 @@ def test_linkml_still_rejects_what_the_schema_does_cover(tmp_path):
 
 def test_the_committed_kb_is_coherent():
     """Every record, not just the ones with counts."""
-    issues = []
+    issues, scanned, blocks = [], 0, 0
     for directory in ("kb/communities", "data/isolates"):
         for path in sorted((REPO / directory).glob("*.yaml")):
+            scanned += 1
+            blocks += len(list(_blocks(yaml.safe_load(path.read_text()))))
             issues.extend(validate_gtdb_coherence(path))
+    # Without these, moving or renaming kb/communities empties both globs and
+    # this passes having checked nothing (#390 review).
+    assert scanned > 300, f"expected the whole KB, scanned only {scanned} records"
+    assert blocks > 500, f"expected the grounded KB, saw only {blocks} blocks"
     assert not issues, "incoherent gtdb_classification in the KB:\n" + "\n".join(
         f"  {issue}" for issue in issues[:20]
     )
@@ -195,7 +219,18 @@ def test_validate_strict_reports_the_incoherence(tmp_path):
     path.write_text(yaml.dump(doc, sort_keys=False, allow_unicode=True))
 
     result = subprocess.run(
-        ["uv", "run", "python", "scripts/validate_strict.py", str(path)],
+        # `--out` matters: the default is cwd-relative and lands on the
+        # git-tracked reports/instance_validation_failures.tsv, so running this
+        # test alone left the tree dirty with /tmp paths in a committed file.
+        [
+            "uv",
+            "run",
+            "python",
+            "scripts/validate_strict.py",
+            str(path),
+            "--out",
+            str(tmp_path / "report.tsv"),
+        ],
         capture_output=True,
         text=True,
         cwd=REPO,
@@ -210,7 +245,15 @@ def test_validate_strict_still_passes_the_real_kb_record(tmp_path):
     path = tmp_path / "clean.yaml"
     path.write_text(FIXTURE.read_text())
     result = subprocess.run(
-        ["uv", "run", "python", "scripts/validate_strict.py", str(path)],
+        [
+            "uv",
+            "run",
+            "python",
+            "scripts/validate_strict.py",
+            str(path),
+            "--out",
+            str(tmp_path / "report.tsv"),
+        ],
         capture_output=True,
         text=True,
         cwd=REPO,
@@ -218,3 +261,64 @@ def test_validate_strict_still_passes_the_real_kb_record(tmp_path):
     assert (
         result.returncode == 0
     ), f"a clean record failed validate-strict:\n{result.stdout[-2000:]}"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (3.0, "support_exceeds_total"),  # integral float: comparisons must still run
+        (0.0, "nonpositive_total"),
+        (3.5, "non_integral_count"),  # a genome count cannot be fractional
+        ("3", "non_numeric_count"),
+        ([3], "non_numeric_count"),
+        (True, "non_numeric_count"),  # isinstance(True, int) is True in Python
+    ],
+)
+def test_non_integer_counts_do_not_slip_through(value, expected):
+    """The regression this module shipped with, and the type holes around it.
+
+    Guarding with `isinstance(total, int)` reads as type-safety and is not:
+    it is False for `3.0`, and JSON-Schema `type: integer` accepts `3.0`. So
+    `total_genomes: 3.0` passed both gates while the inline logic this module
+    replaced caught it. Skipping a value silently is what made that invisible,
+    so anything non-numeric is now reported rather than ignored (#390 review).
+    """
+    block = _valid_block()
+    block.update(support_genomes=99, total_genomes=value)
+    assert expected in {category for category, _ in check_block(block)}
+
+
+def test_a_malformed_term_does_not_crash_the_run(tmp_path):
+    """A crash here kills `validate-strict` outright, not just one file.
+
+    `validate_one` calls this outside its try/except, so an AttributeError
+    propagates through the process pool and `main()` dies — taking the TSV
+    report with it, so every other file's errors are lost too. A scalar `term:`
+    is an ordinary hand-edit (#390 review).
+    """
+    record = tmp_path / "malformed.yaml"
+    record.write_text(
+        "taxonomy:\n"
+        "- taxon_term:\n"
+        "    term: NCBITaxon:403\n"  # a scalar where a mapping belongs
+        "    gtdb_classification:\n"
+        "      support_genomes: 9\n"
+        "      total_genomes: 3\n"
+    )
+
+    issues = validate_gtdb_coherence(record)
+
+    assert "support_exceeds_total" in {
+        issue.category for issue in issues
+    }, "the malformed term must not stop the block being checked"
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["- just\n- a list\n", "a bare scalar\n", "taxonomy: not-a-list\n", "taxonomy:\n- 3\n"],
+)
+def test_structurally_odd_documents_are_survived(tmp_path, text):
+    """`validate_one` hands these straight here — only `None` is short-circuited."""
+    record = tmp_path / "odd.yaml"
+    record.write_text(text)
+    assert validate_gtdb_coherence(record) == []

--- a/tests/test_gtdb_coherence_validator.py
+++ b/tests/test_gtdb_coherence_validator.py
@@ -1,0 +1,220 @@
+"""The relational checks LinkML cannot express, and the gate that runs them (#387).
+
+The schema bounds `support_genomes` and `total_genomes` individually but has no
+cross-field arithmetic, so `linkml-validate` accepts a block claiming 99
+supporting genomes out of 3. It also accepts `total_genomes: null`, because
+`value_presence: PRESENT` compiles to JSON-Schema `required` and a null satisfies
+that — LinkML emits `type: ["integer", "null"]` for every optional slot, so the
+class rule can only ever guard a *missing* key.
+
+These rules used to live only in `tests/test_gtdb_grounding_freshness.py`. That
+covers the committed KB on every CI run and does nothing for a hand-authored
+record someone validates with `just validate`. They now live in
+`communitymech.validators.gtdb_coherence`, called from that test, from
+`just validate-gtdb`, and from `scripts/validate_strict.py` — which is a CI gate.
+
+Each check below is paired with an assertion that `linkml-validate` **accepts**
+the same instance, so the tests document what the schema does not cover rather
+than asserting it in prose. If one of those starts failing, LinkML tightened and
+the constraint should move into the schema.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from communitymech.validators.gtdb_coherence import (
+    check_block,
+    validate_gtdb_coherence,
+)
+
+REPO = Path(__file__).parent.parent
+SCHEMA = REPO / "src/communitymech/schema/communitymech.yaml"
+FIXTURE = REPO / "kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml"
+
+
+def _valid_block() -> dict:
+    return {
+        "gtdb_id": "GTDB:f__Methylomonadaceae",
+        "gtdb_taxon": "Methylomonadaceae",
+        "ncbi_source_id": "NCBITaxon:403",
+        "majority_fraction": 0.695,
+        "support_genomes": 107,
+        "total_genomes": 154,
+        "is_reclassified": True,
+    }
+
+
+def _linkml_accepts(tmp_path: Path, block: dict) -> bool:
+    """Does `linkml-validate` accept a real record carrying this block?"""
+    doc = yaml.safe_load(FIXTURE.read_text())
+    for entry in doc["taxonomy"]:
+        term = entry.get("taxon_term") or {}
+        if term.get("gtdb_classification") and "support_genomes" in term["gtdb_classification"]:
+            term["gtdb_classification"] = block
+            break
+    else:  # pragma: no cover - fixture drift
+        pytest.fail("fixture has no block with support_genomes")
+
+    path = tmp_path / "probe.yaml"
+    path.write_text(yaml.dump(doc, sort_keys=False, allow_unicode=True))
+    return (
+        subprocess.run(
+            ["uv", "run", "linkml-validate", "-s", str(SCHEMA), str(path)],
+            capture_output=True,
+            cwd=REPO,
+        ).returncode
+        == 0
+    )
+
+
+def test_a_correct_block_is_clean():
+    """Guards every negative case below: if all blocks failed, they'd pass vacuously."""
+    assert check_block(_valid_block()) == []
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected"),
+    [
+        ({"support_genomes": 99, "total_genomes": 3}, "support_exceeds_total"),
+        ({"support_genomes": 2, "total_genomes": 9999}, "fraction_disagrees_with_counts"),
+        ({"total_genomes": None}, "null_count"),
+        ({"support_genomes": None}, "null_count"),
+        ({"majority_fraction": 0.4}, "fraction_out_of_range"),
+        ({"majority_fraction": 7.5}, "fraction_out_of_range"),
+    ],
+)
+def test_incoherent_blocks_are_caught(mutation, expected):
+    block = _valid_block()
+    block.update(mutation)
+    assert expected in {category for category, _ in check_block(block)}
+
+
+def test_a_numerator_without_a_denominator_is_caught():
+    block = _valid_block()
+    del block["total_genomes"]
+    assert "numerator_without_denominator" in {c for c, _ in check_block(block)}
+
+
+def test_a_species_block_with_only_a_denominator_is_fine():
+    """The normal species case — 336 blocks. Flagging it would fail the whole KB."""
+    block = _valid_block()
+    del block["support_genomes"]
+    assert check_block(block) == []
+
+
+def test_rounding_slack_is_tolerated_but_drift_is_not():
+    """`majority_fraction` is stored rounded, so the check needs a tolerance.
+
+    107/154 is 0.6948..., stored as 0.695. A tolerance any looser than one unit
+    in the last place stops catching real drift, so both sides are pinned.
+    """
+    ok = _valid_block()
+    assert check_block(ok) == [], "legitimate rounding must not be flagged"
+
+    drifted = _valid_block()
+    drifted["majority_fraction"] = 0.71
+    assert "fraction_disagrees_with_counts" in {c for c, _ in check_block(drifted)}
+
+
+@pytest.mark.parametrize("total", [0, -5])
+def test_a_nonpositive_total_is_caught(total):
+    block = _valid_block()
+    block.update(total_genomes=total, support_genomes=0)
+    assert "nonpositive_total" in {c for c, _ in check_block(block)}
+
+
+# ---------------------------------------------------------------------------
+# What the schema does NOT catch — asserted, so the gap is a decision.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        {"support_genomes": 99, "total_genomes": 3},
+        {"support_genomes": 2, "total_genomes": 9999},
+        {"total_genomes": None},
+    ],
+)
+def test_linkml_accepts_what_this_validator_rejects(tmp_path, mutation):
+    """The reason this module exists rather than a schema constraint.
+
+    If one of these starts failing, LinkML gained cross-field expression (or
+    stopped allowing nulls on optional slots) and the check should move into the
+    schema — delete the corresponding case here when it does.
+    """
+    block = _valid_block()
+    block.update(mutation)
+    assert check_block(block), "this fixture is supposed to be incoherent"
+    assert _linkml_accepts(
+        tmp_path, block
+    ), "linkml-validate now rejects this — move the constraint into the schema"
+
+
+def test_linkml_still_rejects_what_the_schema_does_cover(tmp_path):
+    """Guards the above: proves `_linkml_accepts` can return False at all."""
+    block = _valid_block()
+    del block["total_genomes"]  # class rule: support present -> total present
+    assert not _linkml_accepts(tmp_path, block)
+
+
+# ---------------------------------------------------------------------------
+# The gate itself.
+# ---------------------------------------------------------------------------
+
+
+def test_the_committed_kb_is_coherent():
+    """Every record, not just the ones with counts."""
+    issues = []
+    for directory in ("kb/communities", "data/isolates"):
+        for path in sorted((REPO / directory).glob("*.yaml")):
+            issues.extend(validate_gtdb_coherence(path))
+    assert not issues, "incoherent gtdb_classification in the KB:\n" + "\n".join(
+        f"  {issue}" for issue in issues[:20]
+    )
+
+
+def test_validate_strict_reports_the_incoherence(tmp_path):
+    """The check must fire through the CI gate, not only when called directly.
+
+    `validate-strict` is where this actually protects the repo; wiring it in and
+    never exercising the wiring is how a gate ends up green and blind.
+    """
+    doc = yaml.safe_load(FIXTURE.read_text())
+    for entry in doc["taxonomy"]:
+        block = (entry.get("taxon_term") or {}).get("gtdb_classification")
+        if block and "support_genomes" in block:
+            block.update(support_genomes=99, total_genomes=3)
+            break
+    path = tmp_path / "broken.yaml"
+    path.write_text(yaml.dump(doc, sort_keys=False, allow_unicode=True))
+
+    result = subprocess.run(
+        ["uv", "run", "python", "scripts/validate_strict.py", str(path)],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+    )
+
+    assert result.returncode == 1, "validate-strict passed a record it should fail"
+    assert "gtdb_support_exceeds_total" in (result.stdout + result.stderr)
+
+
+def test_validate_strict_still_passes_the_real_kb_record(tmp_path):
+    """Guards the test above against failing for an unrelated reason."""
+    path = tmp_path / "clean.yaml"
+    path.write_text(FIXTURE.read_text())
+    result = subprocess.run(
+        ["uv", "run", "python", "scripts/validate_strict.py", str(path)],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+    )
+    assert (
+        result.returncode == 0
+    ), f"a clean record failed validate-strict:\n{result.stdout[-2000:]}"

--- a/tests/test_gtdb_grounding_freshness.py
+++ b/tests/test_gtdb_grounding_freshness.py
@@ -124,7 +124,11 @@ def test_grounding_is_internally_coherent(grounded):
     """A block whose fields contradict each other passed every check above.
 
     `gtdb_id`, `gtdb_taxon` and the tail of `gtdb_lineage` are three spellings of
-    one answer. `linkml-validate` accepts `majority_fraction: 7.5` today.
+    one answer.
+
+    The schema does bound `majority_fraction` at 1.0, so `7.5` is rejected — an
+    earlier version of this docstring claimed otherwise. What it cannot bound is
+    the *lower* half: `0.4` validates, and the tool grounds only on a majority.
 
     The **evidence-count** half of this now lives in
     `communitymech.validators.gtdb_coherence` and is called here rather than

--- a/tests/test_gtdb_grounding_freshness.py
+++ b/tests/test_gtdb_grounding_freshness.py
@@ -124,10 +124,16 @@ def test_grounding_is_internally_coherent(grounded):
     """A block whose fields contradict each other passed every check above.
 
     `gtdb_id`, `gtdb_taxon` and the tail of `gtdb_lineage` are three spellings of
-    one answer, and `majority_fraction` is a share of genomes, so it cannot
-    exceed 1 — nor fall at or below 0.5, since the tool grounds on a majority.
-    `linkml-validate` accepts `majority_fraction: 7.5` today.
+    one answer. `linkml-validate` accepts `majority_fraction: 7.5` today.
+
+    The **evidence-count** half of this now lives in
+    `communitymech.validators.gtdb_coherence` and is called here rather than
+    duplicated (#387). That module is also wired into `just validate-strict`, so
+    a hand-authored record hits the same checks this test applies to the
+    committed KB — which was the gap: these rules used to exist only in pytest.
     """
+    from communitymech.validators.gtdb_coherence import check_block
+
     problems = []
     for record, name, _, g in grounded:
         gtdb_id, taxon, lineage = (
@@ -147,29 +153,7 @@ def test_grounding_is_internally_coherent(grounded):
         if taxon and rank_token and taxon.replace(" ", "_") != rank_token.split("__", 1)[-1]:
             problems.append(f"{where}\n      gtdb_id={gtdb_id} but gtdb_taxon={taxon!r}")
 
-        fraction = g.get("majority_fraction")
-        if fraction is not None and not (0.5 <= fraction <= 1.0):
-            problems.append(f"{where}\n      majority_fraction={fraction} outside (0.5, 1]")
-
-        # The evidence counts (#383). `linkml-validate` checks their type and
-        # non-negativity but nothing relates them to each other or to the
-        # fraction, so a block claiming 99 supporting genomes out of 3 validates.
-        support, total = g.get("support_genomes"), g.get("total_genomes")
-        if total is not None and total <= 0:
-            problems.append(f"{where}\n      total_genomes={total} — a majority over no genomes")
-        if support is not None and total is not None:
-            if support > total:
-                problems.append(f"{where}\n      support_genomes={support} > total_genomes={total}")
-            elif total > 0 and fraction is not None and round(support / total, 3) != fraction:
-                problems.append(
-                    f"{where}\n      {support}/{total} = {round(support / total, 3)} but "
-                    f"majority_fraction={fraction}"
-                )
-        if support is not None and total is None:
-            problems.append(
-                f"{where}\n      support_genomes={support} with no total_genomes — a "
-                f"numerator without its denominator says nothing"
-            )
+        problems.extend(f"{where}\n      [{cat}] {msg}" for cat, msg in check_block(g))
 
     assert not problems, "internally inconsistent gtdb_classification:\n" + "\n".join(
         f"  {p}" for p in problems

--- a/tests/test_gtdb_support_counts.py
+++ b/tests/test_gtdb_support_counts.py
@@ -174,30 +174,24 @@ def test_the_species_path_reports_the_denominator_but_no_numerator(gtdb, mapping
     )
 
 
-def test_every_stored_fraction_agrees_with_its_counts(grounded):
-    """The stored block must be internally consistent, or the counts mislead."""
-    wrong = []
-    for record, name, block in grounded:
-        support, total = block.get("support_genomes"), block.get("total_genomes")
-        fraction = block.get("majority_fraction")
-        if total is None or support is None or fraction is None:
-            continue
-        if total <= 0 or round(support / total, 3) != fraction:
-            wrong.append(f"{record}: {name} — {support}/{total} != {fraction}")
-    assert not wrong, "majority_fraction disagrees with its own counts:\n" + "\n".join(
-        f"  {w}" for w in wrong
-    )
+def test_every_stored_block_is_coherent(grounded):
+    """Delegates to the validator rather than restating its rules (#387).
 
+    These assertions used to be inlined here *and* in
+    `test_gtdb_grounding_freshness.py` — and the two copies drifted: this one
+    compared `round(support/total, 3) != fraction` exactly, so a block at
+    `majority_fraction: 0.6948` passed `just validate-gtdb` and failed `just
+    test`. A curator trusting the fast gate would ship a record CI rejects.
+    One implementation now, called from three gates (#390 review).
+    """
+    from communitymech.validators.gtdb_coherence import check_block
 
-def test_support_never_exceeds_the_total(grounded):
-    bad = [
-        f"{record}: {name} — support {block['support_genomes']} > total {block['total_genomes']}"
+    wrong = [
+        f"{record}: {name} — [{category}] {message}"
         for record, name, block in grounded
-        if block.get("total_genomes") is not None
-        and block.get("support_genomes") is not None
-        and block["support_genomes"] > block["total_genomes"]
+        for category, message in check_block(block)
     ]
-    assert not bad, "\n".join(bad)
+    assert not wrong, "incoherent gtdb_classification:\n" + "\n".join(f"  {w}" for w in wrong)
 
 
 def test_the_kb_carries_the_counts(grounded):
@@ -614,7 +608,10 @@ def test_the_coherence_gate_does_catch_that_null(gtdb):
     spec.loader.exec_module(freshness)
 
     bad = [("rec.yaml", "Some taxon", None, {"support_genomes": 5, "total_genomes": None})]
-    with pytest.raises(AssertionError, match="no total_genomes"):
+    # `total_genomes` is present-but-null, so this is `null_count`, not
+    # `numerator_without_denominator` — the key exists. Matching on the wrong
+    # category is how a cross-file coupling passes for the wrong reason.
+    with pytest.raises(AssertionError, match="null_count"):
         freshness.test_grounding_is_internally_coherent(bad)
 
 


### PR DESCRIPTION
Addresses #387. **Deliberately does not close it** — see the last section.

## What LinkML cannot do, verified rather than assumed

I generated the JSON Schema and read it, instead of inferring from behaviour:

```
support_genomes: {"minimum": 1, "type": ["integer", "null"]}
total_genomes:   {"minimum": 1, "type": ["integer", "null"]}
rule:            {"if": {"required": ["support_genomes"]},
                  "then": {"required": ["total_genomes"]}}
```

Two consequences:

1. **No cross-field arithmetic.** Nothing can relate `support_genomes` to `total_genomes` or to `majority_fraction`, so `99` supporting genomes out of `3` is valid.
2. **`type: ["integer", "null"]` on every optional slot.** `value_presence: PRESENT` compiles to `required`, which an explicit `total_genomes: null` satisfies, and `minimum` does not apply to null. So the class rule added in #388 guards a *missing* key only.

The second is not a schema-authoring problem to work around — it is what the backend emits for any optional slot.

## What this PR changes

The rules already existed, but only inside `tests/test_gtdb_grounding_freshness.py`. That covers the committed KB on every CI run and does **nothing** for a hand-authored record someone validates with `just validate`. That was #387'"'"'s actual concern, and it survived #388.

They now live in `src/communitymech/validators/gtdb_coherence.py` and run from three places:

- the pytest gate, which **delegates** rather than duplicating — one implementation
- `just validate-gtdb FILE` / `just validate-gtdb-all` — the fast single-file form
- `scripts/validate_strict.py`, i.e. **`just validate-strict`, a CI gate** with broad path triggers

### Checks

| category | catches |
|---|---|
| `null_count` | `total_genomes: null` — the hole the class rule cannot see |
| `numerator_without_denominator` | `support_genomes` with no `total_genomes` |
| `nonpositive_total` | a majority computed over 0 genomes |
| `support_exceeds_total` | more supporting genomes than genomes counted |
| `fraction_disagrees_with_counts` | stored fraction drifted from its own counts |
| `fraction_out_of_range` | a "majority" at or below 0.5 |

Tolerance is one unit in the last place, since `majority_fraction` is stored at 3 decimals. Pinned from **both** sides — 107/154 = 0.6948 stored as 0.695 must pass, and 0.71 must fail — because loosening the tolerance is the obvious way this check quietly stops working.

## Canary

Three records that `linkml-validate` **accepts**, run through the gate before wiring anything further:

| instance | `linkml-validate` | `validate-strict` |
|---|---|---|
| `support_genomes: 99, total_genomes: 3` | ACCEPTS | **`gtdb_support_exceeds_total`** |
| `total_genomes: null` | ACCEPTS | **`gtdb_null_count`** |
| `majority_fraction` edited to `0.51` | ACCEPTS | **`gtdb_fraction_disagrees_with_counts`** |

All 316 real records stay clean.

## Tests

Each negative case is paired with an assertion that `linkml-validate` *accepts* the same instance, so the gap is recorded as a decision rather than prose. If LinkML ever gains cross-field expression or stops allowing nulls on optional slots, those tests fail and say to move the constraint into the schema.

Eight mutants, all fail: every check removed individually, the tolerance loosened to 0.5, and **the `validate-strict` wiring replaced with an empty loop** — that last one matters, because wiring a gate in and never exercising the wiring is how a gate ends up green and blind.

Also fixed a broken sentence I left in the `total_genomes` description in #388.

## Why #387 stays open

It asked for the constraint to be **in the schema**, and it is not. What changed is that it is now enforced everywhere schema validation runs, including on records that never go through `gtdb_ground.py`. The issue should close when LinkML gains the capability, or when #294'"'"'s `grounding_status` rework restructures this class and can carry it.

`just validate-all`, `just validate-strict`, `just validate-gtdb-all` clean; 1096 passed; lint clean.
