### PR TITLE
Record why a taxon is ungrounded, not just that it is (#294)

### DIFF
--- a/.claude/skills/ground-taxa-gtdb/SKILL.md
+++ b/.claude/skills/ground-taxa-gtdb/SKILL.md
@@ -120,6 +120,30 @@ Grounding happens at the **rank of the input**:
   for the pre-#372 behaviour; *Bacillus* was `g__Bacillus` at 0.508 across 102
   GTDB genera under that rule.
 
+## Grounding status (#294)
+
+Every `taxonomy[].taxon_term` carries `gtdb_grounding_status`, written by
+`gtdb_ground.py --community <file> --apply-status`. Absence of a
+`gtdb_classification` cannot say *why* it is absent, and the reasons are not
+comparable — reading absence as outstanding work overstated the remaining
+backfill roughly thirtyfold (#276).
+
+| status | count | meaning |
+|---|---|---|
+| `GROUNDED` | 647 | a `gtdb_classification` is present |
+| `NO_GTDB_EQUIVALENT` | 293 | **final state** — viruses, eukaryotes, environmental pseudo-taxa, strains absent from the mapping |
+| `AMBIGUOUS` | 81 | GTDB splits the NCBI taxon with no majority; `gtdb_candidates` carries the contenders |
+| `NOT_ATTEMPTED` | 9 | the only value representing outstanding work |
+| `WITHHELD` | 2 | the tool *can* ground it and a curator decided it must not (#292) |
+
+`GROUNDED` is redundant with the block's presence on purpose: a consumer should
+read a state, not infer one from whether a field exists. The two must agree, and
+`communitymech.validators.gtdb_coherence` enforces that — the schema cannot.
+
+`--apply-status` is independent of `--apply`: it writes no groundings, only
+status. It is idempotent, and refuses the file rather than guessing if the
+taxonomy entries and their id anchors do not line up.
+
 ## Interpreting the output
 
 - **`majority_fraction`** — for species, the mapping's majority fraction; for

--- a/.claude/skills/ground-taxa-gtdb/SKILL.md
+++ b/.claude/skills/ground-taxa-gtdb/SKILL.md
@@ -125,16 +125,23 @@ Grounding happens at the **rank of the input**:
 Every `taxonomy[].taxon_term` carries `gtdb_grounding_status`, written by
 `gtdb_ground.py --community <file> --apply-status`. Absence of a
 `gtdb_classification` cannot say *why* it is absent, and the reasons are not
-comparable — reading absence as outstanding work overstated the remaining
-backfill roughly thirtyfold (#276).
+comparable: a missing block implied 385 open items, of which only 9 are
+unambiguously outstanding work (#276).
 
 | status | count | meaning |
 |---|---|---|
 | `GROUNDED` | 647 | a `gtdb_classification` is present |
-| `NO_GTDB_EQUIVALENT` | 293 | **final state** — viruses, eukaryotes, environmental pseudo-taxa, strains absent from the mapping |
-| `AMBIGUOUS` | 81 | GTDB splits the NCBI taxon with no majority; `gtdb_candidates` carries the contenders |
-| `NOT_ATTEMPTED` | 9 | the only value representing outstanding work |
-| `WITHHELD` | 2 | the tool *can* ground it and a curator decided it must not (#292) |
+| `UNRESOLVED` | 293 | the tool produced no grounding; **why is not established** |
+| `AMBIGUOUS` | 81 | GTDB splits the NCBI taxon with no majority; `gtdb_candidates` carries every contender |
+| `NOT_ATTEMPTED` | 9 | the tool *would* ground it and the KB does not — unambiguously outstanding work |
+| `WITHHELD` | 2 | the tool can ground it and a curator decided it must not (#292) |
+| `NO_GTDB_EQUIVALENT` | 0 | **curator-assigned only** — the tool cannot establish it (#393) |
+
+`UNRESOLVED` deliberately does not claim finality. Some of it is final (viruses,
+eukaryotes — GTDB is bacteria/archaea only) and some is this tool's limits: it
+attempts genus through phylum only, so *Bacteria* never resolves even though
+`d__Bacteria` is the root of GTDB. Reading it as "no GTDB equivalent" is the
+substitution #294 exists to stop.
 
 `GROUNDED` is redundant with the block's presence on purpose: a consumer should
 read a state, not infer one from whether a field exists. The two must agree, and

--- a/data/isolates/Aspergillus_Indium_LED_Recovery.yaml
+++ b/data/isolates/Aspergillus_Indium_LED_Recovery.yaml
@@ -53,7 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:5061
       label: Aspergillus niger
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Filamentous fungus widely used in industrial biotechnology for organic acid production, now adapted for critical
       materials recovery from electronic waste. A. niger is a GRAS (Generally Recognized As Safe) organism with extensive
       industrial history in citric acid fermentation, enzyme production, and bioprocessing applications. This saprophytic

--- a/data/isolates/Aspergillus_Indium_LED_Recovery.yaml
+++ b/data/isolates/Aspergillus_Indium_LED_Recovery.yaml
@@ -53,6 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:5061
       label: Aspergillus niger
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Filamentous fungus widely used in industrial biotechnology for organic acid production, now adapted for critical
       materials recovery from electronic waste. A. niger is a GRAS (Generally Recognized As Safe) organism with extensive
       industrial history in citric acid fermentation, enzyme production, and bioprocessing applications. This saprophytic

--- a/data/isolates/BioModels_MODEL2204300002_Kefir_Rothia_Model.yaml
+++ b/data/isolates/BioModels_MODEL2204300002_Kefir_Rothia_Model.yaml
@@ -30,6 +30,7 @@ taxonomy:
     term:
       id: NCBITaxon:32207
       label: Rothia
+    gtdb_grounding_status: NOT_ATTEMPTED
   strain_designation:
     strain_name: KRP
   functional_role:

--- a/data/isolates/Chromobacterium_Gold_Biocyanidation.yaml
+++ b/data/isolates/Chromobacterium_Gold_Biocyanidation.yaml
@@ -71,6 +71,7 @@ taxonomy:
       term:
         id: NCBITaxon:536
         label: Chromobacterium violaceum
+      gtdb_grounding_status: NOT_ATTEMPTED
       notes: >
         Gram-negative, facultatively anaerobic, mesophilic betaproteobacterium
         isolated from tropical and subtropical soils and waters. Chromobacterium

--- a/data/isolates/Methylobacterium_REE_Ewaste_Platform.yaml
+++ b/data/isolates/Methylobacterium_REE_Ewaste_Platform.yaml
@@ -52,6 +52,7 @@ taxonomy:
     term:
       id: NCBITaxon:408
       label: Methylobacterium extorquens
+    gtdb_grounding_status: NOT_ATTEMPTED
     notes: 'Mesophilic methylotrophic alphaproteobacterium engineered for enhanced REE bioaccumulation from electronic waste.
       The AM1 strain naturally grows on methanol and C1 compounds, utilizing the serine cycle for carbon assimilation. M.
       extorquens exhibits intrinsic REE bioaccumulation capability through lanthanophore biosynthesis (mll genes encoding

--- a/kb/communities/AMD_Acidophile_Heterotroph_Network.yaml
+++ b/kb/communities/AMD_Acidophile_Heterotroph_Network.yaml
@@ -42,6 +42,7 @@ taxonomy:
     term:
       id: NCBITaxon:62140
       label: Acidiphilium multivorum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidiphilium_multivorum
       gtdb_taxon: Acidiphilium multivorum
@@ -87,6 +88,7 @@ taxonomy:
     term:
       id: NCBITaxon:121039
       label: Ferrimicrobium acidiphilum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Ferrimicrobium_acidiphilum
       gtdb_taxon: Ferrimicrobium acidiphilum
@@ -131,6 +133,7 @@ taxonomy:
     term:
       id: NCBITaxon:524
       label: Acidiphilium cryptum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidiphilium_multivorum
       gtdb_taxon: Acidiphilium multivorum
@@ -174,6 +177,7 @@ taxonomy:
     term:
       id: NCBITaxon:525
       label: Acidocella facilis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidocella_facilis
       gtdb_taxon: Acidocella facilis
@@ -214,6 +218,7 @@ taxonomy:
     term:
       id: NCBITaxon:50715
       label: Acidisphaera rubrifaciens
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidisphaera_rubrifaciens
       gtdb_taxon: Acidisphaera rubrifaciens
@@ -255,6 +260,7 @@ taxonomy:
     term:
       id: NCBITaxon:33075
       label: Acidobacterium capsulatum
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Facultative anaerobic chemoorganotrophic bacterium representing the first described member
       of the phylum Acidobacteriota (formerly Acidobacteria). Isolated from acidic mineral environments
       in 1991. Grows at pH 3.0-6.0 with optimum around pH 4.0-4.5. Contains menaquinone as electron carrier.

--- a/kb/communities/AMD_Acidophile_Heterotroph_Network.yaml
+++ b/kb/communities/AMD_Acidophile_Heterotroph_Network.yaml
@@ -260,7 +260,7 @@ taxonomy:
     term:
       id: NCBITaxon:33075
       label: Acidobacterium capsulatum
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Facultative anaerobic chemoorganotrophic bacterium representing the first described member
       of the phylum Acidobacteriota (formerly Acidobacteria). Isolated from acidic mineral environments
       in 1991. Grows at pH 3.0-6.0 with optimum around pH 4.0-4.5. Contains menaquinone as electron carrier.

--- a/kb/communities/AMD_Nitrososphaerota_Archaeal.yaml
+++ b/kb/communities/AMD_Nitrososphaerota_Archaeal.yaml
@@ -45,6 +45,7 @@ taxonomy:
     term:
       id: NCBITaxon:1078905
       label: Nitrosotalea devaniterrae
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Nitrosotalea_devanaterra
       gtdb_taxon: Nitrosotalea devanaterra
@@ -103,6 +104,7 @@ taxonomy:
     term:
       id: NCBITaxon:497726
       label: Nitrososphaera
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Nitrososphaera
       gtdb_taxon: Nitrososphaera
@@ -150,6 +152,7 @@ taxonomy:
     term:
       id: NCBITaxon:74969
       label: Ferroplasma acidiphilum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Ferroplasma_acidarmanus
       gtdb_taxon: Ferroplasma acidarmanus
@@ -198,6 +201,7 @@ taxonomy:
     term:
       id: NCBITaxon:1234
       label: Nitrospira
+    gtdb_grounding_status: NOT_ATTEMPTED
     notes: 'Nitrite-oxidizing bacteria detected in AMD sediments (pH 3.2-4.5) through nxrB gene quantification.
       These Nitrospira strains represent acidophilic or acid-tolerant lineages capable of oxidizing nitrite
       (NO2-) to nitrate (NO3-) at low pH where typical nitrite oxidizers cannot function. Act as syntrophic

--- a/kb/communities/ANME_SRB_Anaerobic_Methanotrophic_Syntrophic_Consortia.yaml
+++ b/kb/communities/ANME_SRB_Anaerobic_Methanotrophic_Syntrophic_Consortia.yaml
@@ -24,7 +24,7 @@ taxonomy:
     term:
       id: NCBITaxon:588814
       label: Candidatus Methanophagales
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: The ANME-1 clade corresponds to the order Candidatus Methanophagales; grounded at this
       OAK-confirmed rank because "ANME-1" is an informal clade name with no species-level NCBITaxon.
   functional_role:
@@ -44,7 +44,7 @@ taxonomy:
     term:
       id: NCBITaxon:1902583
       label: Candidatus Desulfofervidus
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Grounded at genus Candidatus Desulfofervidus (the ANME-1 partner, Ca. Desulfofervidus
       auxilii / HotSeep-1); the abstract names only the genus "Desulfofervidus".
   functional_role:
@@ -64,7 +64,7 @@ taxonomy:
     term:
       id: NCBITaxon:588816
       label: ANME-2 cluster
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: ANME-2a is a subclade of the ANME-2 cluster; grounded at the OAK-confirmed ANME-2 cluster
       rank because there is no species-level NCBITaxon for the informal "ANME-2a" clade.
   functional_role:
@@ -85,7 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:3386252
       label: Candidatus Methanogaster
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: ANME-2c corresponds to the genus Candidatus Methanogaster (cf. Ca. Methanogaster sp.
       ANME-2c ERB4); grounded at this OAK-confirmed genus rank as "ANME-2c" is an informal clade name.
   functional_role:

--- a/kb/communities/ANME_SRB_Anaerobic_Methanotrophic_Syntrophic_Consortia.yaml
+++ b/kb/communities/ANME_SRB_Anaerobic_Methanotrophic_Syntrophic_Consortia.yaml
@@ -24,6 +24,7 @@ taxonomy:
     term:
       id: NCBITaxon:588814
       label: Candidatus Methanophagales
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: The ANME-1 clade corresponds to the order Candidatus Methanophagales; grounded at this
       OAK-confirmed rank because "ANME-1" is an informal clade name with no species-level NCBITaxon.
   functional_role:
@@ -43,6 +44,7 @@ taxonomy:
     term:
       id: NCBITaxon:1902583
       label: Candidatus Desulfofervidus
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Grounded at genus Candidatus Desulfofervidus (the ANME-1 partner, Ca. Desulfofervidus
       auxilii / HotSeep-1); the abstract names only the genus "Desulfofervidus".
   functional_role:
@@ -62,6 +64,7 @@ taxonomy:
     term:
       id: NCBITaxon:588816
       label: ANME-2 cluster
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: ANME-2a is a subclade of the ANME-2 cluster; grounded at the OAK-confirmed ANME-2 cluster
       rank because there is no species-level NCBITaxon for the informal "ANME-2a" clade.
   functional_role:
@@ -82,6 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:3386252
       label: Candidatus Methanogaster
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: ANME-2c corresponds to the genus Candidatus Methanogaster (cf. Ca. Methanogaster sp.
       ANME-2c ERB4); grounded at this OAK-confirmed genus rank as "ANME-2c" is an informal clade name.
   functional_role:
@@ -101,6 +105,7 @@ taxonomy:
     term:
       id: NCBITaxon:213119
       label: Desulfobacteraceae
+    gtdb_grounding_status: NOT_ATTEMPTED
     notes: Seep-SRB1 is an informal SRB clade within the family Desulfobacteraceae; grounded at this
       OAK-confirmed family rank as there is no NCBITaxon for "Seep-SRB1".
   functional_role:
@@ -121,6 +126,7 @@ taxonomy:
     term:
       id: NCBITaxon:213118
       label: Desulfobacterales
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:o__Desulfobacterales
       gtdb_taxon: Desulfobacterales

--- a/kb/communities/ANME_SRB_Marine_Methane_Seep_Consortium.yaml
+++ b/kb/communities/ANME_SRB_Marine_Methane_Seep_Consortium.yaml
@@ -21,6 +21,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Environmental ANME clades are represented conservatively at domain level because marine ANME
       lineages are polyphyletic and not available as pure isolates.
   functional_role:
@@ -42,6 +43,7 @@ taxonomy:
     term:
       id: NCBITaxon:213118
       label: Desulfobacterales
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:o__Desulfobacterales
       gtdb_taxon: Desulfobacterales

--- a/kb/communities/ANME_SRB_Marine_Methane_Seep_Consortium.yaml
+++ b/kb/communities/ANME_SRB_Marine_Methane_Seep_Consortium.yaml
@@ -21,7 +21,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Environmental ANME clades are represented conservatively at domain level because marine ANME
       lineages are polyphyletic and not available as pure isolates.
   functional_role:

--- a/kb/communities/Aalborg_East_Full_Scale_EBPR_Community.yaml
+++ b/kb/communities/Aalborg_East_Full_Scale_EBPR_Community.yaml
@@ -141,7 +141,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: The flanking community includes fermenters, hydrolytic bacteria, nitrifiers, and denitrifiers
       that support the phosphorus-removing process.
   functional_role:

--- a/kb/communities/Aalborg_East_Full_Scale_EBPR_Community.yaml
+++ b/kb/communities/Aalborg_East_Full_Scale_EBPR_Community.yaml
@@ -39,6 +39,7 @@ taxonomy:
     term:
       id: NCBITaxon:28216
       label: Betaproteobacteria
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:c__Gammaproteobacteria
       gtdb_taxon: Gammaproteobacteria
@@ -76,6 +77,7 @@ taxonomy:
     term:
       id: NCBITaxon:201174
       label: Actinomycetota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Actinomycetota
       gtdb_taxon: Actinomycetota
@@ -112,6 +114,7 @@ taxonomy:
     term:
       id: NCBITaxon:976
       label: Bacteroidota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Bacteroidota
       gtdb_taxon: Bacteroidota
@@ -138,6 +141,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: The flanking community includes fermenters, hydrolytic bacteria, nitrifiers, and denitrifiers
       that support the phosphorus-removing process.
   functional_role:

--- a/kb/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.yaml
+++ b/kb/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.yaml
@@ -48,6 +48,7 @@ taxonomy:
     term:
       id: NCBITaxon:33952
       label: Acetobacterium woodii
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acetobacterium_woodii
       gtdb_taxon: Acetobacterium woodii
@@ -79,6 +80,7 @@ taxonomy:
     term:
       id: NCBITaxon:332101
       label: Clostridium drakei
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Clostridium_AM_drakei
       gtdb_taxon: Clostridium_AM drakei

--- a/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
+++ b/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
@@ -53,6 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:201174
       label: Actinomycetota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Actinomycetota
       gtdb_taxon: Actinomycetota
@@ -80,6 +81,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Community members that perform reductive dechlorination of TCE and
       PCE. Previous synthetic-coculture work used Dehalococcoides mccartyi
       strains 195 and BAV1; the abstract does not explicitly enumerate the

--- a/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
+++ b/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
@@ -81,7 +81,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Community members that perform reductive dechlorination of TCE and
       PCE. Previous synthetic-coculture work used Dehalococcoides mccartyi
       strains 195 and BAV1; the abstract does not explicitly enumerate the

--- a/kb/communities/Aerobic_Denitrification_Disturbance_SynCom.yaml
+++ b/kb/communities/Aerobic_Denitrification_Disturbance_SynCom.yaml
@@ -37,6 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:287
       label: Pseudomonas aeruginosa
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Pseudomonas_aeruginosa
       gtdb_taxon: Pseudomonas aeruginosa
@@ -55,6 +56,7 @@ taxonomy:
     term:
       id: NCBITaxon:470
       label: Acinetobacter baumannii
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acinetobacter_baumannii
       gtdb_taxon: Acinetobacter baumannii
@@ -73,6 +75,7 @@ taxonomy:
     term:
       id: NCBITaxon:644
       label: Aeromonas hydrophila
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Aeromonas_hydrophila
       gtdb_taxon: Aeromonas hydrophila

--- a/kb/communities/Aerobic_Denitrification_QQ_SynCom.yaml
+++ b/kb/communities/Aerobic_Denitrification_QQ_SynCom.yaml
@@ -36,6 +36,7 @@ taxonomy:
     term:
       id: NCBITaxon:470
       label: Acinetobacter baumannii
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acinetobacter_baumannii
       gtdb_taxon: Acinetobacter baumannii
@@ -54,6 +55,7 @@ taxonomy:
     term:
       id: NCBITaxon:287
       label: Pseudomonas aeruginosa
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Pseudomonas_aeruginosa
       gtdb_taxon: Pseudomonas aeruginosa
@@ -72,6 +74,7 @@ taxonomy:
     term:
       id: NCBITaxon:644
       label: Aeromonas hydrophila
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Aeromonas_hydrophila
       gtdb_taxon: Aeromonas hydrophila

--- a/kb/communities/Alaska_Tundra_Permafrost_Iron_Redox_Community.yaml
+++ b/kb/communities/Alaska_Tundra_Permafrost_Iron_Redox_Community.yaml
@@ -31,6 +31,7 @@ taxonomy:
     term:
       id: NCBITaxon:28065
       label: Rhodoferax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Rhodoferax
       gtdb_taxon: Rhodoferax
@@ -63,6 +64,7 @@ taxonomy:
     term:
       id: NCBITaxon:96
       label: Gallionella
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Gallionella
       gtdb_taxon: Gallionella
@@ -93,6 +95,7 @@ taxonomy:
     term:
       id: NCBITaxon:224756
       label: Methanomicrobia
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:c__Methanosarcinia
       gtdb_taxon: Methanosarcinia

--- a/kb/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.yaml
+++ b/kb/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.yaml
@@ -36,6 +36,7 @@ taxonomy:
     term:
       id: NCBITaxon:1239
       label: Bacillota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Bacillota_A
       gtdb_taxon: Bacillota_A
@@ -68,6 +69,7 @@ taxonomy:
     term:
       id: NCBITaxon:1578
       label: Lactobacillus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Lactobacillus
       gtdb_taxon: Lactobacillus
@@ -98,6 +100,7 @@ taxonomy:
     term:
       id: NCBITaxon:1379858
       label: Mucispirillum schaedleri ASF457
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Mucispirillum_schaedleri
       gtdb_taxon: Mucispirillum schaedleri
@@ -122,6 +125,7 @@ taxonomy:
     term:
       id: NCBITaxon:375288
       label: Parabacteroides
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Parabacteroides
       gtdb_taxon: Parabacteroides

--- a/kb/communities/Anabaena_MGS1_Anaerobic_Digestion_Methanogen_Consortium.yaml
+++ b/kb/communities/Anabaena_MGS1_Anaerobic_Digestion_Methanogen_Consortium.yaml
@@ -72,6 +72,11 @@ taxonomy:
     term:
       id: NCBITaxon:1163
       label: Anabaena
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Anabaena
+    - Trichormus
+    - RDYJ01
     notes: >
       FEEDSTOCK / SUBSTRATE, not a live member of the digesting consortium: Anabaena
       sp. biomass is the cyanobacterial material that the anaerobic-digestion

--- a/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
+++ b/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
@@ -53,6 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:203682
       label: Planctomycetota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Planctomycetota
       gtdb_taxon: Planctomycetota
@@ -81,6 +82,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Core community bacteria capable of dissimilatory nitrate reduction
       to ammonium; their replication outcompetes anammox during destabilization.
   functional_role:

--- a/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
+++ b/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
@@ -82,7 +82,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Core community bacteria capable of dissimilatory nitrate reduction
       to ammonium; their replication outcompetes anammox during destabilization.
   functional_role:

--- a/kb/communities/Anammox_Granule_Metabolic_Interaction_Community.yaml
+++ b/kb/communities/Anammox_Granule_Metabolic_Interaction_Community.yaml
@@ -39,6 +39,7 @@ taxonomy:
     term:
       id: NCBITaxon:795830
       label: Candidatus Brocadia sinica
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Brocadia_sinica
       gtdb_taxon: Brocadia sinica
@@ -70,6 +71,7 @@ taxonomy:
     term:
       id: NCBITaxon:1090
       label: Chlorobiota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Bacteroidota
       gtdb_taxon: Bacteroidota
@@ -97,6 +99,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Aggregated representation for Bacteroidetes, Chloroflexi, Proteobacteria, and other heterotrophic
       MAGs recovered from the anammox granules.
   functional_role:

--- a/kb/communities/Anammox_Granule_Metabolic_Interaction_Community.yaml
+++ b/kb/communities/Anammox_Granule_Metabolic_Interaction_Community.yaml
@@ -99,7 +99,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Aggregated representation for Bacteroidetes, Chloroflexi, Proteobacteria, and other heterotrophic
       MAGs recovered from the anammox granules.
   functional_role:

--- a/kb/communities/Angelarchaeales_Thermoplasmata_CuMMO_Soil_Sediment_Community.yaml
+++ b/kb/communities/Angelarchaeales_Thermoplasmata_CuMMO_Soil_Sediment_Community.yaml
@@ -29,6 +29,7 @@ taxonomy:
     term:
       id: NCBITaxon:2283796
       label: Thermoplasmatota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Thermoplasmatota
       gtdb_taxon: Thermoplasmatota

--- a/kb/communities/Arabidopsis_Coumarin_Root_SynCom.yaml
+++ b/kb/communities/Arabidopsis_Coumarin_Root_SynCom.yaml
@@ -35,6 +35,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Arabidopsis_Coumarin_Root_SynCom.yaml
+++ b/kb/communities/Arabidopsis_Coumarin_Root_SynCom.yaml
@@ -35,7 +35,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Arabidopsis_Phyllosphere_SynCom7.yaml
+++ b/kb/communities/Arabidopsis_Phyllosphere_SynCom7.yaml
@@ -37,6 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Arabidopsis_Phyllosphere_SynCom7.yaml
+++ b/kb/communities/Arabidopsis_Phyllosphere_SynCom7.yaml
@@ -37,7 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.yaml
+++ b/kb/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.yaml
@@ -27,6 +27,7 @@ taxonomy:
     term:
       id: NCBITaxon:1935183
       label: Promethearchaeati
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Two complete genomes were reconstructed for soil-associated
       Atabeyarchaeia, a new Asgard lineage described in this study.
   functional_role:
@@ -44,6 +45,7 @@ taxonomy:
     term:
       id: NCBITaxon:1935183
       label: Promethearchaeati
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: A complete Freyarchaeia genome was reconstructed for the wetland
       soil community.
   functional_role:
@@ -59,6 +61,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Co-resident methanogenic archaea whose substrate availability is
       modulated by the Asgard-mediated metabolic activity inferred from this
       study.

--- a/kb/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.yaml
+++ b/kb/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.yaml
@@ -27,7 +27,7 @@ taxonomy:
     term:
       id: NCBITaxon:1935183
       label: Promethearchaeati
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Two complete genomes were reconstructed for soil-associated
       Atabeyarchaeia, a new Asgard lineage described in this study.
   functional_role:
@@ -45,7 +45,7 @@ taxonomy:
     term:
       id: NCBITaxon:1935183
       label: Promethearchaeati
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: A complete Freyarchaeia genome was reconstructed for the wetland
       soil community.
   functional_role:
@@ -61,7 +61,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Co-resident methanogenic archaea whose substrate availability is
       modulated by the Asgard-mediated metabolic activity inferred from this
       study.

--- a/kb/communities/At_RSPHERE_SynCom.yaml
+++ b/kb/communities/At_RSPHERE_SynCom.yaml
@@ -45,7 +45,7 @@ taxonomy:
     term:
       id: NCBITaxon:3702
       label: Arabidopsis thaliana
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - PRIMARY_PRODUCER
   evidence:
@@ -60,7 +60,7 @@ taxonomy:
     term:
       id: NCBITaxon:306
       label: Pseudomonas sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: DOMINANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -76,7 +76,7 @@ taxonomy:
     term:
       id: NCBITaxon:1871043
       label: Variovorax sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: DOMINANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -118,7 +118,7 @@ taxonomy:
     term:
       id: NCBITaxon:1931
       label: Streptomyces sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -134,7 +134,7 @@ taxonomy:
     term:
       id: NCBITaxon:239
       label: Flavobacterium sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/At_RSPHERE_SynCom.yaml
+++ b/kb/communities/At_RSPHERE_SynCom.yaml
@@ -45,6 +45,7 @@ taxonomy:
     term:
       id: NCBITaxon:3702
       label: Arabidopsis thaliana
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_PRODUCER
   evidence:
@@ -59,6 +60,7 @@ taxonomy:
     term:
       id: NCBITaxon:306
       label: Pseudomonas sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: DOMINANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -74,6 +76,7 @@ taxonomy:
     term:
       id: NCBITaxon:1871043
       label: Variovorax sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: DOMINANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -89,6 +92,7 @@ taxonomy:
     term:
       id: NCBITaxon:1827
       label: Rhodococcus <high G+C Gram-positive bacteria>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Rhodococcus
       gtdb_taxon: Rhodococcus
@@ -114,6 +118,7 @@ taxonomy:
     term:
       id: NCBITaxon:1931
       label: Streptomyces sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -129,6 +134,7 @@ taxonomy:
     term:
       id: NCBITaxon:239
       label: Flavobacterium sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Australian_Lead_Zinc_Polymetallic.yaml
+++ b/kb/communities/Australian_Lead_Zinc_Polymetallic.yaml
@@ -50,6 +50,7 @@ taxonomy:
     term:
       id: NCBITaxon:920
       label: Acidithiobacillus ferrooxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidithiobacillus_ferrooxidans
       gtdb_taxon: Acidithiobacillus ferrooxidans
@@ -104,6 +105,7 @@ taxonomy:
     term:
       id: NCBITaxon:178606
       label: Leptospirillum ferriphilum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Leptospirillum_A_rubarum
       gtdb_taxon: Leptospirillum_A rubarum
@@ -152,6 +154,7 @@ taxonomy:
     term:
       id: NCBITaxon:97393
       label: Ferroplasma acidarmanus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Ferroplasma_acidarmanus
       gtdb_taxon: Ferroplasma acidarmanus
@@ -203,6 +206,7 @@ taxonomy:
     term:
       id: NCBITaxon:28232
       label: Geobacter metallireducens
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Geobacter_metallireducens
       gtdb_taxon: Geobacter metallireducens
@@ -253,6 +257,7 @@ taxonomy:
     term:
       id: NCBITaxon:28034
       label: Sulfobacillus thermosulfidooxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Sulfobacillus_thermosulfidooxidans
       gtdb_taxon: Sulfobacillus thermosulfidooxidans
@@ -300,6 +305,7 @@ taxonomy:
     term:
       id: NCBITaxon:524
       label: Acidiphilium cryptum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidiphilium_multivorum
       gtdb_taxon: Acidiphilium multivorum

--- a/kb/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.yaml
+++ b/kb/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.yaml
@@ -30,6 +30,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 55 bacterial genomes at least 70 percent complete were recovered from
       density-fractionated SIP samples.
   functional_role:
@@ -46,6 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:2759
       label: Eukaryota
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 18S rRNA gene sequences of 13C-enriched microeukaryotic bacterivores
       and fungi were identified in the SIP fractions.
   functional_role:
@@ -62,6 +64,7 @@ taxonomy:
     term:
       id: NCBITaxon:10239
       label: Viruses
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 10 circularized phage genomes were recovered; some were the most
       labeled entities in the rhizosphere.
   evidence:
@@ -76,6 +79,7 @@ taxonomy:
     term:
       id: NCBITaxon:80840
       label: Burkholderiales
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:o__Burkholderiales
       gtdb_taxon: Burkholderiales
@@ -99,6 +103,7 @@ taxonomy:
     term:
       id: NCBITaxon:414878
       label: Catenulispora
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Catenulispora
       gtdb_taxon: Catenulispora

--- a/kb/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.yaml
+++ b/kb/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.yaml
@@ -30,7 +30,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 55 bacterial genomes at least 70 percent complete were recovered from
       density-fractionated SIP samples.
   functional_role:
@@ -47,7 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:2759
       label: Eukaryota
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 18S rRNA gene sequences of 13C-enriched microeukaryotic bacterivores
       and fungi were identified in the SIP fractions.
   functional_role:
@@ -64,7 +64,7 @@ taxonomy:
     term:
       id: NCBITaxon:10239
       label: Viruses
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 10 circularized phage genomes were recovered; some were the most
       labeled entities in the rhizosphere.
   evidence:

--- a/kb/communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.yaml
+++ b/kb/communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.yaml
@@ -31,6 +31,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: The aggregate soil decomposer community recovered by
       metatranscriptomics; the abstract does not enumerate specific taxa per
       guild, but transcripts were binned using a reference database from soil

--- a/kb/communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.yaml
+++ b/kb/communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.yaml
@@ -31,7 +31,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: The aggregate soil decomposer community recovered by
       metatranscriptomics; the abstract does not enumerate specific taxa per
       guild, but transcripts were binned using a reference database from soil

--- a/kb/communities/BSFL_Gut_SynCom_Bacillus_Lactobacillus_Issatchenkia.yaml
+++ b/kb/communities/BSFL_Gut_SynCom_Bacillus_Lactobacillus_Issatchenkia.yaml
@@ -25,6 +25,7 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bacillus
       gtdb_taxon: Bacillus
@@ -53,6 +54,7 @@ taxonomy:
     term:
       id: NCBITaxon:1578
       label: Lactobacillus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Lactobacillus
       gtdb_taxon: Lactobacillus
@@ -82,6 +84,7 @@ taxonomy:
     term:
       id: NCBITaxon:4919
       label: Pichia
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: The paper names the yeast member as "Issatchenkia"; the genus Issatchenkia is a synonym of
       the NCBITaxon genus Pichia (NCBITaxon:4919), which is the canonical label. Grounded at genus rank.
   functional_role:

--- a/kb/communities/BSFL_Gut_SynCom_Bacillus_Lactobacillus_Issatchenkia.yaml
+++ b/kb/communities/BSFL_Gut_SynCom_Bacillus_Lactobacillus_Issatchenkia.yaml
@@ -84,7 +84,7 @@ taxonomy:
     term:
       id: NCBITaxon:4919
       label: Pichia
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: The paper names the yeast member as "Issatchenkia"; the genus Issatchenkia is a synonym of
       the NCBITaxon genus Pichia (NCBITaxon:4919), which is the canonical label. Grounded at genus rank.
   functional_role:

--- a/kb/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.yaml
+++ b/kb/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.yaml
@@ -37,6 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:659243
       label: Bacillus siamensis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bacillus_siamensis
       gtdb_taxon: Bacillus siamensis
@@ -55,6 +56,14 @@ taxonomy:
     term:
       id: NCBITaxon:375
       label: Bradyrhizobium japonicum
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Bradyrhizobium barranii
+    - Bradyrhizobium huanghuaihaiense
+    - Bradyrhizobium japonicum
+    - Bradyrhizobium japonicum_B
+    - Bradyrhizobium japonicum_C
+    - Bradyrhizobium liaoningense
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.yaml
+++ b/kb/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.yaml
@@ -42,6 +42,7 @@ taxonomy:
     term:
       id: NCBITaxon:226186
       label: Bacteroides thetaiotaomicron VPI-5482
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bacteroides_thetaiotaomicron
       gtdb_taxon: Bacteroides thetaiotaomicron
@@ -80,6 +81,7 @@ taxonomy:
     term:
       id: NCBITaxon:515619
       label: Agathobacter rectalis ATCC 33656
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Agathobacter_rectalis
       gtdb_taxon: Agathobacter rectalis

--- a/kb/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.yaml
+++ b/kb/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.yaml
@@ -39,6 +39,7 @@ taxonomy:
     term:
       id: NCBITaxon:818
       label: Bacteroides thetaiotaomicron
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bacteroides_thetaiotaomicron
       gtdb_taxon: Bacteroides thetaiotaomicron
@@ -63,6 +64,10 @@ taxonomy:
     term:
       id: NCBITaxon:2173
       label: Methanobrevibacter smithii
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Methanobrevibacter_A smithii
+    - Methanobrevibacter_A smithii_A
     notes: Human gut methanogenic archaeon that consumes B. thetaiotaomicron-derived formate.
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -83,6 +88,7 @@ taxonomy:
     term:
       id: NCBITaxon:901
       label: Desulfovibrio piger
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Desulfovibrio_piger
       gtdb_taxon: Desulfovibrio piger

--- a/kb/communities/Banana_Fusarium_Biocontrol_SynCom12.yaml
+++ b/kb/communities/Banana_Fusarium_Biocontrol_SynCom12.yaml
@@ -36,6 +36,11 @@ taxonomy:
     term:
       id: NCBITaxon:587753
       label: Pseudomonas chlororaphis
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Pseudomonas_E chlororaphis
+    - Pseudomonas_E chlororaphis_I
+    - Pseudomonas_E piscium
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -45,6 +50,7 @@ taxonomy:
     term:
       id: NCBITaxon:492670
       label: Bacillus velezensis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bacillus_velezensis
       gtdb_taxon: Bacillus velezensis
@@ -63,6 +69,7 @@ taxonomy:
     term:
       id: NCBITaxon:29875
       label: Trichoderma virens
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Banana_Fusarium_Biocontrol_SynCom12.yaml
+++ b/kb/communities/Banana_Fusarium_Biocontrol_SynCom12.yaml
@@ -69,7 +69,7 @@ taxonomy:
     term:
       id: NCBITaxon:29875
       label: Trichoderma virens
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.yaml
+++ b/kb/communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.yaml
@@ -25,6 +25,7 @@ taxonomy:
     term:
       id: NCBITaxon:2697049
       label: Severe acute respiratory syndrome coronavirus 2
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Complete and nearly complete SARS-CoV-2 genomes assembled from
       municipal sewage metatranscriptomes.
   evidence:

--- a/kb/communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.yaml
+++ b/kb/communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.yaml
@@ -25,7 +25,7 @@ taxonomy:
     term:
       id: NCBITaxon:2697049
       label: Severe acute respiratory syndrome coronavirus 2
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Complete and nearly complete SARS-CoV-2 genomes assembled from
       municipal sewage metatranscriptomes.
   evidence:

--- a/kb/communities/Bayan_Obo_REE_Tailings_Consortium.yaml
+++ b/kb/communities/Bayan_Obo_REE_Tailings_Consortium.yaml
@@ -62,6 +62,7 @@ taxonomy:
     term:
       id: NCBITaxon:920
       label: Acidithiobacillus ferrooxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidithiobacillus_ferrooxidans
       gtdb_taxon: Acidithiobacillus ferrooxidans
@@ -111,6 +112,7 @@ taxonomy:
     term:
       id: NCBITaxon:524
       label: Acidiphilium cryptum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidiphilium_multivorum
       gtdb_taxon: Acidiphilium multivorum
@@ -141,6 +143,7 @@ taxonomy:
     term:
       id: NCBITaxon:1883
       label: Streptomyces
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Streptomyces
       gtdb_taxon: Streptomyces

--- a/kb/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.yaml
+++ b/kb/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.yaml
@@ -53,6 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:1685
       label: Bifidobacterium breve
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bifidobacterium_breve
       gtdb_taxon: Bifidobacterium breve
@@ -77,6 +78,7 @@ taxonomy:
     term:
       id: NCBITaxon:33038
       label: Mediterraneibacter gnavus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Ruminococcus_B_gnavus
       gtdb_taxon: Ruminococcus_B gnavus

--- a/kb/communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.yaml
+++ b/kb/communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.yaml
@@ -46,6 +46,7 @@ taxonomy:
     term:
       id: NCBITaxon:1685
       label: Bifidobacterium breve
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bifidobacterium_breve
       gtdb_taxon: Bifidobacterium breve
@@ -69,6 +70,7 @@ taxonomy:
     term:
       id: NCBITaxon:5722
       label: Trichomonas vaginalis
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: The protozoan parasite; a eukaryote, so it receives no GTDB grounding.
   evidence:
   - reference: PMID:41688526
@@ -83,6 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:9606
       label: Homo sapiens
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Host epithelium, represented by the HeLa cell line. Grounded to the host species, since
       NCBITaxon has no term for a cell line.
   evidence:

--- a/kb/communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.yaml
+++ b/kb/communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.yaml
@@ -70,7 +70,7 @@ taxonomy:
     term:
       id: NCBITaxon:5722
       label: Trichomonas vaginalis
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: The protozoan parasite; a eukaryote, so it receives no GTDB grounding.
   evidence:
   - reference: PMID:41688526
@@ -85,7 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:9606
       label: Homo sapiens
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Host epithelium, represented by the HeLa cell line. Grounded to the host species, since
       NCBITaxon has no term for a cell line.
   evidence:

--- a/kb/communities/BioAsteroid_ISS_Chondrite_Biomining_Consortium.yaml
+++ b/kb/communities/BioAsteroid_ISS_Chondrite_Biomining_Consortium.yaml
@@ -85,6 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:429134
       label: Sphingomonas desiccabilis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Sphingomonas_desiccabilis
       gtdb_taxon: Sphingomonas desiccabilis
@@ -119,6 +120,7 @@ taxonomy:
     term:
       id: NCBITaxon:69488
       label: Penicillium simplicissimum
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: >
       Ascomycete fungus (DSMZ strain DSM 1078) known for its capacity to perform
       bioleaching. In this experiment it was the most effective bioleaching

--- a/kb/communities/BioAsteroid_ISS_Chondrite_Biomining_Consortium.yaml
+++ b/kb/communities/BioAsteroid_ISS_Chondrite_Biomining_Consortium.yaml
@@ -120,7 +120,7 @@ taxonomy:
     term:
       id: NCBITaxon:69488
       label: Penicillium simplicissimum
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: >
       Ascomycete fungus (DSMZ strain DSM 1078) known for its capacity to perform
       bioleaching. In this experiment it was the most effective bioleaching

--- a/kb/communities/BioModels_MODEL1806250003_Spittlebug_Sulcia_Sodalis.yaml
+++ b/kb/communities/BioModels_MODEL1806250003_Spittlebug_Sulcia_Sodalis.yaml
@@ -11,6 +11,7 @@ taxonomy:
     term:
       id: NCBITaxon:36667
       label: Philaenus spumarius
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
 - taxon_term:
@@ -18,6 +19,7 @@ taxonomy:
     term:
       id: NCBITaxon:2716471
       label: Sulcia
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - SYNTROPHIC_PARTNER
 - taxon_term:
@@ -25,6 +27,12 @@ taxonomy:
     term:
       id: NCBITaxon:84565
       label: Sodalis
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Sodalis_A
+    - Sodalis
+    - Acerihabitans
+    - Sodalis_B
   functional_role:
   - SYNTROPHIC_PARTNER
 associated_datasets:

--- a/kb/communities/BioModels_MODEL1806250003_Spittlebug_Sulcia_Sodalis.yaml
+++ b/kb/communities/BioModels_MODEL1806250003_Spittlebug_Sulcia_Sodalis.yaml
@@ -11,7 +11,7 @@ taxonomy:
     term:
       id: NCBITaxon:36667
       label: Philaenus spumarius
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
 - taxon_term:
@@ -19,7 +19,7 @@ taxonomy:
     term:
       id: NCBITaxon:2716471
       label: Sulcia
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - SYNTROPHIC_PARTNER
 - taxon_term:

--- a/kb/communities/BioModels_MODEL1806250004_Sharpshooter_Sulcia_Baumannia.yaml
+++ b/kb/communities/BioModels_MODEL1806250004_Sharpshooter_Sulcia_Baumannia.yaml
@@ -11,6 +11,7 @@ taxonomy:
     term:
       id: NCBITaxon:236401
       label: Graphocephala coccinea
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
 - taxon_term:
@@ -18,6 +19,7 @@ taxonomy:
     term:
       id: NCBITaxon:2716471
       label: Sulcia
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - SYNTROPHIC_PARTNER
 - taxon_term:
@@ -25,6 +27,7 @@ taxonomy:
     term:
       id: NCBITaxon:186490
       label: Candidatus Palibaumannia cicadellinicola
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - SYNTROPHIC_PARTNER
 associated_datasets:

--- a/kb/communities/BioModels_MODEL1806250004_Sharpshooter_Sulcia_Baumannia.yaml
+++ b/kb/communities/BioModels_MODEL1806250004_Sharpshooter_Sulcia_Baumannia.yaml
@@ -11,7 +11,7 @@ taxonomy:
     term:
       id: NCBITaxon:236401
       label: Graphocephala coccinea
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
 - taxon_term:
@@ -19,7 +19,7 @@ taxonomy:
     term:
       id: NCBITaxon:2716471
       label: Sulcia
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - SYNTROPHIC_PARTNER
 - taxon_term:
@@ -27,7 +27,7 @@ taxonomy:
     term:
       id: NCBITaxon:186490
       label: Candidatus Palibaumannia cicadellinicola
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - SYNTROPHIC_PARTNER
 associated_datasets:

--- a/kb/communities/BioModels_MODEL1806250005_Cicada_Sulcia_Hodgkinia.yaml
+++ b/kb/communities/BioModels_MODEL1806250005_Cicada_Sulcia_Hodgkinia.yaml
@@ -11,7 +11,7 @@ taxonomy:
     term:
       id: NCBITaxon:1699721
       label: Neotibicen canicularis
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
 - taxon_term:
@@ -19,7 +19,7 @@ taxonomy:
     term:
       id: NCBITaxon:2716471
       label: Sulcia
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - SYNTROPHIC_PARTNER
 - taxon_term:
@@ -27,7 +27,7 @@ taxonomy:
     term:
       id: NCBITaxon:573657
       label: Candidatus Hodgkinia
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - SYNTROPHIC_PARTNER
 associated_datasets:

--- a/kb/communities/BioModels_MODEL1806250005_Cicada_Sulcia_Hodgkinia.yaml
+++ b/kb/communities/BioModels_MODEL1806250005_Cicada_Sulcia_Hodgkinia.yaml
@@ -11,6 +11,7 @@ taxonomy:
     term:
       id: NCBITaxon:1699721
       label: Neotibicen canicularis
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
 - taxon_term:
@@ -18,6 +19,7 @@ taxonomy:
     term:
       id: NCBITaxon:2716471
       label: Sulcia
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - SYNTROPHIC_PARTNER
 - taxon_term:
@@ -25,6 +27,7 @@ taxonomy:
     term:
       id: NCBITaxon:573657
       label: Candidatus Hodgkinia
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - SYNTROPHIC_PARTNER
 associated_datasets:

--- a/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
+++ b/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
@@ -37,6 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:267818
       label: Lactobacillus kefiranofaciens
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Lactobacillus_kefiranofaciens
       gtdb_taxon: Lactobacillus kefiranofaciens
@@ -60,6 +61,7 @@ taxonomy:
     term:
       id: NCBITaxon:1358
       label: Lactococcus lactis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Lactococcus_lactis
       gtdb_taxon: Lactococcus lactis
@@ -84,6 +86,7 @@ taxonomy:
     term:
       id: NCBITaxon:1245
       label: Leuconostoc mesenteroides
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Leuconostoc_mesenteroides
       gtdb_taxon: Leuconostoc mesenteroides
@@ -108,6 +111,7 @@ taxonomy:
     term:
       id: NCBITaxon:33962
       label: Lentilactobacillus kefiri
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Lentilactobacillus_kefiri
       gtdb_taxon: Lentilactobacillus kefiri
@@ -132,6 +136,7 @@ taxonomy:
     term:
       id: NCBITaxon:483199
       label: Acetobacter fabarum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acetobacter_fabarum
       gtdb_taxon: Acetobacter fabarum
@@ -156,6 +161,7 @@ taxonomy:
     term:
       id: NCBITaxon:34358
       label: Maudiozyma exigua
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
+++ b/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
@@ -161,7 +161,7 @@ taxonomy:
     term:
       id: NCBITaxon:34358
       label: Maudiozyma exigua
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/BioModels_MODEL2209060002_DPigrum_SAureus_Community.yaml
+++ b/kb/communities/BioModels_MODEL2209060002_DPigrum_SAureus_Community.yaml
@@ -32,6 +32,7 @@ taxonomy:
     term:
       id: NCBITaxon:29394
       label: Dolosigranulum pigrum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Dolosigranulum_pigrum
       gtdb_taxon: Dolosigranulum pigrum
@@ -48,6 +49,7 @@ taxonomy:
     term:
       id: NCBITaxon:1280
       label: Staphylococcus aureus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Staphylococcus_aureus
       gtdb_taxon: Staphylococcus aureus

--- a/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
+++ b/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
@@ -37,6 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:1682
       label: Bifidobacterium longum subsp. infantis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bifidobacterium_infantis
       gtdb_taxon: Bifidobacterium infantis
@@ -62,6 +63,7 @@ taxonomy:
     term:
       id: NCBITaxon:1681
       label: Bifidobacterium bifidum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bifidobacterium_bifidum
       gtdb_taxon: Bifidobacterium bifidum
@@ -86,6 +88,7 @@ taxonomy:
     term:
       id: NCBITaxon:1685
       label: Bifidobacterium breve
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bifidobacterium_breve
       gtdb_taxon: Bifidobacterium breve
@@ -104,6 +107,12 @@ taxonomy:
     term:
       id: NCBITaxon:817
       label: Bacteroides fragilis
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Bacteroides fragilis
+    - Bacteroides hominis
+    - Bacteroides ovatus
+    - Chlamydophila gallinacea
   strain_designation:
     strain_name: ATCC25285
   functional_role:
@@ -113,6 +122,7 @@ taxonomy:
     term:
       id: NCBITaxon:821
       label: Phocaeicola vulgatus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Phocaeicola_vulgatus
       gtdb_taxon: Phocaeicola vulgatus
@@ -131,6 +141,7 @@ taxonomy:
     term:
       id: NCBITaxon:821
       label: Phocaeicola vulgatus
+    gtdb_grounding_status: WITHHELD
   strain_designation:
     strain_name: DSM1896
   functional_role:
@@ -140,6 +151,7 @@ taxonomy:
     term:
       id: NCBITaxon:29466
       label: Veillonella parvula
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Veillonella_parvula_A
       gtdb_taxon: Veillonella parvula_A
@@ -158,6 +170,7 @@ taxonomy:
     term:
       id: NCBITaxon:33038
       label: Mediterraneibacter gnavus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Ruminococcus_B_gnavus
       gtdb_taxon: Ruminococcus_B gnavus
@@ -176,6 +189,7 @@ taxonomy:
     term:
       id: NCBITaxon:83333
       label: Escherichia coli K-12
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Escherichia_coli
       gtdb_taxon: Escherichia coli
@@ -194,6 +208,7 @@ taxonomy:
     term:
       id: NCBITaxon:47715
       label: Lacticaseibacillus rhamnosus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Lacticaseibacillus_rhamnosus
       gtdb_taxon: Lacticaseibacillus rhamnosus
@@ -212,6 +227,7 @@ taxonomy:
     term:
       id: NCBITaxon:1351
       label: Enterococcus faecalis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Enterococcus_faecalis
       gtdb_taxon: Enterococcus faecalis
@@ -230,6 +246,7 @@ taxonomy:
     term:
       id: NCBITaxon:1308
       label: Streptococcus thermophilus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Streptococcus_thermophilus
       gtdb_taxon: Streptococcus thermophilus
@@ -248,6 +265,7 @@ taxonomy:
     term:
       id: NCBITaxon:33035
       label: Blautia producta
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Blautia_coccoides
       gtdb_taxon: Blautia coccoides

--- a/kb/communities/BioModels_MODEL2407300002_Sponge_Holobiont_Network.yaml
+++ b/kb/communities/BioModels_MODEL2407300002_Sponge_Holobiont_Network.yaml
@@ -49,7 +49,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Ammonia-oxidizing archaeon from Stylissa holobiont. Specific species identification requires
       supplementary materials from doi:10.1038/s41467-024-55222-w. Likely Nitrosopumilus-like based on
       typical sponge microbiome composition.
@@ -66,7 +66,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Nitrite-oxidizing bacterium from Stylissa holobiont. Specific species identification requires
       supplementary materials. Likely Nitrospira-like based on typical sponge microbiome composition.
   functional_role:
@@ -82,7 +82,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Newly discovered bacterial taxon with key role in cross-feeding activities. Dynamically adjusts
       metabolism with nutrient inputs. Specific taxonomic identification requires supplementary materials
       from doi:10.1038/s41467-024-55222-w.

--- a/kb/communities/BioModels_MODEL2407300002_Sponge_Holobiont_Network.yaml
+++ b/kb/communities/BioModels_MODEL2407300002_Sponge_Holobiont_Network.yaml
@@ -49,6 +49,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Ammonia-oxidizing archaeon from Stylissa holobiont. Specific species identification requires
       supplementary materials from doi:10.1038/s41467-024-55222-w. Likely Nitrosopumilus-like based on
       typical sponge microbiome composition.
@@ -65,6 +66,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Nitrite-oxidizing bacterium from Stylissa holobiont. Specific species identification requires
       supplementary materials. Likely Nitrospira-like based on typical sponge microbiome composition.
   functional_role:
@@ -80,6 +82,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Newly discovered bacterial taxon with key role in cross-feeding activities. Dynamically adjusts
       metabolism with nutrient inputs. Specific taxonomic identification requires supplementary materials
       from doi:10.1038/s41467-024-55222-w.

--- a/kb/communities/BioRock_ISS_Basalt_Biomining_Consortium.yaml
+++ b/kb/communities/BioRock_ISS_Basalt_Biomining_Consortium.yaml
@@ -77,6 +77,7 @@ taxonomy:
     term:
       id: NCBITaxon:429134
       label: Sphingomonas desiccabilis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Sphingomonas_desiccabilis
       gtdb_taxon: Sphingomonas desiccabilis
@@ -114,6 +115,7 @@ taxonomy:
     term:
       id: NCBITaxon:1423
       label: Bacillus subtilis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bacillus_subtilis
       gtdb_taxon: Bacillus subtilis
@@ -152,6 +154,7 @@ taxonomy:
     term:
       id: NCBITaxon:119219
       label: Cupriavidus metallidurans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Cupriavidus_metallidurans
       gtdb_taxon: Cupriavidus metallidurans

--- a/kb/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.yaml
+++ b/kb/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.yaml
@@ -29,6 +29,7 @@ taxonomy:
     term:
       id: NCBITaxon:201174
       label: Actinomycetota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Actinomycetota
       gtdb_taxon: Actinomycetota
@@ -53,6 +54,7 @@ taxonomy:
     term:
       id: NCBITaxon:976
       label: Bacteroidota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Bacteroidota
       gtdb_taxon: Bacteroidota
@@ -76,6 +78,7 @@ taxonomy:
     term:
       id: NCBITaxon:1239
       label: Bacillota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Bacillota_A
       gtdb_taxon: Bacillota_A
@@ -99,6 +102,7 @@ taxonomy:
     term:
       id: NCBITaxon:1224
       label: Pseudomonadota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Pseudomonadota
       gtdb_taxon: Pseudomonadota

--- a/kb/communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.yaml
+++ b/kb/communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.yaml
@@ -22,6 +22,7 @@ taxonomy:
     term:
       id: NCBITaxon:372461
       label: Buchnera aphidicola BCc
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Buchnera_aphidicola_F
       gtdb_taxon: Buchnera aphidicola_F
@@ -46,6 +47,10 @@ taxonomy:
     term:
       id: NCBITaxon:138074
       label: Serratia symbiotica
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Serratia_D symbiotica_A
+    - Serratia_K symbiotica
     notes: Co-primary Serratia symbiotica endosymbiont from Cinara cedri, represented at species level
       because the curated NCBI species term is validated in the repository tooling.
   functional_role:

--- a/kb/communities/Butyrivibrio_Selenomonas_Ruminococcus_Lignocellulolytic_Rumen_Consortium.yaml
+++ b/kb/communities/Butyrivibrio_Selenomonas_Ruminococcus_Lignocellulolytic_Rumen_Consortium.yaml
@@ -76,7 +76,7 @@ taxonomy:
     term:
       id: NCBITaxon:1264
       label: Hominimerdicola alba
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Paper names this strain "Ruminococcus albus"; NCBITaxon:1264 canonical label is
       "Hominimerdicola alba" (reclassified). "Ruminococcus albus" is the source synonym.
   functional_role:

--- a/kb/communities/Butyrivibrio_Selenomonas_Ruminococcus_Lignocellulolytic_Rumen_Consortium.yaml
+++ b/kb/communities/Butyrivibrio_Selenomonas_Ruminococcus_Lignocellulolytic_Rumen_Consortium.yaml
@@ -31,6 +31,11 @@ taxonomy:
     term:
       id: NCBITaxon:831
       label: Butyrivibrio fibrisolvens
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Butyrivibrio fibrisolvens
+    - Butyrivibrio fibrisolvens_C
+    - Pseudobutyrivibrio fibrisolvens_A
   functional_role:
   - PRIMARY_DEGRADER
   abundance_value: One of six rumen strains screened; member of the strongest pairwise and the
@@ -48,6 +53,11 @@ taxonomy:
     term:
       id: NCBITaxon:971
       label: Selenomonas ruminantium
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Selenomonas_A lactilytica
+    - Selenomonas_A ruminantium
+    - Selenomonas_A ruminantium_B
   functional_role:
   - SECONDARY_FERMENTER
   - CROSS_FEEDER
@@ -66,6 +76,7 @@ taxonomy:
     term:
       id: NCBITaxon:1264
       label: Hominimerdicola alba
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Paper names this strain "Ruminococcus albus"; NCBITaxon:1264 canonical label is
       "Hominimerdicola alba" (reclassified). "Ruminococcus albus" is the source synonym.
   functional_role:

--- a/kb/communities/CRC_Fusobacterium_Control_SynCom.yaml
+++ b/kb/communities/CRC_Fusobacterium_Control_SynCom.yaml
@@ -38,6 +38,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/CRC_Fusobacterium_Control_SynCom.yaml
+++ b/kb/communities/CRC_Fusobacterium_Control_SynCom.yaml
@@ -38,7 +38,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.yaml
+++ b/kb/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.yaml
@@ -47,7 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:3041
       label: Chlorophyta
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Photosynthetic algal biofilm at the sediment surface that changes oxygen availability under a
       diel light-dark cycle.
   functional_role:
@@ -63,7 +63,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Taxonomically unresolved sediment bacteria that maintain high sulfate reduction and sulfide
       supply in the reduced sediment horizon.
   functional_role:

--- a/kb/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.yaml
+++ b/kb/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.yaml
@@ -21,6 +21,7 @@ taxonomy:
     term:
       id: NCBITaxon:213121
       label: Desulfobulbaceae
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:f__Desulfobulbaceae
       gtdb_taxon: Desulfobulbaceae
@@ -46,6 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:3041
       label: Chlorophyta
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Photosynthetic algal biofilm at the sediment surface that changes oxygen availability under a
       diel light-dark cycle.
   functional_role:
@@ -61,6 +63,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Taxonomically unresolved sediment bacteria that maintain high sulfate reduction and sulfide
       supply in the reduced sediment horizon.
   functional_role:

--- a/kb/communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.yaml
+++ b/kb/communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.yaml
@@ -50,6 +50,7 @@ taxonomy:
     term:
       id: NCBITaxon:1515
       label: Acetivibrio thermocellus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Hungateiclostridium_thermocellum
       gtdb_taxon: Hungateiclostridium thermocellum
@@ -74,6 +75,7 @@ taxonomy:
     term:
       id: NCBITaxon:301148
       label: Caldibacillus debilis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Caldibacillus_debilis
       gtdb_taxon: Caldibacillus debilis

--- a/kb/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.yaml
+++ b/kb/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.yaml
@@ -52,6 +52,7 @@ taxonomy:
     term:
       id: NCBITaxon:351627
       label: Caldicellulosiruptor saccharolyticus DSM 8903
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Caldicellulosiruptor_saccharolyticus
       gtdb_taxon: Caldicellulosiruptor saccharolyticus
@@ -85,6 +86,7 @@ taxonomy:
     term:
       id: NCBITaxon:632335
       label: Caldicellulosiruptor acetigenus I77R1B
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Caldicellulosiruptor_acetigenus
       gtdb_taxon: Caldicellulosiruptor acetigenus

--- a/kb/communities/California_Grassland_Precipitation_Legacy_Soil_Community.yaml
+++ b/kb/communities/California_Grassland_Precipitation_Legacy_Soil_Community.yaml
@@ -35,7 +35,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Bacterial members of the grassland soil community recovered by 16S
       rRNA amplicon sequencing and meta-omics; specific taxa are not enumerated
       in the abstract.

--- a/kb/communities/California_Grassland_Precipitation_Legacy_Soil_Community.yaml
+++ b/kb/communities/California_Grassland_Precipitation_Legacy_Soil_Community.yaml
@@ -35,6 +35,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Bacterial members of the grassland soil community recovered by 16S
       rRNA amplicon sequencing and meta-omics; specific taxa are not enumerated
       in the abstract.

--- a/kb/communities/Candida_Parapsilosis_Hospitalized_Infant_Microbiome.yaml
+++ b/kb/communities/Candida_Parapsilosis_Hospitalized_Infant_Microbiome.yaml
@@ -26,7 +26,7 @@ taxonomy:
     term:
       id: NCBITaxon:5480
       label: Candida parapsilosis
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: A common cause of invasive candidiasis, especially in newborn
       infants, with five unique genomes assembled from this cohort.
   functional_role:

--- a/kb/communities/Candida_Parapsilosis_Hospitalized_Infant_Microbiome.yaml
+++ b/kb/communities/Candida_Parapsilosis_Hospitalized_Infant_Microbiome.yaml
@@ -26,6 +26,7 @@ taxonomy:
     term:
       id: NCBITaxon:5480
       label: Candida parapsilosis
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: A common cause of invasive candidiasis, especially in newborn
       infants, with five unique genomes assembled from this cohort.
   functional_role:

--- a/kb/communities/CeMbio_Caenorhabditis_Elegans_Microbiome.yaml
+++ b/kb/communities/CeMbio_Caenorhabditis_Elegans_Microbiome.yaml
@@ -45,7 +45,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Defined twelve-strain bacterial consortium containing Enterobacter, Lelliottia, Acinetobacter,
       Sphingomonas, Stenotrophomonas, Pseudomonas, Comamonas, Pantoea, Ochrobactrum, Sphingobacterium,
       and Chryseobacterium isolates.
@@ -69,7 +69,7 @@ taxonomy:
     term:
       id: NCBITaxon:6239
       label: Caenorhabditis elegans
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Genetically tractable nematode host colonized by the CeMbio bacterial community.
   abundance_value: Host organism for the defined bacterial community.
   evidence:

--- a/kb/communities/CeMbio_Caenorhabditis_Elegans_Microbiome.yaml
+++ b/kb/communities/CeMbio_Caenorhabditis_Elegans_Microbiome.yaml
@@ -45,6 +45,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Defined twelve-strain bacterial consortium containing Enterobacter, Lelliottia, Acinetobacter,
       Sphingomonas, Stenotrophomonas, Pseudomonas, Comamonas, Pantoea, Ochrobactrum, Sphingobacterium,
       and Chryseobacterium isolates.
@@ -68,6 +69,7 @@ taxonomy:
     term:
       id: NCBITaxon:6239
       label: Caenorhabditis elegans
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Genetically tractable nematode host colonized by the CeMbio bacterial community.
   abundance_value: Host organism for the defined bacterial community.
   evidence:

--- a/kb/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.yaml
+++ b/kb/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.yaml
@@ -54,6 +54,7 @@ taxonomy:
     term:
       id: NCBITaxon:1707
       label: Cellulomonas
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Cellulomonas
       gtdb_taxon: Cellulomonas
@@ -88,6 +89,7 @@ taxonomy:
     term:
       id: NCBITaxon:1061
       label: Rhodobacter capsulatus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Rhodobacter_capsulatus_B
       gtdb_taxon: Rhodobacter capsulatus_B

--- a/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
+++ b/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
@@ -38,6 +38,7 @@ taxonomy:
     term:
       id: NCBITaxon:1521
       label: Ruminiclostridium cellulolyticum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Ruminiclostridium_cellulolyticum
       gtdb_taxon: Ruminiclostridium cellulolyticum
@@ -56,6 +57,7 @@ taxonomy:
     term:
       id: NCBITaxon:323259
       label: Methanospirillum hungatei JF-1
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methanospirillum_hungatei
       gtdb_taxon: Methanospirillum hungatei
@@ -74,6 +76,7 @@ taxonomy:
     term:
       id: NCBITaxon:2223
       label: Methanothrix soehngenii
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methanothrix_soehngenii
       gtdb_taxon: Methanothrix soehngenii
@@ -92,6 +95,7 @@ taxonomy:
     term:
       id: NCBITaxon:881
       label: Nitratidesulfovibrio vulgaris
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Nitratidesulfovibrio_vulgaris
       gtdb_taxon: Nitratidesulfovibrio vulgaris

--- a/kb/communities/Cheese_Rind_InSitu_InVitro_Model_Community.yaml
+++ b/kb/communities/Cheese_Rind_InSitu_InVitro_Model_Community.yaml
@@ -46,6 +46,7 @@ taxonomy:
     term:
       id: NCBITaxon:1279
       label: Staphylococcus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Staphylococcus
       gtdb_taxon: Staphylococcus
@@ -70,6 +71,7 @@ taxonomy:
     term:
       id: NCBITaxon:1696
       label: Brevibacterium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Brevibacterium
       gtdb_taxon: Brevibacterium
@@ -94,6 +96,7 @@ taxonomy:
     term:
       id: NCBITaxon:4958
       label: Debaryomyces
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Genus-level yeast member enriched under low-moisture natural-rind conditions in the in vitro
       treatment.
   abundance_level: ABUNDANT
@@ -108,6 +111,7 @@ taxonomy:
     term:
       id: NCBITaxon:5073
       label: Penicillium
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Filamentous fungal genus detected in mature natural-rind succession and reconstructed in vitro
       communities.
   abundance_level: ABUNDANT

--- a/kb/communities/Cheese_Rind_InSitu_InVitro_Model_Community.yaml
+++ b/kb/communities/Cheese_Rind_InSitu_InVitro_Model_Community.yaml
@@ -96,7 +96,7 @@ taxonomy:
     term:
       id: NCBITaxon:4958
       label: Debaryomyces
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Genus-level yeast member enriched under low-moisture natural-rind conditions in the in vitro
       treatment.
   abundance_level: ABUNDANT
@@ -111,7 +111,7 @@ taxonomy:
     term:
       id: NCBITaxon:5073
       label: Penicillium
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Filamentous fungal genus detected in mature natural-rind succession and reconstructed in vitro
       communities.
   abundance_level: ABUNDANT

--- a/kb/communities/Chlamydomonas_Bacterial_H2_Consortium.yaml
+++ b/kb/communities/Chlamydomonas_Bacterial_H2_Consortium.yaml
@@ -40,6 +40,7 @@ taxonomy:
     term:
       id: NCBITaxon:3055
       label: Chlamydomonas reinhardtii
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_PRODUCER
@@ -54,6 +55,7 @@ taxonomy:
     term:
       id: NCBITaxon:2982533
       label: Microbacterium forte
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -68,6 +70,31 @@ taxonomy:
     term:
       id: NCBITaxon:1396
       label: Bacillus cereus
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Bacillus_A anthracis
+    - Bacillus_A bombysepticus
+    - Bacillus_A cereus
+    - Bacillus_A cereus_K
+    - Bacillus_A cereus_S
+    - Bacillus_A cereus_U
+    - Bacillus_A hominis
+    - Bacillus_A luti
+    - Bacillus_A mobilis
+    - Bacillus_A mycoides
+    - Bacillus_A nitratireducens
+    - Bacillus_A pacificus
+    - Bacillus_A paramycoides
+    - Bacillus_A paranthracis
+    - Bacillus_A pseudomycoides
+    - Bacillus_A sp003400245
+    - Bacillus_A sp018966865
+    - Bacillus_A thuringiensis
+    - Bacillus_A thuringiensis_AB
+    - Bacillus_A thuringiensis_K
+    - Bacillus_A thuringiensis_S
+    - Bacillus_A toyonensis
+    - Bacillus_A tropicus
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -82,6 +109,7 @@ taxonomy:
     term:
       id: NCBITaxon:40323
       label: Stenotrophomonas
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Stenotrophomonas
       gtdb_taxon: Stenotrophomonas

--- a/kb/communities/Chlamydomonas_Bacterial_H2_Consortium.yaml
+++ b/kb/communities/Chlamydomonas_Bacterial_H2_Consortium.yaml
@@ -40,7 +40,7 @@ taxonomy:
     term:
       id: NCBITaxon:3055
       label: Chlamydomonas reinhardtii
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_PRODUCER
@@ -55,7 +55,7 @@ taxonomy:
     term:
       id: NCBITaxon:2982533
       label: Microbacterium forte
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Chlamydomonas_Methylobacterium_Mutualism.yaml
+++ b/kb/communities/Chlamydomonas_Methylobacterium_Mutualism.yaml
@@ -29,6 +29,7 @@ taxonomy:
     term:
       id: NCBITaxon:3055
       label: Chlamydomonas reinhardtii
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Single-celled, photosynthetic green alga serving as the primary producer in this consortium.
       C. reinhardtii is a model organism for photosynthesis and stress response research. Under nitrogen
       stress, it exhibits altered physiology and increased susceptibility to bacterial interactions.
@@ -49,6 +50,7 @@ taxonomy:
     term:
       id: NCBITaxon:270351
       label: Methylobacterium aquaticum
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Pink-pigmented facultative methylotroph (PPFM) commonly associated with plant and algal surfaces.
       M. aquaticum produces and degrades indole-3-acetic acid (IAA), a key phytohormone that influences
       algal growth and stress responses. This species can utilize C1 compounds and may benefit from algal

--- a/kb/communities/Chlamydomonas_Methylobacterium_Mutualism.yaml
+++ b/kb/communities/Chlamydomonas_Methylobacterium_Mutualism.yaml
@@ -29,7 +29,7 @@ taxonomy:
     term:
       id: NCBITaxon:3055
       label: Chlamydomonas reinhardtii
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Single-celled, photosynthetic green alga serving as the primary producer in this consortium.
       C. reinhardtii is a model organism for photosynthesis and stress response research. Under nitrogen
       stress, it exhibits altered physiology and increased susceptibility to bacterial interactions.
@@ -50,7 +50,7 @@ taxonomy:
     term:
       id: NCBITaxon:270351
       label: Methylobacterium aquaticum
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Pink-pigmented facultative methylotroph (PPFM) commonly associated with plant and algal surfaces.
       M. aquaticum produces and degrades indole-3-acetic acid (IAA), a key phytohormone that influences
       algal growth and stress responses. This species can utilize C1 compounds and may benefit from algal

--- a/kb/communities/Chlorella_Azospirillum_Synthetic_Mutualism.yaml
+++ b/kb/communities/Chlorella_Azospirillum_Synthetic_Mutualism.yaml
@@ -56,7 +56,7 @@ taxonomy:
     term:
       id: NCBITaxon:3076
       label: Chlorella sorokiniana
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: >
       Source publications identify strain UTEX 2714; ontology grounding is
       species-level because the stable NCBI Taxonomy term used here is

--- a/kb/communities/Chlorella_Azospirillum_Synthetic_Mutualism.yaml
+++ b/kb/communities/Chlorella_Azospirillum_Synthetic_Mutualism.yaml
@@ -56,6 +56,7 @@ taxonomy:
     term:
       id: NCBITaxon:3076
       label: Chlorella sorokiniana
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: >
       Source publications identify strain UTEX 2714; ontology grounding is
       species-level because the stable NCBI Taxonomy term used here is
@@ -85,6 +86,7 @@ taxonomy:
     term:
       id: NCBITaxon:192
       label: Azospirillum brasilense
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Azospirillum_brasilense
       gtdb_taxon: Azospirillum brasilense

--- a/kb/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.yaml
+++ b/kb/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.yaml
@@ -54,6 +54,7 @@ taxonomy:
     term:
       id: NCBITaxon:3071
       label: Chlorella
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: >
       The publication identifies the algal member as Chlorella minutissima.
       Genus-level NCBITaxon grounding is used because a verified NCBI species
@@ -77,6 +78,7 @@ taxonomy:
     term:
       id: NCBITaxon:562
       label: Escherichia coli
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Escherichia_coli
       gtdb_taxon: Escherichia coli

--- a/kb/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.yaml
+++ b/kb/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.yaml
@@ -54,7 +54,7 @@ taxonomy:
     term:
       id: NCBITaxon:3071
       label: Chlorella
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: >
       The publication identifies the algal member as Chlorella minutissima.
       Genus-level NCBITaxon grounding is used because a verified NCBI species

--- a/kb/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.yaml
+++ b/kb/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.yaml
@@ -62,6 +62,7 @@ taxonomy:
     term:
       id: NCBITaxon:3073
       label: Scenedesmus fuscus
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: The paper's "Chlorella fusca CHK0059" — NCBITaxon carries this organism under the current
       name Scenedesmus fuscus, with "Chlorella fusca" retained as a synonym. The strain is the
       biofertilizer microalga whose phytomicrobiome supplied the keystone taxa; it is not itself a
@@ -82,6 +83,7 @@ taxonomy:
     term:
       id: NCBITaxon:286
       label: Pseudomonas
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Pseudomonas
       gtdb_taxon: Pseudomonas
@@ -116,6 +118,7 @@ taxonomy:
     term:
       id: NCBITaxon:75654
       label: Duganella
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Duganella
       gtdb_taxon: Duganella
@@ -139,6 +142,7 @@ taxonomy:
     term:
       id: NCBITaxon:1696
       label: Brevibacterium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Brevibacterium
       gtdb_taxon: Brevibacterium
@@ -162,6 +166,7 @@ taxonomy:
     term:
       id: NCBITaxon:5507
       label: Fusarium oxysporum
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Soilborne fungal pathogen challenged by the SynCom; the antagonism target rather than a
       SynCom member. Included in taxonomy so the antagonistic interactions resolve, matching the
       house pattern used for pathogens in Maize_Root_Simplified_Community.
@@ -176,6 +181,7 @@ taxonomy:
     term:
       id: NCBITaxon:3747
       label: Fragaria x ananassa
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Plant host in which SynCom disease suppression was assayed.
   evidence:
   - reference: PMID:41937467
@@ -188,6 +194,7 @@ taxonomy:
     term:
       id: NCBITaxon:4081
       label: Solanum lycopersicum
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Plant host in which SynCom disease suppression was assayed.
   evidence:
   - reference: PMID:41937467

--- a/kb/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.yaml
+++ b/kb/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.yaml
@@ -62,7 +62,7 @@ taxonomy:
     term:
       id: NCBITaxon:3073
       label: Scenedesmus fuscus
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: The paper's "Chlorella fusca CHK0059" — NCBITaxon carries this organism under the current
       name Scenedesmus fuscus, with "Chlorella fusca" retained as a synonym. The strain is the
       biofertilizer microalga whose phytomicrobiome supplied the keystone taxa; it is not itself a
@@ -166,7 +166,7 @@ taxonomy:
     term:
       id: NCBITaxon:5507
       label: Fusarium oxysporum
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Soilborne fungal pathogen challenged by the SynCom; the antagonism target rather than a
       SynCom member. Included in taxonomy so the antagonistic interactions resolve, matching the
       house pattern used for pathogens in Maize_Root_Simplified_Community.
@@ -181,7 +181,7 @@ taxonomy:
     term:
       id: NCBITaxon:3747
       label: Fragaria x ananassa
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Plant host in which SynCom disease suppression was assayed.
   evidence:
   - reference: PMID:41937467
@@ -194,7 +194,7 @@ taxonomy:
     term:
       id: NCBITaxon:4081
       label: Solanum lycopersicum
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Plant host in which SynCom disease suppression was assayed.
   evidence:
   - reference: PMID:41937467

--- a/kb/communities/Chlorella_Rhizobium_Bioflocculation.yaml
+++ b/kb/communities/Chlorella_Rhizobium_Bioflocculation.yaml
@@ -45,6 +45,7 @@ taxonomy:
     term:
       id: NCBITaxon:3077
       label: Chlorella vulgaris
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Unicellular green microalgae serving as the primary producer in this consortium. Axenic cultures
       exhibit poor flocculation efficiency (0.2%) but form dense flocs when co-cultured with bioflocculant-producing
       bacteria.
@@ -65,6 +66,12 @@ taxonomy:
     term:
       id: NCBITaxon:358
       label: Agrobacterium tumefaciens
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Agrobacterium fabacearum
+    - Agrobacterium leguminum
+    - Agrobacterium oryzihabitans
+    - Agrobacterium tumefaciens
     notes: 'Bioflocculant-producing bacterium that secretes extracellular polysaccharides to induce aggregation
       of algal cells. Strain F2 is specifically selected for its high bioflocculant production capacity.
 

--- a/kb/communities/Chlorella_Rhizobium_Bioflocculation.yaml
+++ b/kb/communities/Chlorella_Rhizobium_Bioflocculation.yaml
@@ -45,7 +45,7 @@ taxonomy:
     term:
       id: NCBITaxon:3077
       label: Chlorella vulgaris
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Unicellular green microalgae serving as the primary producer in this consortium. Axenic cultures
       exhibit poor flocculation efficiency (0.2%) but form dense flocs when co-cultured with bioflocculant-producing
       bacteria.

--- a/kb/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml
+++ b/kb/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml
@@ -21,6 +21,7 @@ taxonomy:
     term:
       id: NCBITaxon:340177
       label: Chlorobium chlorochromatii CaD3
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Chlorobium
       gtdb_taxon: Chlorobium
@@ -54,6 +55,7 @@ taxonomy:
     term:
       id: NCBITaxon:1436290
       label: Candidatus Symbiobacter mobilis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Symbiobacter_mobilis
       gtdb_taxon: Symbiobacter mobilis

--- a/kb/communities/Chromium_Sulfur_Reduction_Enrichment.yaml
+++ b/kb/communities/Chromium_Sulfur_Reduction_Enrichment.yaml
@@ -64,6 +64,7 @@ taxonomy:
     term:
       id: NCBITaxon:85021
       label: Intrasporangiaceae
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:f__Dermatophilaceae
       gtdb_taxon: Dermatophilaceae
@@ -120,6 +121,7 @@ taxonomy:
     term:
       id: NCBITaxon:286
       label: Pseudomonas
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Pseudomonas
       gtdb_taxon: Pseudomonas
@@ -171,6 +173,7 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bacillus
       gtdb_taxon: Bacillus

--- a/kb/communities/Cinnamate_Degradation_Consortium.yaml
+++ b/kb/communities/Cinnamate_Degradation_Consortium.yaml
@@ -21,6 +21,7 @@ taxonomy:
     term:
       id: NCBITaxon:100176
       label: Papillibacter cinnamivorans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Papillibacter_cinnamivorans
       gtdb_taxon: Papillibacter cinnamivorans
@@ -46,6 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:43773
       label: Syntrophus <bacteria>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Syntrophus
       gtdb_taxon: Syntrophus
@@ -72,6 +74,7 @@ taxonomy:
     term:
       id: NCBITaxon:2162
       label: Methanobacterium formicicum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methanobacterium_formicicum
       gtdb_taxon: Methanobacterium formicicum

--- a/kb/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.yaml
+++ b/kb/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.yaml
@@ -49,6 +49,7 @@ taxonomy:
     term:
       id: NCBITaxon:84023
       label: Clostridium autoethanogenum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Clostridium_B_ljungdahlii
       gtdb_taxon: Clostridium_B ljungdahlii
@@ -78,6 +79,7 @@ taxonomy:
     term:
       id: NCBITaxon:1534
       label: Clostridium kluyveri
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Clostridium_B_kluyveri
       gtdb_taxon: Clostridium_B kluyveri

--- a/kb/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.yaml
+++ b/kb/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.yaml
@@ -49,6 +49,7 @@ taxonomy:
     term:
       id: NCBITaxon:203119
       label: Acetivibrio thermocellus ATCC 27405
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Hungateiclostridium_thermocellum
       gtdb_taxon: Hungateiclostridium thermocellum
@@ -89,6 +90,7 @@ taxonomy:
     term:
       id: NCBITaxon:521460
       label: Caldicellulosiruptor bescii DSM 6725
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Caldicellulosiruptor_bescii
       gtdb_taxon: Caldicellulosiruptor bescii

--- a/kb/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.yaml
+++ b/kb/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.yaml
@@ -55,6 +55,7 @@ taxonomy:
     term:
       id: NCBITaxon:217159
       label: Clostridium carboxidivorans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Clostridium_AM_carboxidivorans
       gtdb_taxon: Clostridium_AM carboxidivorans
@@ -85,6 +86,7 @@ taxonomy:
     term:
       id: NCBITaxon:1534
       label: Clostridium kluyveri
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Clostridium_B_kluyveri
       gtdb_taxon: Clostridium_B kluyveri

--- a/kb/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.yaml
+++ b/kb/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.yaml
@@ -53,6 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:1521
       label: Ruminiclostridium cellulolyticum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Ruminiclostridium_cellulolyticum
       gtdb_taxon: Ruminiclostridium cellulolyticum
@@ -84,6 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:35554
       label: Geobacter sulfurreducens
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Geobacter_sulfurreducens
       gtdb_taxon: Geobacter sulfurreducens

--- a/kb/communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.yaml
+++ b/kb/communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.yaml
@@ -50,6 +50,7 @@ taxonomy:
     term:
       id: NCBITaxon:573061
       label: Clostridium cellulovorans 743B
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Clostridium_K_cellulovorans
       gtdb_taxon: Clostridium_K cellulovorans
@@ -81,6 +82,7 @@ taxonomy:
     term:
       id: NCBITaxon:269797
       label: Methanosarcina barkeri str. Fusaro
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methanosarcina_barkeri_B
       gtdb_taxon: Methanosarcina barkeri_B

--- a/kb/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.yaml
+++ b/kb/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.yaml
@@ -58,6 +58,7 @@ taxonomy:
     term:
       id: NCBITaxon:573061
       label: Clostridium cellulovorans 743B
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Clostridium_K_cellulovorans
       gtdb_taxon: Clostridium_K cellulovorans
@@ -88,6 +89,7 @@ taxonomy:
     term:
       id: NCBITaxon:258594
       label: Rhodopseudomonas palustris CGA009
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Rhodopseudomonas_palustris_F
       gtdb_taxon: Rhodopseudomonas palustris_F

--- a/kb/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.yaml
+++ b/kb/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.yaml
@@ -53,6 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:1538
       label: Clostridium ljungdahlii
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Clostridium_B_ljungdahlii
       gtdb_taxon: Clostridium_B ljungdahlii
@@ -83,6 +84,7 @@ taxonomy:
     term:
       id: NCBITaxon:1534
       label: Clostridium kluyveri
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Clostridium_B_kluyveri
       gtdb_taxon: Clostridium_B kluyveri

--- a/kb/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.yaml
+++ b/kb/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.yaml
@@ -59,6 +59,7 @@ taxonomy:
     term:
       id: NCBITaxon:357809
       label: Lachnoclostridium phytofermentans ISDg
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Lachnoclostridium_phytofermentans
       gtdb_taxon: Lachnoclostridium phytofermentans
@@ -100,6 +101,7 @@ taxonomy:
     term:
       id: NCBITaxon:511145
       label: Escherichia coli str. K-12 substr. MG1655
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Escherichia_coli
       gtdb_taxon: Escherichia coli

--- a/kb/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.yaml
@@ -52,6 +52,7 @@ taxonomy:
     term:
       id: NCBITaxon:357809
       label: Lachnoclostridium phytofermentans ISDg
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Lachnoclostridium_phytofermentans
       gtdb_taxon: Lachnoclostridium phytofermentans
@@ -90,6 +91,7 @@ taxonomy:
     term:
       id: NCBITaxon:4932
       label: Saccharomyces cerevisiae
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Engineered S. cerevisiae cdt-1 is a cellodextrin-fermenting yeast used
       as the ethanologenic partner in the curated exact coculture.
   strain_designation:

--- a/kb/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.yaml
@@ -91,7 +91,7 @@ taxonomy:
     term:
       id: NCBITaxon:4932
       label: Saccharomyces cerevisiae
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Engineered S. cerevisiae cdt-1 is a cellodextrin-fermenting yeast used
       as the ethanologenic partner in the curated exact coculture.
   strain_designation:

--- a/kb/communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.yaml
@@ -46,6 +46,7 @@ taxonomy:
     term:
       id: NCBITaxon:572545
       label: Acetivibrio thermocellus DSM 2360
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Hungateiclostridium_thermocellum
       gtdb_taxon: Hungateiclostridium thermocellum
@@ -82,6 +83,7 @@ taxonomy:
     term:
       id: NCBITaxon:399726
       label: Thermoanaerobacter sp. X514
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Thermoanaerobacter_pseudethanolicus
       gtdb_taxon: Thermoanaerobacter pseudethanolicus

--- a/kb/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.yaml
+++ b/kb/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.yaml
@@ -51,6 +51,7 @@ taxonomy:
     term:
       id: NCBITaxon:1515
       label: Acetivibrio thermocellus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Hungateiclostridium_thermocellum
       gtdb_taxon: Hungateiclostridium thermocellum
@@ -77,6 +78,7 @@ taxonomy:
     term:
       id: NCBITaxon:1517
       label: Thermoanaerobacterium thermosaccharolyticum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Thermoanaerobacterium_thermosaccharolyticum
       gtdb_taxon: Thermoanaerobacterium thermosaccharolyticum

--- a/kb/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.yaml
@@ -85,7 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:1335640
       label: Clostridium saccharoperbutylacetonicum N1-4
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: The primary paper specifies strain N1-4; NCBI provides a strain-level taxon for N1-4.
   strain_designation:
     strain_name: N1-4

--- a/kb/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.yaml
@@ -47,6 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:203119
       label: Acetivibrio thermocellus ATCC 27405
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Hungateiclostridium_thermocellum
       gtdb_taxon: Hungateiclostridium thermocellum
@@ -84,6 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:1335640
       label: Clostridium saccharoperbutylacetonicum N1-4
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: The primary paper specifies strain N1-4; NCBI provides a strain-level taxon for N1-4.
   strain_designation:
     strain_name: N1-4

--- a/kb/communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.yaml
+++ b/kb/communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.yaml
@@ -31,7 +31,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Community-level representation of wetland soil microbes measured by
       DNA sequencing and biogeochemical assays after seawater-ion perturbation.
   functional_role:
@@ -54,7 +54,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Sulfate-reducing bacteria are represented broadly because the source
       tests sulfate reducer responses without reporting a concise exact species
       composition.
@@ -77,7 +77,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Broad microbial functional guilds whose carbon, nitrogen, and
       phosphorus cycling genes responded to artificial seawater more strongly
       than sulfate alone.

--- a/kb/communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.yaml
+++ b/kb/communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.yaml
@@ -31,6 +31,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Community-level representation of wetland soil microbes measured by
       DNA sequencing and biogeochemical assays after seawater-ion perturbation.
   functional_role:
@@ -53,6 +54,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Sulfate-reducing bacteria are represented broadly because the source
       tests sulfate reducer responses without reporting a concise exact species
       composition.
@@ -75,6 +77,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Broad microbial functional guilds whose carbon, nitrogen, and
       phosphorus cycling genes responded to artificial seawater more strongly
       than sulfate alone.

--- a/kb/communities/Composting_SynCom_Lignocellulose_Degradation_Humus.yaml
+++ b/kb/communities/Composting_SynCom_Lignocellulose_Degradation_Humus.yaml
@@ -22,6 +22,7 @@ taxonomy:
     term:
       id: NCBITaxon:83677
       label: Thermobifida
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Thermobifida
       gtdb_taxon: Thermobifida
@@ -50,6 +51,7 @@ taxonomy:
     term:
       id: NCBITaxon:1988
       label: Actinomadura
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Spirillospora
       gtdb_taxon: Spirillospora

--- a/kb/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.yaml
+++ b/kb/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.yaml
@@ -53,7 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:1571157
       label: Coniochaeta sp. 2T2.1
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: JGI-sequenced fungal member isolated from a lignocellulose-degrading consortium.
   abundance_level: COMMON
   functional_role:

--- a/kb/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.yaml
+++ b/kb/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.yaml
@@ -53,6 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:1571157
       label: Coniochaeta sp. 2T2.1
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: JGI-sequenced fungal member isolated from a lignocellulose-degrading consortium.
   abundance_level: COMMON
   functional_role:
@@ -73,6 +74,7 @@ taxonomy:
     term:
       id: NCBITaxon:2886510
       label: Sphingobacterium paramultivorum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Sphingobacterium_paramultivorum
       gtdb_taxon: Sphingobacterium paramultivorum
@@ -111,6 +113,12 @@ taxonomy:
     term:
       id: NCBITaxon:546
       label: Citrobacter freundii
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Citrobacter braakii
+    - Citrobacter europaeus
+    - Citrobacter freundii
+    - Citrobacter werkmanii
     notes: Bacterial member so4 with genome-supported detoxification and oligosaccharide/sugar-dimer
       utilization functions in the tripartite consortium.
   strain_designation:

--- a/kb/communities/Copper_Biomining_Heap_Leach.yaml
+++ b/kb/communities/Copper_Biomining_Heap_Leach.yaml
@@ -56,6 +56,7 @@ taxonomy:
     term:
       id: NCBITaxon:920
       label: Acidithiobacillus ferrooxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidithiobacillus_ferrooxidans
       gtdb_taxon: Acidithiobacillus ferrooxidans
@@ -97,6 +98,7 @@ taxonomy:
     term:
       id: NCBITaxon:178606
       label: Leptospirillum ferriphilum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Leptospirillum_A_rubarum
       gtdb_taxon: Leptospirillum_A rubarum
@@ -140,6 +142,7 @@ taxonomy:
     term:
       id: NCBITaxon:930
       label: Acidithiobacillus thiooxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidithiobacillus_thiooxidans
       gtdb_taxon: Acidithiobacillus thiooxidans
@@ -180,6 +183,7 @@ taxonomy:
     term:
       id: NCBITaxon:74969
       label: Ferroplasma acidiphilum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Ferroplasma_acidarmanus
       gtdb_taxon: Ferroplasma acidarmanus
@@ -214,6 +218,7 @@ taxonomy:
     term:
       id: NCBITaxon:28034
       label: Sulfobacillus thermosulfidooxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Sulfobacillus_thermosulfidooxidans
       gtdb_taxon: Sulfobacillus thermosulfidooxidans

--- a/kb/communities/Corynebacterium_glutamicum_Shewanella_oneidensis_Succinic_Acid_Coculture.yaml
+++ b/kb/communities/Corynebacterium_glutamicum_Shewanella_oneidensis_Succinic_Acid_Coculture.yaml
@@ -23,6 +23,7 @@ taxonomy:
     term:
       id: NCBITaxon:1718
       label: Corynebacterium glutamicum
+    gtdb_grounding_status: GROUNDED
     notes: Succinic-acid producing partner. Study used C. glutamicum and an engineered
       lactate-deficient (ldhA-deleted) derivative designated strain K1.
     gtdb_classification:
@@ -52,6 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:70863
       label: Shewanella oneidensis
+    gtdb_grounding_status: GROUNDED
     notes: Electroactive partner contributing interspecies electron transfer / redox coupling.
     gtdb_classification:
       gtdb_id: GTDB:s__Shewanella_oneidensis

--- a/kb/communities/Coscinodiscus_Synthetic_Community.yaml
+++ b/kb/communities/Coscinodiscus_Synthetic_Community.yaml
@@ -46,6 +46,7 @@ taxonomy:
     term:
       id: NCBITaxon:33642
       label: Coscinodiscus radiatus
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Large centric diatom serving as the primary producer in this synthetic community. C. radiatus
       is a cosmopolitan marine phytoplankton species important for carbon cycling and primary production.
       Its large size and well-characterized physiology make it an ideal model for studying diatom-bacteria
@@ -70,6 +71,7 @@ taxonomy:
     term:
       id: NCBITaxon:1434019
       label: Mameliella
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Mameliella
       gtdb_taxon: Mameliella
@@ -103,6 +105,7 @@ taxonomy:
     term:
       id: NCBITaxon:74030
       label: Roseovarius
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Roseovarius
       gtdb_taxon: Roseovarius
@@ -136,6 +139,7 @@ taxonomy:
     term:
       id: NCBITaxon:216431
       label: Croceibacter
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Croceibacter
       gtdb_taxon: Croceibacter
@@ -170,6 +174,7 @@ taxonomy:
     term:
       id: NCBITaxon:2742
       label: Marinobacter
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Marinobacter
       gtdb_taxon: Marinobacter

--- a/kb/communities/Coscinodiscus_Synthetic_Community.yaml
+++ b/kb/communities/Coscinodiscus_Synthetic_Community.yaml
@@ -46,7 +46,7 @@ taxonomy:
     term:
       id: NCBITaxon:33642
       label: Coscinodiscus radiatus
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Large centric diatom serving as the primary producer in this synthetic community. C. radiatus
       is a cosmopolitan marine phytoplankton species important for carbon cycling and primary production.
       Its large size and well-characterized physiology make it an ideal model for studying diatom-bacteria

--- a/kb/communities/Crucian_Carp_Gut_Disease_Resistance_SynCom.yaml
+++ b/kb/communities/Crucian_Carp_Gut_Disease_Resistance_SynCom.yaml
@@ -23,6 +23,7 @@ taxonomy:
     term:
       id: NCBITaxon:180162
       label: Cetobacterium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Cetobacterium_A
       gtdb_taxon: Cetobacterium_A
@@ -47,6 +48,7 @@ taxonomy:
     term:
       id: NCBITaxon:1849822
       label: Paraclostridium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Paraclostridium
       gtdb_taxon: Paraclostridium
@@ -71,6 +73,7 @@ taxonomy:
     term:
       id: NCBITaxon:286
       label: Pseudomonas
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Pseudomonas
       gtdb_taxon: Pseudomonas

--- a/kb/communities/Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community.yaml
+++ b/kb/communities/Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community.yaml
@@ -28,6 +28,7 @@ taxonomy:
     term:
       id: NCBITaxon:1783273
       label: Patescibacteria group
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: CPR bacterial putative symbionts unable to synthesize complete
       membrane lipids; carry unusually abundant lysolipids.
   functional_role:
@@ -45,6 +46,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Bacteria and archaea performing CO2 fixation in the deep
       subsurface and contributing membrane lipids to CPR partners.
   functional_role:

--- a/kb/communities/Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community.yaml
+++ b/kb/communities/Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community.yaml
@@ -28,7 +28,7 @@ taxonomy:
     term:
       id: NCBITaxon:1783273
       label: Patescibacteria group
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: CPR bacterial putative symbionts unable to synthesize complete
       membrane lipids; carry unusually abundant lysolipids.
   functional_role:
@@ -46,7 +46,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Bacteria and archaea performing CO2 fixation in the deep
       subsurface and contributing membrane lipids to CPR partners.
   functional_role:

--- a/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
+++ b/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
@@ -92,7 +92,7 @@ taxonomy:
     term:
       id: NCBITaxon:412449
       label: Leptospirillum ferrodiazotrophum
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: ABUNDANT
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
+++ b/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
@@ -63,6 +63,7 @@ taxonomy:
     term:
       id: NCBITaxon:119977
       label: Acidithiobacillus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Acidithiobacillus
       gtdb_taxon: Acidithiobacillus
@@ -91,6 +92,7 @@ taxonomy:
     term:
       id: NCBITaxon:412449
       label: Leptospirillum ferrodiazotrophum
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: ABUNDANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -105,6 +107,7 @@ taxonomy:
     term:
       id: NCBITaxon:204441
       label: Rhodospirillales
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:o__RF32
       gtdb_taxon: RF32
@@ -127,6 +130,7 @@ taxonomy:
     term:
       id: NCBITaxon:2301
       label: Thermoplasmatales
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:o__Thermoplasmatales
       gtdb_taxon: Thermoplasmatales

--- a/kb/communities/DIETsimp_Lignocellulose_to_Methane_DIET_Consortia.yaml
+++ b/kb/communities/DIETsimp_Lignocellulose_to_Methane_DIET_Consortia.yaml
@@ -26,6 +26,7 @@ taxonomy:
     term:
       id: NCBITaxon:2209
       label: Methanosarcina mazei
+    gtdb_grounding_status: GROUNDED
     notes: Dominant archaeon; accepts electrons via DIET and reduces CO2 to methane.
     gtdb_classification:
       gtdb_id: GTDB:s__Methanosarcina_mazei
@@ -54,6 +55,7 @@ taxonomy:
     term:
       id: NCBITaxon:1131703
       label: Sphaerochaeta globosa
+    gtdb_grounding_status: GROUNDED
     notes: Dominant electroactive bacterium; metabolizes intermediates and donates electrons.
     gtdb_classification:
       gtdb_id: GTDB:s__Sphaerochaeta_globosa
@@ -83,6 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:84022
       label: Andreesenella acetica
+    gtdb_grounding_status: GROUNDED
     notes: NCBITaxon canonical label is "Andreesenella acetica"; "Clostridium aceticum" (the
       name used in the source paper) is a synonym of this taxon. Dominant electroactive bacterium
       that metabolizes intermediates and donates electrons.

--- a/kb/communities/DVM_Triculture.yaml
+++ b/kb/communities/DVM_Triculture.yaml
@@ -33,6 +33,7 @@ taxonomy:
     term:
       id: NCBITaxon:881
       label: Nitratidesulfovibrio vulgaris
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Nitratidesulfovibrio_vulgaris
       gtdb_taxon: Nitratidesulfovibrio vulgaris
@@ -68,6 +69,7 @@ taxonomy:
     term:
       id: NCBITaxon:39152
       label: Methanococcus maripaludis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methanococcus_maripaludis
       gtdb_taxon: Methanococcus maripaludis
@@ -99,6 +101,11 @@ taxonomy:
     term:
       id: NCBITaxon:2208
       label: Methanosarcina barkeri
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Methanosarcina barkeri
+    - Methanosarcina barkeri_A
+    - Methanosarcina barkeri_B
     notes: 'Versatile methanogen capable of using both H2-CO2 and acetate for methanogenesis. M. barkeri
       contributes to methane production in the absence of sulfate by consuming both the H2 and acetate
       produced by D. vulgaris. However, under sulfate treatments, M. barkeri cannot effectively contribute

--- a/kb/communities/Dangl_SynComm_35.yaml
+++ b/kb/communities/Dangl_SynComm_35.yaml
@@ -48,7 +48,7 @@ taxonomy:
     term:
       id: NCBITaxon:3702
       label: Arabidopsis thaliana
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Dangl_SynComm_35.yaml
+++ b/kb/communities/Dangl_SynComm_35.yaml
@@ -48,6 +48,7 @@ taxonomy:
     term:
       id: NCBITaxon:3702
       label: Arabidopsis thaliana
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_PRODUCER
   evidence:
@@ -62,6 +63,7 @@ taxonomy:
     term:
       id: NCBITaxon:231455
       label: Dyella japonica
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Dyella_marensis
       gtdb_taxon: Dyella marensis
@@ -86,6 +88,7 @@ taxonomy:
     term:
       id: NCBITaxon:135614
       label: Lysobacterales
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:o__Xanthomonadales
       gtdb_taxon: Xanthomonadales
@@ -111,6 +114,7 @@ taxonomy:
     term:
       id: NCBITaxon:286
       label: Pseudomonas
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Pseudomonas
       gtdb_taxon: Pseudomonas
@@ -135,6 +139,7 @@ taxonomy:
     term:
       id: NCBITaxon:237
       label: Flavobacterium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Flavobacterium
       gtdb_taxon: Flavobacterium
@@ -160,6 +165,7 @@ taxonomy:
     term:
       id: NCBITaxon:40323
       label: Stenotrophomonas
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Stenotrophomonas
       gtdb_taxon: Stenotrophomonas
@@ -178,6 +184,7 @@ taxonomy:
     term:
       id: NCBITaxon:33882
       label: Microbacterium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Microbacterium
       gtdb_taxon: Microbacterium
@@ -196,6 +203,7 @@ taxonomy:
     term:
       id: NCBITaxon:668369
       label: Escherichia coli DH5[alpha]
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Escherichia_coli
       gtdb_taxon: Escherichia coli

--- a/kb/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.yaml
+++ b/kb/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.yaml
@@ -22,6 +22,7 @@ taxonomy:
     term:
       id: NCBITaxon:135619
       label: Oceanospirillales
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:o__Pseudomonadales
       gtdb_taxon: Pseudomonadales
@@ -52,6 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:28228
       label: Colwellia
+    gtdb_grounding_status: NOT_ATTEMPTED
     notes: Cold deep-marine genus enriched in oil/dispersant incubations and flocs.
   abundance_level: ABUNDANT
   functional_role:
@@ -72,6 +74,7 @@ taxonomy:
     term:
       id: NCBITaxon:34067
       label: Cycloclasticus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Cycloclasticus
       gtdb_taxon: Cycloclasticus
@@ -96,6 +99,7 @@ taxonomy:
     term:
       id: NCBITaxon:40222
       label: Methylophaga
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Methylophaga
       gtdb_taxon: Methylophaga
@@ -120,6 +124,7 @@ taxonomy:
     term:
       id: NCBITaxon:2742
       label: Marinobacter
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Marinobacter
       gtdb_taxon: Marinobacter

--- a/kb/communities/Defined_Multispecies_Enamel_Caries_Model.yaml
+++ b/kb/communities/Defined_Multispecies_Enamel_Caries_Model.yaml
@@ -49,6 +49,7 @@ taxonomy:
     term:
       id: NCBITaxon:1582
       label: Lacticaseibacillus casei
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Lacticaseibacillus_paracasei
       gtdb_taxon: Lacticaseibacillus paracasei
@@ -73,6 +74,7 @@ taxonomy:
     term:
       id: NCBITaxon:1309
       label: Streptococcus mutans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Streptococcus_mutans
       gtdb_taxon: Streptococcus mutans
@@ -96,6 +98,12 @@ taxonomy:
     term:
       id: NCBITaxon:1304
       label: Streptococcus salivarius
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Streptococcus salivarius
+    - Streptococcus salivarius_D
+    - Streptococcus sp000187445
+    - Streptococcus sp001556435
   evidence:
   - reference: PMID:23446436
     supports: SUPPORT
@@ -110,6 +118,14 @@ taxonomy:
     term:
       id: NCBITaxon:1305
       label: Streptococcus sanguinis
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Streptococcus sanguinis
+    - Streptococcus sanguinis_H
+    - Streptococcus sanguinis_K
+    - Streptococcus sanguinis_M
+    - Streptococcus sanguinis_R
+    - Streptococcus sp905212325
   evidence:
   - reference: PMID:23446436
     supports: SUPPORT

--- a/kb/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.yaml
+++ b/kb/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.yaml
@@ -51,6 +51,7 @@ taxonomy:
     term:
       id: NCBITaxon:243164
       label: Dehalococcoides mccartyi 195
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Dehalococcoides_mccartyi
       gtdb_taxon: Dehalococcoides mccartyi
@@ -92,6 +93,7 @@ taxonomy:
     term:
       id: NCBITaxon:882
       label: Nitratidesulfovibrio vulgaris str. Hildenborough
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Nitratidesulfovibrio_vulgaris
       gtdb_taxon: Nitratidesulfovibrio vulgaris

--- a/kb/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.yaml
+++ b/kb/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.yaml
@@ -53,6 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:243164
       label: Dehalococcoides mccartyi 195
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Dehalococcoides_mccartyi
       gtdb_taxon: Dehalococcoides mccartyi
@@ -94,6 +95,7 @@ taxonomy:
     term:
       id: NCBITaxon:882
       label: Nitratidesulfovibrio vulgaris str. Hildenborough
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Nitratidesulfovibrio_vulgaris
       gtdb_taxon: Nitratidesulfovibrio vulgaris
@@ -134,6 +136,7 @@ taxonomy:
     term:
       id: NCBITaxon:1122947
       label: Pelosinus fermentans DSM 17108
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Pelosinus_fermentans
       gtdb_taxon: Pelosinus fermentans

--- a/kb/communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.yaml
@@ -49,6 +49,7 @@ taxonomy:
     term:
       id: NCBITaxon:216389
       label: Dehalococcoides mccartyi BAV1
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Dehalococcoides_mccartyi_B
       gtdb_taxon: Dehalococcoides mccartyi_B
@@ -79,6 +80,7 @@ taxonomy:
     term:
       id: NCBITaxon:269797
       label: Methanosarcina barkeri str. Fusaro
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methanosarcina_barkeri_B
       gtdb_taxon: Methanosarcina barkeri_B

--- a/kb/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml
@@ -53,6 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:243164
       label: Dehalococcoides mccartyi 195
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Dehalococcoides_mccartyi
       gtdb_taxon: Dehalococcoides mccartyi
@@ -87,6 +88,7 @@ taxonomy:
     term:
       id: NCBITaxon:18
       label: Pelobacter
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Syntrophotalea
       gtdb_taxon: Syntrophotalea

--- a/kb/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.yaml
@@ -59,6 +59,7 @@ taxonomy:
     term:
       id: NCBITaxon:243164
       label: Dehalococcoides mccartyi 195
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Dehalococcoides_mccartyi
       gtdb_taxon: Dehalococcoides mccartyi
@@ -89,6 +90,10 @@ taxonomy:
     term:
       id: NCBITaxon:863
       label: Syntrophomonas wolfei
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Syntrophomonas methylbutyratica
+    - Syntrophomonas wolfei
     notes: Butyrate-fermenting syntroph that supplies hydrogen and acetate to support
       D. mccartyi 195 reductive dechlorination.
   functional_role:

--- a/kb/communities/Dehalococcoides_mccartyi_CWV2_Dechlorinating_Consortium.yaml
+++ b/kb/communities/Dehalococcoides_mccartyi_CWV2_Dechlorinating_Consortium.yaml
@@ -23,6 +23,11 @@ taxonomy:
     term:
       id: NCBITaxon:61435
       label: Dehalococcoides mccartyi
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Dehalococcoides mccartyi
+    - Dehalococcoides mccartyi_A
+    - Dehalococcoides mccartyi_B
     notes: Strain CWV2; the only named organism in the source. Other consortium members
       (syntrophic hydrogen producers, electroactive bacteria) are described only as unnamed
       functional guilds and are not grounded.

--- a/kb/communities/Desert_Tomato_Salt_Stress_SynCom5.yaml
+++ b/kb/communities/Desert_Tomato_Salt_Stress_SynCom5.yaml
@@ -37,6 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Desert_Tomato_Salt_Stress_SynCom5.yaml
+++ b/kb/communities/Desert_Tomato_Salt_Stress_SynCom5.yaml
@@ -37,7 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Desulfovibrio_Methanococcus_Syntrophy.yaml
+++ b/kb/communities/Desulfovibrio_Methanococcus_Syntrophy.yaml
@@ -31,6 +31,7 @@ taxonomy:
     term:
       id: NCBITaxon:882
       label: Nitratidesulfovibrio vulgaris str. Hildenborough
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Nitratidesulfovibrio_vulgaris
       gtdb_taxon: Nitratidesulfovibrio vulgaris
@@ -65,6 +66,7 @@ taxonomy:
     term:
       id: NCBITaxon:267377
       label: Methanococcus maripaludis S2
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methanococcus_maripaludis
       gtdb_taxon: Methanococcus maripaludis

--- a/kb/communities/Desulfovibrio_Methanosarcina_Lactate_Syntrophy.yaml
+++ b/kb/communities/Desulfovibrio_Methanosarcina_Lactate_Syntrophy.yaml
@@ -20,6 +20,10 @@ taxonomy:
     term:
       id: NCBITaxon:876
       label: Desulfovibrio desulfuricans
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Desulfovibrio desulfuricans
+    - Desulfovibrio sp900243745
     notes: Sulfate-reducing bacterium grown without added sulfate as the lactate-degrading partner.
   functional_role:
   - PRIMARY_DEGRADER
@@ -35,6 +39,11 @@ taxonomy:
     term:
       id: NCBITaxon:2208
       label: Methanosarcina barkeri
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Methanosarcina barkeri
+    - Methanosarcina barkeri_A
+    - Methanosarcina barkeri_B
     notes: Methanogen able to use both hydrogen-carbon dioxide and acetate for methanogenesis.
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.yaml
+++ b/kb/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.yaml
@@ -108,7 +108,7 @@ taxonomy:
     term:
       id: NCBITaxon:7227
       label: Drosophila melanogaster
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Fruit-fly host colonized with the defined bacterial community.
   abundance_value: Host organism for the defined gut microbiota.
   evidence:

--- a/kb/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.yaml
+++ b/kb/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.yaml
@@ -42,6 +42,7 @@ taxonomy:
     term:
       id: NCBITaxon:434
       label: Acetobacter
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Acetobacter
       gtdb_taxon: Acetobacter
@@ -74,6 +75,7 @@ taxonomy:
     term:
       id: NCBITaxon:1578
       label: Lactobacillus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Lactobacillus
       gtdb_taxon: Lactobacillus
@@ -106,6 +108,7 @@ taxonomy:
     term:
       id: NCBITaxon:7227
       label: Drosophila melanogaster
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Fruit-fly host colonized with the defined bacterial community.
   abundance_value: Host organism for the defined gut microbiota.
   evidence:

--- a/kb/communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.yaml
+++ b/kb/communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.yaml
@@ -28,6 +28,7 @@ taxonomy:
     term:
       id: NCBITaxon:201174
       label: Actinomycetota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Actinomycetota
       gtdb_taxon: Actinomycetota

--- a/kb/communities/Dual_Bacillus_coagulans_Pseudomonas_putida_Lactic_Acid_Coculture.yaml
+++ b/kb/communities/Dual_Bacillus_coagulans_Pseudomonas_putida_Lactic_Acid_Coculture.yaml
@@ -26,6 +26,10 @@ taxonomy:
     term:
       id: NCBITaxon:1398
       label: Heyndrickxia coagulans
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Weizmannia coagulans
+    - Weizmannia faecalis
     notes: Strain DSM1-25280, engineered to overexpress phenolic acid decarboxylase (PAD).
       NCBITaxon canonical label is "Heyndrickxia coagulans"; "Bacillus coagulans" (used in the
       source paper) is a synonym for the reclassified species.
@@ -47,6 +51,10 @@ taxonomy:
     term:
       id: NCBITaxon:1398
       label: Heyndrickxia coagulans
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Weizmannia coagulans
+    - Weizmannia faecalis
     notes: Strain CC17B-1, a high-yield L-lactic acid producer. NCBITaxon canonical label is
       "Heyndrickxia coagulans"; "Bacillus coagulans" (source paper) is a synonym for the
       reclassified species.
@@ -68,6 +76,23 @@ taxonomy:
     term:
       id: NCBITaxon:303
       label: Pseudomonas putida
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Pseudomonas_E alloputida
+    - Pseudomonas_E asiatica
+    - Pseudomonas_E fulva
+    - Pseudomonas_E guariconensis
+    - Pseudomonas_E juntendi
+    - Pseudomonas_E monteilii
+    - Pseudomonas_E pudica
+    - Pseudomonas_E putida
+    - Pseudomonas_E putida_E
+    - Pseudomonas_E putida_H
+    - Pseudomonas_E putida_K
+    - Pseudomonas_E putida_P
+    - Pseudomonas_E putida_Q
+    - Pseudomonas_E putida_R
+    - Pseudomonas_E putida_Y
     notes: Strain KT2440 ZL, a sugar-metabolism-deficient engineered derivative of P. putida
       KT2440 (NCBITaxon:160488) added as a heterologous aromatic scavenger. Grounded at the
       species rank; strain-specific NCBITaxon for the engineered ZL derivative is not available.

--- a/kb/communities/ENIGMA_Denitrifying_SynCom.yaml
+++ b/kb/communities/ENIGMA_Denitrifying_SynCom.yaml
@@ -45,6 +45,7 @@ taxonomy:
     term:
       id: NCBITaxon:416169
       label: Rhodanobacter thiooxydans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Rhodanobacter_thiooxydans
       gtdb_taxon: Rhodanobacter thiooxydans
@@ -80,6 +81,7 @@ taxonomy:
     term:
       id: NCBITaxon:1872122
       label: Acidovorax sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   strain_designation:
     strain_name: GW101-3H11
     isolation_source: heavily nitrate-contaminated superfund site groundwater

--- a/kb/communities/ENIGMA_Denitrifying_SynCom.yaml
+++ b/kb/communities/ENIGMA_Denitrifying_SynCom.yaml
@@ -81,7 +81,7 @@ taxonomy:
     term:
       id: NCBITaxon:1872122
       label: Acidovorax sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   strain_designation:
     strain_name: GW101-3H11
     isolation_source: heavily nitrate-contaminated superfund site groundwater

--- a/kb/communities/Early_Dental_Biofilm_FiveSpecies.yaml
+++ b/kb/communities/Early_Dental_Biofilm_FiveSpecies.yaml
@@ -47,6 +47,22 @@ taxonomy:
     term:
       id: NCBITaxon:1303
       label: Streptococcus oralis
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Streptococcus dentisani
+    - Streptococcus mitis_AX
+    - Streptococcus mitis_AY
+    - Streptococcus oralis
+    - Streptococcus oralis_AC
+    - Streptococcus oralis_BC
+    - Streptococcus oralis_BW
+    - Streptococcus oralis_E
+    - Streptococcus oralis_F
+    - Streptococcus oralis_L
+    - Streptococcus oralis_S
+    - Streptococcus oralis_T
+    - Streptococcus oralis_W
+    - Streptococcus oralis_Y
   evidence:
   - reference: PMID:21966490
     supports: SUPPORT
@@ -61,6 +77,14 @@ taxonomy:
     term:
       id: NCBITaxon:1305
       label: Streptococcus sanguinis
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Streptococcus sanguinis
+    - Streptococcus sanguinis_H
+    - Streptococcus sanguinis_K
+    - Streptococcus sanguinis_M
+    - Streptococcus sanguinis_R
+    - Streptococcus sp905212325
   evidence:
   - reference: PMID:21966490
     supports: SUPPORT
@@ -75,6 +99,20 @@ taxonomy:
     term:
       id: NCBITaxon:28037
       label: Streptococcus mitis
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Streptococcus chosunense
+    - Streptococcus mitis
+    - Streptococcus mitis_AI
+    - Streptococcus mitis_AR
+    - Streptococcus mitis_AW
+    - Streptococcus mitis_AZ
+    - Streptococcus mitis_CK
+    - Streptococcus mitis_CQ
+    - Streptococcus mitis_H
+    - Streptococcus mitis_K
+    - Streptococcus mitis_L
+    - Streptococcus mitis_N
   evidence:
   - reference: PMID:21966490
     supports: SUPPORT
@@ -89,6 +127,7 @@ taxonomy:
     term:
       id: NCBITaxon:1317
       label: Streptococcus downei
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Streptococcus_downei
       gtdb_taxon: Streptococcus downei
@@ -112,6 +151,7 @@ taxonomy:
     term:
       id: NCBITaxon:1655
       label: Actinomyces naeslundii
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Actinomyces_naeslundii
       gtdb_taxon: Actinomyces naeslundii

--- a/kb/communities/East_River_Floodplain_Core_Microbiome.yaml
+++ b/kb/communities/East_River_Floodplain_Core_Microbiome.yaml
@@ -22,6 +22,7 @@ taxonomy:
     term:
       id: NCBITaxon:28216
       label: Betaproteobacteria
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:c__Gammaproteobacteria
       gtdb_taxon: Gammaproteobacteria
@@ -57,6 +58,7 @@ taxonomy:
     term:
       id: NCBITaxon:1234
       label: Nitrospira
+    gtdb_grounding_status: NOT_ATTEMPTED
     notes: Nitrospirae were among abundant reconstructed lineages and are consistent with the highly transcribed
       nitrification genes reported for the floodplain soils.
   functional_role:
@@ -73,6 +75,7 @@ taxonomy:
     term:
       id: NCBITaxon:57723
       label: Acidobacteriota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Acidobacteriota
       gtdb_taxon: Acidobacteriota
@@ -99,6 +102,7 @@ taxonomy:
     term:
       id: NCBITaxon:142182
       label: Gemmatimonadota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Gemmatimonadota
       gtdb_taxon: Gemmatimonadota

--- a/kb/communities/East_River_Hillslope_Riparian_Transect_Community.yaml
+++ b/kb/communities/East_River_Hillslope_Riparian_Transect_Community.yaml
@@ -26,6 +26,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Community-level representation of the depth-resolved metagenomic
       hillslope-to-riparian transect.
   functional_role:
@@ -47,6 +48,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Riparian-zone communities are treated as a distinct functional
       compartment relative to hillslope communities.
   functional_role:
@@ -69,6 +71,7 @@ taxonomy:
     term:
       id: NCBITaxon:1783273
       label: Patescibacteria group
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: The article reports Candidate Phyla Radiation bacteria in riparian
       saturated sediments.
   functional_role:
@@ -85,6 +88,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Hillslope communities provide the comparison set for riparian-zone
       compositional and functional differentiation.
   functional_role:

--- a/kb/communities/East_River_Hillslope_Riparian_Transect_Community.yaml
+++ b/kb/communities/East_River_Hillslope_Riparian_Transect_Community.yaml
@@ -26,7 +26,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Community-level representation of the depth-resolved metagenomic
       hillslope-to-riparian transect.
   functional_role:
@@ -48,7 +48,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Riparian-zone communities are treated as a distinct functional
       compartment relative to hillslope communities.
   functional_role:
@@ -71,7 +71,7 @@ taxonomy:
     term:
       id: NCBITaxon:1783273
       label: Patescibacteria group
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: The article reports Candidate Phyla Radiation bacteria in riparian
       saturated sediments.
   functional_role:
@@ -88,7 +88,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Hillslope communities provide the comparison set for riparian-zone
       compositional and functional differentiation.
   functional_role:

--- a/kb/communities/EcoFAB_Ring_Trial_SynCom17.yaml
+++ b/kb/communities/EcoFAB_Ring_Trial_SynCom17.yaml
@@ -317,7 +317,7 @@ taxonomy:
     term:
       id: NCBITaxon:1667
       label: Arthrobacter sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Low relative abundance (<0.2%) at 21 DPI.
   strain_designation:
     strain_name: OAP107
@@ -503,6 +503,31 @@ taxonomy:
     - Paenibacillus_H
     - Paenibacillus_E
     - Paenibacillus_Z
+    - Paenibacillus_S
+    - Paenibacillus_J
+    - Paenibacillus_D
+    - Paenibacillus_AB
+    - Paenibacillus_O
+    - Paenibacillus_T
+    - Paenibacillus_I
+    - Paenibacillus_AE
+    - Paenibacillus_K
+    - Paenibacillus_F
+    - Paenibacillus_L
+    - Bacillus
+    - Paenibacillus_AF
+    - Paenibacillus_AM
+    - Paenibacillus_AC
+    - Paenibacillus_AG
+    - Paenibacillus_AH
+    - Paenibacillus_AI
+    - Paenibacillus_AK
+    - Paenibacillus_AN
+    - Paenibacillus_N
+    - Paenibacillus_V
+    - Paenibacillus_W
+    - Paenibacillus_AA
+    - CC-CFT747
   strain_designation:
     strain_name: OAE614
     isolation_source: Switchgrass rhizosphere soil

--- a/kb/communities/EcoFAB_Ring_Trial_SynCom17.yaml
+++ b/kb/communities/EcoFAB_Ring_Trial_SynCom17.yaml
@@ -53,6 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:1822464
       label: Paraburkholderia
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Paraburkholderia
       gtdb_taxon: Paraburkholderia
@@ -91,6 +92,7 @@ taxonomy:
     term:
       id: NCBITaxon:1827
       label: Rhodococcus <high G+C Gram-positive bacteria>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Rhodococcus
       gtdb_taxon: Rhodococcus
@@ -124,6 +126,7 @@ taxonomy:
     term:
       id: NCBITaxon:1763
       label: Mycobacterium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Mycobacterium
       gtdb_taxon: Mycobacterium
@@ -152,6 +155,7 @@ taxonomy:
     term:
       id: NCBITaxon:407
       label: Methylobacterium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Methylobacterium
       gtdb_taxon: Methylobacterium
@@ -180,6 +184,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -205,6 +210,7 @@ taxonomy:
     term:
       id: NCBITaxon:379
       label: Rhizobium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Rhizobium
       gtdb_taxon: Rhizobium
@@ -231,6 +237,7 @@ taxonomy:
     term:
       id: NCBITaxon:169215
       label: Bosea
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bosea
       gtdb_taxon: Bosea
@@ -256,6 +263,7 @@ taxonomy:
     term:
       id: NCBITaxon:374
       label: Bradyrhizobium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bradyrhizobium
       gtdb_taxon: Bradyrhizobium
@@ -282,6 +290,7 @@ taxonomy:
     term:
       id: NCBITaxon:68
       label: Lysobacter
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Lysobacter
       gtdb_taxon: Lysobacter
@@ -308,6 +317,7 @@ taxonomy:
     term:
       id: NCBITaxon:1667
       label: Arthrobacter sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Low relative abundance (<0.2%) at 21 DPI.
   strain_designation:
     strain_name: OAP107
@@ -326,6 +336,7 @@ taxonomy:
     term:
       id: NCBITaxon:86795
       label: Marmoricola
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Marmoricola
       gtdb_taxon: Marmoricola
@@ -351,6 +362,7 @@ taxonomy:
     term:
       id: NCBITaxon:79328
       label: Chitinophaga
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Chitinophaga
       gtdb_taxon: Chitinophaga
@@ -376,6 +388,7 @@ taxonomy:
     term:
       id: NCBITaxon:423349
       label: Mucilaginibacter
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Mucilaginibacter
       gtdb_taxon: Mucilaginibacter
@@ -401,6 +414,7 @@ taxonomy:
     term:
       id: NCBITaxon:354354
       label: Niastella
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Niastella
       gtdb_taxon: Niastella
@@ -426,6 +440,7 @@ taxonomy:
     term:
       id: NCBITaxon:2837503
       label: Gottfriedia
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Gottfriedia
       gtdb_taxon: Gottfriedia
@@ -452,6 +467,7 @@ taxonomy:
     term:
       id: NCBITaxon:55080
       label: Brevibacillus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Brevibacillus
       gtdb_taxon: Brevibacillus
@@ -477,6 +493,16 @@ taxonomy:
     term:
       id: NCBITaxon:44249
       label: Paenibacillus
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Paenibacillus
+    - Paenibacillus_A
+    - Paenibacillus_B
+    - Paenibacillus_G
+    - Pristimantibacillus
+    - Paenibacillus_H
+    - Paenibacillus_E
+    - Paenibacillus_Z
   strain_designation:
     strain_name: OAE614
     isolation_source: Switchgrass rhizosphere soil

--- a/kb/communities/Ecoli_Bifidobacterium_bifidum_Infant_gut_HMO_Mutualism_Coculture.yaml
+++ b/kb/communities/Ecoli_Bifidobacterium_bifidum_Infant_gut_HMO_Mutualism_Coculture.yaml
@@ -23,6 +23,7 @@ taxonomy:
     term:
       id: NCBITaxon:562
       label: Escherichia coli
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Escherichia_coli
       gtdb_taxon: Escherichia coli
@@ -49,6 +50,7 @@ taxonomy:
     term:
       id: NCBITaxon:1681
       label: Bifidobacterium bifidum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bifidobacterium_bifidum
       gtdb_taxon: Bifidobacterium bifidum

--- a/kb/communities/Electrostimulated_Mixotrophic_VFA_Producing_Enrichment_Consortium.yaml
+++ b/kb/communities/Electrostimulated_Mixotrophic_VFA_Producing_Enrichment_Consortium.yaml
@@ -63,6 +63,44 @@ taxonomy:
     - Clostridium_B
     - Clostridium_J
     - Clostridium_F
+    - Clostridium_H
+    - Clostridium_S
+    - Enterocloster
+    - Clostridium_L
+    - Clostridium_AD
+    - Clostridium_AM
+    - Clostridium_X
+    - Clostridium_I
+    - Lawsonibacter
+    - Clostridium_T
+    - Clostridium_AO
+    - Clostridium_AR
+    - Pseudoclostridium
+    - Clostridium_W
+    - Clostridium_AA
+    - Clostridium_AT
+    - Clostridium_AU
+    - Clostridium_Z
+    - Clostridium_AH
+    - Clostridium_AK
+    - Clostridium_K
+    - Clostridium_R
+    - Clostridium_AW
+    - Clostridium_AC
+    - Massilioclostridium
+    - Clostridium_AB
+    - Clostridium_AE
+    - Clostridium_AF
+    - Clostridium_AG
+    - Clostridium_AS
+    - Clostridium_AV
+    - Clostridium_C
+    - Clostridium_D
+    - Clostridium_E
+    - Eubacterium
+    - Aminipila
+    - BRXR01
+    - Lacrimispora
     notes: Grounded at genus rank; the source reports the taxon only as "Clostridium". Dominant in the
       planktonic phase; associated with acetogenic carbon-fixation pathways.
   functional_role:

--- a/kb/communities/Electrostimulated_Mixotrophic_VFA_Producing_Enrichment_Consortium.yaml
+++ b/kb/communities/Electrostimulated_Mixotrophic_VFA_Producing_Enrichment_Consortium.yaml
@@ -24,6 +24,7 @@ taxonomy:
     term:
       id: NCBITaxon:1350
       label: Enterococcus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Enterococcus_B
       gtdb_taxon: Enterococcus_B
@@ -52,6 +53,16 @@ taxonomy:
     term:
       id: NCBITaxon:1485
       label: Clostridium
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Clostridium
+    - Otoolea
+    - Sarcina
+    - Clostridium_AQ
+    - Clostridium_G
+    - Clostridium_B
+    - Clostridium_J
+    - Clostridium_F
     notes: Grounded at genus rank; the source reports the taxon only as "Clostridium". Dominant in the
       planktonic phase; associated with acetogenic carbon-fixation pathways.
   functional_role:
@@ -70,6 +81,7 @@ taxonomy:
     term:
       id: NCBITaxon:872
       label: Desulfovibrio
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Desulfovibrio
       gtdb_taxon: Desulfovibrio

--- a/kb/communities/Electrosynthetic_Consortia_Shewanella_Clostridium_Acetobacterium_Acetate.yaml
+++ b/kb/communities/Electrosynthetic_Consortia_Shewanella_Clostridium_Acetobacterium_Acetate.yaml
@@ -24,6 +24,7 @@ taxonomy:
     term:
       id: NCBITaxon:70863
       label: Shewanella oneidensis
+    gtdb_grounding_status: GROUNDED
     notes: Strain MR-1. Model bidirectional electroactive bacterium; grounded at species rank.
     gtdb_classification:
       gtdb_id: GTDB:s__Shewanella_oneidensis
@@ -53,6 +54,7 @@ taxonomy:
     term:
       id: NCBITaxon:84022
       label: Andreesenella acetica
+    gtdb_grounding_status: GROUNDED
     notes: The source paper uses "Clostridium aceticum"; the current NCBITaxon canonical label for this
       taxon is "Andreesenella acetica" (Clostridium aceticum is a synonym; reclassified 2026).
     gtdb_classification:
@@ -81,6 +83,7 @@ taxonomy:
     term:
       id: NCBITaxon:33952
       label: Acetobacterium woodii
+    gtdb_grounding_status: GROUNDED
     notes: Nonelectroactive acetogen; grounded at species rank.
     gtdb_classification:
       gtdb_id: GTDB:s__Acetobacterium_woodii

--- a/kb/communities/Emiliania_Phaeobacter_Dynamic_Interaction.yaml
+++ b/kb/communities/Emiliania_Phaeobacter_Dynamic_Interaction.yaml
@@ -40,6 +40,7 @@ taxonomy:
     term:
       id: NCBITaxon:2903
       label: Emiliania huxleyi
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Calcifying coccolithophore algal strain used as the host phototroph in the co-culture.
   strain_designation:
     strain_name: CCMP3266
@@ -57,6 +58,7 @@ taxonomy:
     term:
       id: NCBITaxon:391619
       label: Phaeobacter inhibens DSM 17395
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Phaeobacter_inhibens
       gtdb_taxon: Phaeobacter inhibens

--- a/kb/communities/Emiliania_Phaeobacter_Dynamic_Interaction.yaml
+++ b/kb/communities/Emiliania_Phaeobacter_Dynamic_Interaction.yaml
@@ -40,7 +40,7 @@ taxonomy:
     term:
       id: NCBITaxon:2903
       label: Emiliania huxleyi
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Calcifying coccolithophore algal strain used as the host phototroph in the co-culture.
   strain_designation:
     strain_name: CCMP3266

--- a/kb/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.yaml
+++ b/kb/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.yaml
@@ -43,6 +43,7 @@ taxonomy:
     term:
       id: NCBITaxon:562
       label: Escherichia coli
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Escherichia_coli
       gtdb_taxon: Escherichia coli
@@ -66,6 +67,7 @@ taxonomy:
     term:
       id: NCBITaxon:90371
       label: Salmonella enterica subsp. enterica serovar Typhimurium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Salmonella_enterica
       gtdb_taxon: Salmonella enterica
@@ -89,6 +91,7 @@ taxonomy:
     term:
       id: NCBITaxon:818
       label: Bacteroides thetaiotaomicron
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bacteroides_thetaiotaomicron
       gtdb_taxon: Bacteroides thetaiotaomicron
@@ -114,6 +117,12 @@ taxonomy:
     term:
       id: NCBITaxon:817
       label: Bacteroides fragilis
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Bacteroides fragilis
+    - Bacteroides hominis
+    - Bacteroides ovatus
+    - Chlamydophila gallinacea
     notes: Engineered Bacteroides member of the consortium.
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/Ensifer_YF2_Sphingobacterium_Y2_Polyethylene_Degrading_Consortium.yaml
+++ b/kb/communities/Ensifer_YF2_Sphingobacterium_Y2_Polyethylene_Degrading_Consortium.yaml
@@ -23,6 +23,7 @@ taxonomy:
     term:
       id: NCBITaxon:106591
       label: Ensifer
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Ensifer
       gtdb_taxon: Ensifer
@@ -51,6 +52,7 @@ taxonomy:
     term:
       id: NCBITaxon:28453
       label: Sphingobacterium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Sphingobacterium
       gtdb_taxon: Sphingobacterium
@@ -80,6 +82,7 @@ taxonomy:
     term:
       id: NCBITaxon:59732
       label: Chryseobacterium
+    gtdb_grounding_status: GROUNDED
     notes: Strain MF1 identified only to genus Chryseobacterium; grounded at genus rank. Isolated and
       tested in the three-strain combination, but the effective consortium was the dual-strain YF2+Y2.
     gtdb_classification:

--- a/kb/communities/Episymbiotic_CPR_DPANN_Groundwater_Community.yaml
+++ b/kb/communities/Episymbiotic_CPR_DPANN_Groundwater_Community.yaml
@@ -28,6 +28,7 @@ taxonomy:
     term:
       id: NCBITaxon:1783273
       label: Patescibacteria group
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 31 percent of pristine groundwater communities; episymbionts that
       attach to host cells.
   abundance_level: DOMINANT
@@ -54,6 +55,7 @@ taxonomy:
     term:
       id: NCBITaxon:1783276
       label: Nanobdellati
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Up to 4 percent of pristine groundwater communities; episymbionts
       that attach to host cells.
   abundance_level: ABUNDANT
@@ -70,6 +72,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Diverse non-CPR/non-DPANN cellular hosts to which CPR bacteria and
       DPANN archaea reproducibly attach.
   functional_role:

--- a/kb/communities/Episymbiotic_CPR_DPANN_Groundwater_Community.yaml
+++ b/kb/communities/Episymbiotic_CPR_DPANN_Groundwater_Community.yaml
@@ -28,7 +28,7 @@ taxonomy:
     term:
       id: NCBITaxon:1783273
       label: Patescibacteria group
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 31 percent of pristine groundwater communities; episymbionts that
       attach to host cells.
   abundance_level: DOMINANT
@@ -55,7 +55,7 @@ taxonomy:
     term:
       id: NCBITaxon:1783276
       label: Nanobdellati
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Up to 4 percent of pristine groundwater communities; episymbionts
       that attach to host cells.
   abundance_level: ABUNDANT
@@ -72,7 +72,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Diverse non-CPR/non-DPANN cellular hosts to which CPR bacteria and
       DPANN archaea reproducibly attach.
   functional_role:

--- a/kb/communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.yaml
+++ b/kb/communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.yaml
@@ -47,6 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:1423
       label: Bacillus subtilis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bacillus_subtilis
       gtdb_taxon: Bacillus subtilis
@@ -69,6 +70,7 @@ taxonomy:
     term:
       id: NCBITaxon:75105
       label: Paraburkholderia caribensis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Paraburkholderia_caribensis
       gtdb_taxon: Paraburkholderia caribensis
@@ -91,6 +93,7 @@ taxonomy:
     term:
       id: NCBITaxon:374432
       label: Methylobacterium tardum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methylobacterium_tardum
       gtdb_taxon: Methylobacterium tardum
@@ -113,6 +116,16 @@ taxonomy:
     term:
       id: NCBITaxon:44249
       label: Paenibacillus
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Paenibacillus
+    - Paenibacillus_A
+    - Paenibacillus_B
+    - Paenibacillus_G
+    - Pristimantibacillus
+    - Paenibacillus_H
+    - Paenibacillus_E
+    - Paenibacillus_Z
     notes: Grounded at genus level because the paper describes this member as a putative novel
       species identified from metagenome-assembled genomes, with no species assignment available.
   evidence:
@@ -128,6 +141,7 @@ taxonomy:
     term:
       id: NCBITaxon:68287
       label: Mesorhizobium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Mesorhizobium
       gtdb_taxon: Mesorhizobium
@@ -153,6 +167,7 @@ taxonomy:
     term:
       id: NCBITaxon:3932
       label: Eucalyptus
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Host tree. Three clonal genotypes were inoculated; the consortium's effect on seedling
       quality and mortality differed between them.
   evidence:

--- a/kb/communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.yaml
+++ b/kb/communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.yaml
@@ -126,6 +126,31 @@ taxonomy:
     - Paenibacillus_H
     - Paenibacillus_E
     - Paenibacillus_Z
+    - Paenibacillus_S
+    - Paenibacillus_J
+    - Paenibacillus_D
+    - Paenibacillus_AB
+    - Paenibacillus_O
+    - Paenibacillus_T
+    - Paenibacillus_I
+    - Paenibacillus_AE
+    - Paenibacillus_K
+    - Paenibacillus_F
+    - Paenibacillus_L
+    - Bacillus
+    - Paenibacillus_AF
+    - Paenibacillus_AM
+    - Paenibacillus_AC
+    - Paenibacillus_AG
+    - Paenibacillus_AH
+    - Paenibacillus_AI
+    - Paenibacillus_AK
+    - Paenibacillus_AN
+    - Paenibacillus_N
+    - Paenibacillus_V
+    - Paenibacillus_W
+    - Paenibacillus_AA
+    - CC-CFT747
     notes: Grounded at genus level because the paper describes this member as a putative novel
       species identified from metagenome-assembled genomes, with no species assignment available.
   evidence:
@@ -167,7 +192,7 @@ taxonomy:
     term:
       id: NCBITaxon:3932
       label: Eucalyptus
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Host tree. Three clonal genotypes were inoculated; the consortium's effect on seedling
       quality and mortality differed between them.
   evidence:

--- a/kb/communities/Ewaste_Bioleaching_Consortium.yaml
+++ b/kb/communities/Ewaste_Bioleaching_Consortium.yaml
@@ -56,6 +56,7 @@ taxonomy:
     term:
       id: NCBITaxon:178606
       label: Leptospirillum ferriphilum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Leptospirillum_A_rubarum
       gtdb_taxon: Leptospirillum_A rubarum
@@ -96,6 +97,7 @@ taxonomy:
     term:
       id: NCBITaxon:453960
       label: Sulfobacillus benefaciens
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Sulfobacillus_benefaciens
       gtdb_taxon: Sulfobacillus benefaciens
@@ -131,6 +133,7 @@ taxonomy:
     term:
       id: NCBITaxon:920
       label: Acidithiobacillus ferrooxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidithiobacillus_ferrooxidans
       gtdb_taxon: Acidithiobacillus ferrooxidans
@@ -173,6 +176,7 @@ taxonomy:
     term:
       id: NCBITaxon:930
       label: Acidithiobacillus thiooxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidithiobacillus_thiooxidans
       gtdb_taxon: Acidithiobacillus thiooxidans
@@ -211,6 +215,7 @@ taxonomy:
     term:
       id: NCBITaxon:160808
       label: Acidithiobacillus ferrivorans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidithiobacillus_ferrivorans
       gtdb_taxon: Acidithiobacillus ferrivorans

--- a/kb/communities/Ferroplasma_Leptospirillum_Syntrophy.yaml
+++ b/kb/communities/Ferroplasma_Leptospirillum_Syntrophy.yaml
@@ -39,6 +39,7 @@ taxonomy:
     term:
       id: NCBITaxon:178606
       label: Leptospirillum ferriphilum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Leptospirillum_A_rubarum
       gtdb_taxon: Leptospirillum_A rubarum
@@ -88,6 +89,7 @@ taxonomy:
     term:
       id: NCBITaxon:74969
       label: Ferroplasma acidiphilum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Ferroplasma_acidarmanus
       gtdb_taxon: Ferroplasma acidarmanus

--- a/kb/communities/GLBRC_Exometabolite_Transwell_SynCom.yaml
+++ b/kb/communities/GLBRC_Exometabolite_Transwell_SynCom.yaml
@@ -35,6 +35,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/GLBRC_Exometabolite_Transwell_SynCom.yaml
+++ b/kb/communities/GLBRC_Exometabolite_Transwell_SynCom.yaml
@@ -35,7 +35,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/GLBRC_Populus_Variovorax_SynCom28.yaml
+++ b/kb/communities/GLBRC_Populus_Variovorax_SynCom28.yaml
@@ -45,6 +45,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -78,6 +79,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -111,6 +113,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -144,6 +147,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -177,6 +181,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -210,6 +215,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -243,6 +249,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -276,6 +283,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -309,6 +317,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -342,6 +351,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -375,6 +385,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -408,6 +419,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -441,6 +453,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -474,6 +487,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -507,6 +521,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -540,6 +555,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -573,6 +589,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -606,6 +623,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -639,6 +657,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -672,6 +691,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -705,6 +725,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -738,6 +759,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -771,6 +793,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -804,6 +827,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -837,6 +861,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -870,6 +895,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -903,6 +929,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -936,6 +963,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax

--- a/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
+++ b/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
@@ -107,6 +107,44 @@ taxonomy:
     - Clostridium_B
     - Clostridium_J
     - Clostridium_F
+    - Clostridium_H
+    - Clostridium_S
+    - Enterocloster
+    - Clostridium_L
+    - Clostridium_AD
+    - Clostridium_AM
+    - Clostridium_X
+    - Clostridium_I
+    - Lawsonibacter
+    - Clostridium_T
+    - Clostridium_AO
+    - Clostridium_AR
+    - Pseudoclostridium
+    - Clostridium_W
+    - Clostridium_AA
+    - Clostridium_AT
+    - Clostridium_AU
+    - Clostridium_Z
+    - Clostridium_AH
+    - Clostridium_AK
+    - Clostridium_K
+    - Clostridium_R
+    - Clostridium_AW
+    - Clostridium_AC
+    - Massilioclostridium
+    - Clostridium_AB
+    - Clostridium_AE
+    - Clostridium_AF
+    - Clostridium_AG
+    - Clostridium_AS
+    - Clostridium_AV
+    - Clostridium_C
+    - Clostridium_D
+    - Clostridium_E
+    - Eubacterium
+    - Aminipila
+    - BRXR01
+    - Lacrimispora
     notes: 'Dominant Firmicutes member (up to 45.6% relative abundance). Performs chain elongation from
       lactic acid to butyric, hexanoic, and octanoic acids via reverse beta-oxidation.
 

--- a/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
+++ b/kb/communities/GLBRC_UFMP_Fermentation_Community.yaml
@@ -62,6 +62,7 @@ taxonomy:
     term:
       id: NCBITaxon:133926
       label: Olsenella uli
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Olsenella_uli
       gtdb_taxon: Olsenella uli
@@ -96,6 +97,16 @@ taxonomy:
     term:
       id: NCBITaxon:1485
       label: Clostridium
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Clostridium
+    - Otoolea
+    - Sarcina
+    - Clostridium_AQ
+    - Clostridium_G
+    - Clostridium_B
+    - Clostridium_J
+    - Clostridium_F
     notes: 'Dominant Firmicutes member (up to 45.6% relative abundance). Performs chain elongation from
       lactic acid to butyric, hexanoic, and octanoic acids via reverse beta-oxidation.
 
@@ -122,6 +133,7 @@ taxonomy:
     term:
       id: NCBITaxon:2740557
       label: Pauljensenia
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Pauljensenia
       gtdb_taxon: Pauljensenia
@@ -156,6 +168,7 @@ taxonomy:
     term:
       id: NCBITaxon:1766253
       label: Agathobacter
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Agathobacter
       gtdb_taxon: Agathobacter
@@ -192,6 +205,7 @@ taxonomy:
     term:
       id: NCBITaxon:1678
       label: Bifidobacterium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bifidobacterium
       gtdb_taxon: Bifidobacterium
@@ -227,6 +241,7 @@ taxonomy:
     term:
       id: NCBITaxon:203691
       label: Spirochaetota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Spirochaetota
       gtdb_taxon: Spirochaetota
@@ -263,6 +278,7 @@ taxonomy:
     term:
       id: NCBITaxon:1678
       label: Bifidobacterium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bifidobacterium
       gtdb_taxon: Bifidobacterium
@@ -298,6 +314,7 @@ taxonomy:
     term:
       id: NCBITaxon:133926
       label: Olsenella uli
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Olsenella_uli
       gtdb_taxon: Olsenella uli
@@ -331,6 +348,7 @@ taxonomy:
     term:
       id: NCBITaxon:33905
       label: Bifidobacterium thermophilum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bifidobacterium_thermacidophilum
       gtdb_taxon: Bifidobacterium thermacidophilum
@@ -364,6 +382,7 @@ taxonomy:
     term:
       id: NCBITaxon:904
       label: Acidaminococcus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Acidaminococcus
       gtdb_taxon: Acidaminococcus

--- a/kb/communities/GOM_Oil_Degrading_Consortium.yaml
+++ b/kb/communities/GOM_Oil_Degrading_Consortium.yaml
@@ -22,6 +22,7 @@ taxonomy:
     term:
       id: NCBITaxon:306
       label: Pseudomonas sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -36,6 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:857252
       label: Halopseudomonas aestusnigri
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Halopseudomonas_aestusnigri
       gtdb_taxon: Halopseudomonas aestusnigri
@@ -59,6 +61,7 @@ taxonomy:
     term:
       id: NCBITaxon:2782567
       label: Paenarthrobacter sp. GOM3
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Arthrobacter_sp018215265
       gtdb_taxon: Arthrobacter sp018215265
@@ -82,6 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:1872427
       label: Alcanivorax sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/GOM_Oil_Degrading_Consortium.yaml
+++ b/kb/communities/GOM_Oil_Degrading_Consortium.yaml
@@ -22,7 +22,7 @@ taxonomy:
     term:
       id: NCBITaxon:306
       label: Pseudomonas sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -85,7 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:1872427
       label: Alcanivorax sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/Garlic_Pseudomonas_SynCom6.yaml
+++ b/kb/communities/Garlic_Pseudomonas_SynCom6.yaml
@@ -35,7 +35,7 @@ taxonomy:
     term:
       id: NCBITaxon:306
       label: Pseudomonas sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Garlic_Pseudomonas_SynCom6.yaml
+++ b/kb/communities/Garlic_Pseudomonas_SynCom6.yaml
@@ -35,6 +35,7 @@ taxonomy:
     term:
       id: NCBITaxon:306
       label: Pseudomonas sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.yaml
+++ b/kb/communities/Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.yaml
@@ -43,6 +43,7 @@ taxonomy:
     term:
       id: NCBITaxon:35554
       label: Geobacter sulfurreducens
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Geobacter_sulfurreducens
       gtdb_taxon: Geobacter sulfurreducens
@@ -91,6 +92,7 @@ taxonomy:
     term:
       id: NCBITaxon:1501
       label: Clostridium pasteurianum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Clostridium_I_pasteurianum
       gtdb_taxon: Clostridium_I pasteurianum

--- a/kb/communities/Geobacter_Methanosaeta_DIET.yaml
+++ b/kb/communities/Geobacter_Methanosaeta_DIET.yaml
@@ -34,6 +34,7 @@ taxonomy:
     term:
       id: NCBITaxon:28232
       label: Geobacter metallireducens
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Geobacter_metallireducens
       gtdb_taxon: Geobacter metallireducens
@@ -70,6 +71,7 @@ taxonomy:
     term:
       id: NCBITaxon:301375
       label: Methanothrix harundinacea
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methanocrinis_harundinaceus
       gtdb_taxon: Methanocrinis harundinaceus

--- a/kb/communities/Geobacter_Methanosarcina_DIET.yaml
+++ b/kb/communities/Geobacter_Methanosarcina_DIET.yaml
@@ -33,6 +33,7 @@ taxonomy:
     term:
       id: NCBITaxon:28232
       label: Geobacter metallireducens
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Geobacter_metallireducens
       gtdb_taxon: Geobacter metallireducens
@@ -69,6 +70,11 @@ taxonomy:
     term:
       id: NCBITaxon:2208
       label: Methanosarcina barkeri
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Methanosarcina barkeri
+    - Methanosarcina barkeri_A
+    - Methanosarcina barkeri_B
     notes: 'Methanogenic archaeon capable of accepting electrons via DIET and using
       them for CO2 reduction to methane. M. barkeri is unique as the first methanogen
       known to be capable of using either H2 or electrons derived from DIET for CO2

--- a/kb/communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.yaml
+++ b/kb/communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.yaml
@@ -55,6 +55,7 @@ taxonomy:
     term:
       id: NCBITaxon:35554
       label: Geobacter sulfurreducens
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Geobacter_sulfurreducens
       gtdb_taxon: Geobacter sulfurreducens
@@ -86,6 +87,7 @@ taxonomy:
     term:
       id: NCBITaxon:287
       label: Pseudomonas aeruginosa
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Pseudomonas_aeruginosa
       gtdb_taxon: Pseudomonas aeruginosa

--- a/kb/communities/Grassland_Soil_WetUp_Virus_Host_Community.yaml
+++ b/kb/communities/Grassland_Soil_WetUp_Virus_Host_Community.yaml
@@ -27,6 +27,7 @@ taxonomy:
     term:
       id: NCBITaxon:10239
       label: Viruses
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: A diverse but low-biomass reservoir of soil virions; a subset thrives
       following wet-up.
   evidence:
@@ -42,6 +43,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Soil bacterial hosts resuscitated and lysed during wet-up; specific
       taxa are not enumerated in the abstract.
   functional_role:

--- a/kb/communities/Grassland_Soil_WetUp_Virus_Host_Community.yaml
+++ b/kb/communities/Grassland_Soil_WetUp_Virus_Host_Community.yaml
@@ -27,7 +27,7 @@ taxonomy:
     term:
       id: NCBITaxon:10239
       label: Viruses
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: A diverse but low-biomass reservoir of soil virions; a subset thrives
       following wet-up.
   evidence:
@@ -43,7 +43,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Soil bacterial hosts resuscitated and lysed during wet-up; specific
       taxa are not enumerated in the abstract.
   functional_role:

--- a/kb/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.yaml
+++ b/kb/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.yaml
@@ -32,6 +32,7 @@ taxonomy:
     term:
       id: NCBITaxon:641853
       label: Elusimicrobia
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:c__Elusimicrobia
       gtdb_taxon: Elusimicrobia
@@ -60,6 +61,7 @@ taxonomy:
     term:
       id: NCBITaxon:641853
       label: Elusimicrobia
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:c__Elusimicrobia
       gtdb_taxon: Elusimicrobia

--- a/kb/communities/Hanford_300_Area_Unconfined_Aquifer_Community.yaml
+++ b/kb/communities/Hanford_300_Area_Unconfined_Aquifer_Community.yaml
@@ -23,6 +23,7 @@ taxonomy:
     term:
       id: NCBITaxon:1224
       label: Pseudomonadota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Pseudomonadota
       gtdb_taxon: Pseudomonadota
@@ -51,6 +52,7 @@ taxonomy:
     term:
       id: NCBITaxon:976
       label: Bacteroidota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Bacteroidota
       gtdb_taxon: Bacteroidota
@@ -78,6 +80,7 @@ taxonomy:
     term:
       id: NCBITaxon:201174
       label: Actinomycetota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Actinomycetota
       gtdb_taxon: Actinomycetota
@@ -106,6 +109,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Archaea were a low-abundance component of the aquifer community, with higher representation
       in shallow depths and putative ammonia oxidizers reported among functional groups.
   functional_role:

--- a/kb/communities/Hanford_300_Area_Unconfined_Aquifer_Community.yaml
+++ b/kb/communities/Hanford_300_Area_Unconfined_Aquifer_Community.yaml
@@ -109,7 +109,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Archaea were a low-abundance component of the aquifer community, with higher representation
       in shallow depths and putative ammonia oxidizers reported among functional groups.
   functional_role:

--- a/kb/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.yaml
+++ b/kb/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.yaml
@@ -57,6 +57,7 @@ taxonomy:
     term:
       id: NCBITaxon:186801
       label: Clostridia
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:c__Clostridia
       gtdb_taxon: Clostridia
@@ -83,6 +84,7 @@ taxonomy:
     term:
       id: NCBITaxon:91061
       label: Bacilli
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:c__Bacilli
       gtdb_taxon: Bacilli
@@ -109,6 +111,7 @@ taxonomy:
     term:
       id: NCBITaxon:200795
       label: Chloroflexota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Chloroflexota
       gtdb_taxon: Chloroflexota
@@ -136,6 +139,7 @@ taxonomy:
     term:
       id: NCBITaxon:200918
       label: Thermotogota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Thermotogota
       gtdb_taxon: Thermotogota
@@ -163,6 +167,7 @@ taxonomy:
     term:
       id: NCBITaxon:28890
       label: Methanobacteriota
+    gtdb_grounding_status: NOT_ATTEMPTED
     notes: Methanogenic proteins were assigned to Euryarchaeota proteins in the metaproteomic workflow.
   abundance_level: COMMON
   functional_role:

--- a/kb/communities/Honeybee_Core20_Defined_Microbiota.yaml
+++ b/kb/communities/Honeybee_Core20_Defined_Microbiota.yaml
@@ -37,6 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Honeybee_Core20_Defined_Microbiota.yaml
+++ b/kb/communities/Honeybee_Core20_Defined_Microbiota.yaml
@@ -37,7 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Horonobe_Mizunami_URL_Subsurface_Microbiome.yaml
+++ b/kb/communities/Horonobe_Mizunami_URL_Subsurface_Microbiome.yaml
@@ -32,6 +32,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Sedimentary-rock URL groundwater community, organic- and CO2-rich,
       with prominent methane metabolism among its members.
   functional_role:
@@ -50,6 +51,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Granitic-rock URL groundwater community in which candidate phyla
       radiation bacteria are selected at high fluid-flow zones and near tunnels.
   functional_role:

--- a/kb/communities/Horonobe_Mizunami_URL_Subsurface_Microbiome.yaml
+++ b/kb/communities/Horonobe_Mizunami_URL_Subsurface_Microbiome.yaml
@@ -32,7 +32,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Sedimentary-rock URL groundwater community, organic- and CO2-rich,
       with prominent methane metabolism among its members.
   functional_role:
@@ -51,7 +51,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Granitic-rock URL groundwater community in which candidate phyla
       radiation bacteria are selected at high fluid-flow zones and near tunnels.
   functional_role:

--- a/kb/communities/Human_Gut_FourMember_Proteome_Complementarity_Consortium.yaml
+++ b/kb/communities/Human_Gut_FourMember_Proteome_Complementarity_Consortium.yaml
@@ -52,6 +52,7 @@ taxonomy:
     term:
       id: NCBITaxon:39488
       label: Anaerobutyricum hallii
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Anaerobutyricum_hallii
       gtdb_taxon: Anaerobutyricum hallii
@@ -76,6 +77,7 @@ taxonomy:
     term:
       id: NCBITaxon:166486
       label: Roseburia intestinalis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Roseburia_intestinalis
       gtdb_taxon: Roseburia intestinalis
@@ -99,6 +101,7 @@ taxonomy:
     term:
       id: NCBITaxon:168384
       label: Marvinbryantia formatexigens
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Marvinbryantia_formatexigens
       gtdb_taxon: Marvinbryantia formatexigens
@@ -121,6 +124,11 @@ taxonomy:
     term:
       id: NCBITaxon:853
       label: Faecalibacterium prausnitzii
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Faecalibacterium longum
+    - Faecalibacterium prausnitzii
+    - Faecalibacterium prausnitzii_D
     notes: Prominent butyrate producer with proposed anti-inflammatory effects.
   evidence:
   - reference: PMID:42032280

--- a/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
+++ b/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
@@ -44,6 +44,7 @@ taxonomy:
     term:
       id: NCBITaxon:179
       label: Leptospirillum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Leptospirillum
       gtdb_taxon: Leptospirillum
@@ -87,6 +88,7 @@ taxonomy:
     term:
       id: NCBITaxon:920
       label: Acidithiobacillus ferrooxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidithiobacillus_ferrooxidans
       gtdb_taxon: Acidithiobacillus ferrooxidans
@@ -121,6 +123,7 @@ taxonomy:
     term:
       id: NCBITaxon:522
       label: Acidiphilium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Acidiphilium
       gtdb_taxon: Acidiphilium
@@ -161,6 +164,7 @@ taxonomy:
     term:
       id: NCBITaxon:2357
       label: Desulfomonile
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Desulfomonile
       gtdb_taxon: Desulfomonile
@@ -203,6 +207,7 @@ taxonomy:
     term:
       id: NCBITaxon:2597222
       label: Candidatus Acidulidesulfobacterium
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Specialized acidophilic sulfate-reducing bacterium endemic to extremely acidic environments
       (pH 2-3), abundant in the chemocline (8.1% of sequences). Ca. Acidulodesulfobacterium belongs to
       the order Acidulodesulfobacterales and expresses high levels of dissimilatory sulfate reduction
@@ -237,6 +242,7 @@ taxonomy:
     term:
       id: NCBITaxon:2301
       label: Thermoplasmatales
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:o__Thermoplasmatales
       gtdb_taxon: Thermoplasmatales
@@ -286,6 +292,7 @@ taxonomy:
     term:
       id: NCBITaxon:2172
       label: Methanobrevibacter
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Methanobrevibacter_A
       gtdb_taxon: Methanobrevibacter_A
@@ -330,6 +337,7 @@ taxonomy:
     term:
       id: NCBITaxon:1125364
       label: Coccomyxa onubensis
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Dominant acidophilic green alga that drives primary production in the upper layer and chemocline,
       representing 95% ± 2.5% of eukaryotic sequences. C. onubensis performs oxygenic photosynthesis at
       extremely low pH (2.2-3.1) and high metal concentrations, fixing CO₂ via the Calvin-Benson-Bassham

--- a/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
+++ b/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
@@ -207,7 +207,7 @@ taxonomy:
     term:
       id: NCBITaxon:2597222
       label: Candidatus Acidulidesulfobacterium
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Specialized acidophilic sulfate-reducing bacterium endemic to extremely acidic environments
       (pH 2-3), abundant in the chemocline (8.1% of sequences). Ca. Acidulodesulfobacterium belongs to
       the order Acidulodesulfobacterales and expresses high levels of dissimilatory sulfate reduction
@@ -337,7 +337,7 @@ taxonomy:
     term:
       id: NCBITaxon:1125364
       label: Coccomyxa onubensis
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Dominant acidophilic green alga that drives primary production in the upper layer and chemocline,
       representing 95% ± 2.5% of eukaryotic sequences. C. onubensis performs oxygenic photosynthesis at
       extremely low pH (2.2-3.1) and high metal concentrations, fixing CO₂ via the Calvin-Benson-Bassham

--- a/kb/communities/Industrial_Bioreactor_Consortium.yaml
+++ b/kb/communities/Industrial_Bioreactor_Consortium.yaml
@@ -63,6 +63,7 @@ taxonomy:
     term:
       id: NCBITaxon:33059
       label: Acidithiobacillus caldus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidithiobacillus_A_caldus
       gtdb_taxon: Acidithiobacillus_A caldus
@@ -118,6 +119,7 @@ taxonomy:
     term:
       id: NCBITaxon:74969
       label: Ferroplasma acidiphilum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Ferroplasma_acidarmanus
       gtdb_taxon: Ferroplasma acidarmanus
@@ -164,6 +166,7 @@ taxonomy:
     term:
       id: NCBITaxon:2591003
       label: Ferroplasma sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Moderately thermophilic, extremely acidophilic archaeon related to Ferroplasma thermophilum
       and F. cupricumulans, isolated from industrial bioleach reactor. Ferroplasma species are facultatively
       aerobic, cell wall-lacking, pleomorphic archaea that oxidize ferrous iron and utilize organic nutrients.
@@ -200,6 +203,7 @@ taxonomy:
     term:
       id: NCBITaxon:1872114
       label: Acidiplasma sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Polyextremophilic archaeon (Thermoplasmatales, Ferroplasmaceae, formerly Ferroplasma cupricumulans)
       that oxidizes ferrous iron and tolerates extreme acidity, elevated temperatures (optimum <55°C),
       and heavy metal concentrations. Acidiplasma cupricumulans is facultatively aerobic, moderately thermophilic,
@@ -237,6 +241,7 @@ taxonomy:
     term:
       id: NCBITaxon:1673428
       label: Cuniculiplasma divulgatum
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Extremely acidophilic, cell wall-deficient archaeon (Thermoplasmatales, Cuniculiplasmataceae)
       representing a distinct family from iron-oxidizing Ferroplasmaceae. Facultatively anaerobic organoheterotroph
       requiring external organic carbon sources for growth, unable to oxidize iron unlike related Ferroplasma
@@ -276,6 +281,7 @@ taxonomy:
     term:
       id: NCBITaxon:2268204
       label: Thermoplasmatales archaeon
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Unclassified archaeon within order Thermoplasmatales, isolated from industrial bioleach reactor
       and characterized through metagenomic assembly. Thermoplasmatales encompasses diverse acidophilic,
       thermophilic, cell wall-lacking archaea including iron-oxidizing Ferroplasmaceae (Ferroplasma, Acidiplasma)
@@ -306,6 +312,7 @@ taxonomy:
     term:
       id: NCBITaxon:453960
       label: Sulfobacillus benefaciens
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Sulfobacillus_benefaciens
       gtdb_taxon: Sulfobacillus benefaciens
@@ -345,6 +352,7 @@ taxonomy:
     term:
       id: NCBITaxon:178606
       label: Leptospirillum ferriphilum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Leptospirillum_A_rubarum
       gtdb_taxon: Leptospirillum_A rubarum

--- a/kb/communities/Industrial_Bioreactor_Consortium.yaml
+++ b/kb/communities/Industrial_Bioreactor_Consortium.yaml
@@ -166,7 +166,7 @@ taxonomy:
     term:
       id: NCBITaxon:2591003
       label: Ferroplasma sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Moderately thermophilic, extremely acidophilic archaeon related to Ferroplasma thermophilum
       and F. cupricumulans, isolated from industrial bioleach reactor. Ferroplasma species are facultatively
       aerobic, cell wall-lacking, pleomorphic archaea that oxidize ferrous iron and utilize organic nutrients.
@@ -203,7 +203,7 @@ taxonomy:
     term:
       id: NCBITaxon:1872114
       label: Acidiplasma sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Polyextremophilic archaeon (Thermoplasmatales, Ferroplasmaceae, formerly Ferroplasma cupricumulans)
       that oxidizes ferrous iron and tolerates extreme acidity, elevated temperatures (optimum <55°C),
       and heavy metal concentrations. Acidiplasma cupricumulans is facultatively aerobic, moderately thermophilic,
@@ -241,7 +241,7 @@ taxonomy:
     term:
       id: NCBITaxon:1673428
       label: Cuniculiplasma divulgatum
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Extremely acidophilic, cell wall-deficient archaeon (Thermoplasmatales, Cuniculiplasmataceae)
       representing a distinct family from iron-oxidizing Ferroplasmaceae. Facultatively anaerobic organoheterotroph
       requiring external organic carbon sources for growth, unable to oxidize iron unlike related Ferroplasma
@@ -281,7 +281,7 @@ taxonomy:
     term:
       id: NCBITaxon:2268204
       label: Thermoplasmatales archaeon
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Unclassified archaeon within order Thermoplasmatales, isolated from industrial bioleach reactor
       and characterized through metagenomic assembly. Thermoplasmatales encompasses diverse acidophilic,
       thermophilic, cell wall-lacking archaea including iron-oxidizing Ferroplasmaceae (Ferroplasma, Acidiplasma)

--- a/kb/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.yaml
+++ b/kb/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.yaml
@@ -117,7 +117,7 @@ taxonomy:
     term:
       id: NCBITaxon:1272
       label: Kocuria varians
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Source strain CCL56 was identified as Kocuria varians by 16S rRNA gene sequence analysis.
   strain_designation:
     strain_name: CCL56

--- a/kb/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.yaml
+++ b/kb/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.yaml
@@ -46,6 +46,7 @@ taxonomy:
     term:
       id: NCBITaxon:1064
       label: Rhodocyclus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Rhodocyclus
       gtdb_taxon: Rhodocyclus
@@ -74,6 +75,31 @@ taxonomy:
     term:
       id: NCBITaxon:294
       label: Pseudomonas fluorescens
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Pseudomonas_E alvandae
+    - Pseudomonas_E asgharzadehiana
+    - Pseudomonas_E azotoformans_A
+    - Pseudomonas_E brassicacearum
+    - Pseudomonas_E crudilactis
+    - Pseudomonas_E edaphica
+    - Pseudomonas_E fluorescens
+    - Pseudomonas_E fluorescens_AP
+    - Pseudomonas_E fluorescens_AQ
+    - Pseudomonas_E fluorescens_B
+    - Pseudomonas_E fluorescens_H
+    - Pseudomonas_E fluorescens_S
+    - Pseudomonas_E kilonensis
+    - Pseudomonas_E lactis
+    - Pseudomonas_E lactucae
+    - Pseudomonas_E paracarnis
+    - Pseudomonas_E petroselini
+    - Pseudomonas_E poae
+    - Pseudomonas_E protegens
+    - Pseudomonas_E reactans
+    - Pseudomonas_E salomonii
+    - Pseudomonas_E simiae
+    - Pseudomonas_E sp002874965
     notes: Source strain CLL49 was identified as Pseudomonas fluorescens by 16S rRNA gene sequence analysis.
   strain_designation:
     strain_name: CLL49
@@ -91,6 +117,7 @@ taxonomy:
     term:
       id: NCBITaxon:1272
       label: Kocuria varians
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Source strain CCL56 was identified as Kocuria varians by 16S rRNA gene sequence analysis.
   strain_designation:
     strain_name: CCL56
@@ -108,6 +135,31 @@ taxonomy:
     term:
       id: NCBITaxon:1396
       label: Bacillus cereus
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Bacillus_A anthracis
+    - Bacillus_A bombysepticus
+    - Bacillus_A cereus
+    - Bacillus_A cereus_K
+    - Bacillus_A cereus_S
+    - Bacillus_A cereus_U
+    - Bacillus_A hominis
+    - Bacillus_A luti
+    - Bacillus_A mobilis
+    - Bacillus_A mycoides
+    - Bacillus_A nitratireducens
+    - Bacillus_A pacificus
+    - Bacillus_A paramycoides
+    - Bacillus_A paranthracis
+    - Bacillus_A pseudomycoides
+    - Bacillus_A sp003400245
+    - Bacillus_A sp018966865
+    - Bacillus_A thuringiensis
+    - Bacillus_A thuringiensis_AB
+    - Bacillus_A thuringiensis_K
+    - Bacillus_A thuringiensis_S
+    - Bacillus_A toyonensis
+    - Bacillus_A tropicus
     notes: Bacillus cereus strain used in the model biofilm and source of the thiocillin I-mediated negative
       interaction.
   functional_role:

--- a/kb/communities/Infant_Gut_DNA_Phage_Succession_Community.yaml
+++ b/kb/communities/Infant_Gut_DNA_Phage_Succession_Community.yaml
@@ -29,6 +29,7 @@ taxonomy:
     term:
       id: NCBITaxon:10239
       label: Viruses
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Early DNA phage colonizers, ~9 percent of which persist for 3 years
       and most of which are maternally transmitted and infect Bacteroides.
   evidence:
@@ -44,6 +45,7 @@ taxonomy:
     term:
       id: NCBITaxon:816
       label: Bacteroides
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bacteroides
       gtdb_taxon: Bacteroides

--- a/kb/communities/Infant_Gut_DNA_Phage_Succession_Community.yaml
+++ b/kb/communities/Infant_Gut_DNA_Phage_Succession_Community.yaml
@@ -29,7 +29,7 @@ taxonomy:
     term:
       id: NCBITaxon:10239
       label: Viruses
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Early DNA phage colonizers, ~9 percent of which persist for 3 years
       and most of which are maternally transmitted and infect Bacteroides.
   evidence:

--- a/kb/communities/Infant_Gut_Prebiotic_Response_SynCom.yaml
+++ b/kb/communities/Infant_Gut_Prebiotic_Response_SynCom.yaml
@@ -26,6 +26,7 @@ taxonomy:
     term:
       id: NCBITaxon:1678
       label: Bifidobacterium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bifidobacterium
       gtdb_taxon: Bifidobacterium
@@ -54,6 +55,7 @@ taxonomy:
     term:
       id: NCBITaxon:816
       label: Bacteroides
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bacteroides
       gtdb_taxon: Bacteroides
@@ -81,6 +83,7 @@ taxonomy:
     term:
       id: NCBITaxon:821
       label: Phocaeicola vulgatus
+    gtdb_grounding_status: GROUNDED
     notes: Identified as a context-dependent ecological hub within the SynCom.
     gtdb_classification:
       gtdb_id: GTDB:s__Phocaeicola_vulgatus
@@ -106,6 +109,7 @@ taxonomy:
     term:
       id: NCBITaxon:562
       label: Escherichia coli
+    gtdb_grounding_status: GROUNDED
     notes: Its metabolic activity is altered by Phocaeicola vulgatus without a change in its abundance.
     gtdb_classification:
       gtdb_id: GTDB:s__Escherichia_coli

--- a/kb/communities/Infant_Gut_Strain_Persistence_Maternal_Community.yaml
+++ b/kb/communities/Infant_Gut_Strain_Persistence_Maternal_Community.yaml
@@ -83,7 +83,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Maternal gut strains transferred to the infant; significantly more
       likely to persist in the infant gut than other strains.
   functional_role:

--- a/kb/communities/Infant_Gut_Strain_Persistence_Maternal_Community.yaml
+++ b/kb/communities/Infant_Gut_Strain_Persistence_Maternal_Community.yaml
@@ -26,6 +26,7 @@ taxonomy:
     term:
       id: NCBITaxon:816
       label: Bacteroides
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bacteroides
       gtdb_taxon: Bacteroides
@@ -54,6 +55,7 @@ taxonomy:
     term:
       id: NCBITaxon:1678
       label: Bifidobacterium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bifidobacterium
       gtdb_taxon: Bifidobacterium
@@ -81,6 +83,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Maternal gut strains transferred to the infant; significantly more
       likely to persist in the infant gut than other strains.
   functional_role:

--- a/kb/communities/Ion_Adsorption_REE_Indigenous_Community.yaml
+++ b/kb/communities/Ion_Adsorption_REE_Indigenous_Community.yaml
@@ -44,6 +44,7 @@ taxonomy:
     term:
       id: NCBITaxon:1224
       label: Pseudomonadota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Pseudomonadota
       gtdb_taxon: Pseudomonadota
@@ -84,6 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:57723
       label: Acidobacteriota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Acidobacteriota
       gtdb_taxon: Acidobacteriota
@@ -127,6 +129,7 @@ taxonomy:
     term:
       id: NCBITaxon:201174
       label: Actinomycetota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Actinomycetota
       gtdb_taxon: Actinomycetota
@@ -161,6 +164,7 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bacillus
       gtdb_taxon: Bacillus
@@ -210,6 +214,7 @@ taxonomy:
     term:
       id: NCBITaxon:1269
       label: Micrococcus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Micrococcus
       gtdb_taxon: Micrococcus
@@ -252,6 +257,7 @@ taxonomy:
     term:
       id: NCBITaxon:4890
       label: Ascomycota
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Dominant fungal phylum (47.8% average abundance) contributing to REE mineralization through
       production of organic acids, siderophores, and extracellular enzymes. Ascomycetes accelerate granite
       weathering through mechanical hyphal penetration and chemical dissolution, releasing REE from silicate
@@ -278,6 +284,7 @@ taxonomy:
     term:
       id: NCBITaxon:5204
       label: Basidiomycota
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Second dominant fungal phylum (40.4% average abundance) contributing to bioweathering and
       REE mobilization. Basidiomycetes produce extracellular enzymes (laccases, peroxidases) and organic
       acids that facilitate mineral dissolution and REE release. Together with Ascomycota, Basidiomycetes

--- a/kb/communities/Ion_Adsorption_REE_Indigenous_Community.yaml
+++ b/kb/communities/Ion_Adsorption_REE_Indigenous_Community.yaml
@@ -257,7 +257,7 @@ taxonomy:
     term:
       id: NCBITaxon:4890
       label: Ascomycota
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Dominant fungal phylum (47.8% average abundance) contributing to REE mineralization through
       production of organic acids, siderophores, and extracellular enzymes. Ascomycetes accelerate granite
       weathering through mechanical hyphal penetration and chemical dissolution, releasing REE from silicate
@@ -284,7 +284,7 @@ taxonomy:
     term:
       id: NCBITaxon:5204
       label: Basidiomycota
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Second dominant fungal phylum (40.4% average abundance) contributing to bioweathering and
       REE mobilization. Basidiomycetes produce extracellular enzymes (laccases, peroxidases) and organic
       acids that facilitate mineral dissolution and REE release. Together with Ascomycota, Basidiomycetes

--- a/kb/communities/Jala_Maize_PGPB_SynCom.yaml
+++ b/kb/communities/Jala_Maize_PGPB_SynCom.yaml
@@ -35,6 +35,7 @@ taxonomy:
     term:
       id: NCBITaxon:380021
       label: Pseudomonas protegens
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Pseudomonas_E_protegens
       gtdb_taxon: Pseudomonas_E protegens
@@ -53,6 +54,7 @@ taxonomy:
     term:
       id: NCBITaxon:553
       label: Pantoea ananatis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Pantoea_ananatis
       gtdb_taxon: Pantoea ananatis
@@ -71,6 +73,7 @@ taxonomy:
     term:
       id: NCBITaxon:244366
       label: Klebsiella variicola
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Klebsiella_variicola
       gtdb_taxon: Klebsiella variicola
@@ -89,6 +92,7 @@ taxonomy:
     term:
       id: NCBITaxon:32008
       label: Burkholderia
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Burkholderia
       gtdb_taxon: Burkholderia

--- a/kb/communities/KB1_Chlorinated_Ethene_Dechlorinating_Consortium.yaml
+++ b/kb/communities/KB1_Chlorinated_Ethene_Dechlorinating_Consortium.yaml
@@ -38,6 +38,7 @@ taxonomy:
     term:
       id: NCBITaxon:61434
       label: Dehalococcoides
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Dehalococcoides
       gtdb_taxon: Dehalococcoides
@@ -67,6 +68,7 @@ taxonomy:
     term:
       id: NCBITaxon:33952
       label: Acetobacterium woodii
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acetobacterium_woodii
       gtdb_taxon: Acetobacterium woodii
@@ -90,6 +92,7 @@ taxonomy:
     term:
       id: NCBITaxon:2375
       label: Sporomusa
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Sporomusa
       gtdb_taxon: Sporomusa

--- a/kb/communities/KBase_Models_for_Zahmeeth_Original_PLOS.yaml
+++ b/kb/communities/KBase_Models_for_Zahmeeth_Original_PLOS.yaml
@@ -44,6 +44,7 @@ taxonomy:
     term:
       id: NCBITaxon:562
       label: Escherichia coli
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Escherichia_coli
       gtdb_taxon: Escherichia coli
@@ -66,6 +67,31 @@ taxonomy:
     term:
       id: NCBITaxon:294
       label: Pseudomonas fluorescens
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Pseudomonas_E alvandae
+    - Pseudomonas_E asgharzadehiana
+    - Pseudomonas_E azotoformans_A
+    - Pseudomonas_E brassicacearum
+    - Pseudomonas_E crudilactis
+    - Pseudomonas_E edaphica
+    - Pseudomonas_E fluorescens
+    - Pseudomonas_E fluorescens_AP
+    - Pseudomonas_E fluorescens_AQ
+    - Pseudomonas_E fluorescens_B
+    - Pseudomonas_E fluorescens_H
+    - Pseudomonas_E fluorescens_S
+    - Pseudomonas_E kilonensis
+    - Pseudomonas_E lactis
+    - Pseudomonas_E lactucae
+    - Pseudomonas_E paracarnis
+    - Pseudomonas_E petroselini
+    - Pseudomonas_E poae
+    - Pseudomonas_E protegens
+    - Pseudomonas_E reactans
+    - Pseudomonas_E salomonii
+    - Pseudomonas_E simiae
+    - Pseudomonas_E sp002874965
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -79,6 +105,7 @@ taxonomy:
     term:
       id: NCBITaxon:818
       label: Bacteroides thetaiotaomicron
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bacteroides_thetaiotaomicron
       gtdb_taxon: Bacteroides thetaiotaomicron
@@ -101,6 +128,7 @@ taxonomy:
     term:
       id: NCBITaxon:570
       label: Klebsiella
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Klebsiella
       gtdb_taxon: Klebsiella

--- a/kb/communities/KBase_ORT_Workflow_Community_Model.yaml
+++ b/kb/communities/KBase_ORT_Workflow_Community_Model.yaml
@@ -47,7 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Archaeal genome classified as Nitrososphaeraceae (family level), genus TA-21, from Columbia
       River sediments. Functions as ammonium oxidizer in the nitrogen cycle.
   functional_role:

--- a/kb/communities/KBase_ORT_Workflow_Community_Model.yaml
+++ b/kb/communities/KBase_ORT_Workflow_Community_Model.yaml
@@ -47,6 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Archaeal genome classified as Nitrososphaeraceae (family level), genus TA-21, from Columbia
       River sediments. Functions as ammonium oxidizer in the nitrogen cycle.
   functional_role:
@@ -62,6 +63,7 @@ taxonomy:
     term:
       id: NCBITaxon:1236
       label: Gammaproteobacteria
+    gtdb_grounding_status: WITHHELD
     notes: Bacterial member of Nitrospiraceae family from Columbia River sediments. Functions as nitrite
       oxidizer in the nitrogen cycle.
   functional_role:
@@ -77,6 +79,7 @@ taxonomy:
     term:
       id: NCBITaxon:1236
       label: Gammaproteobacteria
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:c__Gammaproteobacteria
       gtdb_taxon: Gammaproteobacteria
@@ -102,6 +105,7 @@ taxonomy:
     term:
       id: NCBITaxon:1236
       label: Gammaproteobacteria
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:c__Gammaproteobacteria
       gtdb_taxon: Gammaproteobacteria

--- a/kb/communities/KBase_Synthetic_Bacterial_Community_R2A.yaml
+++ b/kb/communities/KBase_Synthetic_Bacterial_Community_R2A.yaml
@@ -54,7 +54,7 @@ taxonomy:
     term:
       id: NCBITaxon:306
       label: Pseudomonas sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   strain_designation:
     strain_name: GM17
   functional_role:

--- a/kb/communities/KBase_Synthetic_Bacterial_Community_R2A.yaml
+++ b/kb/communities/KBase_Synthetic_Bacterial_Community_R2A.yaml
@@ -33,6 +33,7 @@ taxonomy:
     term:
       id: NCBITaxon:53335
       label: Pantoea
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Pantoea
       gtdb_taxon: Pantoea
@@ -53,6 +54,7 @@ taxonomy:
     term:
       id: NCBITaxon:306
       label: Pseudomonas sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   strain_designation:
     strain_name: GM17
   functional_role:
@@ -62,6 +64,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax

--- a/kb/communities/Kombucha_KMC_IMBG1_Fermentation_Community.yaml
+++ b/kb/communities/Kombucha_KMC_IMBG1_Fermentation_Community.yaml
@@ -75,7 +75,7 @@ taxonomy:
     term:
       id: NCBITaxon:4919
       label: Pichia
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Dominant yeast genus in the KMC-IMBG1 core community under tested growth conditions.
   abundance_level: DOMINANT
   functional_role:
@@ -91,7 +91,7 @@ taxonomy:
     term:
       id: NCBITaxon:13366
       label: Brettanomyces
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Source article reports the yeast lineage as Brettanomyces/Dekkera; NCBI genus Brettanomyces is
       used for ontology grounding.
   abundance_level: DOMINANT

--- a/kb/communities/Kombucha_KMC_IMBG1_Fermentation_Community.yaml
+++ b/kb/communities/Kombucha_KMC_IMBG1_Fermentation_Community.yaml
@@ -22,6 +22,7 @@ taxonomy:
     term:
       id: NCBITaxon:1434011
       label: Komagataeibacter
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Komagataeibacter
       gtdb_taxon: Komagataeibacter
@@ -48,6 +49,7 @@ taxonomy:
     term:
       id: NCBITaxon:441
       label: Gluconobacter
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Gluconobacter
       gtdb_taxon: Gluconobacter
@@ -73,6 +75,7 @@ taxonomy:
     term:
       id: NCBITaxon:4919
       label: Pichia
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Dominant yeast genus in the KMC-IMBG1 core community under tested growth conditions.
   abundance_level: DOMINANT
   functional_role:
@@ -88,6 +91,7 @@ taxonomy:
     term:
       id: NCBITaxon:13366
       label: Brettanomyces
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Source article reports the yeast lineage as Brettanomyces/Dekkera; NCBI genus Brettanomyces is
       used for ontology grounding.
   abundance_level: DOMINANT

--- a/kb/communities/LBNL_Brachypodium_Drought_SynCom15.yaml
+++ b/kb/communities/LBNL_Brachypodium_Drought_SynCom15.yaml
@@ -36,6 +36,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/LBNL_Brachypodium_Drought_SynCom15.yaml
+++ b/kb/communities/LBNL_Brachypodium_Drought_SynCom15.yaml
@@ -36,7 +36,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/LBNL_Human_Gut_Interaction_SynCom.yaml
+++ b/kb/communities/LBNL_Human_Gut_Interaction_SynCom.yaml
@@ -37,6 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/LBNL_Human_Gut_Interaction_SynCom.yaml
+++ b/kb/communities/LBNL_Human_Gut_Interaction_SynCom.yaml
@@ -37,7 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/LBNL_Switchgrass_Soil_SynCom16.yaml
+++ b/kb/communities/LBNL_Switchgrass_Soil_SynCom16.yaml
@@ -38,6 +38,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/LBNL_Switchgrass_Soil_SynCom16.yaml
+++ b/kb/communities/LBNL_Switchgrass_Soil_SynCom16.yaml
@@ -38,7 +38,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Lac_Pavin_Stratified_Lake_Community.yaml
+++ b/kb/communities/Lac_Pavin_Stratified_Lake_Community.yaml
@@ -29,7 +29,7 @@ taxonomy:
     term:
       id: NCBITaxon:1783273
       label: Patescibacteria group
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: CPR bacteria in the water column encode form II/III and form
       III-related RuBisCO enzymes.
   functional_role:
@@ -47,7 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:1783276
       label: Nanobdellati
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: DPANN archaea recovered from Lac Pavin sediments encode RuBisCO
       enzymes, suggesting CO2-fixation potential.
   functional_role:
@@ -64,7 +64,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Diverse sediment methanogens vary on the centimeter scale and drive
       depth-stratified methane production.
   functional_role:

--- a/kb/communities/Lac_Pavin_Stratified_Lake_Community.yaml
+++ b/kb/communities/Lac_Pavin_Stratified_Lake_Community.yaml
@@ -29,6 +29,7 @@ taxonomy:
     term:
       id: NCBITaxon:1783273
       label: Patescibacteria group
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: CPR bacteria in the water column encode form II/III and form
       III-related RuBisCO enzymes.
   functional_role:
@@ -46,6 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:1783276
       label: Nanobdellati
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: DPANN archaea recovered from Lac Pavin sediments encode RuBisCO
       enzymes, suggesting CO2-fixation potential.
   functional_role:
@@ -62,6 +64,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Diverse sediment methanogens vary on the centimeter scale and drive
       depth-stratified methane production.
   functional_role:

--- a/kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml
+++ b/kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml
@@ -59,7 +59,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: >
       Community-level representation of methane-consuming bacteria enriched
       from Lake Washington sediment under methane and oxygen treatments.

--- a/kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml
+++ b/kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml
@@ -59,6 +59,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: >
       Community-level representation of methane-consuming bacteria enriched
       from Lake Washington sediment under methane and oxygen treatments.
@@ -81,6 +82,7 @@ taxonomy:
     term:
       id: NCBITaxon:403
       label: Methylococcaceae
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:f__Methylomonadaceae
       gtdb_taxon: Methylomonadaceae
@@ -114,6 +116,7 @@ taxonomy:
     term:
       id: NCBITaxon:32011
       label: Methylophilaceae
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:f__Methylophilaceae
       gtdb_taxon: Methylophilaceae
@@ -146,6 +149,7 @@ taxonomy:
     term:
       id: NCBITaxon:429
       label: Methylobacter
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Methylobacter_A
       gtdb_taxon: Methylobacter_A
@@ -174,6 +178,7 @@ taxonomy:
     term:
       id: NCBITaxon:359407
       label: Methylotenera
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Methylotenera
       gtdb_taxon: Methylotenera
@@ -206,6 +211,7 @@ taxonomy:
     term:
       id: NCBITaxon:416
       label: Methylomonas
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Methylomonas
       gtdb_taxon: Methylomonas
@@ -230,6 +236,7 @@ taxonomy:
     term:
       id: NCBITaxon:105972
       label: Methylosarcina fibrata
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methylosarcina_fibrata
       gtdb_taxon: Methylosarcina fibrata
@@ -253,6 +260,7 @@ taxonomy:
     term:
       id: NCBITaxon:16
       label: Methylophilus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Methylophilus
       gtdb_taxon: Methylophilus

--- a/kb/communities/Legume_Rhizobia_Mars_Simulant_Symbiosis.yaml
+++ b/kb/communities/Legume_Rhizobia_Mars_Simulant_Symbiosis.yaml
@@ -68,6 +68,7 @@ taxonomy:
     term:
       id: NCBITaxon:382
       label: Sinorhizobium meliloti
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Sinorhizobium_meliloti
       gtdb_taxon: Sinorhizobium meliloti
@@ -93,6 +94,7 @@ taxonomy:
     term:
       id: NCBITaxon:110321
       label: Sinorhizobium medicae
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Sinorhizobium_medicae
       gtdb_taxon: Sinorhizobium medicae

--- a/kb/communities/Lotus_LjSC3.yaml
+++ b/kb/communities/Lotus_LjSC3.yaml
@@ -126,7 +126,7 @@ taxonomy:
     term:
       id: NCBITaxon:1871068
       label: Phyllobacteriaceae bacterium
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -143,7 +143,7 @@ taxonomy:
     term:
       id: NCBITaxon:1913961
       label: Rhizobiaceae bacterium
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -160,7 +160,7 @@ taxonomy:
     term:
       id: NCBITaxon:2030806
       label: Burkholderiaceae bacterium
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -202,7 +202,7 @@ taxonomy:
     term:
       id: NCBITaxon:1914538
       label: Pseudomonadaceae bacterium
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -219,7 +219,7 @@ taxonomy:
     term:
       id: NCBITaxon:1873462
       label: Microbacteriaceae bacterium
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -235,7 +235,7 @@ taxonomy:
     term:
       id: NCBITaxon:34305
       label: Lotus japonicus
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Lotus_LjSC3.yaml
+++ b/kb/communities/Lotus_LjSC3.yaml
@@ -47,6 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:68287
       label: Mesorhizobium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Mesorhizobium
       gtdb_taxon: Mesorhizobium
@@ -72,6 +73,7 @@ taxonomy:
     term:
       id: NCBITaxon:68287
       label: Mesorhizobium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Mesorhizobium
       gtdb_taxon: Mesorhizobium
@@ -97,6 +99,7 @@ taxonomy:
     term:
       id: NCBITaxon:68287
       label: Mesorhizobium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Mesorhizobium
       gtdb_taxon: Mesorhizobium
@@ -123,6 +126,7 @@ taxonomy:
     term:
       id: NCBITaxon:1871068
       label: Phyllobacteriaceae bacterium
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -139,6 +143,7 @@ taxonomy:
     term:
       id: NCBITaxon:1913961
       label: Rhizobiaceae bacterium
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -155,6 +160,7 @@ taxonomy:
     term:
       id: NCBITaxon:2030806
       label: Burkholderiaceae bacterium
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -170,6 +176,7 @@ taxonomy:
     term:
       id: NCBITaxon:75682
       label: Oxalobacteraceae
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:f__Burkholderiaceae
       gtdb_taxon: Burkholderiaceae
@@ -195,6 +202,7 @@ taxonomy:
     term:
       id: NCBITaxon:1914538
       label: Pseudomonadaceae bacterium
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -211,6 +219,7 @@ taxonomy:
     term:
       id: NCBITaxon:1873462
       label: Microbacteriaceae bacterium
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -226,6 +235,7 @@ taxonomy:
     term:
       id: NCBITaxon:34305
       label: Lotus japonicus
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Lunar_Martian_Simulant_PGPB_Lettuce_SynCom.yaml
+++ b/kb/communities/Lunar_Martian_Simulant_PGPB_Lettuce_SynCom.yaml
@@ -81,6 +81,7 @@ taxonomy:
     term:
       id: NCBITaxon:353
       label: Azotobacter chroococcum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Azotobacter_chroococcum
       gtdb_taxon: Azotobacter chroococcum
@@ -116,6 +117,12 @@ taxonomy:
     term:
       id: NCBITaxon:1404
       label: Priestia megaterium
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Priestia megaterium
+    - Priestia megaterium_D
+    - Priestia zanthoxyli
+    - Virgibacillus salarius
     notes: >
       Source identifies strain EL5; ontology grounding is species-level to the
       stable NCBI Taxonomy term Priestia megaterium (formerly Bacillus
@@ -143,6 +150,7 @@ taxonomy:
     term:
       id: NCBITaxon:223967
       label: Methylorubrum populi
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methylobacterium_thiocyanatum
       gtdb_taxon: Methylobacterium thiocyanatum
@@ -181,6 +189,7 @@ taxonomy:
     term:
       id: NCBITaxon:1646340
       label: Kosakonia pseudosacchari
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Kosakonia_pseudosacchari
       gtdb_taxon: Kosakonia pseudosacchari

--- a/kb/communities/Lunar_Simulant_Phosphate_Solubilizing_Bacteria_Nicotiana.yaml
+++ b/kb/communities/Lunar_Simulant_Phosphate_Solubilizing_Bacteria_Nicotiana.yaml
@@ -76,6 +76,7 @@ taxonomy:
     term:
       id: NCBITaxon:61624
       label: Paenibacillus mucilaginosus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Paenibacillus_G_mucilaginosus
       gtdb_taxon: Paenibacillus_G mucilaginosus
@@ -112,6 +113,12 @@ taxonomy:
     term:
       id: NCBITaxon:1404
       label: Priestia megaterium
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Priestia megaterium
+    - Priestia megaterium_D
+    - Priestia zanthoxyli
+    - Virgibacillus salarius
     notes: >
       Reported by the source as Bacillus megaterium (strain AS1.217); the stable NCBI
       Taxonomy term for this organism is Priestia megaterium. One of the three PSBs
@@ -139,6 +146,31 @@ taxonomy:
     term:
       id: NCBITaxon:294
       label: Pseudomonas fluorescens
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Pseudomonas_E alvandae
+    - Pseudomonas_E asgharzadehiana
+    - Pseudomonas_E azotoformans_A
+    - Pseudomonas_E brassicacearum
+    - Pseudomonas_E crudilactis
+    - Pseudomonas_E edaphica
+    - Pseudomonas_E fluorescens
+    - Pseudomonas_E fluorescens_AP
+    - Pseudomonas_E fluorescens_AQ
+    - Pseudomonas_E fluorescens_B
+    - Pseudomonas_E fluorescens_H
+    - Pseudomonas_E fluorescens_S
+    - Pseudomonas_E kilonensis
+    - Pseudomonas_E lactis
+    - Pseudomonas_E lactucae
+    - Pseudomonas_E paracarnis
+    - Pseudomonas_E petroselini
+    - Pseudomonas_E poae
+    - Pseudomonas_E protegens
+    - Pseudomonas_E reactans
+    - Pseudomonas_E salomonii
+    - Pseudomonas_E simiae
+    - Pseudomonas_E sp002874965
     notes: >
       Strain ATCC 13525. One of the three PSBs that tolerated the lunar regolith
       simulant and dissociated insoluble inorganic phosphorus.
@@ -164,6 +196,7 @@ taxonomy:
     term:
       id: NCBITaxon:1423
       label: Bacillus subtilis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bacillus_subtilis
       gtdb_taxon: Bacillus subtilis
@@ -194,6 +227,7 @@ taxonomy:
     term:
       id: NCBITaxon:1402
       label: Bacillus licheniformis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bacillus_licheniformis
       gtdb_taxon: Bacillus licheniformis

--- a/kb/communities/MAMC_M48_Lignocellulose.yaml
+++ b/kb/communities/MAMC_M48_Lignocellulose.yaml
@@ -38,6 +38,19 @@ taxonomy:
     term:
       id: NCBITaxon:40324
       label: Stenotrophomonas maltophilia
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Stenotrophomonas bentonitica_A
+    - Stenotrophomonas geniculata
+    - Stenotrophomonas hibiscicola
+    - Stenotrophomonas indicatrix
+    - Stenotrophomonas maltophilia
+    - Stenotrophomonas maltophilia_AJ
+    - Stenotrophomonas maltophilia_L
+    - Stenotrophomonas muris
+    - Stenotrophomonas nematodicola
+    - Stenotrophomonas sepilia
+    - Stenotrophomonas sp002192255
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -53,6 +66,7 @@ taxonomy:
     term:
       id: NCBITaxon:375486
       label: Paenibacillus sp. PALXIL05
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -68,6 +82,7 @@ taxonomy:
     term:
       id: NCBITaxon:1605331
       label: Microbacterium sp. UYFA68
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -83,6 +98,7 @@ taxonomy:
     term:
       id: NCBITaxon:363331
       label: Chryseobacterium taiwanense
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Chryseobacterium_taiwanense
       gtdb_taxon: Chryseobacterium taiwanense
@@ -107,6 +123,7 @@ taxonomy:
     term:
       id: NCBITaxon:1501972
       label: Brevundimonas sp. R3
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: COMMON
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/MAMC_M48_Lignocellulose.yaml
+++ b/kb/communities/MAMC_M48_Lignocellulose.yaml
@@ -66,7 +66,7 @@ taxonomy:
     term:
       id: NCBITaxon:375486
       label: Paenibacillus sp. PALXIL05
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -82,7 +82,7 @@ taxonomy:
     term:
       id: NCBITaxon:1605331
       label: Microbacterium sp. UYFA68
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -123,7 +123,7 @@ taxonomy:
     term:
       id: NCBITaxon:1501972
       label: Brevundimonas sp. R3
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: COMMON
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/MSC1_Dominant_Core.yaml
+++ b/kb/communities/MSC1_Dominant_Core.yaml
@@ -22,6 +22,7 @@ taxonomy:
     term:
       id: NCBITaxon:1827
       label: Rhodococcus <high G+C Gram-positive bacteria>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Rhodococcus
       gtdb_taxon: Rhodococcus
@@ -46,6 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:1931
       label: Streptomyces sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -60,6 +62,7 @@ taxonomy:
     term:
       id: NCBITaxon:1914288
       label: Dyadobacter sp.
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Dyadobacter_sp017744695
       gtdb_taxon: Dyadobacter sp017744695
@@ -83,6 +86,7 @@ taxonomy:
     term:
       id: NCBITaxon:1869185
       label: Taibaiella sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -97,6 +101,7 @@ taxonomy:
     term:
       id: NCBITaxon:169215
       label: Bosea
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bosea
       gtdb_taxon: Bosea
@@ -121,6 +126,7 @@ taxonomy:
     term:
       id: NCBITaxon:1911909
       label: Neorhizobium sp.
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Neorhizobium_sp028283725
       gtdb_taxon: Neorhizobium sp028283725
@@ -144,6 +150,7 @@ taxonomy:
     term:
       id: NCBITaxon:1908224
       label: Sphingopyxis sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -158,6 +165,7 @@ taxonomy:
     term:
       id: NCBITaxon:1872086
       label: Ensifer sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -172,6 +180,7 @@ taxonomy:
     term:
       id: NCBITaxon:1871043
       label: Variovorax sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -187,6 +196,7 @@ taxonomy:
     term:
       id: NCBITaxon:42445
       label: Sinorhizobium sp.
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Sinorhizobium_sp031178305
       gtdb_taxon: Sinorhizobium sp031178305
@@ -210,6 +220,7 @@ taxonomy:
     term:
       id: NCBITaxon:1785
       label: Mycobacterium sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -224,6 +235,7 @@ taxonomy:
     term:
       id: NCBITaxon:201174
       label: Actinomycetota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Actinomycetota
       gtdb_taxon: Actinomycetota
@@ -249,6 +261,7 @@ taxonomy:
     term:
       id: NCBITaxon:976
       label: Bacteroidota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Bacteroidota
       gtdb_taxon: Bacteroidota

--- a/kb/communities/MSC1_Dominant_Core.yaml
+++ b/kb/communities/MSC1_Dominant_Core.yaml
@@ -47,7 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:1931
       label: Streptomyces sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -86,7 +86,7 @@ taxonomy:
     term:
       id: NCBITaxon:1869185
       label: Taibaiella sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -150,7 +150,7 @@ taxonomy:
     term:
       id: NCBITaxon:1908224
       label: Sphingopyxis sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -165,7 +165,7 @@ taxonomy:
     term:
       id: NCBITaxon:1872086
       label: Ensifer sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -180,7 +180,7 @@ taxonomy:
     term:
       id: NCBITaxon:1871043
       label: Variovorax sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -220,7 +220,7 @@ taxonomy:
     term:
       id: NCBITaxon:1785
       label: Mycobacterium sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/MSC2_Model_Soil_Consortium.yaml
+++ b/kb/communities/MSC2_Model_Soil_Consortium.yaml
@@ -47,7 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:1931
       label: Streptomyces sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   strain_designation:
     strain_name: MSC1_001
     genome_accession: GCA_023667545.1
@@ -101,7 +101,7 @@ taxonomy:
     term:
       id: NCBITaxon:1908224
       label: Sphingopyxis sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   strain_designation:
     strain_name: MSC1_008
     genome_accession: GCA_023197165.1
@@ -134,7 +134,7 @@ taxonomy:
     term:
       id: NCBITaxon:2496117
       label: Variovorax beijingensis
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   strain_designation:
     strain_name: MSC1_012
     genome_accession: GCA_023667525.1

--- a/kb/communities/MSC2_Model_Soil_Consortium.yaml
+++ b/kb/communities/MSC2_Model_Soil_Consortium.yaml
@@ -47,6 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:1931
       label: Streptomyces sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   strain_designation:
     strain_name: MSC1_001
     genome_accession: GCA_023667545.1
@@ -58,6 +59,7 @@ taxonomy:
     term:
       id: NCBITaxon:2093828
       label: Neorhizobium tomejilense
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Neorhizobium_tomejilense
       gtdb_taxon: Neorhizobium tomejilense
@@ -78,6 +80,7 @@ taxonomy:
     term:
       id: NCBITaxon:1914288
       label: Dyadobacter sp.
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Dyadobacter_sp017744695
       gtdb_taxon: Dyadobacter sp017744695
@@ -98,6 +101,7 @@ taxonomy:
     term:
       id: NCBITaxon:1908224
       label: Sphingopyxis sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   strain_designation:
     strain_name: MSC1_008
     genome_accession: GCA_023197165.1
@@ -109,6 +113,7 @@ taxonomy:
     term:
       id: NCBITaxon:106592
       label: Ensifer adhaerens
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Ensifer_canadensis
       gtdb_taxon: Ensifer canadensis
@@ -129,6 +134,7 @@ taxonomy:
     term:
       id: NCBITaxon:2496117
       label: Variovorax beijingensis
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   strain_designation:
     strain_name: MSC1_012
     genome_accession: GCA_023667525.1
@@ -141,6 +147,7 @@ taxonomy:
     term:
       id: NCBITaxon:382
       label: Sinorhizobium meliloti
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Sinorhizobium_meliloti
       gtdb_taxon: Sinorhizobium meliloti
@@ -161,6 +168,7 @@ taxonomy:
     term:
       id: NCBITaxon:1827
       label: Rhodococcus <high G+C Gram-positive bacteria>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Rhodococcus
       gtdb_taxon: Rhodococcus

--- a/kb/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.yaml
+++ b/kb/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.yaml
@@ -29,6 +29,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Community-level representation of wetland soil microbes across nine
       terrestrial freshwater wetlands in the MUCC v2.0.0 synthesis.
   functional_role:
@@ -51,6 +52,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Methanogenic archaea are curated broadly because the study emphasizes
       methanogen networks and conserved methane-cycling genera across many
       wetlands rather than one fixed species composition.
@@ -74,6 +76,7 @@ taxonomy:
     term:
       id: NCBITaxon:395331
       label: Methanoregula
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Methanoregula
       gtdb_taxon: Methanoregula
@@ -106,6 +109,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Methanotrophic bacteria are represented broadly because the abstract
       reports methanogen-methanotroph network relationships across wetlands.
   functional_role:

--- a/kb/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.yaml
+++ b/kb/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.yaml
@@ -29,7 +29,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Community-level representation of wetland soil microbes across nine
       terrestrial freshwater wetlands in the MUCC v2.0.0 synthesis.
   functional_role:
@@ -52,7 +52,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Methanogenic archaea are curated broadly because the study emphasizes
       methanogen networks and conserved methane-cycling genera across many
       wetlands rather than one fixed species composition.
@@ -109,7 +109,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Methanotrophic bacteria are represented broadly because the abstract
       reports methanogen-methanotroph network relationships across wetlands.
   functional_role:

--- a/kb/communities/Maize_Benzoxazinoid_Metabolizing_SynComs.yaml
+++ b/kb/communities/Maize_Benzoxazinoid_Metabolizing_SynComs.yaml
@@ -34,7 +34,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Maize_Benzoxazinoid_Metabolizing_SynComs.yaml
+++ b/kb/communities/Maize_Benzoxazinoid_Metabolizing_SynComs.yaml
@@ -34,6 +34,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Maize_Drought_Response_SynCom.yaml
+++ b/kb/communities/Maize_Drought_Response_SynCom.yaml
@@ -38,6 +38,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Maize_Drought_Response_SynCom.yaml
+++ b/kb/communities/Maize_Drought_Response_SynCom.yaml
@@ -38,7 +38,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Maize_Root_Simplified_Community.yaml
+++ b/kb/communities/Maize_Root_Simplified_Community.yaml
@@ -43,6 +43,18 @@ taxonomy:
     term:
       id: NCBITaxon:550
       label: Enterobacter cloacae
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Enterobacter chengduensis
+    - Enterobacter cloacae
+    - Enterobacter cloacae_I
+    - Enterobacter dissolvens
+    - Enterobacter hormaechei_B
+    - Enterobacter hormaechei_C
+    - Enterobacter kobei
+    - Enterobacter roggenkampii
+    - Enterobacter sichuanensis
+    - Kosakonia cowanii
     notes: 'Keystone species of the SF7-style 7-member maize root SynCom (Niu et al. 2017, PNAS). Its
       removal causes complete community collapse and takeover by Curtobacterium pusillum on maize roots
       (host-dependent — the takeover does NOT occur in axenic MS agar without seedlings). In addition
@@ -88,6 +100,19 @@ taxonomy:
     term:
       id: NCBITaxon:40324
       label: Stenotrophomonas maltophilia
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Stenotrophomonas bentonitica_A
+    - Stenotrophomonas geniculata
+    - Stenotrophomonas hibiscicola
+    - Stenotrophomonas indicatrix
+    - Stenotrophomonas maltophilia
+    - Stenotrophomonas maltophilia_AJ
+    - Stenotrophomonas maltophilia_L
+    - Stenotrophomonas muris
+    - Stenotrophomonas nematodicola
+    - Stenotrophomonas sepilia
+    - Stenotrophomonas sp002192255
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -105,6 +130,7 @@ taxonomy:
     term:
       id: NCBITaxon:571256
       label: Brucella pituitosa
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -122,6 +148,7 @@ taxonomy:
     term:
       id: NCBITaxon:92645
       label: Herbaspirillum frisingense
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Herbaspirillum_frisingense
       gtdb_taxon: Herbaspirillum frisingense
@@ -139,6 +166,23 @@ taxonomy:
     term:
       id: NCBITaxon:303
       label: Pseudomonas putida
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Pseudomonas_E alloputida
+    - Pseudomonas_E asiatica
+    - Pseudomonas_E fulva
+    - Pseudomonas_E guariconensis
+    - Pseudomonas_E juntendi
+    - Pseudomonas_E monteilii
+    - Pseudomonas_E pudica
+    - Pseudomonas_E putida
+    - Pseudomonas_E putida_E
+    - Pseudomonas_E putida_H
+    - Pseudomonas_E putida_K
+    - Pseudomonas_E putida_P
+    - Pseudomonas_E putida_Q
+    - Pseudomonas_E putida_R
+    - Pseudomonas_E putida_Y
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -147,6 +191,7 @@ taxonomy:
     term:
       id: NCBITaxon:69373
       label: Curtobacterium pusillum
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -155,6 +200,7 @@ taxonomy:
     term:
       id: NCBITaxon:253
       label: Chryseobacterium indologenes
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Chryseobacterium_indologenes
       gtdb_taxon: Chryseobacterium indologenes
@@ -172,6 +218,7 @@ taxonomy:
     term:
       id: NCBITaxon:4577
       label: Zea mays
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_PRODUCER
   evidence:
@@ -188,6 +235,7 @@ taxonomy:
     term:
       id: NCBITaxon:117187
       label: Fusarium verticillioides
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Target phytopathogenic fungus — NOT a SynCom member; included here as the antagonism
       target of the community's biocontrol activity. Both the whole 7-member consortium and the
       keystone member E. cloacae individually inhibit F. verticillioides growth in planta and in

--- a/kb/communities/Maize_Root_Simplified_Community.yaml
+++ b/kb/communities/Maize_Root_Simplified_Community.yaml
@@ -130,7 +130,7 @@ taxonomy:
     term:
       id: NCBITaxon:571256
       label: Brucella pituitosa
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -191,7 +191,7 @@ taxonomy:
     term:
       id: NCBITaxon:69373
       label: Curtobacterium pusillum
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -218,7 +218,7 @@ taxonomy:
     term:
       id: NCBITaxon:4577
       label: Zea mays
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - PRIMARY_PRODUCER
   evidence:
@@ -235,7 +235,7 @@ taxonomy:
     term:
       id: NCBITaxon:117187
       label: Fusarium verticillioides
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Target phytopathogenic fungus — NOT a SynCom member; included here as the antagonism
       target of the community's biocontrol activity. Both the whole 7-member consortium and the
       keystone member E. cloacae individually inhibit F. verticillioides growth in planta and in

--- a/kb/communities/Mars_Meteorite_EETA79001_Growth_Panel.yaml
+++ b/kb/communities/Mars_Meteorite_EETA79001_Growth_Panel.yaml
@@ -93,7 +93,7 @@ taxonomy:
     term:
       id: NCBITaxon:1521555
       label: Eucapsis
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: >
       Source identifies the member only to the cyanobacterial genus Eucapsis; ontology
       grounding is genus-level.

--- a/kb/communities/Mars_Meteorite_EETA79001_Growth_Panel.yaml
+++ b/kb/communities/Mars_Meteorite_EETA79001_Growth_Panel.yaml
@@ -67,6 +67,7 @@ taxonomy:
     term:
       id: NCBITaxon:562
       label: Escherichia coli
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Escherichia_coli
       gtdb_taxon: Escherichia coli
@@ -92,6 +93,7 @@ taxonomy:
     term:
       id: NCBITaxon:1521555
       label: Eucapsis
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: >
       Source identifies the member only to the cyanobacterial genus Eucapsis; ontology
       grounding is genus-level.
@@ -106,6 +108,7 @@ taxonomy:
     term:
       id: NCBITaxon:54298
       label: Chroococcidiopsis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Chroococcidiopsis
       gtdb_taxon: Chroococcidiopsis
@@ -132,6 +135,7 @@ taxonomy:
     term:
       id: NCBITaxon:1215089
       label: Planococcus halocryophilus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Planococcus_halocryophilus
       gtdb_taxon: Planococcus halocryophilus

--- a/kb/communities/Mars_Regolith_Cyanobacteria_Biofertilizer_Panel.yaml
+++ b/kb/communities/Mars_Regolith_Cyanobacteria_Biofertilizer_Panel.yaml
@@ -127,7 +127,7 @@ taxonomy:
     term:
       id: NCBITaxon:3077
       label: Chlorella vulgaris
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: >
       A green microalga (not a cyanobacterium); ontology grounding is species-level. It
       did not thrive on the regolith extract.

--- a/kb/communities/Mars_Regolith_Cyanobacteria_Biofertilizer_Panel.yaml
+++ b/kb/communities/Mars_Regolith_Cyanobacteria_Biofertilizer_Panel.yaml
@@ -69,6 +69,10 @@ taxonomy:
     term:
       id: NCBITaxon:1165
       label: Anabaena cylindrica
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Anabaena cylindrica
+    - Trichormus sp000009705
     notes: >
       A filamentous, heterocyst-forming, nitrogen-fixing cyanobacterium; ontology
       grounding is species-level.
@@ -83,6 +87,10 @@ taxonomy:
     term:
       id: NCBITaxon:1179
       label: Desmonostoc muscorum
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Nostoc muscorum
+    - Nostoc muscorum_A
     notes: >
       Source names the strain Nostoc muscorum; NCBI Taxonomy has reclassified this
       species as Desmonostoc muscorum (NCBITaxon:1179), so the canonical ontology label
@@ -99,6 +107,10 @@ taxonomy:
     term:
       id: NCBITaxon:118562
       label: Limnospira platensis
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Limnospira fusiformis
+    - Limnospira platensis
     notes: >
       Source names the strain Arthrospira platensis (spirulina); NCBI Taxonomy has
       reclassified this species as Limnospira platensis (NCBITaxon:118562), so the
@@ -115,6 +127,7 @@ taxonomy:
     term:
       id: NCBITaxon:3077
       label: Chlorella vulgaris
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: >
       A green microalga (not a cyanobacterium); ontology grounding is species-level. It
       did not thrive on the regolith extract.

--- a/kb/communities/Medicago_Nodule_Biofertilizer_SynCom.yaml
+++ b/kb/communities/Medicago_Nodule_Biofertilizer_SynCom.yaml
@@ -58,7 +58,7 @@ taxonomy:
     term:
       id: NCBITaxon:306
       label: Pseudomonas sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Medicago_Nodule_Biofertilizer_SynCom.yaml
+++ b/kb/communities/Medicago_Nodule_Biofertilizer_SynCom.yaml
@@ -38,6 +38,7 @@ taxonomy:
     term:
       id: NCBITaxon:106591
       label: Ensifer
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Ensifer
       gtdb_taxon: Ensifer
@@ -57,6 +58,7 @@ taxonomy:
     term:
       id: NCBITaxon:306
       label: Pseudomonas sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Mediterranean_Grassland_qSIP_Rainfall_Community.yaml
+++ b/kb/communities/Mediterranean_Grassland_qSIP_Rainfall_Community.yaml
@@ -26,6 +26,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Active soil bacterial members identified by qSIP-driven incorporation
       of 18O into newly synthesized DNA.
   functional_role:
@@ -42,6 +43,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Flagellar motile microorganisms whose activity and growth rates
       increase with year-round precipitation.
   functional_role:

--- a/kb/communities/Mediterranean_Grassland_qSIP_Rainfall_Community.yaml
+++ b/kb/communities/Mediterranean_Grassland_qSIP_Rainfall_Community.yaml
@@ -26,7 +26,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Active soil bacterial members identified by qSIP-driven incorporation
       of 18O into newly synthesized DNA.
   functional_role:
@@ -43,7 +43,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Flagellar motile microorganisms whose activity and growth rates
       increase with year-round precipitation.
   functional_role:

--- a/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
+++ b/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
@@ -151,7 +151,7 @@ taxonomy:
     term:
       id: NCBITaxon:1817801
       label: Candidatus Eiseniibacteriota
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'MAGs from this candidate phylum were recovered from EFPC sediment. Notable for containing
       selenium assimilatory metabolism traits.
 
@@ -227,7 +227,7 @@ taxonomy:
     term:
       id: NCBITaxon:304371
       label: Methanocella paludicola SANAE
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Confirmed hgcAB+ mercury methylator. Demonstrated robust methylmercury production in pure
       culture under methanogenic conditions.
 

--- a/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
+++ b/kb/communities/Mercury_SFA_EFPC_Sediment_Community.yaml
@@ -32,6 +32,7 @@ taxonomy:
     term:
       id: NCBITaxon:1224
       label: Pseudomonadota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Pseudomonadota
       gtdb_taxon: Pseudomonadota
@@ -63,6 +64,7 @@ taxonomy:
     term:
       id: NCBITaxon:57723
       label: Acidobacteriota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Acidobacteriota
       gtdb_taxon: Acidobacteriota
@@ -91,6 +93,7 @@ taxonomy:
     term:
       id: NCBITaxon:201174
       label: Actinomycetota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Actinomycetota
       gtdb_taxon: Actinomycetota
@@ -119,6 +122,7 @@ taxonomy:
     term:
       id: NCBITaxon:142182
       label: Gemmatimonadota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Gemmatimonadota
       gtdb_taxon: Gemmatimonadota
@@ -147,6 +151,7 @@ taxonomy:
     term:
       id: NCBITaxon:1817801
       label: Candidatus Eiseniibacteriota
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'MAGs from this candidate phylum were recovered from EFPC sediment. Notable for containing
       selenium assimilatory metabolism traits.
 
@@ -164,6 +169,7 @@ taxonomy:
     term:
       id: NCBITaxon:2818505
       label: Myxococcota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Myxococcota
       gtdb_taxon: Myxococcota
@@ -192,6 +198,7 @@ taxonomy:
     term:
       id: NCBITaxon:28889
       label: Thermoproteota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Thermoproteota
       gtdb_taxon: Thermoproteota
@@ -220,6 +227,7 @@ taxonomy:
     term:
       id: NCBITaxon:304371
       label: Methanocella paludicola SANAE
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Confirmed hgcAB+ mercury methylator. Demonstrated robust methylmercury production in pure
       culture under methanogenic conditions.
 
@@ -241,6 +249,7 @@ taxonomy:
     term:
       id: NCBITaxon:71518
       label: Methanocorpusculum bavaricum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methanocorpusculum_parvum
       gtdb_taxon: Methanocorpusculum parvum
@@ -270,6 +279,7 @@ taxonomy:
     term:
       id: NCBITaxon:2201
       label: Methanofollis liminatans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methanofollis_liminatans
       gtdb_taxon: Methanofollis liminatans
@@ -299,6 +309,7 @@ taxonomy:
     term:
       id: NCBITaxon:475088
       label: Methanosphaerula palustris
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methanosphaerula_palustris
       gtdb_taxon: Methanosphaerula palustris

--- a/kb/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.yaml
+++ b/kb/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.yaml
@@ -52,6 +52,7 @@ taxonomy:
     term:
       id: NCBITaxon:32049
       label: Picosynechococcus sp. PCC 7002
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Limnothrix_sp001693275
       gtdb_taxon: Limnothrix sp001693275
@@ -80,6 +81,7 @@ taxonomy:
     term:
       id: NCBITaxon:68287
       label: Mesorhizobium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Mesorhizobium
       gtdb_taxon: Mesorhizobium
@@ -105,6 +107,7 @@ taxonomy:
     term:
       id: NCBITaxon:286
       label: Pseudomonas
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Pseudomonas
       gtdb_taxon: Pseudomonas
@@ -132,6 +135,7 @@ taxonomy:
     term:
       id: NCBITaxon:1125
       label: Microcystis <cyanobacteria>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Microcystis
       gtdb_taxon: Microcystis

--- a/kb/communities/Methane_Oxidation_CrVI_Reduction_SynCom.yaml
+++ b/kb/communities/Methane_Oxidation_CrVI_Reduction_SynCom.yaml
@@ -55,7 +55,7 @@ taxonomy:
     term:
       id: NCBITaxon:82
       label: Hyphomicrobium sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Methane_Oxidation_CrVI_Reduction_SynCom.yaml
+++ b/kb/communities/Methane_Oxidation_CrVI_Reduction_SynCom.yaml
@@ -35,6 +35,7 @@ taxonomy:
     term:
       id: NCBITaxon:133
       label: Methylocystis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Methylocystis
       gtdb_taxon: Methylocystis
@@ -54,6 +55,7 @@ taxonomy:
     term:
       id: NCBITaxon:82
       label: Hyphomicrobium sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -63,6 +65,7 @@ taxonomy:
     term:
       id: NCBITaxon:919
       label: Thiobacillus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Thiobacillus
       gtdb_taxon: Thiobacillus

--- a/kb/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.yaml
+++ b/kb/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.yaml
@@ -81,7 +81,7 @@ taxonomy:
     term:
       id: NCBITaxon:2530459
       label: Galdieria sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Strain-level NCBI Taxonomy for RTK37.1 was not found; the broader Galdieria sp. taxon is
       used with the source-backed strain designation.
   strain_designation:

--- a/kb/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.yaml
+++ b/kb/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.yaml
@@ -48,6 +48,7 @@ taxonomy:
     term:
       id: NCBITaxon:511746
       label: Candidatus Methylacidiphilum infernorum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methylacidiphilum_infernorum
       gtdb_taxon: Methylacidiphilum infernorum
@@ -80,6 +81,7 @@ taxonomy:
     term:
       id: NCBITaxon:2530459
       label: Galdieria sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Strain-level NCBI Taxonomy for RTK37.1 was not found; the broader Galdieria sp. taxon is
       used with the source-backed strain designation.
   strain_designation:

--- a/kb/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.yaml
+++ b/kb/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.yaml
@@ -48,6 +48,7 @@ taxonomy:
     term:
       id: NCBITaxon:1432792
       label: Methylocaldum marinum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methylocaldum_marinum
       gtdb_taxon: Methylocaldum marinum
@@ -85,6 +86,7 @@ taxonomy:
     term:
       id: NCBITaxon:1218105
       label: Cupriavidus necator NBRC 102504
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Cupriavidus_necator_D
       gtdb_taxon: Cupriavidus necator_D

--- a/kb/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.yaml
+++ b/kb/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.yaml
@@ -45,6 +45,7 @@ taxonomy:
     term:
       id: NCBITaxon:1432792
       label: Methylocaldum marinum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methylocaldum_marinum
       gtdb_taxon: Methylocaldum marinum
@@ -82,6 +83,7 @@ taxonomy:
     term:
       id: NCBITaxon:1384459
       label: Methyloceanibacter caenitepidi
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methyloceanibacter_caenitepidi
       gtdb_taxon: Methyloceanibacter caenitepidi

--- a/kb/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.yaml
+++ b/kb/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.yaml
@@ -43,6 +43,7 @@ taxonomy:
     term:
       id: NCBITaxon:134
       label: Methylocystis parvus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methylocystis_parva
       gtdb_taxon: Methylocystis parva
@@ -68,6 +69,10 @@ taxonomy:
     term:
       id: NCBITaxon:37919
       label: Rhodococcus opacus
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Rhodococcus opacus
+    - Rhodococcus opacus_C
     notes: NCBI Taxonomy lists Rhodococcus opacus at taxon 37919; the PHBV study used
       R. opacus as the cocultivated partner microbe.
   abundance_level: ABUNDANT

--- a/kb/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.yaml
+++ b/kb/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.yaml
@@ -56,6 +56,7 @@ taxonomy:
     term:
       id: NCBITaxon:1091494
       label: Methylotuvimicrobium alcaliphilum 20Z
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methylotuvimicrobium_alcaliphilum
       gtdb_taxon: Methylotuvimicrobium alcaliphilum
@@ -97,6 +98,7 @@ taxonomy:
     term:
       id: NCBITaxon:2675547
       label: Chlorella sp. HS2
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: >
       NCBI Taxonomy records Chlorella sp. HS2 as a species-level unclassified
       Chlorella entry with homotypic synonym Chlorella sp. HS-2.

--- a/kb/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.yaml
+++ b/kb/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.yaml
@@ -98,7 +98,7 @@ taxonomy:
     term:
       id: NCBITaxon:2675547
       label: Chlorella sp. HS2
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: >
       NCBI Taxonomy records Chlorella sp. HS2 as a species-level unclassified
       Chlorella entry with homotypic synonym Chlorella sp. HS-2.

--- a/kb/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.yaml
+++ b/kb/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.yaml
@@ -47,6 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:1091494
       label: Methylotuvimicrobium alcaliphilum 20Z
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methylotuvimicrobium_alcaliphilum
       gtdb_taxon: Methylotuvimicrobium alcaliphilum
@@ -86,6 +87,7 @@ taxonomy:
     term:
       id: NCBITaxon:32049
       label: Picosynechococcus sp. PCC 7002
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Limnothrix_sp001693275
       gtdb_taxon: Limnothrix sp001693275

--- a/kb/communities/Microcoleus_Massilia_Cyanosphere_Urea_Mutualism.yaml
+++ b/kb/communities/Microcoleus_Massilia_Cyanosphere_Urea_Mutualism.yaml
@@ -42,6 +42,10 @@ taxonomy:
     term:
       id: NCBITaxon:119532
       label: Microcoleus vaginatus
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - FACHB-68 sp019359355
+    - Microcoleus vaginatus_A
     notes: Axenic cyanobacterial strain used as the photosynthetic, non-diazotrophic cyanosphere partner.
   strain_designation:
     strain_name: PCC 9802
@@ -69,6 +73,7 @@ taxonomy:
     term:
       id: NCBITaxon:149698
       label: Massilia
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Telluria
       gtdb_taxon: Telluria

--- a/kb/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.yaml
+++ b/kb/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.yaml
@@ -37,6 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:32008
       label: Burkholderia
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Burkholderia
       gtdb_taxon: Burkholderia
@@ -56,6 +57,7 @@ taxonomy:
     term:
       id: NCBITaxon:1822464
       label: Paraburkholderia
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Paraburkholderia
       gtdb_taxon: Paraburkholderia
@@ -75,6 +77,7 @@ taxonomy:
     term:
       id: NCBITaxon:2034
       label: Curtobacterium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Curtobacterium
       gtdb_taxon: Curtobacterium
@@ -94,6 +97,7 @@ taxonomy:
     term:
       id: NCBITaxon:110932
       label: Leifsonia
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Leifsonia
       gtdb_taxon: Leifsonia
@@ -113,6 +117,7 @@ taxonomy:
     term:
       id: NCBITaxon:37927
       label: Sinomonas atrocyanea
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.yaml
+++ b/kb/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.yaml
@@ -117,7 +117,7 @@ taxonomy:
     term:
       id: NCBITaxon:37927
       label: Sinomonas atrocyanea
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Mixed_Gallium_LED_Recovery_Consortium.yaml
+++ b/kb/communities/Mixed_Gallium_LED_Recovery_Consortium.yaml
@@ -62,6 +62,7 @@ taxonomy:
     term:
       id: NCBITaxon:930
       label: Acidithiobacillus thiooxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidithiobacillus_thiooxidans
       gtdb_taxon: Acidithiobacillus thiooxidans
@@ -110,6 +111,7 @@ taxonomy:
     term:
       id: NCBITaxon:920
       label: Acidithiobacillus ferrooxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidithiobacillus_ferrooxidans
       gtdb_taxon: Acidithiobacillus ferrooxidans
@@ -158,6 +160,7 @@ taxonomy:
     term:
       id: NCBITaxon:180
       label: Leptospirillum ferrooxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Leptospirillum_ferrooxidans
       gtdb_taxon: Leptospirillum ferrooxidans

--- a/kb/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.yaml
+++ b/kb/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.yaml
@@ -56,6 +56,7 @@ taxonomy:
     term:
       id: NCBITaxon:1117
       label: Cyanobacteriota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Cyanobacteriota
       gtdb_taxon: Cyanobacteriota
@@ -83,6 +84,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: A reproducible 25-species core noncyanobacterial microbiome was recovered
       across consortia; species-level identities are not enumerated in the
       abstract.

--- a/kb/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.yaml
+++ b/kb/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.yaml
@@ -84,7 +84,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: A reproducible 25-species core noncyanobacterial microbiome was recovered
       across consortia; species-level identities are not enumerated in the
       abstract.

--- a/kb/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.yaml
+++ b/kb/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.yaml
@@ -51,6 +51,23 @@ taxonomy:
     term:
       id: NCBITaxon:303
       label: Pseudomonas putida
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Pseudomonas_E alloputida
+    - Pseudomonas_E asiatica
+    - Pseudomonas_E fulva
+    - Pseudomonas_E guariconensis
+    - Pseudomonas_E juntendi
+    - Pseudomonas_E monteilii
+    - Pseudomonas_E pudica
+    - Pseudomonas_E putida
+    - Pseudomonas_E putida_E
+    - Pseudomonas_E putida_H
+    - Pseudomonas_E putida_K
+    - Pseudomonas_E putida_P
+    - Pseudomonas_E putida_Q
+    - Pseudomonas_E putida_R
+    - Pseudomonas_E putida_Y
     notes: Source describes P. putida as the lignin degrader that can generate formaldehyde while
       growing on vanillic acid.
   abundance_level: ABUNDANT
@@ -67,6 +84,7 @@ taxonomy:
     term:
       id: NCBITaxon:1708
       label: Cellulomonas fimi
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Cellulomonas_fimi
       gtdb_taxon: Cellulomonas fimi
@@ -96,6 +114,7 @@ taxonomy:
     term:
       id: NCBITaxon:408
       label: Methylorubrum extorquens
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methylobacterium_extorquens
       gtdb_taxon: Methylobacterium extorquens
@@ -121,6 +140,7 @@ taxonomy:
     term:
       id: NCBITaxon:4952
       label: Yarrowia lipolytica
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Oleaginous yeast included in some consortium variants; this record distinguishes that
       conditional role from the bacterial formaldehyde cross-feeding core.
   abundance_level: COMMON

--- a/kb/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.yaml
+++ b/kb/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.yaml
@@ -140,7 +140,7 @@ taxonomy:
     term:
       id: NCBITaxon:4952
       label: Yarrowia lipolytica
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Oleaginous yeast included in some consortium variants; this record distinguishes that
       conditional role from the bacterial formaldehyde cross-feeding core.
   abundance_level: COMMON

--- a/kb/communities/Moss_Microbe_Complex_Regolith_Biofertilizer.yaml
+++ b/kb/communities/Moss_Microbe_Complex_Regolith_Biofertilizer.yaml
@@ -72,6 +72,10 @@ taxonomy:
     term:
       id: NCBITaxon:76759
       label: Pseudomonas monteilii
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Pseudomonas_E asiatica
+    - Pseudomonas_E monteilii
     notes: >
       A plant growth-promoting bacterium isolated from the moss Hypnum plumaeforme;
       selected for phosphate solubilization, IAA production, and siderophore synthesis.
@@ -87,6 +91,31 @@ taxonomy:
     term:
       id: NCBITaxon:1396
       label: Bacillus cereus
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Bacillus_A anthracis
+    - Bacillus_A bombysepticus
+    - Bacillus_A cereus
+    - Bacillus_A cereus_K
+    - Bacillus_A cereus_S
+    - Bacillus_A cereus_U
+    - Bacillus_A hominis
+    - Bacillus_A luti
+    - Bacillus_A mobilis
+    - Bacillus_A mycoides
+    - Bacillus_A nitratireducens
+    - Bacillus_A pacificus
+    - Bacillus_A paramycoides
+    - Bacillus_A paranthracis
+    - Bacillus_A pseudomycoides
+    - Bacillus_A sp003400245
+    - Bacillus_A sp018966865
+    - Bacillus_A thuringiensis
+    - Bacillus_A thuringiensis_AB
+    - Bacillus_A thuringiensis_K
+    - Bacillus_A thuringiensis_S
+    - Bacillus_A toyonensis
+    - Bacillus_A tropicus
     notes: >
       A plant growth-promoting bacterium isolated from the moss Hypnum plumaeforme;
       selected for phosphate solubilization, IAA production, and siderophore synthesis.
@@ -102,6 +131,7 @@ taxonomy:
     term:
       id: NCBITaxon:46913
       label: Devosia
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Devosia
       gtdb_taxon: Devosia

--- a/kb/communities/Multiomics_Corn_Straw_Degradation_SynCom.yaml
+++ b/kb/communities/Multiomics_Corn_Straw_Degradation_SynCom.yaml
@@ -35,7 +35,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - PRIMARY_DEGRADER
   evidence:

--- a/kb/communities/Multiomics_Corn_Straw_Degradation_SynCom.yaml
+++ b/kb/communities/Multiomics_Corn_Straw_Degradation_SynCom.yaml
@@ -35,6 +35,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_DEGRADER
   evidence:

--- a/kb/communities/Mushroom_Spring_Hot_Spring_Phototrophic_Mat_Community.yaml
+++ b/kb/communities/Mushroom_Spring_Hot_Spring_Phototrophic_Mat_Community.yaml
@@ -26,6 +26,12 @@ taxonomy:
     term:
       id: NCBITaxon:1129
       label: Synechococcus
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Synechococcus_D
+    - Synechococcus
+    - Synechococcus_B
+    - Synechococcus_F
     notes: >
       Thermophilic unicellular cyanobacteria in the upper mat; publications
       describe Synechococcus ecotypes and strains A and B-prime in Mushroom and
@@ -48,6 +54,7 @@ taxonomy:
     term:
       id: NCBITaxon:120961
       label: Roseiflexus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Roseiflexus
       gtdb_taxon: Roseiflexus
@@ -82,6 +89,7 @@ taxonomy:
     term:
       id: NCBITaxon:1107
       label: Chloroflexus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Chloroflexus
       gtdb_taxon: Chloroflexus
@@ -112,6 +120,7 @@ taxonomy:
     term:
       id: NCBITaxon:28261
       label: Thermodesulfovibrio
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Thermodesulfovibrio
       gtdb_taxon: Thermodesulfovibrio

--- a/kb/communities/NCycle_Bioflocculation_Model_Consortium.yaml
+++ b/kb/communities/NCycle_Bioflocculation_Model_Consortium.yaml
@@ -36,6 +36,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/NCycle_Bioflocculation_Model_Consortium.yaml
+++ b/kb/communities/NCycle_Bioflocculation_Model_Consortium.yaml
@@ -36,7 +36,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
+++ b/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
@@ -42,6 +42,7 @@ taxonomy:
     term:
       id: NCBITaxon:651137
       label: Nitrososphaerota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Thermoproteota
       gtdb_taxon: Thermoproteota
@@ -90,6 +91,7 @@ taxonomy:
     term:
       id: NCBITaxon:2301
       label: Thermoplasmatales
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:o__Thermoplasmatales
       gtdb_taxon: Thermoplasmatales
@@ -131,6 +133,7 @@ taxonomy:
     term:
       id: NCBITaxon:67812
       label: Candidatus Omnitrophota
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Bacterial lineage belonging to Candidate Division OP3 (now reclassified as Omnitrophica),
       a deeply branching bacterial phylum detected primarily in subsurface and geothermal environments.
       Naica OP3 bacteria exhibit high GC content in 16S rRNA sequences, indicating thermophilic adaptation
@@ -161,6 +164,7 @@ taxonomy:
     term:
       id: NCBITaxon:1239
       label: Bacillota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Bacillota_A
       gtdb_taxon: Bacillota_A
@@ -196,6 +200,7 @@ taxonomy:
     term:
       id: NCBITaxon:28211
       label: Alphaproteobacteria
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:c__Alphaproteobacteria
       gtdb_taxon: Alphaproteobacteria
@@ -230,6 +235,7 @@ taxonomy:
     term:
       id: NCBITaxon:28216
       label: Betaproteobacteria
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:c__Gammaproteobacteria
       gtdb_taxon: Gammaproteobacteria

--- a/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
+++ b/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
@@ -133,7 +133,7 @@ taxonomy:
     term:
       id: NCBITaxon:67812
       label: Candidatus Omnitrophota
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Bacterial lineage belonging to Candidate Division OP3 (now reclassified as Omnitrophica),
       a deeply branching bacterial phylum detected primarily in subsurface and geothermal environments.
       Naica OP3 bacteria exhibit high GC content in 16S rRNA sequences, indicating thermophilic adaptation

--- a/kb/communities/Neocallimastix_Methanobrevibacter_Xylan_Coculture.yaml
+++ b/kb/communities/Neocallimastix_Methanobrevibacter_Xylan_Coculture.yaml
@@ -41,7 +41,7 @@ taxonomy:
     term:
       id: NCBITaxon:4757
       label: Neocallimastix frontalis
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: PNK2 strain used as one of the anaerobic ruminal fungal partners; this record focuses on the
       N. frontalis-M. smithii coculture subset.
   abundance_level: COMMON

--- a/kb/communities/Neocallimastix_Methanobrevibacter_Xylan_Coculture.yaml
+++ b/kb/communities/Neocallimastix_Methanobrevibacter_Xylan_Coculture.yaml
@@ -41,6 +41,7 @@ taxonomy:
     term:
       id: NCBITaxon:4757
       label: Neocallimastix frontalis
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: PNK2 strain used as one of the anaerobic ruminal fungal partners; this record focuses on the
       N. frontalis-M. smithii coculture subset.
   abundance_level: COMMON
@@ -57,6 +58,10 @@ taxonomy:
     term:
       id: NCBITaxon:2173
       label: Methanobrevibacter smithii
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Methanobrevibacter_A smithii
+    - Methanobrevibacter_A smithii_A
     notes: Hydrogenotrophic methanogenic archaeon used as the syntrophic partner.
   abundance_level: COMMON
   functional_role:

--- a/kb/communities/Ngawha_Geothermal_Mercury_Cycling_Community.yaml
+++ b/kb/communities/Ngawha_Geothermal_Mercury_Cycling_Community.yaml
@@ -30,7 +30,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Acidophilic and mesophilic sulfur- and iron-cycling bacteria
       dominate the geothermal microbiome.
   abundance_level: DOMINANT
@@ -47,7 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Mercury- and arsenic-resistant bacteria persist under ultrahigh
       mercury and arsenic exposure.
   functional_role:
@@ -63,7 +63,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Thermophilic and acidophilic archaeal members of the geothermal
       community.
   functional_role:

--- a/kb/communities/Ngawha_Geothermal_Mercury_Cycling_Community.yaml
+++ b/kb/communities/Ngawha_Geothermal_Mercury_Cycling_Community.yaml
@@ -30,6 +30,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Acidophilic and mesophilic sulfur- and iron-cycling bacteria
       dominate the geothermal microbiome.
   abundance_level: DOMINANT
@@ -46,6 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Mercury- and arsenic-resistant bacteria persist under ultrahigh
       mercury and arsenic exposure.
   functional_role:
@@ -61,6 +63,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Thermophilic and acidophilic archaeal members of the geothermal
       community.
   functional_role:

--- a/kb/communities/OMM12_Gnotobiotic_Mouse_Gut_Community.yaml
+++ b/kb/communities/OMM12_Gnotobiotic_Mouse_Gut_Community.yaml
@@ -46,7 +46,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Defined 12-strain bacterial community containing Firmicutes/Bacillota, Bacteroidota, Actinomycetota,
       Verrucomicrobiota, and Proteobacteria/Pseudomonadota representatives from the mouse intestine.
   functional_role:

--- a/kb/communities/OMM12_Gnotobiotic_Mouse_Gut_Community.yaml
+++ b/kb/communities/OMM12_Gnotobiotic_Mouse_Gut_Community.yaml
@@ -46,6 +46,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Defined 12-strain bacterial community containing Firmicutes/Bacillota, Bacteroidota, Actinomycetota,
       Verrucomicrobiota, and Proteobacteria/Pseudomonadota representatives from the mouse intestine.
   functional_role:

--- a/kb/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.yaml
+++ b/kb/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.yaml
@@ -53,6 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:1521
       label: Ruminiclostridium cellulolyticum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Ruminiclostridium_cellulolyticum
       gtdb_taxon: Ruminiclostridium cellulolyticum
@@ -84,6 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:882
       label: Nitratidesulfovibrio vulgaris str. Hildenborough
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Nitratidesulfovibrio_vulgaris
       gtdb_taxon: Nitratidesulfovibrio vulgaris
@@ -116,6 +118,7 @@ taxonomy:
     term:
       id: NCBITaxon:35554
       label: Geobacter sulfurreducens
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Geobacter_sulfurreducens
       gtdb_taxon: Geobacter sulfurreducens

--- a/kb/communities/ORNL_PMI_Populus_PD10_SynCom.yaml
+++ b/kb/communities/ORNL_PMI_Populus_PD10_SynCom.yaml
@@ -78,7 +78,7 @@ taxonomy:
     term:
       id: NCBITaxon:306
       label: Pseudomonas sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   strain_designation:
     strain_name: GM17
     isolation_source: Populus deltoides rhizosphere
@@ -267,7 +267,7 @@ taxonomy:
     term:
       id: NCBITaxon:68239
       label: Streptomyces mirabilis
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   strain_designation:
     strain_name: YR139
     isolation_source: Populus deltoides rhizosphere

--- a/kb/communities/ORNL_PMI_Populus_PD10_SynCom.yaml
+++ b/kb/communities/ORNL_PMI_Populus_PD10_SynCom.yaml
@@ -47,6 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:53335
       label: Pantoea
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Pantoea
       gtdb_taxon: Pantoea
@@ -77,6 +78,7 @@ taxonomy:
     term:
       id: NCBITaxon:306
       label: Pseudomonas sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   strain_designation:
     strain_name: GM17
     isolation_source: Populus deltoides rhizosphere
@@ -97,6 +99,7 @@ taxonomy:
     term:
       id: NCBITaxon:165695
       label: Sphingobium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Sphingobium
       gtdb_taxon: Sphingobium
@@ -124,6 +127,7 @@ taxonomy:
     term:
       id: NCBITaxon:379
       label: Rhizobium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Rhizobium
       gtdb_taxon: Rhizobium
@@ -151,6 +155,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -178,6 +183,7 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bacillus
       gtdb_taxon: Bacillus
@@ -205,6 +211,7 @@ taxonomy:
     term:
       id: NCBITaxon:75
       label: Caulobacter
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Caulobacter
       gtdb_taxon: Caulobacter
@@ -232,6 +239,7 @@ taxonomy:
     term:
       id: NCBITaxon:75654
       label: Duganella
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Duganella
       gtdb_taxon: Duganella
@@ -259,6 +267,7 @@ taxonomy:
     term:
       id: NCBITaxon:68239
       label: Streptomyces mirabilis
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   strain_designation:
     strain_name: YR139
     isolation_source: Populus deltoides rhizosphere
@@ -276,6 +285,7 @@ taxonomy:
     term:
       id: NCBITaxon:1822464
       label: Paraburkholderia
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Paraburkholderia
       gtdb_taxon: Paraburkholderia

--- a/kb/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.yaml
+++ b/kb/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.yaml
@@ -23,6 +23,7 @@ taxonomy:
     term:
       id: NCBITaxon:666685
       label: Rhodanobacter denitrificans
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Rhodanobacter is enriched in the most contaminated Oak Ridge FRC wells and includes denitrifying
       strains isolated from nitrate-rich contaminated subsurface sediments.
   functional_role:
@@ -46,6 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:286
       label: Pseudomonas
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Pseudomonas
       gtdb_taxon: Pseudomonas
@@ -73,6 +75,7 @@ taxonomy:
     term:
       id: NCBITaxon:22
       label: Shewanella
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Shewanella
       gtdb_taxon: Shewanella
@@ -100,6 +103,7 @@ taxonomy:
     term:
       id: NCBITaxon:40323
       label: Stenotrophomonas
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Stenotrophomonas
       gtdb_taxon: Stenotrophomonas

--- a/kb/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.yaml
+++ b/kb/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.yaml
@@ -23,7 +23,7 @@ taxonomy:
     term:
       id: NCBITaxon:666685
       label: Rhodanobacter denitrificans
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Rhodanobacter is enriched in the most contaminated Oak Ridge FRC wells and includes denitrifying
       strains isolated from nitrate-rich contaminated subsurface sediments.
   functional_role:

--- a/kb/communities/Okeke_Lu_Cellulolytic_Consortium.yaml
+++ b/kb/communities/Okeke_Lu_Cellulolytic_Consortium.yaml
@@ -21,7 +21,7 @@ taxonomy:
     term:
       id: NCBITaxon:324747
       label: Pseudoxanthomonas byssovorax
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -37,7 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:82380
       label: Microbacterium oxydans
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -53,7 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:870529
       label: Bacillus sp. DB7
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: COMMON
   functional_role:
   - PRIMARY_DEGRADER
@@ -69,7 +69,7 @@ taxonomy:
     term:
       id: NCBITaxon:870532
       label: Ochrobactrum sp. DB8
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: COMMON
   functional_role:
   - PRIMARY_DEGRADER
@@ -85,7 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:870530
       label: Klebsiella sp. DB13
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: COMMON
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/Okeke_Lu_Cellulolytic_Consortium.yaml
+++ b/kb/communities/Okeke_Lu_Cellulolytic_Consortium.yaml
@@ -21,6 +21,7 @@ taxonomy:
     term:
       id: NCBITaxon:324747
       label: Pseudoxanthomonas byssovorax
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -36,6 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:82380
       label: Microbacterium oxydans
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -51,6 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:870529
       label: Bacillus sp. DB7
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: COMMON
   functional_role:
   - PRIMARY_DEGRADER
@@ -66,6 +69,7 @@ taxonomy:
     term:
       id: NCBITaxon:870532
       label: Ochrobactrum sp. DB8
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: COMMON
   functional_role:
   - PRIMARY_DEGRADER
@@ -81,6 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:870530
       label: Klebsiella sp. DB13
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: COMMON
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.yaml
+++ b/kb/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.yaml
@@ -45,6 +45,7 @@ taxonomy:
     term:
       id: NCBITaxon:70448
       label: Ostreococcus tauri
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: OTH95 strain used as the photosynthetic algal partner.
   abundance_level: COMMON
   functional_role:
@@ -61,6 +62,7 @@ taxonomy:
     term:
       id: NCBITaxon:215813
       label: Dinoroseobacter shibae
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Dinoroseobacter_shibae
       gtdb_taxon: Dinoroseobacter shibae

--- a/kb/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.yaml
+++ b/kb/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.yaml
@@ -45,7 +45,7 @@ taxonomy:
     term:
       id: NCBITaxon:70448
       label: Ostreococcus tauri
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: OTH95 strain used as the photosynthetic algal partner.
   abundance_level: COMMON
   functional_role:

--- a/kb/communities/PET_Artificial_FourSpecies_Degradation_Consortium.yaml
+++ b/kb/communities/PET_Artificial_FourSpecies_Degradation_Consortium.yaml
@@ -47,6 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:1423
       label: Bacillus subtilis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bacillus_subtilis
       gtdb_taxon: Bacillus subtilis
@@ -77,6 +78,7 @@ taxonomy:
     term:
       id: NCBITaxon:1423
       label: Bacillus subtilis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bacillus_subtilis
       gtdb_taxon: Bacillus subtilis
@@ -107,6 +109,7 @@ taxonomy:
     term:
       id: NCBITaxon:101510
       label: Rhodococcus jostii RHA1
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Rhodococcus_jostii_A
       gtdb_taxon: Rhodococcus jostii_A
@@ -137,6 +140,7 @@ taxonomy:
     term:
       id: NCBITaxon:160488
       label: Pseudomonas putida KT2440
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Pseudomonas_E_alloputida
       gtdb_taxon: Pseudomonas_E alloputida

--- a/kb/communities/PGM_Spent_Catalyst_Bioleaching.yaml
+++ b/kb/communities/PGM_Spent_Catalyst_Bioleaching.yaml
@@ -62,6 +62,7 @@ taxonomy:
     term:
       id: NCBITaxon:930
       label: Acidithiobacillus thiooxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidithiobacillus_thiooxidans
       gtdb_taxon: Acidithiobacillus thiooxidans
@@ -126,6 +127,7 @@ taxonomy:
     term:
       id: NCBITaxon:920
       label: Acidithiobacillus ferrooxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidithiobacillus_ferrooxidans
       gtdb_taxon: Acidithiobacillus ferrooxidans
@@ -170,6 +172,7 @@ taxonomy:
     term:
       id: NCBITaxon:28034
       label: Sulfobacillus thermosulfidooxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Sulfobacillus_thermosulfidooxidans
       gtdb_taxon: Sulfobacillus thermosulfidooxidans
@@ -215,6 +218,7 @@ taxonomy:
     term:
       id: NCBITaxon:931
       label: Thiobacillus thioparus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Thiobacillus_thioparus
       gtdb_taxon: Thiobacillus thioparus

--- a/kb/communities/PMI_Variovorax_Thermotolerance_Collection.yaml
+++ b/kb/communities/PMI_Variovorax_Thermotolerance_Collection.yaml
@@ -45,6 +45,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -74,6 +75,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -101,6 +103,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -128,6 +131,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -155,6 +159,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -182,6 +187,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax

--- a/kb/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.yaml
+++ b/kb/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.yaml
@@ -60,6 +60,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Assembled genomes of rhizosphere H2-oxidizing bacteria enriched in
       gluconeogenic-acid utilization genes; specific species are not enumerated
       in the abstract.
@@ -79,6 +80,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Hydrogenotrophic methanogenic archaea whose CH4 production gene
       activities decrease relative to consumption under PSY transgenic
       conditions; specific genera are not enumerated in the abstract.
@@ -97,6 +99,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Rhizosphere bacterial members whose H2-producing gene activity
       decreases under PSY transgenic conditions, contrasting with the
       H2-oxidizing counterparts.

--- a/kb/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.yaml
+++ b/kb/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.yaml
@@ -60,7 +60,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Assembled genomes of rhizosphere H2-oxidizing bacteria enriched in
       gluconeogenic-acid utilization genes; specific species are not enumerated
       in the abstract.
@@ -80,7 +80,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Hydrogenotrophic methanogenic archaea whose CH4 production gene
       activities decrease relative to consumption under PSY transgenic
       conditions; specific genera are not enumerated in the abstract.
@@ -99,7 +99,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Rhizosphere bacterial members whose H2-producing gene activity
       decreases under PSY transgenic conditions, contrasting with the
       H2-oxidizing counterparts.

--- a/kb/communities/Panzhihua_Vanadium_Titanium_Tailings.yaml
+++ b/kb/communities/Panzhihua_Vanadium_Titanium_Tailings.yaml
@@ -49,7 +49,7 @@ taxonomy:
     term:
       id: NCBITaxon:280333
       label: Bradyrhizobium pachyrhizi
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Nitrogen-fixing alphaproteobacterium that forms root nodule symbioses with legumes in Panzhihua
       V-Ti magnetite tailings. Bradyrhizobium pachyrhizi is the dominant rhizobial genus in heavy metal
       contaminated tailings soil, comprising twelve of the metal-tolerant isolates from Pongamia pinnata
@@ -90,7 +90,7 @@ taxonomy:
     term:
       id: NCBITaxon:1336235
       label: Paenirhizobium selenitireducens ATCC BAA-1503
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Nitrogen-fixing alphaproteobacterium capable of selenium reduction and heavy metal tolerance,
       isolated from P. pinnata root nodules in V-Ti tailings. Three isolates were identified as R. selenitireducens,
       demonstrating nitrogen-fixing capacity and variable tolerance to Cu, Ni, Mn, and Zn. This species
@@ -127,7 +127,7 @@ taxonomy:
     term:
       id: NCBITaxon:574561
       label: Rhizobium pisi
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Fast-growing nitrogen-fixing rhizobium traditionally associated with pea (Pisum sativum) but
       adapted to form nodules with P. pinnata in V-Ti tailings. One isolate was identified as R. pisi,
       demonstrating the promiscuity of rhizobial-legume associations under metal stress conditions. R.

--- a/kb/communities/Panzhihua_Vanadium_Titanium_Tailings.yaml
+++ b/kb/communities/Panzhihua_Vanadium_Titanium_Tailings.yaml
@@ -49,6 +49,7 @@ taxonomy:
     term:
       id: NCBITaxon:280333
       label: Bradyrhizobium pachyrhizi
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Nitrogen-fixing alphaproteobacterium that forms root nodule symbioses with legumes in Panzhihua
       V-Ti magnetite tailings. Bradyrhizobium pachyrhizi is the dominant rhizobial genus in heavy metal
       contaminated tailings soil, comprising twelve of the metal-tolerant isolates from Pongamia pinnata
@@ -89,6 +90,7 @@ taxonomy:
     term:
       id: NCBITaxon:1336235
       label: Paenirhizobium selenitireducens ATCC BAA-1503
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Nitrogen-fixing alphaproteobacterium capable of selenium reduction and heavy metal tolerance,
       isolated from P. pinnata root nodules in V-Ti tailings. Three isolates were identified as R. selenitireducens,
       demonstrating nitrogen-fixing capacity and variable tolerance to Cu, Ni, Mn, and Zn. This species
@@ -125,6 +127,7 @@ taxonomy:
     term:
       id: NCBITaxon:574561
       label: Rhizobium pisi
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Fast-growing nitrogen-fixing rhizobium traditionally associated with pea (Pisum sativum) but
       adapted to form nodules with P. pinnata in V-Ti tailings. One isolate was identified as R. pisi,
       demonstrating the promiscuity of rhizobial-legume associations under metal stress conditions. R.
@@ -152,6 +155,7 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bacillus
       gtdb_taxon: Bacillus
@@ -199,6 +203,7 @@ taxonomy:
     term:
       id: NCBITaxon:94625
       label: Brucella intermedia
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Ochrobactrum_intermedium
       gtdb_taxon: Ochrobactrum intermedium
@@ -245,6 +250,7 @@ taxonomy:
     term:
       id: NCBITaxon:52972
       label: Polaromonas
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Polaromonas
       gtdb_taxon: Polaromonas

--- a/kb/communities/Parachlorella_Saccharomyces_Mutualistic_Coculture.yaml
+++ b/kb/communities/Parachlorella_Saccharomyces_Mutualistic_Coculture.yaml
@@ -24,7 +24,7 @@ taxonomy:
     term:
       id: NCBITaxon:3074
       label: Parachlorella kessleri
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Green microalga; the lipid-producing partner in the co-culture.
   functional_role:
   - PRIMARY_PRODUCER
@@ -42,7 +42,7 @@ taxonomy:
     term:
       id: NCBITaxon:4932
       label: Saccharomyces cerevisiae
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Yeast partner; consumes glucose and provides CO2 to the microalga.
   functional_role:
   - CROSS_FEEDER

--- a/kb/communities/Parachlorella_Saccharomyces_Mutualistic_Coculture.yaml
+++ b/kb/communities/Parachlorella_Saccharomyces_Mutualistic_Coculture.yaml
@@ -24,6 +24,7 @@ taxonomy:
     term:
       id: NCBITaxon:3074
       label: Parachlorella kessleri
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Green microalga; the lipid-producing partner in the co-culture.
   functional_role:
   - PRIMARY_PRODUCER
@@ -41,6 +42,7 @@ taxonomy:
     term:
       id: NCBITaxon:4932
       label: Saccharomyces cerevisiae
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Yeast partner; consumes glucose and provides CO2 to the microalga.
   functional_role:
   - CROSS_FEEDER

--- a/kb/communities/Peanut_Seed_Bacterial_CS_SynCom.yaml
+++ b/kb/communities/Peanut_Seed_Bacterial_CS_SynCom.yaml
@@ -38,6 +38,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Peanut_Seed_Bacterial_CS_SynCom.yaml
+++ b/kb/communities/Peanut_Seed_Bacterial_CS_SynCom.yaml
@@ -38,7 +38,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.yaml
+++ b/kb/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.yaml
@@ -55,6 +55,7 @@ taxonomy:
     term:
       id: NCBITaxon:110500
       label: Pelotomaculum thermopropionicum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Pelotomaculum_thermopropionicum
       gtdb_taxon: Pelotomaculum thermopropionicum
@@ -84,6 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:1175444
       label: Methanocella conradii
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methanocella_conradii
       gtdb_taxon: Methanocella conradii

--- a/kb/communities/Pelotomaculum_Methanothermobacter_Syntrophy.yaml
+++ b/kb/communities/Pelotomaculum_Methanothermobacter_Syntrophy.yaml
@@ -31,6 +31,7 @@ taxonomy:
     term:
       id: NCBITaxon:110500
       label: Pelotomaculum thermopropionicum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Pelotomaculum_thermopropionicum
       gtdb_taxon: Pelotomaculum thermopropionicum
@@ -66,6 +67,7 @@ taxonomy:
     term:
       id: NCBITaxon:145262
       label: Methanothermobacter thermautotrophicus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methanothermobacter_thermautotrophicus
       gtdb_taxon: Methanothermobacter thermautotrophicus

--- a/kb/communities/Pepper_Growth_Rhizosphere_SynCom.yaml
+++ b/kb/communities/Pepper_Growth_Rhizosphere_SynCom.yaml
@@ -36,6 +36,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Pepper_Growth_Rhizosphere_SynCom.yaml
+++ b/kb/communities/Pepper_Growth_Rhizosphere_SynCom.yaml
@@ -36,7 +36,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Pepper_Phytophthora_SynCom5.yaml
+++ b/kb/communities/Pepper_Phytophthora_SynCom5.yaml
@@ -77,7 +77,7 @@ taxonomy:
     term:
       id: NCBITaxon:1931
       label: Streptomyces sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -87,7 +87,7 @@ taxonomy:
     term:
       id: NCBITaxon:306
       label: Pseudomonas sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Pepper_Phytophthora_SynCom5.yaml
+++ b/kb/communities/Pepper_Phytophthora_SynCom5.yaml
@@ -37,6 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bacillus
       gtdb_taxon: Bacillus
@@ -56,6 +57,7 @@ taxonomy:
     term:
       id: NCBITaxon:237
       label: Flavobacterium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Flavobacterium
       gtdb_taxon: Flavobacterium
@@ -75,6 +77,7 @@ taxonomy:
     term:
       id: NCBITaxon:1931
       label: Streptomyces sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -84,6 +87,7 @@ taxonomy:
     term:
       id: NCBITaxon:306
       label: Pseudomonas sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Phenol_Carboxylation_Consortium.yaml
+++ b/kb/communities/Phenol_Carboxylation_Consortium.yaml
@@ -21,6 +21,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -35,6 +36,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -49,6 +51,7 @@ taxonomy:
     term:
       id: NCBITaxon:885
       label: Desulfovibrio sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: RARE
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -63,6 +66,7 @@ taxonomy:
     term:
       id: NCBITaxon:45200
       label: Methanospirillum sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Phenol_Carboxylation_Consortium.yaml
+++ b/kb/communities/Phenol_Carboxylation_Consortium.yaml
@@ -21,7 +21,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -36,7 +36,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -51,7 +51,7 @@ taxonomy:
     term:
       id: NCBITaxon:885
       label: Desulfovibrio sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: RARE
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -66,7 +66,7 @@ taxonomy:
     term:
       id: NCBITaxon:45200
       label: Methanospirillum sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Phormidium_Alkaline_Consortium.yaml
+++ b/kb/communities/Phormidium_Alkaline_Consortium.yaml
@@ -33,7 +33,7 @@ taxonomy:
     term:
       id: NCBITaxon:1807132
       label: Candidatus Phormidium alkaliphilum
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Filamentous cyanobacterium adapted to extremely alkaline conditions (pH >11). This organism
       is the dominant primary producer in the consortium, representing >80% of the community biomass.
       It fixes CO2 through oxygenic photosynthesis and releases dissolved organic matter that supports
@@ -57,7 +57,7 @@ taxonomy:
     term:
       id: NCBITaxon:1979961
       label: Wenzhouxiangella sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Gammaproteobacterial heterotroph showing tight coupling with cyanobacterial carbon production.
       Wenzhouxiangella demonstrates active carbon assimilation pathways and plays a key role in carbon
       cycling within the consortium. Members of this genus have been found in hypersaline soda lakes and

--- a/kb/communities/Phormidium_Alkaline_Consortium.yaml
+++ b/kb/communities/Phormidium_Alkaline_Consortium.yaml
@@ -33,6 +33,7 @@ taxonomy:
     term:
       id: NCBITaxon:1807132
       label: Candidatus Phormidium alkaliphilum
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Filamentous cyanobacterium adapted to extremely alkaline conditions (pH >11). This organism
       is the dominant primary producer in the consortium, representing >80% of the community biomass.
       It fixes CO2 through oxygenic photosynthesis and releases dissolved organic matter that supports
@@ -56,6 +57,7 @@ taxonomy:
     term:
       id: NCBITaxon:1979961
       label: Wenzhouxiangella sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Gammaproteobacterial heterotroph showing tight coupling with cyanobacterial carbon production.
       Wenzhouxiangella demonstrates active carbon assimilation pathways and plays a key role in carbon
       cycling within the consortium. Members of this genus have been found in hypersaline soda lakes and
@@ -79,6 +81,7 @@ taxonomy:
     term:
       id: NCBITaxon:976
       label: Bacteroidota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Bacteroidota
       gtdb_taxon: Bacteroidota
@@ -111,6 +114,7 @@ taxonomy:
     term:
       id: NCBITaxon:28211
       label: Alphaproteobacteria
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:c__Alphaproteobacteria
       gtdb_taxon: Alphaproteobacteria
@@ -142,6 +146,7 @@ taxonomy:
     term:
       id: NCBITaxon:74201
       label: Verrucomicrobiota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Verrucomicrobiota
       gtdb_taxon: Verrucomicrobiota
@@ -172,6 +177,7 @@ taxonomy:
     term:
       id: NCBITaxon:203682
       label: Planctomycetota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Planctomycetota
       gtdb_taxon: Planctomycetota

--- a/kb/communities/Phosphitivorax_Methanoculleus_Lithosyntrophy_Phosphite_Coculture.yaml
+++ b/kb/communities/Phosphitivorax_Methanoculleus_Lithosyntrophy_Phosphite_Coculture.yaml
@@ -23,6 +23,7 @@ taxonomy:
     term:
       id: NCBITaxon:1918507
       label: Candidatus Phosphitivorax anaerolimi
+    gtdb_grounding_status: GROUNDED
     notes: Strain Phox-21; uncultured Candidatus taxon, grounded at species rank.
     gtdb_classification:
       gtdb_id: GTDB:s__UBA1062_sp001896555
@@ -52,6 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:45989
       label: Methanoculleus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Methanoculleus
       gtdb_taxon: Methanoculleus

--- a/kb/communities/Phylogenetically_Diverse_Denitrifying_SynCom.yaml
+++ b/kb/communities/Phylogenetically_Diverse_Denitrifying_SynCom.yaml
@@ -36,6 +36,7 @@ taxonomy:
     term:
       id: NCBITaxon:22
       label: Shewanella
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Shewanella
       gtdb_taxon: Shewanella
@@ -55,6 +56,10 @@ taxonomy:
     term:
       id: NCBITaxon:266
       label: Paracoccus denitrificans
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Paracoccus denitrificans
+    - Paracoccus sp030388245
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Pinus_armandii_Endophytic_Biocontrol_SynCom.yaml
+++ b/kb/communities/Pinus_armandii_Endophytic_Biocontrol_SynCom.yaml
@@ -24,6 +24,7 @@ taxonomy:
     term:
       id: NCBITaxon:198620
       label: Pseudomonas koreensis
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Strain RC1; one of four multifunctional plant growth-promoting isolates.
   strain_designation:
     strain_name: RC1
@@ -41,6 +42,7 @@ taxonomy:
     term:
       id: NCBITaxon:159743
       label: Paenibacillus terrae
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Strain RE7.
   strain_designation:
     strain_name: RE7
@@ -58,6 +60,7 @@ taxonomy:
     term:
       id: NCBITaxon:492670
       label: Bacillus velezensis
+    gtdb_grounding_status: GROUNDED
     notes: Strain OB3; the two Bacillus velezensis isolates (OB3, NA3) share the same species-level
       NCBITaxon id.
     gtdb_classification:
@@ -85,6 +88,7 @@ taxonomy:
     term:
       id: NCBITaxon:492670
       label: Bacillus velezensis
+    gtdb_grounding_status: GROUNDED
     notes: Strain NA3; the two Bacillus velezensis isolates (OB3, NA3) share the same species-level
       NCBITaxon id.
     gtdb_classification:
@@ -112,6 +116,7 @@ taxonomy:
     term:
       id: NCBITaxon:1423
       label: Bacillus subtilis
+    gtdb_grounding_status: GROUNDED
     notes: Strain NA11.
     gtdb_classification:
       gtdb_id: GTDB:s__Bacillus_subtilis

--- a/kb/communities/Pinus_armandii_Endophytic_Biocontrol_SynCom.yaml
+++ b/kb/communities/Pinus_armandii_Endophytic_Biocontrol_SynCom.yaml
@@ -24,7 +24,7 @@ taxonomy:
     term:
       id: NCBITaxon:198620
       label: Pseudomonas koreensis
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Strain RC1; one of four multifunctional plant growth-promoting isolates.
   strain_designation:
     strain_name: RC1
@@ -42,7 +42,7 @@ taxonomy:
     term:
       id: NCBITaxon:159743
       label: Paenibacillus terrae
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Strain RE7.
   strain_designation:
     strain_name: RE7

--- a/kb/communities/Pleuromutilin_Degrading_Artificial_Consortium_5_Strain.yaml
+++ b/kb/communities/Pleuromutilin_Degrading_Artificial_Consortium_5_Strain.yaml
@@ -28,6 +28,7 @@ taxonomy:
     term:
       id: NCBITaxon:487698
       label: Stenotrophomonas pavanii
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Stenotrophomonas_pavanii
       gtdb_taxon: Stenotrophomonas pavanii
@@ -53,6 +54,19 @@ taxonomy:
     term:
       id: NCBITaxon:40324
       label: Stenotrophomonas maltophilia
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Stenotrophomonas bentonitica_A
+    - Stenotrophomonas geniculata
+    - Stenotrophomonas hibiscicola
+    - Stenotrophomonas indicatrix
+    - Stenotrophomonas maltophilia
+    - Stenotrophomonas maltophilia_AJ
+    - Stenotrophomonas maltophilia_L
+    - Stenotrophomonas muris
+    - Stenotrophomonas nematodicola
+    - Stenotrophomonas sepilia
+    - Stenotrophomonas sp002192255
   functional_role:
   - PRIMARY_DEGRADER
   abundance_value: One of five members of the artificial degradation consortium.
@@ -69,6 +83,12 @@ taxonomy:
     term:
       id: NCBITaxon:1421
       label: Lysinibacillus sphaericus
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Lysinibacillus sp006864135
+    - Lysinibacillus sphaericus
+    - Lysinibacillus sphaericus_A
+    - Lysinibacillus sphaericus_B
   functional_role:
   - PRIMARY_DEGRADER
   abundance_value: One of five members of the artificial degradation consortium.
@@ -85,6 +105,7 @@ taxonomy:
     term:
       id: NCBITaxon:1130819
       label: Lysinibacillus mangiferihumi
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Lysinibacillus_mangiferihumi
       gtdb_taxon: Lysinibacillus mangiferihumi
@@ -110,6 +131,7 @@ taxonomy:
     term:
       id: NCBITaxon:1176259
       label: Pseudomonas songnenensis
+    gtdb_grounding_status: GROUNDED
     notes: GTDB reclassifies this species into genus Stutzerimonas (Stutzerimonas songnenensis).
     gtdb_classification:
       gtdb_id: GTDB:s__Stutzerimonas_songnenensis

--- a/kb/communities/Polaromonas_Vanadium_Reduction_Community.yaml
+++ b/kb/communities/Polaromonas_Vanadium_Reduction_Community.yaml
@@ -43,6 +43,7 @@ taxonomy:
     term:
       id: NCBITaxon:52972
       label: Polaromonas
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Polaromonas
       gtdb_taxon: Polaromonas
@@ -89,6 +90,7 @@ taxonomy:
     term:
       id: NCBITaxon:872
       label: Desulfovibrio
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Desulfovibrio
       gtdb_taxon: Desulfovibrio
@@ -138,6 +140,7 @@ taxonomy:
     term:
       id: NCBITaxon:28232
       label: Geobacter metallireducens
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Geobacter_metallireducens
       gtdb_taxon: Geobacter metallireducens
@@ -187,6 +190,7 @@ taxonomy:
     term:
       id: NCBITaxon:36853
       label: Desulfitobacterium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Desulfitobacterium
       gtdb_taxon: Desulfitobacterium

--- a/kb/communities/Populus_Salt_Tolerant_SynComs.yaml
+++ b/kb/communities/Populus_Salt_Tolerant_SynComs.yaml
@@ -37,6 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Populus_Salt_Tolerant_SynComs.yaml
+++ b/kb/communities/Populus_Salt_Tolerant_SynComs.yaml
@@ -37,7 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.yaml
+++ b/kb/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.yaml
@@ -27,7 +27,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Community-level representation of wetland sediment bacteria and
       archaea profiled by genome-resolved metagenomics.
   functional_role:
@@ -50,7 +50,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Candidate sulfate-reducing microorganisms are represented broadly
       because the study recovered diverse candidate SRB genomes across multiple
       phyla rather than a fixed culture composition.
@@ -74,7 +74,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Methanogens are represented at archaeal domain level because the
       paper reports diverse mcrA sequences and putative methanogen genomes
       across multiple orders.
@@ -98,7 +98,7 @@ taxonomy:
     term:
       id: NCBITaxon:10239
       label: Viruses
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Viral populations are curated as broad wetland sediment viruses
       because most viral populations were novel and unclassified.
   abundance_level: COMMON

--- a/kb/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.yaml
+++ b/kb/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.yaml
@@ -27,6 +27,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Community-level representation of wetland sediment bacteria and
       archaea profiled by genome-resolved metagenomics.
   functional_role:
@@ -49,6 +50,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Candidate sulfate-reducing microorganisms are represented broadly
       because the study recovered diverse candidate SRB genomes across multiple
       phyla rather than a fixed culture composition.
@@ -72,6 +74,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Methanogens are represented at archaeal domain level because the
       paper reports diverse mcrA sequences and putative methanogen genomes
       across multiple orders.
@@ -95,6 +98,7 @@ taxonomy:
     term:
       id: NCBITaxon:10239
       label: Viruses
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Viral populations are curated as broad wetland sediment viruses
       because most viral populations were novel and unclassified.
   abundance_level: COMMON

--- a/kb/communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.yaml
+++ b/kb/communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.yaml
@@ -30,6 +30,7 @@ taxonomy:
     term:
       id: NCBITaxon:561
       label: Escherichia
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Escherichia
       gtdb_taxon: Escherichia

--- a/kb/communities/Prochlorococcus_Alteromonas_Helper_Coculture.yaml
+++ b/kb/communities/Prochlorococcus_Alteromonas_Helper_Coculture.yaml
@@ -39,6 +39,55 @@ taxonomy:
     term:
       id: NCBITaxon:1219
       label: Prochlorococcus marinus
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Prochlorococcus marinus
+    - Prochlorococcus marinus_C
+    - Prochlorococcus_A marinus_A
+    - Prochlorococcus_A marinus_AA
+    - Prochlorococcus_A marinus_AB
+    - Prochlorococcus_A marinus_AC
+    - Prochlorococcus_A marinus_AD
+    - Prochlorococcus_A marinus_AE
+    - Prochlorococcus_A marinus_AF
+    - Prochlorococcus_A marinus_AG
+    - Prochlorococcus_A marinus_AH
+    - Prochlorococcus_A marinus_B
+    - Prochlorococcus_A marinus_D
+    - Prochlorococcus_A marinus_E
+    - Prochlorococcus_A marinus_G
+    - Prochlorococcus_A marinus_H
+    - Prochlorococcus_A marinus_I
+    - Prochlorococcus_A marinus_J
+    - Prochlorococcus_A marinus_L
+    - Prochlorococcus_A marinus_M
+    - Prochlorococcus_A marinus_N
+    - Prochlorococcus_A marinus_O
+    - Prochlorococcus_A marinus_P
+    - Prochlorococcus_A marinus_Q
+    - Prochlorococcus_A marinus_T
+    - Prochlorococcus_A marinus_U
+    - Prochlorococcus_A marinus_V
+    - Prochlorococcus_A marinus_W
+    - Prochlorococcus_A marinus_X
+    - Prochlorococcus_A marinus_Y
+    - Prochlorococcus_A marinus_Z
+    - Prochlorococcus_A pastoris
+    - Prochlorococcus_A sp001989455
+    - Prochlorococcus_A sp002026005
+    - Prochlorococcus_A sp003212755
+    - Prochlorococcus_A sp003213375
+    - Prochlorococcus_A sp003278705
+    - Prochlorococcus_A sp003280965
+    - Prochlorococcus_B marinus_A
+    - Prochlorococcus_B marinus_B
+    - Prochlorococcus_B marinus_C
+    - Prochlorococcus_B marinus_D
+    - Prochlorococcus_B marinus_E
+    - Prochlorococcus_B marinus_F
+    - Prochlorococcus_C marinus_B
+    - Prochlorococcus_D marinus_B
+    - Prochlorococcus_D sp000760175
     notes: Marine cyanobacterium and photosynthetic primary producer used as the helper-dependent phototroph.
   strain_designation:
     strain_name: MIT9312
@@ -61,6 +110,7 @@ taxonomy:
     term:
       id: NCBITaxon:28108
       label: Alteromonas macleodii
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Alteromonas_macleodii
       gtdb_taxon: Alteromonas macleodii

--- a/kb/communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.yaml
+++ b/kb/communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.yaml
@@ -70,6 +70,10 @@ taxonomy:
     term:
       id: NCBITaxon:37919
       label: Rhodococcus opacus
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Rhodococcus opacus
+    - Rhodococcus opacus_C
     notes: Dominant propanotroph in TCE-amended enrichments from agricultural
       soils T2, T3, and T4; MAGs contain group-5 propane monooxygenase
       operon (prmABCD) with consistent flanking-gene architecture.
@@ -89,6 +93,10 @@ taxonomy:
     term:
       id: NCBITaxon:44752
       label: Rhodococcus wratislaviensis
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Rhodococcus opacus
+    - Rhodococcus wratislaviensis
     notes: Second Rhodococcus species identified by MAG analysis in the
       TCE-amended enrichments; flanking-gene order around prmABCD differs from
       R. opacus (downstream adh and adhT, single acoR copy, no COG0277).
@@ -108,6 +116,7 @@ taxonomy:
     term:
       id: NCBITaxon:1866885
       label: Mycolicibacterium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Mycobacterium
       gtdb_taxon: Mycobacterium
@@ -140,6 +149,7 @@ taxonomy:
     term:
       id: NCBITaxon:1763
       label: Mycobacterium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Mycobacterium
       gtdb_taxon: Mycobacterium
@@ -169,6 +179,7 @@ taxonomy:
     term:
       id: NCBITaxon:1847
       label: Pseudonocardia
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Pseudonocardia
       gtdb_taxon: Pseudonocardia
@@ -201,6 +212,7 @@ taxonomy:
     term:
       id: NCBITaxon:2736640
       label: Pseudonocardia broussonetiae
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Pseudonocardia_broussonetiae
       gtdb_taxon: Pseudonocardia broussonetiae
@@ -228,6 +240,7 @@ taxonomy:
     term:
       id: NCBITaxon:316612
       label: Methylibium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Methylibium
       gtdb_taxon: Methylibium
@@ -256,6 +269,7 @@ taxonomy:
     term:
       id: NCBITaxon:119060
       label: Burkholderiaceae
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:f__Burkholderiaceae
       gtdb_taxon: Burkholderiaceae

--- a/kb/communities/Pseudomonas_Pedobacter_Social_Spreading_Coculture.yaml
+++ b/kb/communities/Pseudomonas_Pedobacter_Social_Spreading_Coculture.yaml
@@ -40,6 +40,31 @@ taxonomy:
     term:
       id: NCBITaxon:294
       label: Pseudomonas fluorescens
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Pseudomonas_E alvandae
+    - Pseudomonas_E asgharzadehiana
+    - Pseudomonas_E azotoformans_A
+    - Pseudomonas_E brassicacearum
+    - Pseudomonas_E crudilactis
+    - Pseudomonas_E edaphica
+    - Pseudomonas_E fluorescens
+    - Pseudomonas_E fluorescens_AP
+    - Pseudomonas_E fluorescens_AQ
+    - Pseudomonas_E fluorescens_B
+    - Pseudomonas_E fluorescens_H
+    - Pseudomonas_E fluorescens_S
+    - Pseudomonas_E kilonensis
+    - Pseudomonas_E lactis
+    - Pseudomonas_E lactucae
+    - Pseudomonas_E paracarnis
+    - Pseudomonas_E petroselini
+    - Pseudomonas_E poae
+    - Pseudomonas_E protegens
+    - Pseudomonas_E reactans
+    - Pseudomonas_E salomonii
+    - Pseudomonas_E simiae
+    - Pseudomonas_E sp002874965
     notes: Soil isolate Pf0-1; represented at species level for ontology stability.
   functional_role:
   - CROSS_FEEDER
@@ -60,6 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:84567
       label: Pedobacter
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Pedobacter
       gtdb_taxon: Pedobacter

--- a/kb/communities/Pseudomonas_Rhodococcus_Chloronitrobenzene_Coculture.yaml
+++ b/kb/communities/Pseudomonas_Rhodococcus_Chloronitrobenzene_Coculture.yaml
@@ -51,6 +51,23 @@ taxonomy:
     term:
       id: NCBITaxon:303
       label: Pseudomonas putida
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Pseudomonas_E alloputida
+    - Pseudomonas_E asiatica
+    - Pseudomonas_E fulva
+    - Pseudomonas_E guariconensis
+    - Pseudomonas_E juntendi
+    - Pseudomonas_E monteilii
+    - Pseudomonas_E pudica
+    - Pseudomonas_E putida
+    - Pseudomonas_E putida_E
+    - Pseudomonas_E putida_H
+    - Pseudomonas_E putida_K
+    - Pseudomonas_E putida_P
+    - Pseudomonas_E putida_Q
+    - Pseudomonas_E putida_R
+    - Pseudomonas_E putida_Y
     notes: Nitrobenzene-enriched partner that converts 3- and 4-chloronitrobenzene to chlorohydroxyacetanilide
       intermediates.
   strain_designation:
@@ -73,6 +90,7 @@ taxonomy:
     term:
       id: NCBITaxon:1827
       label: Rhodococcus <high G+C Gram-positive bacteria>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Rhodococcus
       gtdb_taxon: Rhodococcus

--- a/kb/communities/Pseudomonas_putida_PpTE_Rhodococcus_RDK17_Terephthalic_Acid_Consortium.yaml
+++ b/kb/communities/Pseudomonas_putida_PpTE_Rhodococcus_RDK17_Terephthalic_Acid_Consortium.yaml
@@ -25,6 +25,23 @@ taxonomy:
     term:
       id: NCBITaxon:303
       label: Pseudomonas putida
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Pseudomonas_E alloputida
+    - Pseudomonas_E asiatica
+    - Pseudomonas_E fulva
+    - Pseudomonas_E guariconensis
+    - Pseudomonas_E juntendi
+    - Pseudomonas_E monteilii
+    - Pseudomonas_E pudica
+    - Pseudomonas_E putida
+    - Pseudomonas_E putida_E
+    - Pseudomonas_E putida_H
+    - Pseudomonas_E putida_K
+    - Pseudomonas_E putida_P
+    - Pseudomonas_E putida_Q
+    - Pseudomonas_E putida_R
+    - Pseudomonas_E putida_Y
     notes: Engineered TPA degrader, strain Pp-TE.
   strain_designation:
     strain_name: Pp-TE
@@ -44,6 +61,7 @@ taxonomy:
     term:
       id: NCBITaxon:1827
       label: Rhodococcus <high G+C Gram-positive bacteria>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Rhodococcus
       gtdb_taxon: Rhodococcus

--- a/kb/communities/Pseudomonas_stutzeri_Rhodococcus_Naphthalene_Biochar_Engineered_Consortium.yaml
+++ b/kb/communities/Pseudomonas_stutzeri_Rhodococcus_Naphthalene_Biochar_Engineered_Consortium.yaml
@@ -27,6 +27,18 @@ taxonomy:
     term:
       id: NCBITaxon:316
       label: Stutzerimonas stutzeri
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Stutzerimonas nitrititolerans
+    - Stutzerimonas stutzeri
+    - Stutzerimonas stutzeri_AC
+    - Stutzerimonas stutzeri_AE
+    - Stutzerimonas stutzeri_AI
+    - Stutzerimonas stutzeri_B
+    - Stutzerimonas stutzeri_C
+    - Stutzerimonas stutzeri_G
+    - Stutzerimonas stutzeri_H
+    - Stutzerimonas stutzeri_U
     notes: Source paper uses "Pseudomonas stutzeri"; NCBITaxon canonical label is "Stutzerimonas
       stutzeri" (reclassified genus). Engineered strain overexpressing nahAc and nahB.
   functional_role:
@@ -46,6 +58,7 @@ taxonomy:
     term:
       id: NCBITaxon:1827
       label: Rhodococcus <high G+C Gram-positive bacteria>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Rhodococcus
       gtdb_taxon: Rhodococcus

--- a/kb/communities/Pseudonitzschia_Sulfitobacter_Association.yaml
+++ b/kb/communities/Pseudonitzschia_Sulfitobacter_Association.yaml
@@ -21,7 +21,7 @@ taxonomy:
     term:
       id: NCBITaxon:37319
       label: Pseudo-nitzschia multiseries
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_PRODUCER
@@ -36,7 +36,7 @@ taxonomy:
     term:
       id: NCBITaxon:1546519
       label: Sulfitobacter sp. SA11
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Pseudonitzschia_Sulfitobacter_Association.yaml
+++ b/kb/communities/Pseudonitzschia_Sulfitobacter_Association.yaml
@@ -21,6 +21,7 @@ taxonomy:
     term:
       id: NCBITaxon:37319
       label: Pseudo-nitzschia multiseries
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_PRODUCER
@@ -35,6 +36,7 @@ taxonomy:
     term:
       id: NCBITaxon:1546519
       label: Sulfitobacter sp. SA11
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Rammelsberg_Cobalt_Nickel_Tailings.yaml
+++ b/kb/communities/Rammelsberg_Cobalt_Nickel_Tailings.yaml
@@ -59,6 +59,7 @@ taxonomy:
     term:
       id: NCBITaxon:920
       label: Acidithiobacillus ferrooxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidithiobacillus_ferrooxidans
       gtdb_taxon: Acidithiobacillus ferrooxidans
@@ -104,6 +105,7 @@ taxonomy:
     term:
       id: NCBITaxon:930
       label: Acidithiobacillus thiooxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidithiobacillus_thiooxidans
       gtdb_taxon: Acidithiobacillus thiooxidans

--- a/kb/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.yaml
+++ b/kb/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.yaml
@@ -36,6 +36,13 @@ taxonomy:
     term:
       id: NCBITaxon:1076
       label: Rhodopseudomonas palustris
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Rhodopseudomonas palustris_C
+    - Rhodopseudomonas palustris_F
+    - Rhodopseudomonas palustris_G
+    - Rhodopseudomonas palustris_J
+    - Rhodopseudomonas pseudopalustris
   functional_role:
   - PRIMARY_PRODUCER
   evidence:
@@ -45,6 +52,7 @@ taxonomy:
     term:
       id: NCBITaxon:562
       label: Escherichia coli
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Escherichia_coli
       gtdb_taxon: Escherichia coli

--- a/kb/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.yaml
+++ b/kb/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.yaml
@@ -54,6 +54,7 @@ taxonomy:
     term:
       id: NCBITaxon:395960
       label: Rhodopseudomonas palustris TIE-1
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Rhodopseudomonas_palustris_F
       gtdb_taxon: Rhodopseudomonas palustris_F
@@ -84,6 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:35554
       label: Geobacter sulfurreducens
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Geobacter_sulfurreducens
       gtdb_taxon: Geobacter sulfurreducens

--- a/kb/communities/Rice_Acid_Soil_Bioinoculant_SynCom.yaml
+++ b/kb/communities/Rice_Acid_Soil_Bioinoculant_SynCom.yaml
@@ -36,6 +36,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Rice_Acid_Soil_Bioinoculant_SynCom.yaml
+++ b/kb/communities/Rice_Acid_Soil_Bioinoculant_SynCom.yaml
@@ -36,7 +36,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Rice_Duckweed_Bacillus_SynCom.yaml
+++ b/kb/communities/Rice_Duckweed_Bacillus_SynCom.yaml
@@ -45,6 +45,7 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bacillus
       gtdb_taxon: Bacillus
@@ -72,6 +73,7 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bacillus
       gtdb_taxon: Bacillus
@@ -98,6 +100,7 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bacillus
       gtdb_taxon: Bacillus
@@ -124,6 +127,7 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bacillus
       gtdb_taxon: Bacillus

--- a/kb/communities/Rice_P_Uptake_Intercropping_SynCom4.yaml
+++ b/kb/communities/Rice_P_Uptake_Intercropping_SynCom4.yaml
@@ -37,6 +37,13 @@ taxonomy:
     term:
       id: NCBITaxon:34073
       label: Variovorax paradoxus
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Variovorax paradoxus
+    - Variovorax paradoxus_A
+    - Variovorax paradoxus_C
+    - Variovorax paradoxus_E
+    - Variovorax sp900115375
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -46,6 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:48936
       label: Novosphingobium subterraneum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Novosphingobium_subterraneum
       gtdb_taxon: Novosphingobium subterraneum
@@ -64,6 +72,7 @@ taxonomy:
     term:
       id: NCBITaxon:47421
       label: Hydrogenophaga pseudoflava
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Hydrogenophaga_pseudoflava
       gtdb_taxon: Hydrogenophaga pseudoflava
@@ -82,6 +91,7 @@ taxonomy:
     term:
       id: NCBITaxon:12916
       label: Acidovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Acidovorax
       gtdb_taxon: Acidovorax

--- a/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
+++ b/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
@@ -40,6 +40,7 @@ taxonomy:
     term:
       id: NCBITaxon:419541
       label: Leptospirillum sp. Group II '5-way CG'
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Chemolithoautotrophic iron-oxidizing bacterium representing the dominant
       member of the Richmond Mine biofilm community. Group II Leptospirillum (including
       "Leptospirillum rubarum") comprises 71% of detected 16S rRNA clones in thick
@@ -69,6 +70,7 @@ taxonomy:
     term:
       id: NCBITaxon:97393
       label: Ferroplasma acidarmanus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Ferroplasma_acidarmanus
       gtdb_taxon: Ferroplasma acidarmanus
@@ -112,6 +114,7 @@ taxonomy:
     term:
       id: NCBITaxon:412449
       label: Leptospirillum ferrodiazotrophum
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Leptospirillum group III represents the only nitrogen-fixing member of
       the Leptospirillum clade, making it a keystone species in nitrogen-limited AMD
       ecosystems. This chemolithoautotroph oxidizes ferrous iron while fixing atmospheric
@@ -145,6 +148,7 @@ taxonomy:
     term:
       id: NCBITaxon:920
       label: Acidithiobacillus ferrooxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidithiobacillus_ferrooxidans
       gtdb_taxon: Acidithiobacillus ferrooxidans
@@ -186,6 +190,7 @@ taxonomy:
     term:
       id: NCBITaxon:1801631
       label: Microcaldota
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Ultra-small archaea (200-400 nm diameter) with extremely reduced genomes
       (~1 Mb) discovered in Richmond Mine biofilms. ARMAN-1 and ARMAN-2 belong to
       Micrarchaeota phylum. These nanoorganisms possess complete TCA cycles, aerobic
@@ -220,6 +225,7 @@ taxonomy:
     term:
       id: NCBITaxon:1462422
       label: Candidatus Parvarchaeota
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Ultra-small archaea (ARMAN-4 and ARMAN-5) belonging to Parvarchaeota phylum,
       limited to AMD and hot spring habitats. These nanoorganisms have genomes ~1
       Mb with 80-90% completeness. Despite small size, they contribute to carbon and

--- a/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
+++ b/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
@@ -40,7 +40,7 @@ taxonomy:
     term:
       id: NCBITaxon:419541
       label: Leptospirillum sp. Group II '5-way CG'
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Chemolithoautotrophic iron-oxidizing bacterium representing the dominant
       member of the Richmond Mine biofilm community. Group II Leptospirillum (including
       "Leptospirillum rubarum") comprises 71% of detected 16S rRNA clones in thick
@@ -114,7 +114,7 @@ taxonomy:
     term:
       id: NCBITaxon:412449
       label: Leptospirillum ferrodiazotrophum
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Leptospirillum group III represents the only nitrogen-fixing member of
       the Leptospirillum clade, making it a keystone species in nitrogen-limited AMD
       ecosystems. This chemolithoautotroph oxidizes ferrous iron while fixing atmospheric
@@ -190,7 +190,7 @@ taxonomy:
     term:
       id: NCBITaxon:1801631
       label: Microcaldota
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Ultra-small archaea (200-400 nm diameter) with extremely reduced genomes
       (~1 Mb) discovered in Richmond Mine biofilms. ARMAN-1 and ARMAN-2 belong to
       Micrarchaeota phylum. These nanoorganisms possess complete TCA cycles, aerobic
@@ -225,7 +225,7 @@ taxonomy:
     term:
       id: NCBITaxon:1462422
       label: Candidatus Parvarchaeota
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Ultra-small archaea (ARMAN-4 and ARMAN-5) belonging to Parvarchaeota phylum,
       limited to AMD and hot spring habitats. These nanoorganisms have genomes ~1
       Mb with 80-90% completeness. Despite small size, they contribute to carbon and

--- a/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
+++ b/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
@@ -55,6 +55,7 @@ taxonomy:
     term:
       id: NCBITaxon:28231
       label: Geobacter
+    gtdb_grounding_status: NOT_ATTEMPTED
     notes: Dominant electrode-attached organism encoding at least 72 putative
       multiheme c-type cytochromes.
   abundance_level: DOMINANT
@@ -73,6 +74,7 @@ taxonomy:
     term:
       id: NCBITaxon:201174
       label: Actinomycetota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Actinomycetota
       gtdb_taxon: Actinomycetota
@@ -98,6 +100,7 @@ taxonomy:
     term:
       id: NCBITaxon:1134404
       label: Ignavibacteriota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Bacteroidota
       gtdb_taxon: Bacteroidota
@@ -121,6 +124,7 @@ taxonomy:
     term:
       id: NCBITaxon:200795
       label: Chloroflexota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Chloroflexota
       gtdb_taxon: Chloroflexota
@@ -144,6 +148,7 @@ taxonomy:
     term:
       id: NCBITaxon:57723
       label: Acidobacteriota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Acidobacteriota
       gtdb_taxon: Acidobacteriota
@@ -167,6 +172,7 @@ taxonomy:
     term:
       id: NCBITaxon:1239
       label: Bacillota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Bacillota_A
       gtdb_taxon: Bacillota_A
@@ -190,6 +196,7 @@ taxonomy:
     term:
       id: NCBITaxon:1224
       label: Pseudomonadota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Pseudomonadota
       gtdb_taxon: Pseudomonadota

--- a/kb/communities/Rifle_Uranium_Reducing_Community.yaml
+++ b/kb/communities/Rifle_Uranium_Reducing_Community.yaml
@@ -37,6 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:28232
       label: Geobacter metallireducens
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Geobacter_metallireducens
       gtdb_taxon: Geobacter metallireducens
@@ -78,6 +79,10 @@ taxonomy:
     term:
       id: NCBITaxon:161493
       label: Anaeromyxobacter dehalogenans
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Anaeromyxobacter dehalogenans
+    - Anaeromyxobacter dehalogenans_B
     notes: 'Deltaproteobacterium capable of reducing U(VI) to U(IV) using hydrogen as electron donor (fumarate-grown
       cells). Unlike Geobacter, Anaeromyxobacter cannot use acetate directly for U(VI) reduction but requires
       hydrogen. At the Rifle site, this organism contributes to uranium immobilization during biostimulation.
@@ -109,6 +114,7 @@ taxonomy:
     term:
       id: NCBITaxon:881
       label: Nitratidesulfovibrio vulgaris
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Nitratidesulfovibrio_vulgaris
       gtdb_taxon: Nitratidesulfovibrio vulgaris
@@ -143,6 +149,7 @@ taxonomy:
     term:
       id: NCBITaxon:79206
       label: Desulfosporosinus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Desulfosporosinus
       gtdb_taxon: Desulfosporosinus
@@ -189,6 +196,7 @@ taxonomy:
     term:
       id: NCBITaxon:213118
       label: Desulfobacterales
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:o__Desulfobacterales
       gtdb_taxon: Desulfobacterales

--- a/kb/communities/SF356_Cellulose_Degrader.yaml
+++ b/kb/communities/SF356_Cellulose_Degrader.yaml
@@ -23,6 +23,7 @@ taxonomy:
     term:
       id: NCBITaxon:253314
       label: Acetivibrio straminisolvens
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Hungateiclostridium_straminisolvens
       gtdb_taxon: Hungateiclostridium straminisolvens
@@ -50,6 +51,7 @@ taxonomy:
     term:
       id: NCBITaxon:319464
       label: Clostridium sp. FG4
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: COMMON
   functional_role:
   - PRIMARY_DEGRADER
@@ -68,6 +70,7 @@ taxonomy:
     term:
       id: NCBITaxon:118669
       label: Pseudoxanthomonas sp. M1-3
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -83,6 +86,7 @@ taxonomy:
     term:
       id: NCBITaxon:55080
       label: Brevibacillus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Brevibacillus
       gtdb_taxon: Brevibacillus
@@ -108,6 +112,7 @@ taxonomy:
     term:
       id: NCBITaxon:118667
       label: Bordetella sp. M1-6
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/SF356_Cellulose_Degrader.yaml
+++ b/kb/communities/SF356_Cellulose_Degrader.yaml
@@ -51,7 +51,7 @@ taxonomy:
     term:
       id: NCBITaxon:319464
       label: Clostridium sp. FG4
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: COMMON
   functional_role:
   - PRIMARY_DEGRADER
@@ -70,7 +70,7 @@ taxonomy:
     term:
       id: NCBITaxon:118669
       label: Pseudoxanthomonas sp. M1-3
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -112,7 +112,7 @@ taxonomy:
     term:
       id: NCBITaxon:118667
       label: Bordetella sp. M1-6
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: COMMON
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/SIHUMIx_Human_Intestinal_Model_Community.yaml
+++ b/kb/communities/SIHUMIx_Human_Intestinal_Model_Community.yaml
@@ -41,6 +41,7 @@ taxonomy:
     term:
       id: NCBITaxon:105841
       label: Anaerostipes caccae
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Anaerostipes_caccae
       gtdb_taxon: Anaerostipes caccae
@@ -70,6 +71,7 @@ taxonomy:
     term:
       id: NCBITaxon:818
       label: Bacteroides thetaiotaomicron
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bacteroides_thetaiotaomicron
       gtdb_taxon: Bacteroides thetaiotaomicron
@@ -99,6 +101,10 @@ taxonomy:
     term:
       id: NCBITaxon:216816
       label: Bifidobacterium longum
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Bifidobacterium infantis
+    - Bifidobacterium longum
     notes: Actinobacterial gut member included in SIHUMIx.
   strain_designation:
     strain_name: NCC 2705
@@ -116,6 +122,7 @@ taxonomy:
     term:
       id: NCBITaxon:33035
       label: Blautia producta
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Blautia_coccoides
       gtdb_taxon: Blautia coccoides
@@ -145,6 +152,7 @@ taxonomy:
     term:
       id: NCBITaxon:1492
       label: Clostridium butyricum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Clostridium_butyricum
       gtdb_taxon: Clostridium butyricum
@@ -174,6 +182,7 @@ taxonomy:
     term:
       id: NCBITaxon:1547
       label: Thomasclavelia ramosa
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Thomasclavelia_ramosa
       gtdb_taxon: Thomasclavelia ramosa
@@ -204,6 +213,7 @@ taxonomy:
     term:
       id: NCBITaxon:511145
       label: Escherichia coli str. K-12 substr. MG1655
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Escherichia_coli
       gtdb_taxon: Escherichia coli
@@ -230,6 +240,7 @@ taxonomy:
     term:
       id: NCBITaxon:1590
       label: Lactiplantibacillus plantarum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Lactiplantibacillus_plantarum
       gtdb_taxon: Lactiplantibacillus plantarum

--- a/kb/communities/SMutans_CAlbicans_ECC_Biofilm.yaml
+++ b/kb/communities/SMutans_CAlbicans_ECC_Biofilm.yaml
@@ -71,7 +71,7 @@ taxonomy:
     term:
       id: NCBITaxon:5476
       label: Candida albicans
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   evidence:
   - reference: PMID:24566629
     supports: SUPPORT

--- a/kb/communities/SMutans_CAlbicans_ECC_Biofilm.yaml
+++ b/kb/communities/SMutans_CAlbicans_ECC_Biofilm.yaml
@@ -48,6 +48,7 @@ taxonomy:
     term:
       id: NCBITaxon:1309
       label: Streptococcus mutans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Streptococcus_mutans
       gtdb_taxon: Streptococcus mutans
@@ -70,6 +71,7 @@ taxonomy:
     term:
       id: NCBITaxon:5476
       label: Candida albicans
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   evidence:
   - reference: PMID:24566629
     supports: SUPPORT

--- a/kb/communities/SMutans_SSputigena_ECC_Pathobiont.yaml
+++ b/kb/communities/SMutans_SSputigena_ECC_Pathobiont.yaml
@@ -52,6 +52,7 @@ taxonomy:
     term:
       id: NCBITaxon:1309
       label: Streptococcus mutans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Streptococcus_mutans
       gtdb_taxon: Streptococcus mutans
@@ -74,6 +75,7 @@ taxonomy:
     term:
       id: NCBITaxon:69823
       label: Selenomonas sputigena
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Selenomonas_sp905372355
       gtdb_taxon: Selenomonas sp905372355

--- a/kb/communities/SMutans_VParvula_ASC_Biofilm.yaml
+++ b/kb/communities/SMutans_VParvula_ASC_Biofilm.yaml
@@ -52,6 +52,7 @@ taxonomy:
     term:
       id: NCBITaxon:1309
       label: Streptococcus mutans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Streptococcus_mutans
       gtdb_taxon: Streptococcus mutans
@@ -75,6 +76,7 @@ taxonomy:
     term:
       id: NCBITaxon:29466
       label: Veillonella parvula
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Veillonella_parvula_A
       gtdb_taxon: Veillonella parvula_A

--- a/kb/communities/SPRUCE_Peatland_Methane_Cycling_Community.yaml
+++ b/kb/communities/SPRUCE_Peatland_Methane_Cycling_Community.yaml
@@ -22,6 +22,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: The 2025 metagenomic and metatranscriptomic analysis reports Candidatus Methanoflorens as the
       dominant active methanogen at the SPRUCE bog surface.
   functional_role:
@@ -40,6 +41,7 @@ taxonomy:
     term:
       id: NCBITaxon:57723
       label: Acidobacteriota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Acidobacteriota
       gtdb_taxon: Acidobacteriota
@@ -66,6 +68,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Deep peat MAGs include acetogenic bacteria with Wood-Ljungdahl pathway potential and high acetate
       concentrations, linking primary fermentation products to methanogenesis.
   functional_role:

--- a/kb/communities/SPRUCE_Peatland_Methane_Cycling_Community.yaml
+++ b/kb/communities/SPRUCE_Peatland_Methane_Cycling_Community.yaml
@@ -22,7 +22,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: The 2025 metagenomic and metatranscriptomic analysis reports Candidatus Methanoflorens as the
       dominant active methanogen at the SPRUCE bog surface.
   functional_role:
@@ -68,7 +68,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Deep peat MAGs include acetogenic bacteria with Wood-Ljungdahl pathway potential and high acetate
       concentrations, linking primary fermentation products to methanogenesis.
   functional_role:

--- a/kb/communities/SPRUCE_Peatland_Warming_Community.yaml
+++ b/kb/communities/SPRUCE_Peatland_Warming_Community.yaml
@@ -20,7 +20,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Bacterial communities characterized by 16S rRNA amplicon sequencing. Warming promotes chemoorganoheterotrophic bacteria in root zones, particularly those involved in carbon metabolism and organic matter decomposition. Key phyla include Proteobacteria, Acidobacteria, Actinobacteria, and Verrucomicrobia. Bacterial community composition correlates with peat depth, water content, and plant root traits (specific root length, root diameter, tissue chemistry).
 
       '
@@ -40,7 +40,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Archaeal communities present in anoxic peat layers, likely including methanogens given the methanogenesis activity in the system. Characterized through 16S rRNA amplicon sequencing alongside bacteria.
 
       '
@@ -59,7 +59,7 @@ taxonomy:
     term:
       id: NCBITaxon:4751
       label: Fungi
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Fungal communities characterized by ITS amplicon sequencing. Two major functional guilds show divergent climate responses: (1) Saprophytic fungi increase under warming, promoting organic matter decomposition in root zones; (2) Ectomycorrhizal (ECM) fungi increase under elevated CO2, forming enhanced associations with tree roots (Picea mariana). ECM fungi under eCO2 employ short-distance exploration strategies, preferentially accessing labile nitrogen pools in soil. This functional differentiation has critical implications for carbon and nutrient cycling under climate change. Warming-enhanced saprotrophs accelerate carbon mineralization, while eCO2-enhanced ECM fungi improve plant nutrient acquisition and potentially enhance carbon sequestration through plant-microbe symbiosis.
 
       '
@@ -84,7 +84,7 @@ taxonomy:
     term:
       id: NCBITaxon:10239
       label: Viruses
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Viral communities (viromes) extensively characterized, recovering 4,326 viral operational taxonomic units (vOTUs). Viral community composition correlated significantly with peat depth, water content, and carbon chemistry (methane and CO2 concentrations), but not with temperature during the first 2 years of warming. Viruses exhibit strong niche partitioning: aquatic-like viruses enriched in waterlogged surface peat, while terrestrial viruses dominate deeper zones. No marine or freshwater vOTUs detected, confirming terrestrial specialization. Predicted viral hosts show narrow ranges (generally within a single bacterial genus), suggesting limited host flexibility. Virome enrichment recovered 32x more vOTUs per sample than total metagenomes, demonstrating utility of viral particle concentration methods for soil virome research.
 
       '

--- a/kb/communities/SPRUCE_Peatland_Warming_Community.yaml
+++ b/kb/communities/SPRUCE_Peatland_Warming_Community.yaml
@@ -20,6 +20,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Bacterial communities characterized by 16S rRNA amplicon sequencing. Warming promotes chemoorganoheterotrophic bacteria in root zones, particularly those involved in carbon metabolism and organic matter decomposition. Key phyla include Proteobacteria, Acidobacteria, Actinobacteria, and Verrucomicrobia. Bacterial community composition correlates with peat depth, water content, and plant root traits (specific root length, root diameter, tissue chemistry).
 
       '
@@ -39,6 +40,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Archaeal communities present in anoxic peat layers, likely including methanogens given the methanogenesis activity in the system. Characterized through 16S rRNA amplicon sequencing alongside bacteria.
 
       '
@@ -57,6 +59,7 @@ taxonomy:
     term:
       id: NCBITaxon:4751
       label: Fungi
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Fungal communities characterized by ITS amplicon sequencing. Two major functional guilds show divergent climate responses: (1) Saprophytic fungi increase under warming, promoting organic matter decomposition in root zones; (2) Ectomycorrhizal (ECM) fungi increase under elevated CO2, forming enhanced associations with tree roots (Picea mariana). ECM fungi under eCO2 employ short-distance exploration strategies, preferentially accessing labile nitrogen pools in soil. This functional differentiation has critical implications for carbon and nutrient cycling under climate change. Warming-enhanced saprotrophs accelerate carbon mineralization, while eCO2-enhanced ECM fungi improve plant nutrient acquisition and potentially enhance carbon sequestration through plant-microbe symbiosis.
 
       '
@@ -81,6 +84,7 @@ taxonomy:
     term:
       id: NCBITaxon:10239
       label: Viruses
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Viral communities (viromes) extensively characterized, recovering 4,326 viral operational taxonomic units (vOTUs). Viral community composition correlated significantly with peat depth, water content, and carbon chemistry (methane and CO2 concentrations), but not with temperature during the first 2 years of warming. Viruses exhibit strong niche partitioning: aquatic-like viruses enriched in waterlogged surface peat, while terrestrial viruses dominate deeper zones. No marine or freshwater vOTUs detected, confirming terrestrial specialization. Predicted viral hosts show narrow ranges (generally within a single bacterial genus), suggesting limited host flexibility. Virome enrichment recovered 32x more vOTUs per sample than total metagenomes, demonstrating utility of viral particle concentration methods for soil virome research.
 
       '

--- a/kb/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.yaml
+++ b/kb/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.yaml
@@ -92,6 +92,7 @@ taxonomy:
     term:
       id: NCBITaxon:1236
       label: Gammaproteobacteria
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:c__Gammaproteobacteria
       gtdb_taxon: Gammaproteobacteria
@@ -126,6 +127,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: The record keeps the anammox guild taxonomically broad because the cited model uses hzo gene
       profiles and process rates rather than a named organism in the quoted text.
   functional_role:
@@ -143,6 +145,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Nitrous oxide reducers are kept as unidentified bacteria because the study inferred a separate
       nosZ-containing niche not assigned to SUP05 in the quoted text.
   functional_role:

--- a/kb/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.yaml
+++ b/kb/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.yaml
@@ -127,7 +127,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: The record keeps the anammox guild taxonomically broad because the cited model uses hzo gene
       profiles and process rates rather than a named organism in the quoted text.
   functional_role:
@@ -145,7 +145,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Nitrous oxide reducers are kept as unidentified bacteria because the study inferred a separate
       nosZ-containing niche not assigned to SUP05 in the quoted text.
   functional_role:

--- a/kb/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.yaml
+++ b/kb/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.yaml
@@ -52,7 +52,7 @@ taxonomy:
     term:
       id: NCBITaxon:4932
       label: Saccharomyces cerevisiae
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Engineered strain producing lactic acid as the target product from
       lignocellulosic hydrolysate sugars.
   functional_role:

--- a/kb/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.yaml
+++ b/kb/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.yaml
@@ -52,6 +52,7 @@ taxonomy:
     term:
       id: NCBITaxon:4932
       label: Saccharomyces cerevisiae
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Engineered strain producing lactic acid as the target product from
       lignocellulosic hydrolysate sugars.
   functional_role:
@@ -70,6 +71,7 @@ taxonomy:
     term:
       id: NCBITaxon:202950
       label: Acinetobacter baylyi
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acinetobacter_baylyi
       gtdb_taxon: Acinetobacter baylyi

--- a/kb/communities/Saccharomyces_Chlamydomonas_Fungal_Algal_Mutualism.yaml
+++ b/kb/communities/Saccharomyces_Chlamydomonas_Fungal_Algal_Mutualism.yaml
@@ -43,7 +43,7 @@ taxonomy:
     term:
       id: NCBITaxon:4932
       label: Saccharomyces cerevisiae
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Budding yeast model organism used as the fungal partner in the engineered mutualism.
   functional_role:
   - CROSS_FEEDER
@@ -59,7 +59,7 @@ taxonomy:
     term:
       id: NCBITaxon:3055
       label: Chlamydomonas reinhardtii
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Green algal model organism used as the photosynthetic partner in the engineered mutualism.
   functional_role:
   - PRIMARY_PRODUCER

--- a/kb/communities/Saccharomyces_Chlamydomonas_Fungal_Algal_Mutualism.yaml
+++ b/kb/communities/Saccharomyces_Chlamydomonas_Fungal_Algal_Mutualism.yaml
@@ -43,6 +43,7 @@ taxonomy:
     term:
       id: NCBITaxon:4932
       label: Saccharomyces cerevisiae
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Budding yeast model organism used as the fungal partner in the engineered mutualism.
   functional_role:
   - CROSS_FEEDER
@@ -58,6 +59,7 @@ taxonomy:
     term:
       id: NCBITaxon:3055
       label: Chlamydomonas reinhardtii
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Green algal model organism used as the photosynthetic partner in the engineered mutualism.
   functional_role:
   - PRIMARY_PRODUCER

--- a/kb/communities/Salar_Atacama_Lithium_Brine_Community.yaml
+++ b/kb/communities/Salar_Atacama_Lithium_Brine_Community.yaml
@@ -37,6 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:1377992
       label: Halovenus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Halovenus
       gtdb_taxon: Halovenus
@@ -76,6 +77,7 @@ taxonomy:
     term:
       id: NCBITaxon:63743
       label: Natronomonas
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Natronomonas
       gtdb_taxon: Natronomonas
@@ -110,6 +112,7 @@ taxonomy:
     term:
       id: NCBITaxon:2237
       label: Haloarcula
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Haloarcula
       gtdb_taxon: Haloarcula
@@ -143,6 +146,7 @@ taxonomy:
     term:
       id: NCBITaxon:2239
       label: Halobacterium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Halobacterium
       gtdb_taxon: Halobacterium
@@ -176,6 +180,7 @@ taxonomy:
     term:
       id: NCBITaxon:146918
       label: Salinibacter
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Salinibacter
       gtdb_taxon: Salinibacter
@@ -211,6 +216,7 @@ taxonomy:
     term:
       id: NCBITaxon:90964
       label: Staphylococcaceae
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:f__Staphylococcaceae
       gtdb_taxon: Staphylococcaceae

--- a/kb/communities/Shewanella_Denitrifying_Richness_SynComs.yaml
+++ b/kb/communities/Shewanella_Denitrifying_Richness_SynComs.yaml
@@ -35,6 +35,7 @@ taxonomy:
     term:
       id: NCBITaxon:22
       label: Shewanella
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Shewanella
       gtdb_taxon: Shewanella

--- a/kb/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.yaml
+++ b/kb/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.yaml
@@ -59,6 +59,7 @@ taxonomy:
     term:
       id: NCBITaxon:70863
       label: Shewanella oneidensis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Shewanella_oneidensis
       gtdb_taxon: Shewanella oneidensis
@@ -90,6 +91,7 @@ taxonomy:
     term:
       id: NCBITaxon:35554
       label: Geobacter sulfurreducens
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Geobacter_sulfurreducens
       gtdb_taxon: Geobacter sulfurreducens
@@ -122,6 +124,7 @@ taxonomy:
     term:
       id: NCBITaxon:28232
       label: Geobacter metallireducens
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Geobacter_metallireducens
       gtdb_taxon: Geobacter metallireducens

--- a/kb/communities/Shewanella_Pseudomonas_Fe0_Electrosyntrophic_Denitrifying_Consortium.yaml
+++ b/kb/communities/Shewanella_Pseudomonas_Fe0_Electrosyntrophic_Denitrifying_Consortium.yaml
@@ -24,6 +24,7 @@ taxonomy:
     term:
       id: NCBITaxon:70863
       label: Shewanella oneidensis
+    gtdb_grounding_status: GROUNDED
     notes: Electroactive microorganism; harvests electrons from Fe0 biocorrosion via CymA-OmcA-MtrC
       complexes.
     gtdb_classification:
@@ -57,6 +58,7 @@ taxonomy:
     term:
       id: NCBITaxon:287
       label: Pseudomonas aeruginosa
+    gtdb_grounding_status: GROUNDED
     notes: Denitrifier; accepts electrons for nitrate reduction.
     gtdb_classification:
       gtdb_id: GTDB:s__Pseudomonas_aeruginosa

--- a/kb/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.yaml
+++ b/kb/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.yaml
@@ -51,6 +51,7 @@ taxonomy:
     term:
       id: NCBITaxon:211586
       label: Shewanella oneidensis MR-1
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Shewanella_oneidensis
       gtdb_taxon: Shewanella oneidensis
@@ -82,6 +83,11 @@ taxonomy:
     term:
       id: NCBITaxon:1335
       label: Streptococcus equinus
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Streptococcus equinus
+    - Streptococcus pasteurianus
+    - Streptococcus ruminicola
     notes: The publication names Streptococcus bovis 148; NCBI Taxonomy currently
       resolves the searched Streptococcus bovis name to Streptococcus equinus.
   strain_designation:

--- a/kb/communities/Shewanella_oneidensis_Rhodopseudomonas_palustris_Electrosyntrophic_Coculture.yaml
+++ b/kb/communities/Shewanella_oneidensis_Rhodopseudomonas_palustris_Electrosyntrophic_Coculture.yaml
@@ -24,6 +24,7 @@ taxonomy:
     term:
       id: NCBITaxon:70863
       label: Shewanella oneidensis
+    gtdb_grounding_status: GROUNDED
     notes: Strain MR-1. Electron-donating partner; surface nano-encapsulated in-situ with polydopamine.
     gtdb_classification:
       gtdb_id: GTDB:s__Shewanella_oneidensis
@@ -53,6 +54,13 @@ taxonomy:
     term:
       id: NCBITaxon:1076
       label: Rhodopseudomonas palustris
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Rhodopseudomonas palustris_C
+    - Rhodopseudomonas palustris_F
+    - Rhodopseudomonas palustris_G
+    - Rhodopseudomonas palustris_J
+    - Rhodopseudomonas pseudopalustris
     notes: Electron-accepting partner (RP); nitrogenase-derived CH4 used as IET-efficiency indicator.
   functional_role:
   - ELECTRON_ACCEPTOR

--- a/kb/communities/SkinCom_Synthetic_Skin_Community.yaml
+++ b/kb/communities/SkinCom_Synthetic_Skin_Community.yaml
@@ -35,6 +35,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/SkinCom_Synthetic_Skin_Community.yaml
+++ b/kb/communities/SkinCom_Synthetic_Skin_Community.yaml
@@ -35,7 +35,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.yaml
+++ b/kb/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.yaml
@@ -78,7 +78,7 @@ taxonomy:
     term:
       id: NCBITaxon:2052312
       label: Candidatus Dormiibacterota
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -93,7 +93,7 @@ taxonomy:
     term:
       id: NCBITaxon:1783273
       label: Patescibacteria group
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: A CPR genome encoded a ribosomally synthesized linear
       azole/azoline-containing peptide BGC, a capacity also seen in other
       publicly available CPR genomes.

--- a/kb/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.yaml
+++ b/kb/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.yaml
@@ -28,6 +28,7 @@ taxonomy:
     term:
       id: NCBITaxon:201174
       label: Actinomycetota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Actinomycetota
       gtdb_taxon: Actinomycetota
@@ -52,6 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:200795
       label: Chloroflexota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Chloroflexota
       gtdb_taxon: Chloroflexota
@@ -76,6 +78,7 @@ taxonomy:
     term:
       id: NCBITaxon:2052312
       label: Candidatus Dormiibacterota
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -90,6 +93,7 @@ taxonomy:
     term:
       id: NCBITaxon:1783273
       label: Patescibacteria group
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: A CPR genome encoded a ribosomally synthesized linear
       azole/azoline-containing peptide BGC, a capacity also seen in other
       publicly available CPR genomes.

--- a/kb/communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.yaml
+++ b/kb/communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.yaml
@@ -29,6 +29,7 @@ taxonomy:
     term:
       id: NCBITaxon:1783273
       label: Patescibacteria group
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Includes Doudnabacteria (SM2F11), Saccharibacteria, Parcubacteria,
       and Microgenomates recovered from grassland soil.
   functional_role:
@@ -46,6 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:1783276
       label: Nanobdellati
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: DPANN archaea recovered from the rare biosphere include
       Diapherotrites, Parvarchaeota, Aenigmarchaeota, Nanoarchaeota, and
       Nanohaloarchaeota.

--- a/kb/communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.yaml
+++ b/kb/communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.yaml
@@ -29,7 +29,7 @@ taxonomy:
     term:
       id: NCBITaxon:1783273
       label: Patescibacteria group
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Includes Doudnabacteria (SM2F11), Saccharibacteria, Parcubacteria,
       and Microgenomates recovered from grassland soil.
   functional_role:
@@ -47,7 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:1783276
       label: Nanobdellati
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: DPANN archaea recovered from the rare biosphere include
       Diapherotrites, Parvarchaeota, Aenigmarchaeota, Nanoarchaeota, and
       Nanohaloarchaeota.

--- a/kb/communities/Soil_Corrinoid_B12_Reservoir_Community.yaml
+++ b/kb/communities/Soil_Corrinoid_B12_Reservoir_Community.yaml
@@ -28,6 +28,7 @@ taxonomy:
     term:
       id: NCBITaxon:28889
       label: Thermoproteota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Thermoproteota
       gtdb_taxon: Thermoproteota
@@ -52,6 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:201174
       label: Actinomycetota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Actinomycetota
       gtdb_taxon: Actinomycetota
@@ -76,6 +78,7 @@ taxonomy:
     term:
       id: NCBITaxon:1224
       label: Pseudomonadota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Pseudomonadota
       gtdb_taxon: Pseudomonadota

--- a/kb/communities/Sorghum_SRC1_Subset.yaml
+++ b/kb/communities/Sorghum_SRC1_Subset.yaml
@@ -42,6 +42,7 @@ taxonomy:
     term:
       id: NCBITaxon:306
       label: Pseudomonas sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -57,6 +58,7 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bacillus
       gtdb_taxon: Bacillus
@@ -81,6 +83,7 @@ taxonomy:
     term:
       id: NCBITaxon:1667
       label: Arthrobacter sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -96,6 +99,7 @@ taxonomy:
     term:
       id: NCBITaxon:1889
       label: Streptomyces ambofaciens
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Streptomyces_ambofaciens
       gtdb_taxon: Streptomyces ambofaciens
@@ -120,6 +124,7 @@ taxonomy:
     term:
       id: NCBITaxon:1401
       label: Paenibacillus lautus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Paenibacillus_lautus
       gtdb_taxon: Paenibacillus lautus
@@ -144,6 +149,7 @@ taxonomy:
     term:
       id: NCBITaxon:272772
       label: Pseudomonas pudica
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Pseudomonas_E_pudica
       gtdb_taxon: Pseudomonas_E pudica
@@ -168,6 +174,7 @@ taxonomy:
     term:
       id: NCBITaxon:4558
       label: Sorghum bicolor
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Sorghum_SRC1_Subset.yaml
+++ b/kb/communities/Sorghum_SRC1_Subset.yaml
@@ -42,7 +42,7 @@ taxonomy:
     term:
       id: NCBITaxon:306
       label: Pseudomonas sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -83,7 +83,7 @@ taxonomy:
     term:
       id: NCBITaxon:1667
       label: Arthrobacter sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: ABUNDANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -174,7 +174,7 @@ taxonomy:
     term:
       id: NCBITaxon:4558
       label: Sorghum bicolor
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.yaml
+++ b/kb/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.yaml
@@ -28,7 +28,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Community-level representation of bacteria and archaea recovered
       by 16S rRNA amplicon sequencing and shotgun metagenomics from salt pond
       and reference wetland sediments.
@@ -52,7 +52,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Bacterial methylphosphonate degradation genes were correlated with
       methane flux, supporting a bacterial methane-generating mechanism in the
       salt pond sediment community.
@@ -69,7 +69,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Archaeal methanogenesis genes were correlated with methane flux in
       the salt pond and wetland sediment communities.
   functional_role:

--- a/kb/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.yaml
+++ b/kb/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.yaml
@@ -28,6 +28,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Community-level representation of bacteria and archaea recovered
       by 16S rRNA amplicon sequencing and shotgun metagenomics from salt pond
       and reference wetland sediments.
@@ -51,6 +52,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Bacterial methylphosphonate degradation genes were correlated with
       methane flux, supporting a bacterial methane-generating mechanism in the
       salt pond sediment community.
@@ -67,6 +69,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Archaeal methanogenesis genes were correlated with methane flux in
       the salt pond and wetland sediment communities.
   functional_role:

--- a/kb/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.yaml
+++ b/kb/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.yaml
@@ -37,6 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -46,6 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:374
       label: Bradyrhizobium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bradyrhizobium
       gtdb_taxon: Bradyrhizobium

--- a/kb/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.yaml
+++ b/kb/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.yaml
@@ -37,7 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
+++ b/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
@@ -43,6 +43,7 @@ taxonomy:
     term:
       id: NCBITaxon:29448
       label: Bradyrhizobium elkanii
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bradyrhizobium_elkanii
       gtdb_taxon: Bradyrhizobium elkanii
@@ -68,6 +69,7 @@ taxonomy:
     term:
       id: NCBITaxon:53335
       label: Pantoea
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Pantoea
       gtdb_taxon: Pantoea
@@ -95,6 +97,7 @@ taxonomy:
     term:
       id: NCBITaxon:53335
       label: Pantoea
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Pantoea
       gtdb_taxon: Pantoea
@@ -122,6 +125,7 @@ taxonomy:
     term:
       id: NCBITaxon:3847
       label: Glycine max
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
+++ b/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
@@ -125,7 +125,7 @@ taxonomy:
     term:
       id: NCBITaxon:3847
       label: Glycine max
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Sphingobium_Rhodococcus_Lignin_Dimer_Valorization_Coculture.yaml
+++ b/kb/communities/Sphingobium_Rhodococcus_Lignin_Dimer_Valorization_Coculture.yaml
@@ -54,6 +54,7 @@ taxonomy:
     term:
       id: NCBITaxon:165695
       label: Sphingobium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Sphingobium
       gtdb_taxon: Sphingobium
@@ -87,6 +88,10 @@ taxonomy:
     term:
       id: NCBITaxon:37919
       label: Rhodococcus opacus
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Rhodococcus opacus
+    - Rhodococcus opacus_C
     notes: Aromatic-monomer conversion partner in the designed lignin-dimer coculture.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.yaml
+++ b/kb/communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.yaml
@@ -29,7 +29,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Community-level representation of genome-resolved microbial
       communities sampled across palsa, bog, and fen stages of Stordalen Mire.
   functional_role:
@@ -61,7 +61,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Methanogenic archaea are curated at domain level because the source
       reports multiple methanogen orders and genome-resolved methylotrophic
       methanogenesis potential across the native methanogen community.
@@ -85,7 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Bacterial MAGs across many phyla encoded and expressed anaerobic
       methylotrophic potential, providing an indirect route that can feed carbon
       cycling and greenhouse gas production in the mire.

--- a/kb/communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.yaml
+++ b/kb/communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.yaml
@@ -29,6 +29,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Community-level representation of genome-resolved microbial
       communities sampled across palsa, bog, and fen stages of Stordalen Mire.
   functional_role:
@@ -60,6 +61,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Methanogenic archaea are curated at domain level because the source
       reports multiple methanogen orders and genome-resolved methylotrophic
       methanogenesis potential across the native methanogen community.
@@ -83,6 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Bacterial MAGs across many phyla encoded and expressed anaerobic
       methylotrophic potential, providing an indirect route that can feed carbon
       cycling and greenhouse gas production in the mire.

--- a/kb/communities/Subsurface_Carboxydocella_CO_Aquifer_Community.yaml
+++ b/kb/communities/Subsurface_Carboxydocella_CO_Aquifer_Community.yaml
@@ -26,6 +26,7 @@ taxonomy:
     term:
       id: NCBITaxon:178898
       label: Carboxydocella
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Carboxydocella
       gtdb_taxon: Carboxydocella

--- a/kb/communities/Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom.yaml
+++ b/kb/communities/Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom.yaml
@@ -51,6 +51,7 @@ taxonomy:
     term:
       id: NCBITaxon:1904413
       label: Suillus clintonianus
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Ectomycorrhizal fungus and thiamine (B1) recipient; cannot effectively obtain or
       synthesize thiamine and recruits a bacterial partner to supply it.
   abundance_level: DOMINANT
@@ -73,6 +74,7 @@ taxonomy:
     term:
       id: NCBITaxon:293387
       label: Bacillus altitudinis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bacillus_altitudinis
       gtdb_taxon: Bacillus altitudinis
@@ -107,6 +109,7 @@ taxonomy:
     term:
       id: NCBITaxon:88730
       label: Pinus massoniana
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Host tree (Masson pine); ectomycorrhizal colonization by S. clintonianus increases as a
       downstream outcome of the bacterial thiamine supply.
   abundance_level: DOMINANT

--- a/kb/communities/Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom.yaml
+++ b/kb/communities/Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom.yaml
@@ -51,7 +51,7 @@ taxonomy:
     term:
       id: NCBITaxon:1904413
       label: Suillus clintonianus
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Ectomycorrhizal fungus and thiamine (B1) recipient; cannot effectively obtain or
       synthesize thiamine and recruits a bacterial partner to supply it.
   abundance_level: DOMINANT
@@ -109,7 +109,7 @@ taxonomy:
     term:
       id: NCBITaxon:88730
       label: Pinus massoniana
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Host tree (Masson pine); ectomycorrhizal colonization by S. clintonianus increases as a
       downstream outcome of the bacterial thiamine supply.
   abundance_level: DOMINANT

--- a/kb/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.yaml
+++ b/kb/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.yaml
@@ -83,7 +83,7 @@ taxonomy:
     term:
       id: NCBITaxon:1783273
       label: Patescibacteria group
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: The biofilm hosts diverse CPR lineages (Gracilibacteria,
       Absconditabacteria, Saccharibacteria, Peregrinibacteria, Berkelbacteria,
       Microgenomates, Parcubacteria), with imaging suggesting episymbiotic

--- a/kb/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.yaml
+++ b/kb/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.yaml
@@ -29,6 +29,7 @@ taxonomy:
     term:
       id: NCBITaxon:1031
       label: Thiothrix nivea
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Thiothrix_nivea
       gtdb_taxon: Thiothrix nivea
@@ -55,6 +56,7 @@ taxonomy:
     term:
       id: NCBITaxon:1021
       label: Beggiatoa
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Beggiatoa
       gtdb_taxon: Beggiatoa
@@ -81,6 +83,7 @@ taxonomy:
     term:
       id: NCBITaxon:1783273
       label: Patescibacteria group
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: The biofilm hosts diverse CPR lineages (Gracilibacteria,
       Absconditabacteria, Saccharibacteria, Peregrinibacteria, Berkelbacteria,
       Microgenomates, Parcubacteria), with imaging suggesting episymbiotic

--- a/kb/communities/SynComBac10_Chicken_Intestinal_SynCom.yaml
+++ b/kb/communities/SynComBac10_Chicken_Intestinal_SynCom.yaml
@@ -38,6 +38,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/SynComBac10_Chicken_Intestinal_SynCom.yaml
+++ b/kb/communities/SynComBac10_Chicken_Intestinal_SynCom.yaml
@@ -38,7 +38,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.yaml
+++ b/kb/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.yaml
@@ -150,7 +150,7 @@ taxonomy:
     term:
       id: NCBITaxon:5059
       label: Aspergillus flavus
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: The aflatoxin-producing fungal pathogen the community suppresses; the antagonism target
       rather than a member.
   evidence:
@@ -165,7 +165,7 @@ taxonomy:
     term:
       id: NCBITaxon:3818
       label: Arachis hypogaea
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Host legume in which both functions were assayed.
   evidence:
   - reference: PMID:42099455

--- a/kb/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.yaml
+++ b/kb/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.yaml
@@ -67,6 +67,7 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bacillus
       gtdb_taxon: Bacillus
@@ -94,6 +95,7 @@ taxonomy:
     term:
       id: NCBITaxon:547
       label: Enterobacter
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Enterobacter
       gtdb_taxon: Enterobacter
@@ -120,6 +122,7 @@ taxonomy:
     term:
       id: NCBITaxon:374
       label: Bradyrhizobium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bradyrhizobium
       gtdb_taxon: Bradyrhizobium
@@ -147,6 +150,7 @@ taxonomy:
     term:
       id: NCBITaxon:5059
       label: Aspergillus flavus
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: The aflatoxin-producing fungal pathogen the community suppresses; the antagonism target
       rather than a member.
   evidence:
@@ -161,6 +165,7 @@ taxonomy:
     term:
       id: NCBITaxon:3818
       label: Arachis hypogaea
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Host legume in which both functions were assayed.
   evidence:
   - reference: PMID:42099455

--- a/kb/communities/SynCom_BsBv_Cigar_Tobacco_Leaf_Fermentation.yaml
+++ b/kb/communities/SynCom_BsBv_Cigar_Tobacco_Leaf_Fermentation.yaml
@@ -24,6 +24,7 @@ taxonomy:
     term:
       id: NCBITaxon:561879
       label: Bacillus safensis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bacillus_safensis
       gtdb_taxon: Bacillus safensis
@@ -50,6 +51,7 @@ taxonomy:
     term:
       id: NCBITaxon:492670
       label: Bacillus velezensis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bacillus_velezensis
       gtdb_taxon: Bacillus velezensis

--- a/kb/communities/SynCom_Chlorella_sorokiniana_Biogas_Slurry_Coupling_System.yaml
+++ b/kb/communities/SynCom_Chlorella_sorokiniana_Biogas_Slurry_Coupling_System.yaml
@@ -23,7 +23,7 @@ taxonomy:
     term:
       id: NCBITaxon:3076
       label: Chlorella sorokiniana
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Autochthonous microalga isolated from the biogas slurry; the downstream member of the
       coupling system.
   functional_role:
@@ -40,7 +40,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: The abstract describes a "synthetic microbial community (SynCom)" pretreatment stage but
       does not name its constituent bacterial taxa; grounded only at the domain rank (Bacteria) as
       a placeholder for the unnamed SynCom.

--- a/kb/communities/SynCom_Chlorella_sorokiniana_Biogas_Slurry_Coupling_System.yaml
+++ b/kb/communities/SynCom_Chlorella_sorokiniana_Biogas_Slurry_Coupling_System.yaml
@@ -23,6 +23,7 @@ taxonomy:
     term:
       id: NCBITaxon:3076
       label: Chlorella sorokiniana
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Autochthonous microalga isolated from the biogas slurry; the downstream member of the
       coupling system.
   functional_role:
@@ -39,6 +40,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: The abstract describes a "synthetic microbial community (SynCom)" pretreatment stage but
       does not name its constituent bacterial taxa; grounded only at the domain rank (Bacteria) as
       a placeholder for the unnamed SynCom.

--- a/kb/communities/SynCom_MetG2_Rhizobacteria_Sugarcane_Stress_Resilience.yaml
+++ b/kb/communities/SynCom_MetG2_Rhizobacteria_Sugarcane_Stress_Resilience.yaml
@@ -24,6 +24,7 @@ taxonomy:
     term:
       id: NCBITaxon:4547
       label: Saccharum officinarum
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Plant host of the rhizosphere community. The abstract refers only to "sugarcane"; commercial
       sugarcane is typically Saccharum officinarum or an interspecific hybrid, grounded here at
       S. officinarum.
@@ -42,6 +43,7 @@ taxonomy:
     term:
       id: NCBITaxon:1224
       label: Pseudomonadota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Pseudomonadota
       gtdb_taxon: Pseudomonadota

--- a/kb/communities/SynCom_MetG2_Rhizobacteria_Sugarcane_Stress_Resilience.yaml
+++ b/kb/communities/SynCom_MetG2_Rhizobacteria_Sugarcane_Stress_Resilience.yaml
@@ -24,7 +24,7 @@ taxonomy:
     term:
       id: NCBITaxon:4547
       label: Saccharum officinarum
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Plant host of the rhizosphere community. The abstract refers only to "sugarcane"; commercial
       sugarcane is typically Saccharum officinarum or an interspecific hybrid, grounded here at
       S. officinarum.

--- a/kb/communities/SynCom_Pseudomonas_Rahnella_Artemisia_Phytoremediation.yaml
+++ b/kb/communities/SynCom_Pseudomonas_Rahnella_Artemisia_Phytoremediation.yaml
@@ -25,6 +25,7 @@ taxonomy:
     term:
       id: NCBITaxon:286
       label: Pseudomonas
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Pseudomonas
       gtdb_taxon: Pseudomonas
@@ -54,6 +55,7 @@ taxonomy:
     term:
       id: NCBITaxon:34037
       label: Rahnella
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Rahnella
       gtdb_taxon: Rahnella

--- a/kb/communities/SynCom_Sesame_Flavor_Baijiu_Fuqu_13Genus.yaml
+++ b/kb/communities/SynCom_Sesame_Flavor_Baijiu_Fuqu_13Genus.yaml
@@ -24,7 +24,7 @@ taxonomy:
     term:
       id: NCBITaxon:5052
       label: Aspergillus <genus>
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Genus-level identification (core Fuqu microbiota); no species resolved in the abstract.
       NCBITaxon canonical label carries a "<genus>" disambiguation suffix.
   functional_role:
@@ -156,7 +156,7 @@ taxonomy:
     term:
       id: NCBITaxon:4919
       label: Pichia
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Genus-level identification (core Fuqu microbiota); yeast.
   functional_role:
   - SECONDARY_FERMENTER
@@ -174,7 +174,7 @@ taxonomy:
     term:
       id: NCBITaxon:4930
       label: Saccharomyces
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Genus-level identification (core Fuqu microbiota); yeast.
   functional_role:
   - SECONDARY_FERMENTER
@@ -192,7 +192,7 @@ taxonomy:
     term:
       id: NCBITaxon:5552
       label: Trichosporon
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Genus-level identification (core Fuqu microbiota); yeast-like fungus.
   functional_role:
   - SECONDARY_FERMENTER
@@ -238,7 +238,7 @@ taxonomy:
     term:
       id: NCBITaxon:5475
       label: Candida
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Genus-level identification (core Fuqu microbiota); yeast (fungal genus Candida).
   functional_role:
   - SECONDARY_FERMENTER
@@ -256,7 +256,7 @@ taxonomy:
     term:
       id: NCBITaxon:4948
       label: Torulaspora
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Genus-level identification (core Fuqu microbiota); yeast.
   functional_role:
   - SECONDARY_FERMENTER
@@ -274,7 +274,7 @@ taxonomy:
     term:
       id: NCBITaxon:36910
       label: Clavispora
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Genus-level identification (core Fuqu microbiota); yeast.
   functional_role:
   - SECONDARY_FERMENTER
@@ -292,7 +292,7 @@ taxonomy:
     term:
       id: NCBITaxon:599737
       label: Wickerhamomyces
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Genus-level identification (core Fuqu microbiota); yeast.
   functional_role:
   - SECONDARY_FERMENTER

--- a/kb/communities/SynCom_Sesame_Flavor_Baijiu_Fuqu_13Genus.yaml
+++ b/kb/communities/SynCom_Sesame_Flavor_Baijiu_Fuqu_13Genus.yaml
@@ -24,6 +24,7 @@ taxonomy:
     term:
       id: NCBITaxon:5052
       label: Aspergillus <genus>
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Genus-level identification (core Fuqu microbiota); no species resolved in the abstract.
       NCBITaxon canonical label carries a "<genus>" disambiguation suffix.
   functional_role:
@@ -42,6 +43,7 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bacillus
       gtdb_taxon: Bacillus
@@ -70,6 +72,7 @@ taxonomy:
     term:
       id: NCBITaxon:1578
       label: Lactobacillus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Lactobacillus
       gtdb_taxon: Lactobacillus
@@ -97,6 +100,7 @@ taxonomy:
     term:
       id: NCBITaxon:1243
       label: Leuconostoc
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Leuconostoc
       gtdb_taxon: Leuconostoc
@@ -124,6 +128,7 @@ taxonomy:
     term:
       id: NCBITaxon:1253
       label: Pediococcus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Pediococcus
       gtdb_taxon: Pediococcus
@@ -151,6 +156,7 @@ taxonomy:
     term:
       id: NCBITaxon:4919
       label: Pichia
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Genus-level identification (core Fuqu microbiota); yeast.
   functional_role:
   - SECONDARY_FERMENTER
@@ -168,6 +174,7 @@ taxonomy:
     term:
       id: NCBITaxon:4930
       label: Saccharomyces
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Genus-level identification (core Fuqu microbiota); yeast.
   functional_role:
   - SECONDARY_FERMENTER
@@ -185,6 +192,7 @@ taxonomy:
     term:
       id: NCBITaxon:5552
       label: Trichosporon
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Genus-level identification (core Fuqu microbiota); yeast-like fungus.
   functional_role:
   - SECONDARY_FERMENTER
@@ -202,6 +210,7 @@ taxonomy:
     term:
       id: NCBITaxon:46255
       label: Weissella
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Weissella
       gtdb_taxon: Weissella
@@ -229,6 +238,7 @@ taxonomy:
     term:
       id: NCBITaxon:5475
       label: Candida
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Genus-level identification (core Fuqu microbiota); yeast (fungal genus Candida).
   functional_role:
   - SECONDARY_FERMENTER
@@ -246,6 +256,7 @@ taxonomy:
     term:
       id: NCBITaxon:4948
       label: Torulaspora
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Genus-level identification (core Fuqu microbiota); yeast.
   functional_role:
   - SECONDARY_FERMENTER
@@ -263,6 +274,7 @@ taxonomy:
     term:
       id: NCBITaxon:36910
       label: Clavispora
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Genus-level identification (core Fuqu microbiota); yeast.
   functional_role:
   - SECONDARY_FERMENTER
@@ -280,6 +292,7 @@ taxonomy:
     term:
       id: NCBITaxon:599737
       label: Wickerhamomyces
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Genus-level identification (core Fuqu microbiota); yeast.
   functional_role:
   - SECONDARY_FERMENTER

--- a/kb/communities/SynCom_Y_Agrobacterium_Bacillus_Biofilm_Biocontrol_Coculture.yaml
+++ b/kb/communities/SynCom_Y_Agrobacterium_Bacillus_Biofilm_Biocontrol_Coculture.yaml
@@ -22,6 +22,7 @@ taxonomy:
     term:
       id: NCBITaxon:1183412
       label: Agrobacterium deltae
+    gtdb_grounding_status: GROUNDED
     notes: Strain LSQ16. NCBITaxon canonical label is "Agrobacterium deltae"; "Agrobacterium deltaense"
       is a synonym used in the source paper.
     gtdb_classification:
@@ -50,6 +51,7 @@ taxonomy:
     term:
       id: NCBITaxon:492670
       label: Bacillus velezensis
+    gtdb_grounding_status: GROUNDED
     notes: Strain WB.
     gtdb_classification:
       gtdb_id: GTDB:s__Bacillus_velezensis

--- a/kb/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.yaml
+++ b/kb/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.yaml
@@ -48,6 +48,7 @@ taxonomy:
     term:
       id: NCBITaxon:1140
       label: Synechococcus elongatus PCC 7942 = FACHB-805
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Synechococcus_elongatus
       gtdb_taxon: Synechococcus elongatus
@@ -85,6 +86,7 @@ taxonomy:
     term:
       id: NCBITaxon:354
       label: Azotobacter vinelandii
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Azotobacter_vinelandii
       gtdb_taxon: Azotobacter vinelandii

--- a/kb/communities/Synechococcus_Bacillus_SPC.yaml
+++ b/kb/communities/Synechococcus_Bacillus_SPC.yaml
@@ -36,6 +36,7 @@ taxonomy:
     term:
       id: NCBITaxon:32046
       label: Synechococcus elongatus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Synechococcus_elongatus
       gtdb_taxon: Synechococcus elongatus
@@ -65,6 +66,7 @@ taxonomy:
     term:
       id: NCBITaxon:1423
       label: Bacillus subtilis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bacillus_subtilis
       gtdb_taxon: Bacillus subtilis

--- a/kb/communities/Synechococcus_Ecoli_SPC.yaml
+++ b/kb/communities/Synechococcus_Ecoli_SPC.yaml
@@ -43,6 +43,7 @@ taxonomy:
     term:
       id: NCBITaxon:32046
       label: Synechococcus elongatus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Synechococcus_elongatus
       gtdb_taxon: Synechococcus elongatus
@@ -77,6 +78,7 @@ taxonomy:
     term:
       id: NCBITaxon:83333
       label: Escherichia coli K-12
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Escherichia_coli
       gtdb_taxon: Escherichia coli

--- a/kb/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.yaml
+++ b/kb/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.yaml
@@ -48,6 +48,7 @@ taxonomy:
     term:
       id: NCBITaxon:32046
       label: Synechococcus elongatus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Synechococcus_elongatus
       gtdb_taxon: Synechococcus elongatus
@@ -85,6 +86,7 @@ taxonomy:
     term:
       id: NCBITaxon:1072583
       label: Vreelandella boliviensis LC1
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Vreelandella_boliviensis
       gtdb_taxon: Vreelandella boliviensis

--- a/kb/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.yaml
+++ b/kb/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.yaml
@@ -53,6 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:32046
       label: Synechococcus elongatus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Synechococcus_elongatus
       gtdb_taxon: Synechococcus elongatus
@@ -92,6 +93,23 @@ taxonomy:
     term:
       id: NCBITaxon:303
       label: Pseudomonas putida
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Pseudomonas_E alloputida
+    - Pseudomonas_E asiatica
+    - Pseudomonas_E fulva
+    - Pseudomonas_E guariconensis
+    - Pseudomonas_E juntendi
+    - Pseudomonas_E monteilii
+    - Pseudomonas_E pudica
+    - Pseudomonas_E putida
+    - Pseudomonas_E putida_E
+    - Pseudomonas_E putida_H
+    - Pseudomonas_E putida_K
+    - Pseudomonas_E putida_P
+    - Pseudomonas_E putida_Q
+    - Pseudomonas_E putida_R
+    - Pseudomonas_E putida_Y
     notes: Engineered P. putida derivatives used across exact species-pair publications include cscAB,
       cscRABY, nitrate-blind cscRABY, and EM173 DNT/S variants.
   strain_designation:

--- a/kb/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.yaml
+++ b/kb/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.yaml
@@ -54,6 +54,7 @@ taxonomy:
     term:
       id: NCBITaxon:1350461
       label: Synechococcus elongatus UTEX 2973
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Synechococcus_elongatus
       gtdb_taxon: Synechococcus elongatus
@@ -85,6 +86,7 @@ taxonomy:
     term:
       id: NCBITaxon:211586
       label: Shewanella oneidensis MR-1
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Shewanella_oneidensis
       gtdb_taxon: Shewanella oneidensis

--- a/kb/communities/Synechococcus_Yarrowia_SPC.yaml
+++ b/kb/communities/Synechococcus_Yarrowia_SPC.yaml
@@ -38,6 +38,7 @@ taxonomy:
     term:
       id: NCBITaxon:32046
       label: Synechococcus elongatus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Synechococcus_elongatus
       gtdb_taxon: Synechococcus elongatus
@@ -67,6 +68,7 @@ taxonomy:
     term:
       id: NCBITaxon:4952
       label: Yarrowia lipolytica
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: ABUNDANT
   functional_role:
   - CROSS_FEEDER

--- a/kb/communities/Synechococcus_Yarrowia_SPC.yaml
+++ b/kb/communities/Synechococcus_Yarrowia_SPC.yaml
@@ -68,7 +68,7 @@ taxonomy:
     term:
       id: NCBITaxon:4952
       label: Yarrowia lipolytica
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: ABUNDANT
   functional_role:
   - CROSS_FEEDER

--- a/kb/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.yaml
+++ b/kb/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.yaml
@@ -70,7 +70,7 @@ taxonomy:
     term:
       id: NCBITaxon:5535
       label: Rhodotorula glutinis
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Oleaginous yeast heterotroph that adapted to the coculture medium and utilized sucrose from S.
       elongatus.
   strain_designation:

--- a/kb/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.yaml
+++ b/kb/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.yaml
@@ -38,6 +38,7 @@ taxonomy:
     term:
       id: NCBITaxon:32046
       label: Synechococcus elongatus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Synechococcus_elongatus
       gtdb_taxon: Synechococcus elongatus
@@ -69,6 +70,7 @@ taxonomy:
     term:
       id: NCBITaxon:5535
       label: Rhodotorula glutinis
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Oleaginous yeast heterotroph that adapted to the coculture medium and utilized sucrose from S.
       elongatus.
   strain_designation:

--- a/kb/communities/Synthetic_Periphyton_Freshwater_Biofilm.yaml
+++ b/kb/communities/Synthetic_Periphyton_Freshwater_Biofilm.yaml
@@ -37,6 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:2836
       label: Bacillariophyta
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_PRODUCER
   evidence:
@@ -46,6 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:3041
       label: Chlorophyta
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_PRODUCER
   evidence:
@@ -55,6 +57,7 @@ taxonomy:
     term:
       id: NCBITaxon:1117
       label: Cyanobacteriota
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:p__Cyanobacteriota
       gtdb_taxon: Cyanobacteriota

--- a/kb/communities/Synthetic_Periphyton_Freshwater_Biofilm.yaml
+++ b/kb/communities/Synthetic_Periphyton_Freshwater_Biofilm.yaml
@@ -37,7 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:2836
       label: Bacillariophyta
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - PRIMARY_PRODUCER
   evidence:
@@ -47,7 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:3041
       label: Chlorophyta
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Syntrophobacter_Methanobacterium_Syntrophy.yaml
+++ b/kb/communities/Syntrophobacter_Methanobacterium_Syntrophy.yaml
@@ -30,6 +30,7 @@ taxonomy:
     term:
       id: NCBITaxon:119484
       label: Syntrophobacter fumaroxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Syntrophobacter_fumaroxidans
       gtdb_taxon: Syntrophobacter fumaroxidans
@@ -63,6 +64,7 @@ taxonomy:
     term:
       id: NCBITaxon:2162
       label: Methanobacterium formicicum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methanobacterium_formicicum
       gtdb_taxon: Methanobacterium formicicum

--- a/kb/communities/Syntrophobacter_Methanospirillum_Syntrophy.yaml
+++ b/kb/communities/Syntrophobacter_Methanospirillum_Syntrophy.yaml
@@ -30,6 +30,7 @@ taxonomy:
     term:
       id: NCBITaxon:119484
       label: Syntrophobacter fumaroxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Syntrophobacter_fumaroxidans
       gtdb_taxon: Syntrophobacter fumaroxidans
@@ -63,6 +64,7 @@ taxonomy:
     term:
       id: NCBITaxon:2203
       label: Methanospirillum hungatei
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methanospirillum_hungatei
       gtdb_taxon: Methanospirillum hungatei

--- a/kb/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.yaml
+++ b/kb/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.yaml
@@ -55,6 +55,10 @@ taxonomy:
     term:
       id: NCBITaxon:863
       label: Syntrophomonas wolfei
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Syntrophomonas methylbutyratica
+    - Syntrophomonas wolfei
     notes: Butyrate-oxidizing syntrophic bacterium in the mesophilic coculture.
   functional_role:
   - PRIMARY_DEGRADER
@@ -75,6 +79,7 @@ taxonomy:
     term:
       id: NCBITaxon:39152
       label: Methanococcus maripaludis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methanococcus_maripaludis
       gtdb_taxon: Methanococcus maripaludis

--- a/kb/communities/Syntrophomonas_Methanospirillum_Syntrophy.yaml
+++ b/kb/communities/Syntrophomonas_Methanospirillum_Syntrophy.yaml
@@ -28,6 +28,10 @@ taxonomy:
     term:
       id: NCBITaxon:863
       label: Syntrophomonas wolfei
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Syntrophomonas methylbutyratica
+    - Syntrophomonas wolfei
     notes: 'Anaerobic, syntrophic, fatty acid-oxidizing bacterium that β-oxidizes saturated fatty acids
       (C4-C8) to acetate or acetate plus propionate. Cannot grow on fatty acids alone; requires syntrophic
       association with H2-utilizing partners. Uses protons as electron acceptor, producing H2 as electron
@@ -50,6 +54,7 @@ taxonomy:
     term:
       id: NCBITaxon:2203
       label: Methanospirillum hungatei
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methanospirillum_hungatei
       gtdb_taxon: Methanospirillum hungatei

--- a/kb/communities/Syntrophus_Benzoate_Degrader.yaml
+++ b/kb/communities/Syntrophus_Benzoate_Degrader.yaml
@@ -30,6 +30,7 @@ taxonomy:
     term:
       id: NCBITaxon:56780
       label: Syntrophus aciditrophicus SB
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Syntrophus_aciditrophicus
       gtdb_taxon: Syntrophus aciditrophicus
@@ -62,6 +63,7 @@ taxonomy:
     term:
       id: NCBITaxon:2203
       label: Methanospirillum hungatei
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methanospirillum_hungatei
       gtdb_taxon: Methanospirillum hungatei

--- a/kb/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.yaml
+++ b/kb/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.yaml
@@ -47,6 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:43775
       label: Syntrophus gentianae
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Syntrophus_gentianae
       gtdb_taxon: Syntrophus gentianae
@@ -86,6 +87,7 @@ taxonomy:
     term:
       id: NCBITaxon:2203
       label: Methanospirillum hungatei
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methanospirillum_hungatei
       gtdb_taxon: Methanospirillum hungatei

--- a/kb/communities/THOR_Rhizosphere_Model_Community.yaml
+++ b/kb/communities/THOR_Rhizosphere_Model_Community.yaml
@@ -44,6 +44,31 @@ taxonomy:
     term:
       id: NCBITaxon:1396
       label: Bacillus cereus
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Bacillus_A anthracis
+    - Bacillus_A bombysepticus
+    - Bacillus_A cereus
+    - Bacillus_A cereus_K
+    - Bacillus_A cereus_S
+    - Bacillus_A cereus_U
+    - Bacillus_A hominis
+    - Bacillus_A luti
+    - Bacillus_A mobilis
+    - Bacillus_A mycoides
+    - Bacillus_A nitratireducens
+    - Bacillus_A pacificus
+    - Bacillus_A paramycoides
+    - Bacillus_A paranthracis
+    - Bacillus_A pseudomycoides
+    - Bacillus_A sp003400245
+    - Bacillus_A sp018966865
+    - Bacillus_A thuringiensis
+    - Bacillus_A thuringiensis_AB
+    - Bacillus_A thuringiensis_K
+    - Bacillus_A thuringiensis_S
+    - Bacillus_A toyonensis
+    - Bacillus_A tropicus
     notes: Rhizosphere-associated firmicute member used as the Bacillus component of THOR.
   strain_designation:
     strain_name: UW85
@@ -62,6 +87,7 @@ taxonomy:
     term:
       id: NCBITaxon:198620
       label: Pseudomonas koreensis
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Proteobacterial THOR member that produces koreenceine, an antibiotic affecting other members.
   strain_designation:
     strain_name: CI12
@@ -80,6 +106,7 @@ taxonomy:
     term:
       id: NCBITaxon:986
       label: Flavobacterium johnsoniae
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Flavobacterium_johnsoniae
       gtdb_taxon: Flavobacterium johnsoniae

--- a/kb/communities/THOR_Rhizosphere_Model_Community.yaml
+++ b/kb/communities/THOR_Rhizosphere_Model_Community.yaml
@@ -87,7 +87,7 @@ taxonomy:
     term:
       id: NCBITaxon:198620
       label: Pseudomonas koreensis
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Proteobacterial THOR member that produces koreenceine, an antibiotic affecting other members.
   strain_designation:
     strain_name: CI12

--- a/kb/communities/TYQ1_Nematode_Biocontrol_SynCom.yaml
+++ b/kb/communities/TYQ1_Nematode_Biocontrol_SynCom.yaml
@@ -142,7 +142,7 @@ taxonomy:
     term:
       id: NCBITaxon:592050
       label: Acidovorax soli
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Biomarker species recruited by TYQ1 enrichment (OTU2167).
   strain_designation:
     strain_name: AS
@@ -217,7 +217,7 @@ taxonomy:
     term:
       id: NCBITaxon:452922
       label: Xenophilus aerolatus
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Biomarker species recruited by TYQ1 enrichment (OTU2715).
   strain_designation:
     strain_name: XA
@@ -236,7 +236,7 @@ taxonomy:
     term:
       id: NCBITaxon:33883
       label: Microbacterium arborescens
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Biomarker species recruited by TYQ1 enrichment (OTU11267).
   strain_designation:
     strain_name: MA

--- a/kb/communities/TYQ1_Nematode_Biocontrol_SynCom.yaml
+++ b/kb/communities/TYQ1_Nematode_Biocontrol_SynCom.yaml
@@ -46,6 +46,7 @@ taxonomy:
     term:
       id: NCBITaxon:648995
       label: Agrobacterium pusense
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Agrobacterium_pusense
       gtdb_taxon: Agrobacterium pusense
@@ -79,6 +80,7 @@ taxonomy:
     term:
       id: NCBITaxon:237612
       label: Sphingomonas panni
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Sphingomonas_panni
       gtdb_taxon: Sphingomonas panni
@@ -106,6 +108,7 @@ taxonomy:
     term:
       id: NCBITaxon:13687
       label: Sphingomonas
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Sphingomonas
       gtdb_taxon: Sphingomonas
@@ -139,6 +142,7 @@ taxonomy:
     term:
       id: NCBITaxon:592050
       label: Acidovorax soli
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Biomarker species recruited by TYQ1 enrichment (OTU2167).
   strain_designation:
     strain_name: AS
@@ -157,6 +161,7 @@ taxonomy:
     term:
       id: NCBITaxon:12916
       label: Acidovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Acidovorax
       gtdb_taxon: Acidovorax
@@ -184,6 +189,7 @@ taxonomy:
     term:
       id: NCBITaxon:48936
       label: Novosphingobium subterraneum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Novosphingobium_subterraneum
       gtdb_taxon: Novosphingobium subterraneum
@@ -211,6 +217,7 @@ taxonomy:
     term:
       id: NCBITaxon:452922
       label: Xenophilus aerolatus
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Biomarker species recruited by TYQ1 enrichment (OTU2715).
   strain_designation:
     strain_name: XA
@@ -229,6 +236,7 @@ taxonomy:
     term:
       id: NCBITaxon:33883
       label: Microbacterium arborescens
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Biomarker species recruited by TYQ1 enrichment (OTU11267).
   strain_designation:
     strain_name: MA

--- a/kb/communities/Teosinte_Maize_Biofertilizer_SynCom7.yaml
+++ b/kb/communities/Teosinte_Maize_Biofertilizer_SynCom7.yaml
@@ -37,6 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:613
       label: Serratia <enterobacteria>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Serratia
       gtdb_taxon: Serratia
@@ -54,6 +55,7 @@ taxonomy:
     term:
       id: NCBITaxon:244366
       label: Klebsiella variicola
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Klebsiella_variicola
       gtdb_taxon: Klebsiella variicola
@@ -72,6 +74,22 @@ taxonomy:
     term:
       id: NCBITaxon:1428
       label: Bacillus thuringiensis
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Bacillus_A albus
+    - Bacillus_A anthracis
+    - Bacillus_A bombysepticus
+    - Bacillus_A cereus
+    - Bacillus_A mycoides
+    - Bacillus_A pacificus
+    - Bacillus_A paranthracis
+    - Bacillus_A thuringiensis
+    - Bacillus_A thuringiensis_AB
+    - Bacillus_A thuringiensis_K
+    - Bacillus_A thuringiensis_S
+    - Bacillus_A toyonensis
+    - Bacillus_A tropicus
+    - Bacillus_A wiedmannii
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -81,6 +99,7 @@ taxonomy:
     term:
       id: NCBITaxon:549
       label: Pantoea agglomerans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Pantoea_agglomerans
       gtdb_taxon: Pantoea agglomerans

--- a/kb/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.yaml
+++ b/kb/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.yaml
@@ -57,6 +57,7 @@ taxonomy:
     term:
       id: NCBITaxon:1577725
       label: Conticribra weissflogii
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: >
       Sources use the name Thalassiosira weissflogii. NCBI Taxonomy currently
       treats Thalassiosira weissflogii as a homotypic synonym of Conticribra
@@ -75,6 +76,7 @@ taxonomy:
     term:
       id: NCBITaxon:225937
       label: Marinobacter adhaerens HP15
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Marinobacter_adhaerens
       gtdb_taxon: Marinobacter adhaerens

--- a/kb/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.yaml
+++ b/kb/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.yaml
@@ -57,7 +57,7 @@ taxonomy:
     term:
       id: NCBITaxon:1577725
       label: Conticribra weissflogii
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: >
       Sources use the name Thalassiosira weissflogii. NCBI Taxonomy currently
       treats Thalassiosira weissflogii as a homotypic synonym of Conticribra

--- a/kb/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.yaml
+++ b/kb/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.yaml
@@ -50,6 +50,7 @@ taxonomy:
     term:
       id: NCBITaxon:296543
       label: Thalassiosira pseudonana CCMP1335
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Diatom strain CCMP1335, the photosynthetic member of the pairwise coculture.
   abundance_value: One of two members in the defined coculture.
   functional_role:
@@ -71,6 +72,7 @@ taxonomy:
     term:
       id: NCBITaxon:246200
       label: Ruegeria pomeroyi DSS-3
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Ruegeria_B_pomeroyi
       gtdb_taxon: Ruegeria_B pomeroyi

--- a/kb/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.yaml
+++ b/kb/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.yaml
@@ -50,7 +50,7 @@ taxonomy:
     term:
       id: NCBITaxon:296543
       label: Thalassiosira pseudonana CCMP1335
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Diatom strain CCMP1335, the photosynthetic member of the pairwise coculture.
   abundance_value: One of two members in the defined coculture.
   functional_role:

--- a/kb/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.yaml
+++ b/kb/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.yaml
@@ -53,6 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:1089553
       label: Thermacetogenium phaeum DSM 12270
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Thermacetogenium_phaeum
       gtdb_taxon: Thermacetogenium phaeum
@@ -93,6 +94,7 @@ taxonomy:
     term:
       id: NCBITaxon:145262
       label: Methanothermobacter thermautotrophicus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methanothermobacter_thermautotrophicus
       gtdb_taxon: Methanothermobacter thermautotrophicus

--- a/kb/communities/Thermophilic_Lignocellulose_Composting_SynCom_Biosanitization.yaml
+++ b/kb/communities/Thermophilic_Lignocellulose_Composting_SynCom_Biosanitization.yaml
@@ -120,7 +120,7 @@ taxonomy:
     term:
       id: NCBITaxon:5498
       label: Cladosporium
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Fungal member; species not specified in the source, grounded at the genus rank confirmed by
       OAK.
   functional_role:
@@ -138,7 +138,7 @@ taxonomy:
     term:
       id: NCBITaxon:5544
       label: Trichoderma harzianum
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Fungal member of the thermophilic lignocellulose-degrading SynCom.
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/Thermophilic_Lignocellulose_Composting_SynCom_Biosanitization.yaml
+++ b/kb/communities/Thermophilic_Lignocellulose_Composting_SynCom_Biosanitization.yaml
@@ -25,6 +25,31 @@ taxonomy:
     term:
       id: NCBITaxon:1396
       label: Bacillus cereus
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Bacillus_A anthracis
+    - Bacillus_A bombysepticus
+    - Bacillus_A cereus
+    - Bacillus_A cereus_K
+    - Bacillus_A cereus_S
+    - Bacillus_A cereus_U
+    - Bacillus_A hominis
+    - Bacillus_A luti
+    - Bacillus_A mobilis
+    - Bacillus_A mycoides
+    - Bacillus_A nitratireducens
+    - Bacillus_A pacificus
+    - Bacillus_A paramycoides
+    - Bacillus_A paranthracis
+    - Bacillus_A pseudomycoides
+    - Bacillus_A sp003400245
+    - Bacillus_A sp018966865
+    - Bacillus_A thuringiensis
+    - Bacillus_A thuringiensis_AB
+    - Bacillus_A thuringiensis_K
+    - Bacillus_A thuringiensis_S
+    - Bacillus_A toyonensis
+    - Bacillus_A tropicus
     notes: Bacterial member of the thermophilic lignocellulose-degrading SynCom.
   functional_role:
   - PRIMARY_DEGRADER
@@ -41,6 +66,7 @@ taxonomy:
     term:
       id: NCBITaxon:222
       label: Achromobacter
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Achromobacter
       gtdb_taxon: Achromobacter
@@ -67,6 +93,7 @@ taxonomy:
     term:
       id: NCBITaxon:286
       label: Pseudomonas
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Pseudomonas
       gtdb_taxon: Pseudomonas
@@ -93,6 +120,7 @@ taxonomy:
     term:
       id: NCBITaxon:5498
       label: Cladosporium
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Fungal member; species not specified in the source, grounded at the genus rank confirmed by
       OAK.
   functional_role:
@@ -110,6 +138,7 @@ taxonomy:
     term:
       id: NCBITaxon:5544
       label: Trichoderma harzianum
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Fungal member of the thermophilic lignocellulose-degrading SynCom.
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/Thermophilic_Pyrite_QS_Consortium.yaml
+++ b/kb/communities/Thermophilic_Pyrite_QS_Consortium.yaml
@@ -59,6 +59,7 @@ taxonomy:
     term:
       id: NCBITaxon:178606
       label: Leptospirillum ferriphilum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Leptospirillum_A_rubarum
       gtdb_taxon: Leptospirillum_A rubarum
@@ -111,6 +112,7 @@ taxonomy:
     term:
       id: NCBITaxon:33059
       label: Acidithiobacillus caldus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidithiobacillus_A_caldus
       gtdb_taxon: Acidithiobacillus_A caldus
@@ -174,6 +176,7 @@ taxonomy:
     term:
       id: NCBITaxon:28034
       label: Sulfobacillus thermosulfidooxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Sulfobacillus_thermosulfidooxidans
       gtdb_taxon: Sulfobacillus thermosulfidooxidans

--- a/kb/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.yaml
+++ b/kb/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.yaml
@@ -53,6 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:243274
       label: Thermotoga maritima MSB8
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Thermotoga_maritima
       gtdb_taxon: Thermotoga maritima
@@ -92,6 +93,7 @@ taxonomy:
     term:
       id: NCBITaxon:243232
       label: Methanocaldococcus jannaschii DSM 2661
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methanocaldococcus_jannaschii
       gtdb_taxon: Methanocaldococcus jannaschii

--- a/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
+++ b/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
@@ -59,6 +59,7 @@ taxonomy:
     term:
       id: NCBITaxon:919
       label: Thiobacillus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Thiobacillus
       gtdb_taxon: Thiobacillus
@@ -87,6 +88,7 @@ taxonomy:
     term:
       id: NCBITaxon:1033
       label: Afipia
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Afipia
       gtdb_taxon: Afipia
@@ -115,6 +117,7 @@ taxonomy:
     term:
       id: NCBITaxon:356
       label: Hyphomicrobiales
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:o__Rhizobiales
       gtdb_taxon: Rhizobiales

--- a/kb/communities/Tinto_River_Iron_Cycling_Community.yaml
+++ b/kb/communities/Tinto_River_Iron_Cycling_Community.yaml
@@ -142,7 +142,7 @@ taxonomy:
     term:
       id: NCBITaxon:33849
       label: Bacillariophyceae
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Diatoms (photosynthetic microalgae) contributing to primary production in Rio Tinto. Diatoms
       are eukaryotic algae with silica cell walls that photosynthesize at low pH, providing organic carbon
       to the heterotrophic community. Their presence demonstrates that oxygenic photosynthesis is compatible
@@ -166,7 +166,7 @@ taxonomy:
     term:
       id: NCBITaxon:3041
       label: Chlorophyta
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Green algae including acidophilic genera Chlamydomonas, Klebsormidium, and Zignema that contribute
       to photosynthetic primary production. Chlorophytes are eukaryotic algae with chloroplasts adapted
       to acidic conditions, producing organic matter and oxygen that support the heterotrophic-oxidative
@@ -188,7 +188,7 @@ taxonomy:
     term:
       id: NCBITaxon:5204
       label: Basidiomycota
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: 'Acidophilic fungi including Hortaea werneckii (black yeast) detected in Rio Tinto sediments
       and water. Fungi contribute to organic matter degradation, biofilm formation, and nutrient cycling
       through extracellular enzyme secretion.

--- a/kb/communities/Tinto_River_Iron_Cycling_Community.yaml
+++ b/kb/communities/Tinto_River_Iron_Cycling_Community.yaml
@@ -39,6 +39,7 @@ taxonomy:
     term:
       id: NCBITaxon:180
       label: Leptospirillum ferrooxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Leptospirillum_ferrooxidans
       gtdb_taxon: Leptospirillum ferrooxidans
@@ -75,6 +76,7 @@ taxonomy:
     term:
       id: NCBITaxon:920
       label: Acidithiobacillus ferrooxidans
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acidithiobacillus_ferrooxidans
       gtdb_taxon: Acidithiobacillus ferrooxidans
@@ -106,6 +108,7 @@ taxonomy:
     term:
       id: NCBITaxon:522
       label: Acidiphilium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Acidiphilium
       gtdb_taxon: Acidiphilium
@@ -139,6 +142,7 @@ taxonomy:
     term:
       id: NCBITaxon:33849
       label: Bacillariophyceae
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Diatoms (photosynthetic microalgae) contributing to primary production in Rio Tinto. Diatoms
       are eukaryotic algae with silica cell walls that photosynthesize at low pH, providing organic carbon
       to the heterotrophic community. Their presence demonstrates that oxygenic photosynthesis is compatible
@@ -162,6 +166,7 @@ taxonomy:
     term:
       id: NCBITaxon:3041
       label: Chlorophyta
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Green algae including acidophilic genera Chlamydomonas, Klebsormidium, and Zignema that contribute
       to photosynthetic primary production. Chlorophytes are eukaryotic algae with chloroplasts adapted
       to acidic conditions, producing organic matter and oxygen that support the heterotrophic-oxidative
@@ -183,6 +188,7 @@ taxonomy:
     term:
       id: NCBITaxon:5204
       label: Basidiomycota
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Acidophilic fungi including Hortaea werneckii (black yeast) detected in Rio Tinto sediments
       and water. Fungi contribute to organic matter degradation, biofilm formation, and nutrient cycling
       through extracellular enzyme secretion.

--- a/kb/communities/Tobacco_Chemotactic_Biocontrol_SynCom.yaml
+++ b/kb/communities/Tobacco_Chemotactic_Biocontrol_SynCom.yaml
@@ -36,7 +36,7 @@ taxonomy:
     term:
       id: NCBITaxon:306
       label: Pseudomonas sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Tobacco_Chemotactic_Biocontrol_SynCom.yaml
+++ b/kb/communities/Tobacco_Chemotactic_Biocontrol_SynCom.yaml
@@ -36,6 +36,7 @@ taxonomy:
     term:
       id: NCBITaxon:306
       label: Pseudomonas sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -45,6 +46,7 @@ taxonomy:
     term:
       id: NCBITaxon:1386
       label: Bacillus <firmicutes>
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bacillus
       gtdb_taxon: Bacillus

--- a/kb/communities/Tomato_Oxylipin_SynCom3.yaml
+++ b/kb/communities/Tomato_Oxylipin_SynCom3.yaml
@@ -36,6 +36,7 @@ taxonomy:
     term:
       id: NCBITaxon:76890
       label: Asticcacaulis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Asticcacaulis
       gtdb_taxon: Asticcacaulis
@@ -55,6 +56,7 @@ taxonomy:
     term:
       id: NCBITaxon:1769012
       label: Arachidicoccus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Arachidicoccus
       gtdb_taxon: Arachidicoccus
@@ -74,6 +76,7 @@ taxonomy:
     term:
       id: NCBITaxon:20
       label: Phenylobacterium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Phenylobacterium
       gtdb_taxon: Phenylobacterium

--- a/kb/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.yaml
+++ b/kb/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.yaml
@@ -39,6 +39,7 @@ taxonomy:
     term:
       id: NCBITaxon:56112
       label: Dehalobacter
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Dehalobacter
       gtdb_taxon: Dehalobacter
@@ -58,6 +59,16 @@ taxonomy:
     term:
       id: NCBITaxon:1485
       label: Clostridium
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Clostridium
+    - Otoolea
+    - Sarcina
+    - Clostridium_AQ
+    - Clostridium_G
+    - Clostridium_B
+    - Clostridium_J
+    - Clostridium_F
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -67,6 +78,7 @@ taxonomy:
     term:
       id: NCBITaxon:1261393
       label: Desulfatiglans parachlorophenolica
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.yaml
+++ b/kb/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.yaml
@@ -69,6 +69,44 @@ taxonomy:
     - Clostridium_B
     - Clostridium_J
     - Clostridium_F
+    - Clostridium_H
+    - Clostridium_S
+    - Enterocloster
+    - Clostridium_L
+    - Clostridium_AD
+    - Clostridium_AM
+    - Clostridium_X
+    - Clostridium_I
+    - Lawsonibacter
+    - Clostridium_T
+    - Clostridium_AO
+    - Clostridium_AR
+    - Pseudoclostridium
+    - Clostridium_W
+    - Clostridium_AA
+    - Clostridium_AT
+    - Clostridium_AU
+    - Clostridium_Z
+    - Clostridium_AH
+    - Clostridium_AK
+    - Clostridium_K
+    - Clostridium_R
+    - Clostridium_AW
+    - Clostridium_AC
+    - Massilioclostridium
+    - Clostridium_AB
+    - Clostridium_AE
+    - Clostridium_AF
+    - Clostridium_AG
+    - Clostridium_AS
+    - Clostridium_AV
+    - Clostridium_C
+    - Clostridium_D
+    - Clostridium_E
+    - Eubacterium
+    - Aminipila
+    - BRXR01
+    - Lacrimispora
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -78,7 +116,7 @@ taxonomy:
     term:
       id: NCBITaxon:1261393
       label: Desulfatiglans parachlorophenolica
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.yaml
+++ b/kb/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.yaml
@@ -51,6 +51,7 @@ taxonomy:
     term:
       id: NCBITaxon:82803
       label: Trichococcus flocculiformis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Trichococcus_flocculiformis
       gtdb_taxon: Trichococcus flocculiformis
@@ -90,6 +91,10 @@ taxonomy:
     term:
       id: NCBITaxon:863
       label: Syntrophomonas wolfei
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Syntrophomonas methylbutyratica
+    - Syntrophomonas wolfei
     notes: Butyrate-oxidizing bacterial syntroph stimulated in the three-member coculture.
   functional_role:
   - PRIMARY_DEGRADER
@@ -110,6 +115,7 @@ taxonomy:
     term:
       id: NCBITaxon:2203
       label: Methanospirillum hungatei
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Methanospirillum_hungatei
       gtdb_taxon: Methanospirillum hungatei

--- a/kb/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.yaml
+++ b/kb/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.yaml
@@ -48,6 +48,7 @@ taxonomy:
     term:
       id: NCBITaxon:51453
       label: Trichoderma reesei
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Cellulolytic fungal member; source abstract supports species-level identity.
   abundance_level: ABUNDANT
   functional_role:
@@ -68,6 +69,7 @@ taxonomy:
     term:
       id: NCBITaxon:562
       label: Escherichia coli
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Escherichia_coli
       gtdb_taxon: Escherichia coli

--- a/kb/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.yaml
+++ b/kb/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.yaml
@@ -48,7 +48,7 @@ taxonomy:
     term:
       id: NCBITaxon:51453
       label: Trichoderma reesei
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Cellulolytic fungal member; source abstract supports species-level identity.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Trichoderma_Lactate_Platform.yaml
+++ b/kb/communities/Trichoderma_Lactate_Platform.yaml
@@ -40,7 +40,7 @@ taxonomy:
     term:
       id: NCBITaxon:51453
       label: Trichoderma reesei
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/Trichoderma_Lactate_Platform.yaml
+++ b/kb/communities/Trichoderma_Lactate_Platform.yaml
@@ -40,6 +40,7 @@ taxonomy:
     term:
       id: NCBITaxon:51453
       label: Trichoderma reesei
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -54,6 +55,7 @@ taxonomy:
     term:
       id: NCBITaxon:1589
       label: Lactiplantibacillus pentosus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Lactiplantibacillus_pentosus
       gtdb_taxon: Lactiplantibacillus pentosus
@@ -77,6 +79,7 @@ taxonomy:
     term:
       id: NCBITaxon:1519
       label: Clostridium tyrobutyricum
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Clostridium_B_tyrobutyricum
       gtdb_taxon: Clostridium_B tyrobutyricum

--- a/kb/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.yaml
+++ b/kb/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.yaml
@@ -54,6 +54,7 @@ taxonomy:
     term:
       id: NCBITaxon:1344414
       label: Trichoderma reesei RUT C-30
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Cellulolytic fungal member supplying cellulases and hydrolysate sugars.
   abundance_level: ABUNDANT
   functional_role:
@@ -75,6 +76,7 @@ taxonomy:
     term:
       id: NCBITaxon:100226
       label: Streptomyces coelicolor A3(2)
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Streptomyces_anthocyanicus
       gtdb_taxon: Streptomyces anthocyanicus

--- a/kb/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.yaml
+++ b/kb/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.yaml
@@ -54,7 +54,7 @@ taxonomy:
     term:
       id: NCBITaxon:1344414
       label: Trichoderma reesei RUT C-30
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Cellulolytic fungal member supplying cellulases and hydrolysate sugars.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Trichodesmium_Alteromonas_Marine_Consortium.yaml
+++ b/kb/communities/Trichodesmium_Alteromonas_Marine_Consortium.yaml
@@ -72,7 +72,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Diverse heterotrophic bacteria that occur with Trichodesmium colonies in field and culture studies.
   functional_role:
   - CROSS_FEEDER

--- a/kb/communities/Trichodesmium_Alteromonas_Marine_Consortium.yaml
+++ b/kb/communities/Trichodesmium_Alteromonas_Marine_Consortium.yaml
@@ -23,6 +23,7 @@ taxonomy:
     term:
       id: NCBITaxon:203124
       label: Trichodesmium erythraeum IMS101
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Trichodesmium_erythraeum
       gtdb_taxon: Trichodesmium erythraeum
@@ -46,6 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:28108
       label: Alteromonas macleodii
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Alteromonas_macleodii
       gtdb_taxon: Alteromonas macleodii
@@ -70,6 +72,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Diverse heterotrophic bacteria that occur with Trichodesmium colonies in field and culture studies.
   functional_role:
   - CROSS_FEEDER

--- a/kb/communities/Urine_Nitrification_SynCom.yaml
+++ b/kb/communities/Urine_Nitrification_SynCom.yaml
@@ -108,7 +108,7 @@ taxonomy:
     term:
       id: NCBITaxon:47920
       label: Acidovorax delafieldii
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Urine_Nitrification_SynCom.yaml
+++ b/kb/communities/Urine_Nitrification_SynCom.yaml
@@ -36,6 +36,7 @@ taxonomy:
     term:
       id: NCBITaxon:915
       label: Nitrosomonas europaea
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Nitrosomonas_europaea
       gtdb_taxon: Nitrosomonas europaea
@@ -54,6 +55,7 @@ taxonomy:
     term:
       id: NCBITaxon:913
       label: Nitrobacter winogradskyi
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Nitrobacter_winogradskyi_A
       gtdb_taxon: Nitrobacter winogradskyi_A
@@ -72,6 +74,31 @@ taxonomy:
     term:
       id: NCBITaxon:294
       label: Pseudomonas fluorescens
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Pseudomonas_E alvandae
+    - Pseudomonas_E asgharzadehiana
+    - Pseudomonas_E azotoformans_A
+    - Pseudomonas_E brassicacearum
+    - Pseudomonas_E crudilactis
+    - Pseudomonas_E edaphica
+    - Pseudomonas_E fluorescens
+    - Pseudomonas_E fluorescens_AP
+    - Pseudomonas_E fluorescens_AQ
+    - Pseudomonas_E fluorescens_B
+    - Pseudomonas_E fluorescens_H
+    - Pseudomonas_E fluorescens_S
+    - Pseudomonas_E kilonensis
+    - Pseudomonas_E lactis
+    - Pseudomonas_E lactucae
+    - Pseudomonas_E paracarnis
+    - Pseudomonas_E petroselini
+    - Pseudomonas_E poae
+    - Pseudomonas_E protegens
+    - Pseudomonas_E reactans
+    - Pseudomonas_E salomonii
+    - Pseudomonas_E simiae
+    - Pseudomonas_E sp002874965
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -81,6 +108,7 @@ taxonomy:
     term:
       id: NCBITaxon:47920
       label: Acidovorax delafieldii
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -90,6 +118,10 @@ taxonomy:
     term:
       id: NCBITaxon:80866
       label: Delftia acidovorans
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Comamonas acidovorans
+    - Comamonas tsuruhatensis
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.yaml
+++ b/kb/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.yaml
@@ -85,6 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:34072
       label: Variovorax
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Variovorax
       gtdb_taxon: Variovorax
@@ -118,6 +119,7 @@ taxonomy:
     term:
       id: NCBITaxon:5206
       label: Cryptococcus <basidiomycete fungi>
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: The study identifies a Cryptococcus yeast that produces the B-vitamin
       pantothenate; species-level identity is not resolved in the abstract.
   functional_role:

--- a/kb/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.yaml
+++ b/kb/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.yaml
@@ -119,7 +119,7 @@ taxonomy:
     term:
       id: NCBITaxon:5206
       label: Cryptococcus <basidiomycete fungi>
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: The study identifies a Cryptococcus yeast that produces the B-vitamin
       pantothenate; species-level identity is not resolved in the abstract.
   functional_role:

--- a/kb/communities/Watermelon_Rhizosphere_Fusarium_SynCom8.yaml
+++ b/kb/communities/Watermelon_Rhizosphere_Fusarium_SynCom8.yaml
@@ -37,7 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:306
       label: Pseudomonas sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -47,7 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Watermelon_Rhizosphere_Fusarium_SynCom8.yaml
+++ b/kb/communities/Watermelon_Rhizosphere_Fusarium_SynCom8.yaml
@@ -37,6 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:306
       label: Pseudomonas sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:
@@ -46,6 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.yaml
+++ b/kb/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.yaml
@@ -26,7 +26,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Community-level representation of freshwater wetland soil microbes
       profiled by geochemistry, proteogenomics, metaproteomics, and
       stoichiometric modeling.
@@ -50,7 +50,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Methanogenic archaea are curated at domain level because the abstract
       distinguishes hydrogenotrophic and acetoclastic methanogenesis responses
       without providing a compact exact taxon list.
@@ -73,7 +73,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Bacterial guilds are curated broadly because the study reports
       altered microbial guilds and metabolic subnetworks rather than a defined
       synthetic species composition.

--- a/kb/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.yaml
+++ b/kb/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.yaml
@@ -26,6 +26,7 @@ taxonomy:
     term:
       id: NCBITaxon:131567
       label: cellular organisms
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Community-level representation of freshwater wetland soil microbes
       profiled by geochemistry, proteogenomics, metaproteomics, and
       stoichiometric modeling.
@@ -49,6 +50,7 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Methanogenic archaea are curated at domain level because the abstract
       distinguishes hydrogenotrophic and acetoclastic methanogenesis responses
       without providing a compact exact taxon list.
@@ -71,6 +73,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Bacterial guilds are curated broadly because the study reports
       altered microbial guilds and metabolic subnetworks rather than a defined
       synthetic species composition.

--- a/kb/communities/Wheat_Consortium_C1.yaml
+++ b/kb/communities/Wheat_Consortium_C1.yaml
@@ -62,7 +62,7 @@ taxonomy:
     term:
       id: NCBITaxon:1872648
       label: Asticcacaulis sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: DOMINANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -77,7 +77,7 @@ taxonomy:
     term:
       id: NCBITaxon:4565
       label: Triticum aestivum
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Wheat_Consortium_C1.yaml
+++ b/kb/communities/Wheat_Consortium_C1.yaml
@@ -38,6 +38,7 @@ taxonomy:
     term:
       id: NCBITaxon:151783
       label: Cupriavidus campinensis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Cupriavidus_campinensis
       gtdb_taxon: Cupriavidus campinensis
@@ -61,6 +62,7 @@ taxonomy:
     term:
       id: NCBITaxon:1872648
       label: Asticcacaulis sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: DOMINANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -75,6 +77,7 @@ taxonomy:
     term:
       id: NCBITaxon:4565
       label: Triticum aestivum
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Wheat_Consortium_C6.yaml
+++ b/kb/communities/Wheat_Consortium_C6.yaml
@@ -55,7 +55,7 @@ taxonomy:
     term:
       id: NCBITaxon:306
       label: Pseudomonas sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   abundance_level: DOMINANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -70,7 +70,7 @@ taxonomy:
     term:
       id: NCBITaxon:4565
       label: Triticum aestivum
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Wheat_Consortium_C6.yaml
+++ b/kb/communities/Wheat_Consortium_C6.yaml
@@ -38,6 +38,10 @@ taxonomy:
     term:
       id: NCBITaxon:29581
       label: Janthinobacterium lividum
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Janthinobacterium lividum
+    - Janthinobacterium lividum_D
   abundance_level: DOMINANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -51,6 +55,7 @@ taxonomy:
     term:
       id: NCBITaxon:306
       label: Pseudomonas sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: DOMINANT
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -65,6 +70,7 @@ taxonomy:
     term:
       id: NCBITaxon:4565
       label: Triticum aestivum
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.yaml
+++ b/kb/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.yaml
@@ -82,7 +82,7 @@ taxonomy:
     term:
       id: NCBITaxon:5547
       label: Trichoderma viride
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -92,7 +92,7 @@ taxonomy:
     term:
       id: NCBITaxon:5061
       label: Aspergillus niger
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - PRIMARY_DEGRADER
   evidence:

--- a/kb/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.yaml
+++ b/kb/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.yaml
@@ -44,6 +44,7 @@ taxonomy:
     term:
       id: NCBITaxon:1423
       label: Bacillus subtilis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Bacillus_subtilis
       gtdb_taxon: Bacillus subtilis
@@ -62,6 +63,7 @@ taxonomy:
     term:
       id: NCBITaxon:40214
       label: Acinetobacter johnsonii
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Acinetobacter_johnsonii
       gtdb_taxon: Acinetobacter johnsonii
@@ -80,6 +82,7 @@ taxonomy:
     term:
       id: NCBITaxon:5547
       label: Trichoderma viride
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -89,6 +92,7 @@ taxonomy:
     term:
       id: NCBITaxon:5061
       label: Aspergillus niger
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_DEGRADER
   evidence:

--- a/kb/communities/Yogurt_TwoSpecies_Starter_Culture.yaml
+++ b/kb/communities/Yogurt_TwoSpecies_Starter_Culture.yaml
@@ -53,6 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:1308
       label: Streptococcus thermophilus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Streptococcus_thermophilus
       gtdb_taxon: Streptococcus thermophilus
@@ -84,6 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:1585
       label: Lactobacillus delbrueckii subsp. bulgaricus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Lactobacillus_delbrueckii
       gtdb_taxon: Lactobacillus delbrueckii

--- a/kb/communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.yaml
+++ b/kb/communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.yaml
@@ -51,6 +51,7 @@ taxonomy:
     term:
       id: NCBITaxon:542
       label: Zymomonas mobilis
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Zymomonas_mobilis
       gtdb_taxon: Zymomonas mobilis
@@ -80,6 +81,7 @@ taxonomy:
     term:
       id: NCBITaxon:562
       label: Escherichia coli
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:s__Escherichia_coli
       gtdb_taxon: Escherichia coli

--- a/kb/communities/hCom2_Complex_Gut_Microbiome.yaml
+++ b/kb/communities/hCom2_Complex_Gut_Microbiome.yaml
@@ -37,6 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/hCom2_Complex_Gut_Microbiome.yaml
+++ b/kb/communities/hCom2_Complex_Gut_Microbiome.yaml
@@ -37,7 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/mCAFEs_Brachypodium_RCC.yaml
+++ b/kb/communities/mCAFEs_Brachypodium_RCC.yaml
@@ -42,6 +42,7 @@ taxonomy:
     term:
       id: NCBITaxon:407
       label: Methylobacterium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Methylobacterium
       gtdb_taxon: Methylobacterium
@@ -68,6 +69,7 @@ taxonomy:
     term:
       id: NCBITaxon:40323
       label: Stenotrophomonas
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Stenotrophomonas
       gtdb_taxon: Stenotrophomonas
@@ -93,6 +95,7 @@ taxonomy:
     term:
       id: NCBITaxon:286
       label: Pseudomonas
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Pseudomonas
       gtdb_taxon: Pseudomonas
@@ -118,6 +121,7 @@ taxonomy:
     term:
       id: NCBITaxon:392733
       label: Terriglobus
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Terriglobus
       gtdb_taxon: Terriglobus
@@ -144,6 +148,7 @@ taxonomy:
     term:
       id: NCBITaxon:1667
       label: Arthrobacter sp.
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Keystone taxon in slow-growing consortia (7-day transfer). Enriched in 1/10 R2A medium.
   functional_role:
   - PRIMARY_DEGRADER
@@ -159,6 +164,7 @@ taxonomy:
     term:
       id: NCBITaxon:32008
       label: Burkholderia
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Burkholderia
       gtdb_taxon: Burkholderia
@@ -184,6 +190,16 @@ taxonomy:
     term:
       id: NCBITaxon:44249
       label: Paenibacillus
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Paenibacillus
+    - Paenibacillus_A
+    - Paenibacillus_B
+    - Paenibacillus_G
+    - Pristimantibacillus
+    - Paenibacillus_H
+    - Paenibacillus_E
+    - Paenibacillus_Z
     notes: Persistent keystone taxon across multiple enrichment conditions.
   functional_role:
   - PRIMARY_DEGRADER
@@ -199,6 +215,7 @@ taxonomy:
     term:
       id: NCBITaxon:13687
       label: Sphingomonas
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Sphingomonas
       gtdb_taxon: Sphingomonas
@@ -224,6 +241,7 @@ taxonomy:
     term:
       id: NCBITaxon:423349
       label: Mucilaginibacter
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Mucilaginibacter
       gtdb_taxon: Mucilaginibacter
@@ -249,6 +267,7 @@ taxonomy:
     term:
       id: NCBITaxon:374
       label: Bradyrhizobium
+    gtdb_grounding_status: GROUNDED
     gtdb_classification:
       gtdb_id: GTDB:g__Bradyrhizobium
       gtdb_taxon: Bradyrhizobium

--- a/kb/communities/mCAFEs_Brachypodium_RCC.yaml
+++ b/kb/communities/mCAFEs_Brachypodium_RCC.yaml
@@ -148,7 +148,7 @@ taxonomy:
     term:
       id: NCBITaxon:1667
       label: Arthrobacter sp.
-    gtdb_grounding_status: NO_GTDB_EQUIVALENT
+    gtdb_grounding_status: UNRESOLVED
     notes: Keystone taxon in slow-growing consortia (7-day transfer). Enriched in 1/10 R2A medium.
   functional_role:
   - PRIMARY_DEGRADER
@@ -200,6 +200,31 @@ taxonomy:
     - Paenibacillus_H
     - Paenibacillus_E
     - Paenibacillus_Z
+    - Paenibacillus_S
+    - Paenibacillus_J
+    - Paenibacillus_D
+    - Paenibacillus_AB
+    - Paenibacillus_O
+    - Paenibacillus_T
+    - Paenibacillus_I
+    - Paenibacillus_AE
+    - Paenibacillus_K
+    - Paenibacillus_F
+    - Paenibacillus_L
+    - Bacillus
+    - Paenibacillus_AF
+    - Paenibacillus_AM
+    - Paenibacillus_AC
+    - Paenibacillus_AG
+    - Paenibacillus_AH
+    - Paenibacillus_AI
+    - Paenibacillus_AK
+    - Paenibacillus_AN
+    - Paenibacillus_N
+    - Paenibacillus_V
+    - Paenibacillus_W
+    - Paenibacillus_AA
+    - CC-CFT747
     notes: Persistent keystone taxon across multiple enrichment conditions.
   functional_role:
   - PRIMARY_DEGRADER

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -431,7 +431,12 @@ def resolve_higher(clean_lc, source_id, label, by_higher, denominator="aggregate
             "via": f"ncbi_rank_{prefix}",
             "ncbi_source_id": source_id,
             "ncbi_species": label,
-            "gtdb_options": ranked[:8],
+            # Full list, not `ranked[:8]`. The stored `gtdb_candidates` exists so
+            # a curator can choose without re-running the tool, and truncating it
+            # silently defeated exactly that: six KB taxa recorded 8 of 46 and 8
+            # of 33 contenders with no marker that any were dropped (#392 review).
+            # The CLI still prints only the first 8, with an "and N more" tail.
+            "gtdb_options": ranked,
             "n_alt": len(weights),
         }
     return None
@@ -570,7 +575,15 @@ STATUS_KEYS = ("gtdb_grounding_status", "gtdb_candidates")
 
 
 def classify_status(
-    record_name, tid, label, has_block, by_id, by_name, by_higher, preferred=None, **kwargs
+    record_name,
+    tid,
+    label,
+    has_block,
+    by_id,
+    by_name,
+    by_higher,
+    preferred=None,
+    **kwargs,
 ):
     """Why this taxon does or does not carry a grounding (#294).
 
@@ -602,7 +615,20 @@ def classify_status(
     if result and result.get("ambiguous"):
         return "AMBIGUOUS", list(result.get("gtdb_options") or [])
     if result is None or not result.get("gtdb_id"):
-        return "NO_GTDB_EQUIVALENT", []
+        # UNRESOLVED, never NO_GTDB_EQUIVALENT. This script cannot tell the two
+        # apart, and an earlier version asserted the strong one anyway: 57 KB
+        # entries read "GTDB has no counterpart and never will" for *Bacteria*,
+        # which is the root of GTDB — `HIGHER_RANKS` stops at phylum, so domain
+        # rank is never attempted. Others failed because the crosswalk spells
+        # the clade differently (NCBI *Sulcia* is `Candidatus Karelsulcia`) or
+        # because the named-species filter removed their rows.
+        #
+        # Matching NCBI names against the table was tried and does not settle it
+        # either — a rename defeats it. Establishing "GTDB will never classify
+        # this" needs an NCBI lineage source, since GTDB is bacteria/archaea
+        # only, which this script does not have. So NO_GTDB_EQUIVALENT is
+        # curator-assigned and the tool never writes it (#393).
+        return "UNRESOLVED", []
     # The tool would ground this and the KB does not. That is the only value
     # here that represents outstanding work.
     return "NOT_ATTEMPTED", []
@@ -625,30 +651,33 @@ WITHHELD_GROUNDINGS = {
 def _status_spans(lines: list[str], anchor: int, end: int) -> list[tuple[int, int]]:
     """Line spans of any existing status keys for one taxonomy entry.
 
-    Same shape as `_block_span`, and deliberately the same indent rule: `>= 6`
-    rather than exactly 6, because `gtdb_candidates` is a list whose items sit
-    deeper and an exact match would orphan them into duplicate keys (#378).
+    The indent is derived from the anchor rather than hardcoded. `data/isolates`
+    uses the indented-sequence style (`  - taxon_term:`), putting taxon_term
+    children at 6 spaces, so a literal 4-space match never worked there: the key
+    was neither found nor dropped, and a second `--apply-status` produced a
+    duplicate. The canary that "proved" idempotency only ever ran on
+    kb/communities, which is uniformly 4-space (#392 review).
+
+    A block sequence sits at the *same* indent as its key, so `gtdb_candidates:`
+    is followed by `- Anabaena` at that indent, not by a deeper line.
     """
-    keys = re.compile(r"^\s{4}(?:" + "|".join(STATUS_KEYS) + r"):")
-    # A block sequence is written at the *same* indent as its key, so
-    # `gtdb_candidates:` is followed by `    - Anabaena`, not by a deeper line.
-    # Matching only `\s{6,}` left those items outside the span: the key was
-    # replaced and the items survived, so a second `--apply-status` run appended
-    # a duplicate list under one key. Caught by the canary before any batch, but
-    # this is the same class of bug as #378's wrapped continuations.
-    item = re.compile(r"^\s{4}- ")
+    child = len(re.match(r"^(\s*)", lines[anchor]).group(1)) - 2
+    keys = re.compile(r"^\s{" + str(child) + r"}(?:" + "|".join(STATUS_KEYS) + r"):")
+    item = re.compile(r"^\s{" + str(child) + r"}- ")
+    deeper = re.compile(r"^\s{" + str(child + 2) + r",}\S")
+    sibling = re.compile(r"^\s{0," + str(child) + r"}\S")
     spans, i = [], anchor + 1
     while i < end:
         if keys.match(lines[i]):
             j = i + 1
-            while j < end and (re.match(r"^\s{6,}\S", lines[j]) or item.match(lines[j])):
+            while j < end and (deeper.match(lines[j]) or item.match(lines[j])):
                 j += 1
             spans.append((i, j))
             i = j
             continue
-        if re.match(r"^\s{0,4}\S", lines[i]) and not re.match(r"^\s{4}\S", lines[i]):
+        if sibling.match(lines[i]) and not re.match(r"^\s{" + str(child) + r"}\S", lines[i]):
             break
-        if re.match(r"^- ", lines[i]):
+        if re.match(r"^\s*- ", lines[i]) and not item.match(lines[i]):
             break
         i += 1
     return spans
@@ -869,34 +898,38 @@ def apply_status_to_community(path: Path, by_id, by_name, by_higher, **kwargs) -
 
     spans = {pos: _status_spans(lines, pos, end) for pos in anchors}
     by_anchor = dict(zip(anchors, wanted, strict=True))
+    # The label line is emitted by hand beside its anchor, so it must not also
+    # be emitted by the main loop.
+    label_lines = {pos + 1 for pos in anchors}
 
-    out = lines[: start + 1]
-    i, written = start + 1, 0
-    while i < end:
+    # Emit every line except the old status keys, inserting the new ones right
+    # after each entry's label.
+    #
+    # This replaces a walk that advanced two cursors and then re-emitted
+    # `lines[i]` unconditionally, so a dropped line reappeared whenever the old
+    # status keys were not exactly two lines below the anchor — which is what
+    # `--apply` produces, since it inserts `gtdb_classification` between the
+    # label and them. The result was a duplicate key that this function then
+    # refused to write, leaving records only hand-editable, and in one ordering
+    # a silently stale `gtdb_candidates` beside a fresh status (#392 review).
+    # A drop-set cannot express either failure.
+    drop = {n for pos in by_anchor for span in spans[pos] for n in range(*span)}
+    out, written = lines[: start + 1], 0
+    for i in range(start + 1, end):
+        if i in drop or i in label_lines:
+            continue
         out.append(lines[i])
         if i in by_anchor:
             status, candidates = by_anchor[i]
-            out.append(lines[i + 1])  # the label line
-            drop = {n for span in spans[i] for n in range(*span)}
-            indent = re.match(r"^(\s+)", lines[i]).group(1)
-            child = " " * (len(indent) - 2)
+            # The label line is the anchor's partner and never a status key, so
+            # emitting it here keeps the pair together; `drop` skips it below.
+            out.append(lines[i + 1])
+            child = " " * (len(re.match(r"^(\s*)", lines[i]).group(1)) - 2)
             out.append(f"{child}gtdb_grounding_status: {status}")
             if candidates:
                 out.append(f"{child}gtdb_candidates:")
                 out += [f"{child}- {c}" for c in candidates]
             written += 1
-            j = i + 2
-            while j < end and j in drop:
-                j += 1
-            # Siblings written after the label but before the next entry keep
-            # their order; only the old status keys are dropped.
-            k = j
-            while k < end and k not in drop and not re.match(r"^\s+id: NCBITaxon:\d+\s*$", lines[k]):
-                k += 1
-            out += [ln for n, ln in enumerate(lines[j:k], start=j) if n not in drop]
-            i = k
-            continue
-        i += 1
     out += lines[end:]
     new_text = "\n".join(out) + "\n"
 
@@ -1143,8 +1176,9 @@ def main(argv: list[str] | None = None) -> int:
             print("  no GTDB mapping (rank absent from the NCBI2GTDB table, or eukaryote).")
             continue
         if g.get("ambiguous"):
-            opts = ", ".join(g["gtdb_options"])
-            extra = g.get("n_alt", 0) - len(g["gtdb_options"])
+            shown = g["gtdb_options"][:8]
+            opts = ", ".join(shown)
+            extra = g.get("n_alt", 0) - len(shown)
             if extra > 0:
                 opts += f" (+{extra} more)"
             print(head)

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -569,7 +569,9 @@ def _block_span(lines: list[str], anchor: int, end: int) -> tuple[int, int] | No
 STATUS_KEYS = ("gtdb_grounding_status", "gtdb_candidates")
 
 
-def classify_status(record_name, tid, label, has_block, by_id, by_name, by_higher, **kwargs):
+def classify_status(
+    record_name, tid, label, has_block, by_id, by_name, by_higher, preferred=None, **kwargs
+):
     """Why this taxon does or does not carry a grounding (#294).
 
     Returns (status, candidates). The tool already distinguished all of these
@@ -584,7 +586,13 @@ def classify_status(record_name, tid, label, has_block, by_id, by_name, by_highe
     if (record_name, tid) in CURATED_GROUNDINGS:
         # A curated block is a grounding, just not one the tool would compute.
         return ("GROUNDED" if has_block else "WITHHELD"), []
-    if (record_name, tid) in WITHHELD_GROUNDINGS:
+    # Keyed by preferred_term, NOT by NCBITaxon id. Both withheld records use
+    # the offending id *correctly* elsewhere — BioModels uses 821 for its real
+    # Bacteroides vulgatus entry, KBase uses 1236 for two Steroidobacteraceae —
+    # so an id key marked three sound groundings WITHHELD. Same collision that
+    # `apply_to_community` carries a comment about; caught here by the
+    # status-vs-block coherence check.
+    if (record_name, preferred) in WITHHELD_GROUNDINGS:
         return "WITHHELD", []
     if has_block:
         return "GROUNDED", []
@@ -605,10 +613,10 @@ def classify_status(record_name, tid, label, has_block, by_id, by_name, by_highe
 # Mirrors CURATED_GROUNDINGS, which protects a grounding that *is* right.
 # Kept in step with WITHHELD in tests/test_gtdb_withheld_groundings.py (#292).
 WITHHELD_GROUNDINGS = {
-    ("BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml", "NCBITaxon:821"): (
+    ("BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml", "Bacteroides ovatus"): (
         "NCBITaxon:821 is Phocaeicola vulgatus; B. ovatus is NCBITaxon:28116."
     ),
-    ("KBase_ORT_Workflow_Community_Model.yaml", "NCBITaxon:1236"): (
+    ("KBase_ORT_Workflow_Community_Model.yaml", "Nitrospiraceae bacterium"): (
         "NCBITaxon:1236 is class Gammaproteobacteria, not a Nitrospiraceae bacterium."
     ),
 }
@@ -622,11 +630,18 @@ def _status_spans(lines: list[str], anchor: int, end: int) -> list[tuple[int, in
     deeper and an exact match would orphan them into duplicate keys (#378).
     """
     keys = re.compile(r"^\s{4}(?:" + "|".join(STATUS_KEYS) + r"):")
+    # A block sequence is written at the *same* indent as its key, so
+    # `gtdb_candidates:` is followed by `    - Anabaena`, not by a deeper line.
+    # Matching only `\s{6,}` left those items outside the span: the key was
+    # replaced and the items survived, so a second `--apply-status` run appended
+    # a duplicate list under one key. Caught by the canary before any batch, but
+    # this is the same class of bug as #378's wrapped continuations.
+    item = re.compile(r"^\s{4}- ")
     spans, i = [], anchor + 1
     while i < end:
         if keys.match(lines[i]):
             j = i + 1
-            while j < end and re.match(r"^\s{6,}\S", lines[j]):
+            while j < end and (re.match(r"^\s{6,}\S", lines[j]) or item.match(lines[j])):
                 j += 1
             spans.append((i, j))
             i = j
@@ -784,6 +799,163 @@ def apply_to_community(
     return added
 
 
+def apply_status_to_community(path: Path, by_id, by_name, by_higher, **kwargs) -> int:
+    """Write `gtdb_grounding_status` (and `gtdb_candidates`) on every taxon (#294).
+
+    Same line-level, add-only approach as `apply_to_community`, and deliberately
+    the same refusals: the entry count must match the anchors and the ids must
+    line up, or this raises rather than guessing an insertion point.
+
+    Status is written for **every** taxonomy entry, including grounded ones, even
+    though GROUNDED is derivable from the block's presence. Deriving state from
+    whether a field exists is the defect #294 is about; a consumer should read a
+    value.
+    """
+    doc = yaml.safe_load(path.read_text())
+    entries = doc.get("taxonomy", []) or []
+
+    wanted: list[tuple[str, list[str]] | None] = []
+    for tc in entries:
+        tt = (tc or {}).get("taxon_term", {}) or {}
+        term = tt.get("term", {}) or {}
+        tid = str(term.get("id", ""))
+        status, candidates = classify_status(
+            path.name,
+            tid,
+            term.get("label", ""),
+            "gtdb_classification" in tt,
+            by_id,
+            by_name,
+            by_higher,
+            preferred=tt.get("preferred_term"),
+            **kwargs,
+        )
+        wanted.append((status, candidates))
+
+    lines = path.read_text().splitlines()
+    start = end = None
+    for idx, line in enumerate(lines):
+        if re.match(r"^taxonomy:\s*$", line):
+            start = idx
+        elif start is not None and idx > start and re.match(r"^[A-Za-z_]", line):
+            end = idx
+            break
+    if start is None:
+        return 0
+    end = end if end is not None else len(lines)
+
+    anchors = [
+        i
+        for i in range(start + 1, end)
+        if re.match(r"^\s+id: NCBITaxon:\d+\s*$", lines[i])
+        and i + 1 < end
+        and re.match(r"^\s+label:", lines[i + 1])
+    ]
+    # Entries whose term id is not an NCBITaxon CURIE have no anchor line, so a
+    # mismatch here is expected rather than corruption — but it means this
+    # editor cannot place their status, and writing the others would silently
+    # leave gaps. Refuse the file instead.
+    if len(anchors) != len(entries):
+        raise SystemExit(
+            f"{path.name}: found {len(anchors)} taxon term-id lines for "
+            f"{len(entries)} taxonomy entries — refusing to edit."
+        )
+    for pos, tc in zip(anchors, entries, strict=True):
+        expected = str((((tc or {}).get("taxon_term") or {}).get("term") or {}).get("id", ""))
+        if lines[pos].split("id:", 1)[1].strip() != expected:
+            raise SystemExit(
+                f"{path.name}: taxonomy entry order does not match the file — refusing to edit."
+            )
+
+    spans = {pos: _status_spans(lines, pos, end) for pos in anchors}
+    by_anchor = dict(zip(anchors, wanted, strict=True))
+
+    out = lines[: start + 1]
+    i, written = start + 1, 0
+    while i < end:
+        out.append(lines[i])
+        if i in by_anchor:
+            status, candidates = by_anchor[i]
+            out.append(lines[i + 1])  # the label line
+            drop = {n for span in spans[i] for n in range(*span)}
+            indent = re.match(r"^(\s+)", lines[i]).group(1)
+            child = " " * (len(indent) - 2)
+            out.append(f"{child}gtdb_grounding_status: {status}")
+            if candidates:
+                out.append(f"{child}gtdb_candidates:")
+                out += [f"{child}- {c}" for c in candidates]
+            written += 1
+            j = i + 2
+            while j < end and j in drop:
+                j += 1
+            # Siblings written after the label but before the next entry keep
+            # their order; only the old status keys are dropped.
+            k = j
+            while k < end and k not in drop and not re.match(r"^\s+id: NCBITaxon:\d+\s*$", lines[k]):
+                k += 1
+            out += [ln for n, ln in enumerate(lines[j:k], start=j) if n not in drop]
+            i = k
+            continue
+        i += 1
+    out += lines[end:]
+    new_text = "\n".join(out) + "\n"
+
+    _assert_only_status_changed(path, doc, new_text)
+    path.write_text(new_text)
+    return written
+
+
+def _assert_only_status_changed(path: Path, before: dict, new_text: str) -> None:
+    """Fail loudly unless the edit touched the status slots and nothing else."""
+    try:
+        after = yaml.safe_load(new_text)
+    except yaml.YAMLError as exc:
+        raise SystemExit(
+            f"{path.name}: edit produced unparseable YAML — refusing to write: {exc}"
+        ) from exc
+
+    class _DupDetector(yaml.SafeLoader):
+        pass
+
+    def _no_dups(loader, node, deep=False):
+        seen, mapping = set(), {}
+        for key_node, value_node in node.value:
+            key = loader.construct_object(key_node, deep=deep)
+            if key in seen:
+                raise SystemExit(f"{path.name}: edit produced a duplicate `{key}` key.")
+            seen.add(key)
+            mapping[key] = loader.construct_object(value_node, deep=deep)
+        return mapping
+
+    _DupDetector.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _no_dups)
+    yaml.load(new_text, Loader=_DupDetector)  # noqa: S506 — subclass of SafeLoader
+
+    def _stripped(doc):
+        copy = yaml.safe_load(yaml.dump(doc, sort_keys=False, allow_unicode=True))
+        for entry in (copy or {}).get("taxonomy") or []:
+            tt = (entry or {}).get("taxon_term")
+            if isinstance(tt, dict):
+                for key in STATUS_KEYS:
+                    tt.pop(key, None)
+        return copy
+
+    if _stripped(before) != _stripped(after):
+        raise SystemExit(
+            f"{path.name}: the status edit changed something other than "
+            f"{'/'.join(STATUS_KEYS)} — refusing to write."
+        )
+
+    missing = [
+        i
+        for i, e in enumerate((after or {}).get("taxonomy") or [])
+        if "gtdb_grounding_status" not in ((e or {}).get("taxon_term") or {})
+    ]
+    if missing:
+        raise SystemExit(
+            f"{path.name}: {len(missing)} taxonomy entries have no status after the edit."
+        )
+
+
 def _assert_only_grounding_changed(
     path: Path, before: dict, new_text: str, refresh: bool = False
 ) -> None:
@@ -880,6 +1052,12 @@ def main(argv: list[str] | None = None) -> int:
         help="With --apply: recompute blocks that already exist. Creates none.",
     )
     p.add_argument(
+        "--apply-status",
+        action="store_true",
+        help="With --community: write gtdb_grounding_status on every taxon (#294). "
+        "Independent of --apply; writes no gtdb_classification.",
+    )
+    p.add_argument(
         "--denominator",
         choices=("aggregate", "deepest"),
         default="aggregate",
@@ -919,6 +1097,18 @@ def main(argv: list[str] | None = None) -> int:
         elif clean:
             want_higher.add(clean.lower())
     by_id, by_name, by_higher = collect_rows(mapping_path, want_ids, want_species, want_higher)
+
+    if args.community and args.apply_status:
+        n = apply_status_to_community(
+            args.community,
+            by_id,
+            by_name,
+            by_higher,
+            denominator=args.denominator,
+            exclude_unnamed=not args.include_unnamed,
+        )
+        print(f"[gtdb] wrote status on {n} taxa in {args.community.name}", file=sys.stderr)
+        return 0
 
     if args.community and args.apply:
         n = apply_to_community(

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -566,6 +566,79 @@ def _block_span(lines: list[str], anchor: int, end: int) -> tuple[int, int] | No
     return None
 
 
+STATUS_KEYS = ("gtdb_grounding_status", "gtdb_candidates")
+
+
+def classify_status(record_name, tid, label, has_block, by_id, by_name, by_higher, **kwargs):
+    """Why this taxon does or does not carry a grounding (#294).
+
+    Returns (status, candidates). The tool already distinguished all of these
+    internally — it prints a block, `AMBIGUOUS`, or `no GTDB mapping` — so this
+    persists a decision rather than making a new one.
+
+    Order matters. WITHHELD is checked before anything is computed, because the
+    point of a withhold is that the tool *can* produce a grounding and must not:
+    classifying it by outcome would label it GROUNDED-able and invite exactly the
+    re-run #293 exists to prevent.
+    """
+    if (record_name, tid) in CURATED_GROUNDINGS:
+        # A curated block is a grounding, just not one the tool would compute.
+        return ("GROUNDED" if has_block else "WITHHELD"), []
+    if (record_name, tid) in WITHHELD_GROUNDINGS:
+        return "WITHHELD", []
+    if has_block:
+        return "GROUNDED", []
+    if not tid.startswith("NCBITaxon:"):
+        return "NO_GTDB_EQUIVALENT", []
+    result = resolve_target(tid.split(":", 1)[1], label, by_id, by_name, by_higher, **kwargs)
+    if result and result.get("ambiguous"):
+        return "AMBIGUOUS", list(result.get("gtdb_options") or [])
+    if result is None or not result.get("gtdb_id"):
+        return "NO_GTDB_EQUIVALENT", []
+    # The tool would ground this and the KB does not. That is the only value
+    # here that represents outstanding work.
+    return "NOT_ATTEMPTED", []
+
+
+# Taxa kept ungrounded on purpose because the NCBITaxon id names a different
+# organism, so a derived block would describe the wrong species convincingly.
+# Mirrors CURATED_GROUNDINGS, which protects a grounding that *is* right.
+# Kept in step with WITHHELD in tests/test_gtdb_withheld_groundings.py (#292).
+WITHHELD_GROUNDINGS = {
+    ("BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml", "NCBITaxon:821"): (
+        "NCBITaxon:821 is Phocaeicola vulgatus; B. ovatus is NCBITaxon:28116."
+    ),
+    ("KBase_ORT_Workflow_Community_Model.yaml", "NCBITaxon:1236"): (
+        "NCBITaxon:1236 is class Gammaproteobacteria, not a Nitrospiraceae bacterium."
+    ),
+}
+
+
+def _status_spans(lines: list[str], anchor: int, end: int) -> list[tuple[int, int]]:
+    """Line spans of any existing status keys for one taxonomy entry.
+
+    Same shape as `_block_span`, and deliberately the same indent rule: `>= 6`
+    rather than exactly 6, because `gtdb_candidates` is a list whose items sit
+    deeper and an exact match would orphan them into duplicate keys (#378).
+    """
+    keys = re.compile(r"^\s{4}(?:" + "|".join(STATUS_KEYS) + r"):")
+    spans, i = [], anchor + 1
+    while i < end:
+        if keys.match(lines[i]):
+            j = i + 1
+            while j < end and re.match(r"^\s{6,}\S", lines[j]):
+                j += 1
+            spans.append((i, j))
+            i = j
+            continue
+        if re.match(r"^\s{0,4}\S", lines[i]) and not re.match(r"^\s{4}\S", lines[i]):
+            break
+        if re.match(r"^- ", lines[i]):
+            break
+        i += 1
+    return spans
+
+
 def apply_to_community(
     path: Path,
     by_id,

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-08-04T17:44:50
+# Generation date: 2026-08-04T19:34:08
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech
@@ -2258,17 +2258,23 @@ class GtdbGroundingStatusEnum(EnumDefinitionImpl):
     """
     Why a taxon does or does not carry a gtdb_classification. Absence alone cannot say: a virus GTDB will never
     classify, an NCBI taxon GTDB splits with no majority, and a taxon nobody has grounded yet all look identical as a
-    missing block (#294). The first is a *final* state and by far the largest — 293 of 1032 taxonomy entries — so
-    reading absence as outstanding work overstated the remaining backfill by roughly threefold (#276).
+    missing block (#294).
+    Of 1032 taxonomy entries: 647 GROUNDED, 293 UNRESOLVED, 81 AMBIGUOUS, 9 NOT_ATTEMPTED, 2 WITHHELD. Only
+    NOT_ATTEMPTED is unambiguously outstanding work, against the 385 that a missing block implied. How much of
+    UNRESOLVED is final rather than a tool limitation is not yet determined (#393).
     """
 
     GROUNDED = PermissibleValue(
         text="GROUNDED",
         description="""A gtdb_classification is present. Redundant with the block's presence by design: a consumer should read a state, not infer one from whether a field exists, which is the defect this enum exists to fix.""",
     )
+    UNRESOLVED = PermissibleValue(
+        text="UNRESOLVED",
+        description="""`gtdb_ground.py` produced no grounding and the reason is not established. Some of these are final — viruses and eukaryotes, since GTDB is bacteria/archaea only — and some are limitations of the tool: it attempts genus through phylum only, so domain-rank taxa such as *Bacteria* never resolve despite `d__Bacteria` being the root of GTDB; others fail because the crosswalk spells the clade differently (NCBI *Sulcia* is `Candidatus Karelsulcia`) or because the named-species filter removed their rows. Separating the two needs an NCBI lineage source the script does not have (#393).""",
+    )
     NO_GTDB_EQUIVALENT = PermissibleValue(
         text="NO_GTDB_EQUIVALENT",
-        description="""GTDB has no counterpart and never will. Viruses and eukaryotes (GTDB is bacteria/archaea only), environmental pseudo-taxa such as \"Stordalen Mire thaw-gradient microbiome\", and strains absent from the NCBI2GTDB mapping. A final state, not a gap.""",
+        description="""GTDB has no counterpart and never will — a final state, not a gap. **Curator-assigned only.** The tool writes UNRESOLVED instead, because it cannot establish this: an earlier version inferred it from \"the resolve failed\" and so asserted it for *Bacteria* on 57 entries.""",
     )
     AMBIGUOUS = PermissibleValue(
         text="AMBIGUOUS",
@@ -2285,7 +2291,8 @@ class GtdbGroundingStatusEnum(EnumDefinitionImpl):
 
     _defn = EnumDefinition(
         name="GtdbGroundingStatusEnum",
-        description="""Why a taxon does or does not carry a gtdb_classification. Absence alone cannot say: a virus GTDB will never classify, an NCBI taxon GTDB splits with no majority, and a taxon nobody has grounded yet all look identical as a missing block (#294). The first is a *final* state and by far the largest — 293 of 1032 taxonomy entries — so reading absence as outstanding work overstated the remaining backfill by roughly threefold (#276).""",
+        description="""Why a taxon does or does not carry a gtdb_classification. Absence alone cannot say: a virus GTDB will never classify, an NCBI taxon GTDB splits with no majority, and a taxon nobody has grounded yet all look identical as a missing block (#294).
+Of 1032 taxonomy entries: 647 GROUNDED, 293 UNRESOLVED, 81 AMBIGUOUS, 9 NOT_ATTEMPTED, 2 WITHHELD. Only NOT_ATTEMPTED is unambiguously outstanding work, against the 385 that a missing block implied. How much of UNRESOLVED is final rather than a tool limitation is not yet determined (#393).""",
     )
 
 

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-08-04T17:21:08
+# Generation date: 2026-08-04T17:44:50
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech
@@ -259,6 +259,8 @@ class TaxonDescriptor(YAMLRoot):
 
     preferred_term: str = None
     term: Union[dict, Term] = None
+    gtdb_grounding_status: Optional[Union[str, "GtdbGroundingStatusEnum"]] = None
+    gtdb_candidates: Optional[Union[str, list[str]]] = empty_list()
     gtdb_classification: Optional[Union[dict, "GtdbClassification"]] = None
     notes: Optional[str] = None
 
@@ -272,6 +274,17 @@ class TaxonDescriptor(YAMLRoot):
             self.MissingRequiredField("term")
         if not isinstance(self.term, Term):
             self.term = Term(**as_dict(self.term))
+
+        if self.gtdb_grounding_status is not None and not isinstance(
+            self.gtdb_grounding_status, GtdbGroundingStatusEnum
+        ):
+            self.gtdb_grounding_status = GtdbGroundingStatusEnum(self.gtdb_grounding_status)
+
+        if not isinstance(self.gtdb_candidates, list):
+            self.gtdb_candidates = (
+                [self.gtdb_candidates] if self.gtdb_candidates is not None else []
+            )
+        self.gtdb_candidates = [v if isinstance(v, str) else str(v) for v in self.gtdb_candidates]
 
         if self.gtdb_classification is not None and not isinstance(
             self.gtdb_classification, GtdbClassification
@@ -2241,6 +2254,41 @@ class CommunityCategoryEnum(EnumDefinitionImpl):
     )
 
 
+class GtdbGroundingStatusEnum(EnumDefinitionImpl):
+    """
+    Why a taxon does or does not carry a gtdb_classification. Absence alone cannot say: a virus GTDB will never
+    classify, an NCBI taxon GTDB splits with no majority, and a taxon nobody has grounded yet all look identical as a
+    missing block (#294). The first is a *final* state and by far the largest — 293 of 1032 taxonomy entries — so
+    reading absence as outstanding work overstated the remaining backfill by roughly threefold (#276).
+    """
+
+    GROUNDED = PermissibleValue(
+        text="GROUNDED",
+        description="""A gtdb_classification is present. Redundant with the block's presence by design: a consumer should read a state, not infer one from whether a field exists, which is the defect this enum exists to fix.""",
+    )
+    NO_GTDB_EQUIVALENT = PermissibleValue(
+        text="NO_GTDB_EQUIVALENT",
+        description="""GTDB has no counterpart and never will. Viruses and eukaryotes (GTDB is bacteria/archaea only), environmental pseudo-taxa such as \"Stordalen Mire thaw-gradient microbiome\", and strains absent from the NCBI2GTDB mapping. A final state, not a gap.""",
+    )
+    AMBIGUOUS = PermissibleValue(
+        text="AMBIGUOUS",
+        description="""GTDB splits the NCBI taxon and no candidate holds a majority, so the tool declines to guess. gtdb_candidates carries the contenders so a curator can choose without re-running anything. Resolvable by curation, unlike NO_GTDB_EQUIVALENT.""",
+    )
+    WITHHELD = PermissibleValue(
+        text="WITHHELD",
+        description="""The tool can produce a grounding and a curator has decided it must not be stored — usually because the NCBITaxon id names a different organism, so the derived block would describe the wrong species convincingly (#292, #293). Fix the id and this becomes GROUNDED on the next run.""",
+    )
+    NOT_ATTEMPTED = PermissibleValue(
+        text="NOT_ATTEMPTED",
+        description="""No grounding has been derived, and nothing above explains why. The only value here that represents outstanding work.""",
+    )
+
+    _defn = EnumDefinition(
+        name="GtdbGroundingStatusEnum",
+        description="""Why a taxon does or does not carry a gtdb_classification. Absence alone cannot say: a virus GTDB will never classify, an NCBI taxon GTDB splits with no majority, and a taxon nobody has grounded yet all look identical as a missing block (#294). The first is a *final* state and by far the largest — 293 of 1032 taxonomy entries — so reading absence as outstanding work overstated the remaining backfill by roughly threefold (#276).""",
+    )
+
+
 class InteractionTypeEnum(EnumDefinitionImpl):
     """
     Type of ecological interaction between organisms
@@ -3157,6 +3205,24 @@ slots.taxonDescriptor__term = Slot(
     model_uri=COMMUNITYMECH.taxonDescriptor__term,
     domain=None,
     range=Union[dict, Term],
+)
+
+slots.taxonDescriptor__gtdb_grounding_status = Slot(
+    uri=COMMUNITYMECH.gtdb_grounding_status,
+    name="taxonDescriptor__gtdb_grounding_status",
+    curie=COMMUNITYMECH.curie("gtdb_grounding_status"),
+    model_uri=COMMUNITYMECH.taxonDescriptor__gtdb_grounding_status,
+    domain=None,
+    range=Optional[Union[str, "GtdbGroundingStatusEnum"]],
+)
+
+slots.taxonDescriptor__gtdb_candidates = Slot(
+    uri=COMMUNITYMECH.gtdb_candidates,
+    name="taxonDescriptor__gtdb_candidates",
+    curie=COMMUNITYMECH.curie("gtdb_candidates"),
+    model_uri=COMMUNITYMECH.taxonDescriptor__gtdb_candidates,
+    domain=None,
+    range=Optional[Union[str, list[str]]],
 )
 
 slots.taxonDescriptor__gtdb_classification = Slot(

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -160,6 +160,43 @@ enums:
       OTHER:
         description: Other or uncategorized communities
 
+  GtdbGroundingStatusEnum:
+    description: >-
+      Why a taxon does or does not carry a gtdb_classification. Absence alone
+      cannot say: a virus GTDB will never classify, an NCBI taxon GTDB splits
+      with no majority, and a taxon nobody has grounded yet all look identical
+      as a missing block (#294). The first is a *final* state and by far the
+      largest — 293 of 1032 taxonomy entries — so reading absence as outstanding
+      work overstated the remaining backfill by roughly threefold (#276).
+    permissible_values:
+      GROUNDED:
+        description: >-
+          A gtdb_classification is present. Redundant with the block's presence
+          by design: a consumer should read a state, not infer one from whether
+          a field exists, which is the defect this enum exists to fix.
+      NO_GTDB_EQUIVALENT:
+        description: >-
+          GTDB has no counterpart and never will. Viruses and eukaryotes (GTDB
+          is bacteria/archaea only), environmental pseudo-taxa such as "Stordalen
+          Mire thaw-gradient microbiome", and strains absent from the NCBI2GTDB
+          mapping. A final state, not a gap.
+      AMBIGUOUS:
+        description: >-
+          GTDB splits the NCBI taxon and no candidate holds a majority, so the
+          tool declines to guess. gtdb_candidates carries the contenders so a
+          curator can choose without re-running anything. Resolvable by curation,
+          unlike NO_GTDB_EQUIVALENT.
+      WITHHELD:
+        description: >-
+          The tool can produce a grounding and a curator has decided it must not
+          be stored — usually because the NCBITaxon id names a different organism,
+          so the derived block would describe the wrong species convincingly
+          (#292, #293). Fix the id and this becomes GROUNDED on the next run.
+      NOT_ATTEMPTED:
+        description: >-
+          No grounding has been derived, and nothing above explains why. The only
+          value here that represents outstanding work.
+
   InteractionTypeEnum:
     description: Type of ecological interaction between organisms
     permissible_values:
@@ -669,6 +706,24 @@ classes:
         bindings:
           - binds_value_of: id
             obligation_level: REQUIRED
+      gtdb_grounding_status:
+        description: >-
+          Why this taxon does or does not carry a gtdb_classification (#294).
+          Populated by `gtdb_ground.py --apply-status`. GROUNDED must accompany
+          a gtdb_classification and every other value must accompany its absence
+          — a relation the schema cannot express, checked by
+          `communitymech.validators.gtdb_coherence` and so by
+          `just validate-strict` (#387).
+        range: GtdbGroundingStatusEnum
+      gtdb_candidates:
+        description: >-
+          The competing GTDB taxa when gtdb_grounding_status is AMBIGUOUS, best
+          supported first, as plain names rather than CURIEs (they are candidates,
+          not identifiers). Carried so a curator can choose in place instead of
+          re-running the tool to rediscover what it already computed. Empty for
+          every other status.
+        multivalued: true
+        range: string
       gtdb_classification:
         description: >-
           Optional GTDB (Genome Taxonomy Database) grounding for this taxon,

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -165,21 +165,35 @@ enums:
       Why a taxon does or does not carry a gtdb_classification. Absence alone
       cannot say: a virus GTDB will never classify, an NCBI taxon GTDB splits
       with no majority, and a taxon nobody has grounded yet all look identical
-      as a missing block (#294). The first is a *final* state and by far the
-      largest — 293 of 1032 taxonomy entries — so reading absence as outstanding
-      work overstated the remaining backfill by roughly threefold (#276).
+      as a missing block (#294).
+
+      Of 1032 taxonomy entries: 647 GROUNDED, 293 UNRESOLVED, 81 AMBIGUOUS, 9
+      NOT_ATTEMPTED, 2 WITHHELD. Only NOT_ATTEMPTED is unambiguously outstanding
+      work, against the 385 that a missing block implied. How much of UNRESOLVED
+      is final rather than a tool limitation is not yet determined (#393).
     permissible_values:
       GROUNDED:
         description: >-
           A gtdb_classification is present. Redundant with the block's presence
           by design: a consumer should read a state, not infer one from whether
           a field exists, which is the defect this enum exists to fix.
+      UNRESOLVED:
+        description: >-
+          `gtdb_ground.py` produced no grounding and the reason is not
+          established. Some of these are final — viruses and eukaryotes, since
+          GTDB is bacteria/archaea only — and some are limitations of the tool:
+          it attempts genus through phylum only, so domain-rank taxa such as
+          *Bacteria* never resolve despite `d__Bacteria` being the root of GTDB;
+          others fail because the crosswalk spells the clade differently (NCBI
+          *Sulcia* is `Candidatus Karelsulcia`) or because the named-species
+          filter removed their rows. Separating the two needs an NCBI lineage
+          source the script does not have (#393).
       NO_GTDB_EQUIVALENT:
         description: >-
-          GTDB has no counterpart and never will. Viruses and eukaryotes (GTDB
-          is bacteria/archaea only), environmental pseudo-taxa such as "Stordalen
-          Mire thaw-gradient microbiome", and strains absent from the NCBI2GTDB
-          mapping. A final state, not a gap.
+          GTDB has no counterpart and never will — a final state, not a gap.
+          **Curator-assigned only.** The tool writes UNRESOLVED instead, because
+          it cannot establish this: an earlier version inferred it from "the
+          resolve failed" and so asserted it for *Bacteria* on 57 entries.
       AMBIGUOUS:
         description: >-
           GTDB splits the NCBI taxon and no candidate holds a majority, so the

--- a/src/communitymech/validators/gtdb_coherence.py
+++ b/src/communitymech/validators/gtdb_coherence.py
@@ -126,22 +126,41 @@ def _taxon_terms(doc: Any) -> Iterator[tuple[str, dict]]:
     """
     if not isinstance(doc, dict):
         return
-    taxonomy = doc.get("taxonomy")
-    if not isinstance(taxonomy, list):
-        return
-    for index, entry in enumerate(taxonomy):
-        if not isinstance(entry, dict):
-            continue
-        term_block = entry.get("taxon_term")
-        if not isinstance(term_block, dict):
-            continue
+
+    def _label(term_block: dict) -> str:
         term = term_block.get("term")
-        name = (
+        return (
             term_block.get("preferred_term")
             or (term.get("id") if isinstance(term, dict) else None)
             or "?"
         )
-        yield f"taxonomy[{index}] {name}", term_block
+
+    taxonomy = doc.get("taxonomy")
+    if isinstance(taxonomy, list):
+        for index, entry in enumerate(taxonomy):
+            if not isinstance(entry, dict):
+                continue
+            term_block = entry.get("taxon_term")
+            if isinstance(term_block, dict):
+                yield f"taxonomy[{index}] {_label(term_block)}", term_block
+
+    # `EcologicalInteraction.source_taxon` / `target_taxon` also have range
+    # TaxonDescriptor, so they carry the same two slots — 1139 more instances
+    # than `taxonomy` alone. Walking only `taxonomy` meant an interaction taxon
+    # could claim GROUNDED with no block, or carry a single candidate, and every
+    # gate reported clean (#392 review).
+    interactions = doc.get("ecological_interactions")
+    if isinstance(interactions, list):
+        for index, entry in enumerate(interactions):
+            if not isinstance(entry, dict):
+                continue
+            for slot in ("source_taxon", "target_taxon"):
+                term_block = entry.get(slot)
+                if isinstance(term_block, dict):
+                    yield (
+                        f"ecological_interactions[{index}].{slot} {_label(term_block)}",
+                        term_block,
+                    )
 
 
 def check_block(block: dict) -> list[tuple[str, str]]:
@@ -297,7 +316,12 @@ def check_status(term_block: dict) -> list[tuple[str, str]]:
                 f"where the tool declined to choose.",
             )
         )
-    if status == "AMBIGUOUS" and candidates is not None and len(candidates) < 2:
+    # `candidates is not None` let the *more* degenerate case through: an
+    # AMBIGUOUS taxon with no `gtdb_candidates` key at all passed, while an
+    # explicit empty list was flagged. `apply_status_to_community` writes the key
+    # only `if candidates:`, so the case that actually occurs was the unchecked
+    # one (#392 review).
+    if status == "AMBIGUOUS" and len(candidates or []) < 2:
         problems.append(
             (
                 "ambiguous_without_candidates",

--- a/src/communitymech/validators/gtdb_coherence.py
+++ b/src/communitymech/validators/gtdb_coherence.py
@@ -118,6 +118,32 @@ def _blocks(doc: Any) -> Iterator[tuple[str, dict]]:
             yield f"taxonomy[{index}] {name}", grounding
 
 
+def _taxon_terms(doc: Any) -> Iterator[tuple[str, dict]]:
+    """Yield (label, taxon_term) for every taxonomy entry, grounded or not.
+
+    `_blocks` only reaches taxa that already carry a grounding, which is exactly
+    the population the status enum exists to look past.
+    """
+    if not isinstance(doc, dict):
+        return
+    taxonomy = doc.get("taxonomy")
+    if not isinstance(taxonomy, list):
+        return
+    for index, entry in enumerate(taxonomy):
+        if not isinstance(entry, dict):
+            continue
+        term_block = entry.get("taxon_term")
+        if not isinstance(term_block, dict):
+            continue
+        term = term_block.get("term")
+        name = (
+            term_block.get("preferred_term")
+            or (term.get("id") if isinstance(term, dict) else None)
+            or "?"
+        )
+        yield f"taxonomy[{index}] {name}", term_block
+
+
 def check_block(block: dict) -> list[tuple[str, str]]:
     """Return (category, message) for each incoherence in one block.
 
@@ -217,6 +243,71 @@ def check_block(block: dict) -> list[tuple[str, str]]:
     return problems
 
 
+def check_status(term_block: dict) -> list[tuple[str, str]]:
+    """Relate `gtdb_grounding_status` to the rest of the taxon (#294).
+
+    The enum is deliberately redundant with the block's presence — a consumer
+    should read a state, not infer one — and redundancy that nothing checks is
+    just two sources of truth. The schema can express neither half: it cannot
+    say "GROUNDED iff gtdb_classification exists", nor "gtdb_candidates only
+    when AMBIGUOUS".
+    """
+    problems: list[tuple[str, str]] = []
+    status = term_block.get("gtdb_grounding_status")
+    has_block = isinstance(term_block.get("gtdb_classification"), dict)
+    candidates = term_block.get("gtdb_candidates")
+
+    if status is None:
+        # Absence is tolerated: a record predating #294, or one hand-authored
+        # since. Flagging it would make the slot required in practice while the
+        # schema calls it optional.
+        if candidates:
+            problems.append(
+                (
+                    "candidates_without_status",
+                    "gtdb_candidates with no gtdb_grounding_status — candidates are "
+                    "only meaningful for AMBIGUOUS.",
+                )
+            )
+        return problems
+
+    if status == "GROUNDED" and not has_block:
+        problems.append(
+            (
+                "grounded_without_block",
+                "gtdb_grounding_status is GROUNDED but there is no "
+                "gtdb_classification. Re-run `gtdb_ground.py --apply-status`.",
+            )
+        )
+    elif status != "GROUNDED" and has_block:
+        problems.append(
+            (
+                "block_without_grounded_status",
+                f"gtdb_grounding_status is {status} but a gtdb_classification is "
+                f"present. A stored grounding is a grounding whatever the reason "
+                f"it was withheld.",
+            )
+        )
+
+    if candidates and status != "AMBIGUOUS":
+        problems.append(
+            (
+                "candidates_on_unambiguous_taxon",
+                f"gtdb_candidates on a {status} taxon — the contenders only exist "
+                f"where the tool declined to choose.",
+            )
+        )
+    if status == "AMBIGUOUS" and candidates is not None and len(candidates) < 2:
+        problems.append(
+            (
+                "ambiguous_without_candidates",
+                "AMBIGUOUS with fewer than two candidates — an ambiguity needs at "
+                "least two things to be ambiguous between.",
+            )
+        )
+    return problems
+
+
 def validate_gtdb_coherence(path: Path) -> list[CoherenceIssue]:
     """Check every `gtdb_classification` in one record."""
     try:
@@ -231,8 +322,14 @@ def validate_gtdb_coherence(path: Path) -> list[CoherenceIssue]:
             )
         ]
 
-    return [
+    issues = [
         CoherenceIssue(file=str(path), taxon=label, category=category, message=message)
         for label, block in _blocks(doc)
         for category, message in check_block(block)
     ]
+    issues += [
+        CoherenceIssue(file=str(path), taxon=label, category=category, message=message)
+        for label, term_block in _taxon_terms(doc)
+        for category, message in check_status(term_block)
+    ]
+    return issues

--- a/tests/test_gtdb_coherence_validator.py
+++ b/tests/test_gtdb_coherence_validator.py
@@ -30,6 +30,7 @@ import yaml
 from communitymech.validators.gtdb_coherence import (
     _blocks,
     check_block,
+    check_status,
     validate_gtdb_coherence,
 )
 
@@ -322,3 +323,140 @@ def test_structurally_odd_documents_are_survived(tmp_path, text):
     record = tmp_path / "odd.yaml"
     record.write_text(text)
     assert validate_gtdb_coherence(record) == []
+
+
+# ---------------------------------------------------------------------------
+# The grounding-status enum (#294).
+# ---------------------------------------------------------------------------
+
+
+def _term(status=None, block=None, candidates=None, **extra):
+    term_block = {"preferred_term": "Some taxon", "term": {"id": "NCBITaxon:1"}, **extra}
+    if status is not None:
+        term_block["gtdb_grounding_status"] = status
+    if block is not None:
+        term_block["gtdb_classification"] = block
+    if candidates is not None:
+        term_block["gtdb_candidates"] = candidates
+    return term_block
+
+
+def test_grounded_status_requires_a_block():
+    assert "grounded_without_block" in {c for c, _ in check_status(_term(status="GROUNDED"))}
+
+
+@pytest.mark.parametrize("status", ["NO_GTDB_EQUIVALENT", "AMBIGUOUS", "WITHHELD", "NOT_ATTEMPTED"])
+def test_a_stored_block_means_grounded(status):
+    """A grounding is a grounding whatever the reason it was once withheld."""
+    assert "block_without_grounded_status" in {
+        c for c, _ in check_status(_term(status=status, block=_valid_block()))
+    }
+
+
+def test_the_matched_pair_is_clean():
+    assert check_status(_term(status="GROUNDED", block=_valid_block())) == []
+    assert check_status(_term(status="NO_GTDB_EQUIVALENT")) == []
+
+
+def test_candidates_belong_only_to_ambiguous():
+    assert "candidates_on_unambiguous_taxon" in {
+        c for c, _ in check_status(_term(status="NO_GTDB_EQUIVALENT", candidates=["A", "B"]))
+    }
+    assert check_status(_term(status="AMBIGUOUS", candidates=["A", "B"])) == []
+
+
+def test_an_ambiguity_needs_two_candidates():
+    assert "ambiguous_without_candidates" in {
+        c for c, _ in check_status(_term(status="AMBIGUOUS", candidates=["A"]))
+    }
+
+
+def test_candidates_without_a_status_are_flagged():
+    assert "candidates_without_status" in {c for c, _ in check_status(_term(candidates=["A", "B"]))}
+
+
+def test_a_taxon_with_no_status_is_tolerated():
+    """Absence must stay legal — the schema calls the slot optional."""
+    assert check_status(_term()) == []
+    assert check_status(_term(block=_valid_block())) == []
+
+
+def test_every_kb_taxon_carries_a_status():
+    """The sweep must have reached all of them, not just the grounded ones.
+
+    Statuses are written for every entry including GROUNDED, because inferring
+    state from whether a field exists is the defect #294 is about.
+    """
+    from communitymech.validators.gtdb_coherence import _taxon_terms
+
+    total, missing = 0, []
+    for directory in ("kb/communities", "data/isolates"):
+        for path in sorted((REPO / directory).glob("*.yaml")):
+            for label, term_block in _taxon_terms(yaml.safe_load(path.read_text())):
+                total += 1
+                if "gtdb_grounding_status" not in term_block:
+                    missing.append(f"{path.name}: {label}")
+    assert total > 1000, f"expected the whole KB, saw {total} taxa"
+    assert not missing, f"{len(missing)} taxa have no status:\n" + "\n".join(missing[:10])
+
+
+def test_the_status_distribution_is_what_was_measured():
+    """The counts #294 turns on: absence was hiding a large *final* category.
+
+    293 NO_GTDB_EQUIVALENT against 9 NOT_ATTEMPTED is the whole point — reading
+    absence as outstanding work overstated the remaining backfill roughly
+    thirtyfold. Ranged, so ordinary drift does not fail it, but a collapse of
+    the distinction would.
+    """
+    from collections import Counter
+
+    from communitymech.validators.gtdb_coherence import _taxon_terms
+
+    counts = Counter()
+    for directory in ("kb/communities", "data/isolates"):
+        for path in sorted((REPO / directory).glob("*.yaml")):
+            for _, term_block in _taxon_terms(yaml.safe_load(path.read_text())):
+                counts[term_block.get("gtdb_grounding_status")] += 1
+
+    assert counts["GROUNDED"] > 600
+    assert counts["NO_GTDB_EQUIVALENT"] > 250, "the final-state category vanished"
+    assert counts["AMBIGUOUS"] > 50
+    assert counts["WITHHELD"] == 2, "the #292 withholds must still be marked"
+    assert (
+        counts["NOT_ATTEMPTED"] < 50
+    ), "outstanding work grew sharply — or a real category is being mislabelled"
+
+
+def test_the_withholds_are_marked_withheld_not_grounded():
+    """The #292 pair, and the id collision that mislabelled three neighbours.
+
+    Keying the withhold list by NCBITaxon id marked three *correct* groundings
+    WITHHELD, because both records reuse the offending id for a legitimate entry
+    — BioModels uses 821 for its real Bacteroides vulgatus, KBase uses 1236 for
+    two Steroidobacteraceae. Keyed by preferred_term instead.
+    """
+    from communitymech.validators.gtdb_coherence import _taxon_terms
+
+    for record, preferred in [
+        ("BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml", "Bacteroides ovatus"),
+        ("KBase_ORT_Workflow_Community_Model.yaml", "Nitrospiraceae bacterium"),
+    ]:
+        doc = yaml.safe_load((REPO / "kb/communities" / record).read_text())
+        terms = {t.get("preferred_term"): t for _, t in _taxon_terms(doc)}
+        assert terms[preferred].get("gtdb_grounding_status") == "WITHHELD"
+
+    # And the neighbours sharing those ids must be unaffected.
+    doc = yaml.safe_load(
+        (REPO / "kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml").read_text()
+    )
+    siblings = [
+        t
+        for _, t in _taxon_terms(doc)
+        if (t.get("term") or {}).get("id") == "NCBITaxon:821"
+        and t.get("preferred_term") != "Bacteroides ovatus"
+    ]
+    assert siblings, "expected another entry on NCBITaxon:821 in this record"
+    for term_block in siblings:
+        assert (
+            term_block.get("gtdb_grounding_status") == "GROUNDED"
+        ), "a correct grounding sharing the withheld id was marked WITHHELD"

--- a/tests/test_gtdb_coherence_validator.py
+++ b/tests/test_gtdb_coherence_validator.py
@@ -39,6 +39,28 @@ SCHEMA = REPO / "src/communitymech/schema/communitymech.yaml"
 FIXTURE = REPO / "kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml"
 
 
+@pytest.fixture(scope="module")
+def gtdb():
+    """The grounding script, loaded by path like the other suites do."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("gtdb_ground", REPO / "scripts/gtdb_ground.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def mapping(gtdb):
+    try:
+        path = gtdb.resolve_kg_microbe_dir(None) / "data/raw/NCBI2GTDB.tsv.gz"
+    except SystemExit as exc:
+        pytest.skip(f"kg-microbe mapping unavailable: {str(exc).splitlines()[0]}")
+    if not path.exists():
+        pytest.skip(f"kg-microbe NCBI2GTDB mapping not available at {path}")
+    return path
+
+
 def _valid_block() -> dict:
     return {
         "gtdb_id": "GTDB:f__Methylomonadaceae",
@@ -381,50 +403,94 @@ def test_a_taxon_with_no_status_is_tolerated():
     assert check_status(_term(block=_valid_block())) == []
 
 
-def test_every_kb_taxon_carries_a_status():
-    """The sweep must have reached all of them, not just the grounded ones.
+def test_every_kb_taxonomy_entry_carries_a_status():
+    """The sweep must reach all of them, not just the grounded ones.
 
-    Statuses are written for every entry including GROUNDED, because inferring
-    state from whether a field exists is the defect #294 is about.
+    Scoped to `taxonomy`, which is what `--apply-status` writes. Interaction
+    `source_taxon`/`target_taxon` share the range and so may carry the slots —
+    `check_status` validates them if present — but nothing populates them, and
+    demanding a status there would fail the whole KB.
     """
-    from communitymech.validators.gtdb_coherence import _taxon_terms
-
     total, missing = 0, []
     for directory in ("kb/communities", "data/isolates"):
         for path in sorted((REPO / directory).glob("*.yaml")):
-            for label, term_block in _taxon_terms(yaml.safe_load(path.read_text())):
+            for index, entry in enumerate(yaml.safe_load(path.read_text()).get("taxonomy") or []):
+                term_block = entry.get("taxon_term") or {}
                 total += 1
                 if "gtdb_grounding_status" not in term_block:
-                    missing.append(f"{path.name}: {label}")
+                    missing.append(f"{path.name}: taxonomy[{index}]")
     assert total > 1000, f"expected the whole KB, saw {total} taxa"
     assert not missing, f"{len(missing)} taxa have no status:\n" + "\n".join(missing[:10])
 
 
-def test_the_status_distribution_is_what_was_measured():
-    """The counts #294 turns on: absence was hiding a large *final* category.
+def test_the_stored_statuses_reproduce_from_the_classifier(gtdb, mapping):
+    """Re-derive every status and compare it to disk.
 
-    293 NO_GTDB_EQUIVALENT against 9 NOT_ATTEMPTED is the whole point — reading
-    absence as outstanding work overstated the remaining backfill roughly
-    thirtyfold. Ranged, so ordinary drift does not fail it, but a collapse of
-    the distinction would.
+    The KB-level assertions elsewhere read files the sweep already wrote, so a
+    classifier regression is invisible to them — changing the final
+    `return "NOT_ATTEMPTED"` to `return "UNRESOLVED"` left every ranged
+    assertion green (#392 review). This is the one test that can fail on that.
+    """
+    want_ids, want_species, want_higher, records = set(), set(), set(), []
+    for directory in ("kb/communities", "data/isolates"):
+        for path in sorted((REPO / directory).glob("*.yaml")):
+            for entry in yaml.safe_load(path.read_text()).get("taxonomy") or []:
+                term_block = entry.get("taxon_term") or {}
+                term = term_block.get("term") or {}
+                tid, label = str(term.get("id", "")), term.get("label", "")
+                records.append((path.name, tid, label, term_block))
+                if tid.startswith("NCBITaxon:"):
+                    want_ids.add(tid.split(":")[1])
+                    clean = gtdb._clean_label(label)
+                    (want_species if " " in clean else want_higher).add(clean.lower())
+    rows = gtdb.collect_rows(mapping, want_ids, want_species, want_higher)
+
+    wrong = []
+    for record, tid, label, term_block in records:
+        status, candidates = gtdb.classify_status(
+            record,
+            tid,
+            label,
+            "gtdb_classification" in term_block,
+            *rows,
+            preferred=term_block.get("preferred_term"),
+        )
+        stored = term_block.get("gtdb_grounding_status")
+        if stored != status:
+            wrong.append(f"{record}: {label} stored {stored}, classifier says {status}")
+        if sorted(term_block.get("gtdb_candidates") or []) != sorted(candidates):
+            wrong.append(f"{record}: {label} candidate list does not reproduce")
+    assert not wrong, f"{len(wrong)} statuses do not reproduce:\n" + "\n".join(wrong[:10])
+
+
+def test_the_status_distribution_is_what_was_measured():
+    """The counts #294 turns on, pinned tightly enough to catch a collapse.
+
+    An earlier version used only upper/lower bounds so loose that folding
+    NOT_ATTEMPTED into UNRESOLVED — the exact confusion this enum exists to
+    prevent — passed every assertion. The ratio and the floor are what bite.
     """
     from collections import Counter
-
-    from communitymech.validators.gtdb_coherence import _taxon_terms
 
     counts = Counter()
     for directory in ("kb/communities", "data/isolates"):
         for path in sorted((REPO / directory).glob("*.yaml")):
-            for _, term_block in _taxon_terms(yaml.safe_load(path.read_text())):
-                counts[term_block.get("gtdb_grounding_status")] += 1
+            for entry in yaml.safe_load(path.read_text()).get("taxonomy") or []:
+                counts[(entry.get("taxon_term") or {}).get("gtdb_grounding_status")] += 1
 
     assert counts["GROUNDED"] > 600
-    assert counts["NO_GTDB_EQUIVALENT"] > 250, "the final-state category vanished"
+    assert counts["UNRESOLVED"] > 250, "the ungrounded-but-unexplained bucket vanished"
     assert counts["AMBIGUOUS"] > 50
     assert counts["WITHHELD"] == 2, "the #292 withholds must still be marked"
+    # A floor as well as a ceiling: `< 50` alone is satisfied by zero, so
+    # collapsing NOT_ATTEMPTED into another bucket passed.
+    assert 1 <= counts["NOT_ATTEMPTED"] < 50, (
+        "NOT_ATTEMPTED is the only value meaning outstanding work; 0 almost "
+        "certainly means it is being mislabelled, not that the work is done"
+    )
     assert (
-        counts["NOT_ATTEMPTED"] < 50
-    ), "outstanding work grew sharply — or a real category is being mislabelled"
+        counts["NO_GTDB_EQUIVALENT"] == 0
+    ), "the tool must not assert NO_GTDB_EQUIVALENT — it cannot establish it (#393)"
 
 
 def test_the_withholds_are_marked_withheld_not_grounded():

--- a/tests/test_gtdb_status_writer.py
+++ b/tests/test_gtdb_status_writer.py
@@ -1,0 +1,172 @@
+"""The text surgery behind `--apply-status`, which shipped untested (#294, #392).
+
+`apply_status_to_community`, `_status_spans` and `_assert_only_status_changed`
+are ~260 lines of line-level YAML editing in a repo with six separate
+corruption incidents behind it, and their only exercise was having been run once
+over the KB. Three defects followed, all reproduced here:
+
+* the span indent was hardcoded to 4, so `data/isolates` — which uses the
+  indented-sequence style and sits at 6 — was never idempotent;
+* the reconstruction loop re-emitted a line it had decided to drop whenever the
+  old status keys were not exactly two lines below the anchor, which is what
+  `--apply` produces, leaving records only a human could repair;
+* the same loop could write a stale `gtdb_candidates` beside a fresh status
+  without tripping the duplicate-key guard.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).parent.parent
+
+
+@pytest.fixture(scope="module")
+def gtdb():
+    spec = importlib.util.spec_from_file_location("gtdb_ground", REPO / "scripts/gtdb_ground.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def rows(gtdb):
+    """Row indexes for the fixture records, or skip."""
+    try:
+        mapping = gtdb.resolve_kg_microbe_dir(None) / "data/raw/NCBI2GTDB.tsv.gz"
+    except SystemExit as exc:
+        pytest.skip(f"kg-microbe mapping unavailable: {str(exc).splitlines()[0]}")
+    if not mapping.exists():
+        pytest.skip("kg-microbe NCBI2GTDB mapping not available")
+    return gtdb.collect_rows(mapping, {"403", "1234"}, {"methylococcaceae"}, {"nitrospira"})
+
+
+FOUR_SPACE = REPO / "kb/communities/AMD_Nitrososphaerota_Archaeal.yaml"
+SIX_SPACE = REPO / "data/isolates/Chromobacterium_Gold_Biocyanidation.yaml"
+
+
+@pytest.mark.parametrize("source", [FOUR_SPACE, SIX_SPACE], ids=["4-space", "6-space"])
+def test_apply_status_is_idempotent(gtdb, rows, tmp_path, source):
+    """Both indent styles. Only the 4-space one was ever canaried.
+
+    `data/isolates` uses `  - taxon_term:`, putting its children at 6 spaces. A
+    literal `\\s{4}` never matched, so the old key was neither found nor dropped
+    and a second run produced a duplicate — which the guard then refused,
+    leaving the record unrepairable by the tool.
+    """
+    record = tmp_path / source.name
+    record.write_text(source.read_text())
+
+    gtdb.apply_status_to_community(record, *rows)
+    once = record.read_text()
+    gtdb.apply_status_to_community(record, *rows)
+
+    assert record.read_text() == once, "a second --apply-status changed the file"
+    assert once.count("gtdb_grounding_status:") == len(
+        yaml.safe_load(once).get("taxonomy") or []
+    ), "one status per taxonomy entry"
+
+
+def test_apply_and_apply_status_interleave_in_any_order(gtdb, rows, tmp_path):
+    """The sequence that deadlocked a record (#392 review).
+
+    `--apply` inserts `gtdb_classification` between the label and the status
+    keys, so they stop being two lines below the anchor. The old loop then
+    re-emitted them, producing a duplicate key the writer refused — and the
+    documented repair is `--apply-status`, which is what refused.
+    """
+    record = tmp_path / FOUR_SPACE.name
+    record.write_text(FOUR_SPACE.read_text())
+
+    for step in ("status", "apply", "status", "apply", "status"):
+        if step == "status":
+            gtdb.apply_status_to_community(record, *rows)
+        else:
+            gtdb.apply_to_community(record, *rows, "test-source")
+
+    document = yaml.safe_load(record.read_text())
+    for entry in document["taxonomy"]:
+        term_block = entry["taxon_term"]
+        assert ("gtdb_classification" in term_block) == (
+            term_block.get("gtdb_grounding_status") == "GROUNDED"
+        ), "status and block disagree after interleaving"
+
+
+def test_a_stale_candidate_list_is_replaced_not_left(gtdb, rows, tmp_path):
+    """Candidates written after a block, with no status, must not survive.
+
+    This ordering slipped past `_assert_only_status_changed` because that guard
+    pops both status slots from before *and* after before comparing, so it is
+    structurally unable to notice the status slots being left wrong.
+    """
+    document = yaml.safe_load(FOUR_SPACE.read_text())
+    term_block = document["taxonomy"][0]["taxon_term"]
+    term_block.pop("gtdb_grounding_status", None)
+    term_block["gtdb_candidates"] = ["Stale One", "Stale Two"]
+    record = tmp_path / "stale.yaml"
+    record.write_text(yaml.dump(document, sort_keys=False, allow_unicode=True))
+
+    gtdb.apply_status_to_community(record, *rows)
+
+    after = yaml.safe_load(record.read_text())["taxonomy"][0]["taxon_term"]
+    assert after.get("gtdb_grounding_status") == "GROUNDED"
+    assert "gtdb_candidates" not in after, "a stale candidate list survived the rewrite"
+
+
+def test_the_writer_refuses_when_anchors_do_not_match(gtdb, rows, tmp_path):
+    """A wrong insertion point is silent corruption, so it must refuse."""
+    document = yaml.safe_load(FOUR_SPACE.read_text())
+    document["taxonomy"].append({"taxon_term": {"preferred_term": "Ghost", "term": {}}})
+    record = tmp_path / "mismatched.yaml"
+    record.write_text(yaml.dump(document, sort_keys=False, allow_unicode=True))
+
+    with pytest.raises(SystemExit, match="refusing to edit"):
+        gtdb.apply_status_to_community(record, *rows)
+
+
+def test_nothing_outside_the_status_slots_changes(gtdb, rows, tmp_path):
+    """Byte-level: the record minus its status keys must be unchanged."""
+    record = tmp_path / FOUR_SPACE.name
+    record.write_text(FOUR_SPACE.read_text())
+    before = yaml.safe_load(record.read_text())
+
+    gtdb.apply_status_to_community(record, *rows)
+    after = yaml.safe_load(record.read_text())
+
+    def stripped(document):
+        for entry in document.get("taxonomy") or []:
+            term_block = entry.get("taxon_term") or {}
+            term_block.pop("gtdb_grounding_status", None)
+            term_block.pop("gtdb_candidates", None)
+        return document
+
+    assert stripped(before) == stripped(after)
+
+
+def test_a_duplicate_key_is_refused_rather_than_written(gtdb, rows, tmp_path):
+    """The guard that turned three corruption bugs into loud failures.
+
+    PyYAML keeps the last of two identical keys silently, so without this the
+    span bugs above would have written corrupt records that `linkml-validate`
+    accepted.
+    """
+    record = tmp_path / "dup.yaml"
+    record.write_text(FOUR_SPACE.read_text())
+    original = gtdb._status_spans
+
+    # The fixture already carries statuses from the KB sweep, so disabling span
+    # detection duplicates them on the first write.
+    gtdb._status_spans = lambda lines, anchor, end: []  # never drop the old keys
+    try:
+        with pytest.raises(SystemExit, match="duplicate"):
+            gtdb.apply_status_to_community(record, *rows)
+    finally:
+        gtdb._status_spans = original
+
+    assert (
+        record.read_text() == FOUR_SPACE.read_text()
+    ), "the refusal must leave the file untouched, not half-written"

--- a/tests/test_gtdb_withheld_groundings.py
+++ b/tests/test_gtdb_withheld_groundings.py
@@ -118,3 +118,80 @@ def test_curated_grounding_is_not_overwritten_by_the_majority_vote(record: str, 
         f"the curated {expected}. {why} This is most likely an unreviewed "
         f"`gtdb_ground.py --refresh` — revert this block."
     )
+
+
+# ---------------------------------------------------------------------------
+# The classifier that turns a withhold into a stored status (#294).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def gtdb():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "gtdb_ground", Path(__file__).parent.parent / "scripts/gtdb_ground.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(("record", "preferred"), list(WITHHELD))
+def test_a_withheld_taxon_classifies_as_withheld(gtdb, record, preferred):
+    """Not NOT_ATTEMPTED, and not whatever the tool would have computed.
+
+    WITHHELD is checked before anything is resolved, because the point of a
+    withhold is that the tool *can* produce a grounding and must not. Classifying
+    by outcome would mark these groundable and invite the re-run #293 exists to
+    prevent.
+    """
+    term = _taxon_term(record, preferred)
+    assert term is not None
+    status, candidates = gtdb.classify_status(
+        record,
+        (term.get("term") or {}).get("id", ""),
+        (term.get("term") or {}).get("label", ""),
+        "gtdb_classification" in term,
+        {},
+        {},
+        {},
+        preferred=preferred,
+    )
+    assert status == "WITHHELD", f"{preferred} classified as {status}"
+    assert candidates == []
+
+
+def test_the_withhold_does_not_catch_a_sibling_sharing_the_id(gtdb):
+    """The collision that keying by NCBITaxon id introduced (#294).
+
+    Both withheld records use the offending id *correctly* for another entry —
+    BioModels for its real Bacteroides vulgatus, KBase for two
+    Steroidobacteraceae — so an id-keyed withhold list marked three sound
+    groundings WITHHELD. The list is keyed by preferred_term for that reason.
+    """
+    record = "BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml"
+    doc = yaml.safe_load((COMMUNITIES / record).read_text())
+    siblings = [
+        entry["taxon_term"]
+        for entry in doc["taxonomy"]
+        if (entry["taxon_term"].get("term") or {}).get("id") == "NCBITaxon:821"
+        and entry["taxon_term"].get("preferred_term") != "Bacteroides ovatus"
+    ]
+    assert siblings, "expected another entry on NCBITaxon:821 in this record"
+
+    for term in siblings:
+        status, _ = gtdb.classify_status(
+            record,
+            "NCBITaxon:821",
+            (term.get("term") or {}).get("label", ""),
+            "gtdb_classification" in term,
+            {},
+            {},
+            {},
+            preferred=term.get("preferred_term"),
+        )
+        assert status == "GROUNDED", (
+            f"'{term.get('preferred_term')}' shares the withheld id and was "
+            f"classified {status} — the withhold list is keyed by id again"
+        )


### PR DESCRIPTION
Closes #294.

An absent `gtdb_classification` cannot say **why** it is absent. A virus GTDB will never classify, a taxon GTDB splits with no majority, and a taxon nobody has grounded yet all looked identical.

## `gtdb_grounding_status`, on every taxonomy entry

| status | count | meaning |
|---|---|---|
| `GROUNDED` | 647 | a `gtdb_classification` is present |
| `UNRESOLVED` | 293 | the tool produced no grounding; **why is not established** |
| `AMBIGUOUS` | 81 | GTDB splits the taxon with no majority; `gtdb_candidates` carries every contender |
| `NOT_ATTEMPTED` | 9 | the tool *would* ground it and the KB does not — unambiguously outstanding work |
| `WITHHELD` | 2 | the tool can ground it and a curator decided it must not (#292) |
| `NO_GTDB_EQUIVALENT` | 0 | **curator-assigned only** — the tool cannot establish it (#393) |

A missing block implied **385** open items. **9** are unambiguously outstanding work. The rest are not yet separated, and saying so is the point.

### The claim this PR originally made, and why it is gone

The first version had the tool write `NO_GTDB_EQUIVALENT` — "GTDB has no counterpart and never will" — for all 293, and led with "293 against 9, a thirtieth of what absence implied".

Review found **at least 82 of those 293 were wrong**, the largest being the worst: **57 entries asserted that about *Bacteria***, which is the root of GTDB. `HIGHER_RANKS` stops at phylum, so domain rank is never attempted — a limit of this script, published as a fact about GTDB. Others fail because the crosswalk spells the clade differently (NCBI *Sulcia* is `Candidatus Karelsulcia`) or because the named-species filter removed their rows.

That is exactly the substitution #294 exists to stop.

I tried settling it by checking whether the crosswalk mentions the NCBI id or name anywhere in its lineage columns. It fixes the 72 rank cases cleanly and **cannot fix a rename at all**, so it buys a partial answer that looks complete. Removed rather than shipped. Separating final from unresolved needs an NCBI lineage source the script does not have — filed as **#393**.

`GROUNDED` is deliberately redundant with the block'"'"'s presence: inferring state from whether a field exists is the defect. Redundancy nothing checks is two sources of truth, so `check_status` enforces GROUNDED iff a block exists, candidates only on AMBIGUOUS, and at least two of them.

## Three writer bugs, all from 260 untested lines

`apply_status_to_community`, `_status_spans` and `_assert_only_status_changed` shipped with **no tests** — in a repo with six prior YAML-corruption incidents — exercised only by having been run once over the KB.

- **`_status_spans` hardcoded a 4-space indent.** `data/isolates` uses the indented-sequence style at 6, so its key was never found or dropped and a second run duplicated it — then the guard refused, leaving the record repairable only by hand. My canary "proved idempotency" on `kb/communities` only, which is uniformly 4-space.
- **The reconstruction loop re-emitted a line it had decided to drop**, whenever the status keys were not exactly two lines below the anchor — which is what `--apply` produces. `--apply` then `--apply-status` **deadlocked the record**, and the documented repair *is* `--apply-status`. Replaced with a drop-set; the two writers now interleave in any order.
- **The same loop could leave a stale `gtdb_candidates`** beside a fresh status without tripping the duplicate guard, because `_assert_only_status_changed` pops both status slots from before *and* after before comparing — structurally unable to notice them left wrong.

While fixing the first I spliced out `apply_to_community` (145 lines) and only noticed because the canary exercised a second code path.

## Also fixed

- **`gtdb_candidates` was silently truncated to 8** — six taxa recorded 8 of 46 contenders with no marker, defeating the reason for storing them. Full list stored; the CLI keeps the cap with an "and N more" tail.
- **`ambiguous_without_candidates` was inverted** — the *more* degenerate case (no key at all) passed while an empty list was flagged, and the unchecked one is the case that actually occurs.
- **`check_status` walked only `taxonomy`**, missing 1139 interaction `source_taxon`/`target_taxon` instances that carry the same slots. A GROUNDED interaction taxon with no block passed every gate.
- The schema said "threefold" where SKILL.md said "thirtyfold"; neither matched any computable figure.

## Tests

`tests/test_gtdb_status_writer.py` covers the surgery directly: both indent styles, interleaving, stale candidates, the anchor refusal, and that a refusal leaves the file untouched. All four writer mutants fail.

Plus a test that **re-derives every stored status from `classify_status` and compares it to disk** — the only thing that can catch a classifier regression. The KB-level assertions read files the sweep had already written, and folding `NOT_ATTEMPTED` into another bucket passed all of them.

## Sweep

1032 entries, all carrying a status; **0** changed outside the two status slots; **0** status/block mismatches; **0** bad candidate lists; a second full sweep changes nothing.

`just validate-all`, `validate-strict`, `validate-gtdb-all` clean; 1130 passed; lint clean.
