### PR TITLE
Stop grounding an exact 50/50 tie, and add a way to withdraw one (#382)

### DIFF
--- a/.claude/skills/ground-taxa-gtdb/SKILL.md
+++ b/.claude/skills/ground-taxa-gtdb/SKILL.md
@@ -107,8 +107,9 @@ Grounding happens at the **rank of the input**:
   miss on id alone). GTDB species split → AMBIGUOUS.
 - **Genus / family / order / …** (single-name label) → `GTDB:g__...` (or
   `f__`/`o__`/…): the script aggregates the GTDB rank column over the genomes
-  under the NCBI taxon and grounds to the GTDB taxon holding a **majority (≥50%)**
-  of them; otherwise AMBIGUOUS. `mapping_source` records the rank and how many
+  under the NCBI taxon and grounds to the GTDB taxon holding a **strict majority
+  (>50%)** of them; otherwise AMBIGUOUS. An exact 50/50 tie is not a majority and
+  does not ground (#382). `mapping_source` records the rank and how many
   GTDB taxa fall under the NCBI taxon (NCBI genus *Bacillus* → `g__Bacillus` at
   0.57, noted as 44 GTDB genera).
 
@@ -125,7 +126,7 @@ Grounding happens at the **rank of the input**:
 Every `taxonomy[].taxon_term` carries `gtdb_grounding_status`, written by
 `gtdb_ground.py --community <file> --apply-status`. Absence of a
 `gtdb_classification` cannot say *why* it is absent, and the reasons are not
-comparable: a missing block implied 385 open items, of which only 9 are
+comparable: a missing block implied 389 open items, of which only 9 are
 unambiguously outstanding work (#276).
 
 | status | count | meaning |
@@ -186,8 +187,11 @@ taxonomy entries and their id anchors do not line up.
   `0.99` the true count spans ~170. A thin grounding is not automatically wrong;
   a small genus is legitimately small. The point is that you can now tell.
 
-  A fraction of exactly **0.5** never grounds: a tie is not a majority, so the
-  tool reports AMBIGUOUS and records both contenders (#382). The name tie-break
+  A **true** 50/50 tie never grounds: it is not a majority, so the tool reports
+  AMBIGUOUS and records both contenders (#382). Note the stored value is rounded
+  to 3 places, so a block *can* read `0.5` legitimately — 5004/10000 is 0.5004,
+  a real if slender majority. Read `support_genomes`/`total_genomes` to tell
+  them apart; a genuine tie has no block at all. The name tie-break
   survives, but only to make the *option list* reproducible — it no longer
   decides an answer. `--withdraw-ambiguous` removes a stored grounding that has
   become ambiguous, which `--refresh` deliberately cannot do.

--- a/.claude/skills/ground-taxa-gtdb/SKILL.md
+++ b/.claude/skills/ground-taxa-gtdb/SKILL.md
@@ -130,9 +130,9 @@ unambiguously outstanding work (#276).
 
 | status | count | meaning |
 |---|---|---|
-| `GROUNDED` | 647 | a `gtdb_classification` is present |
+| `GROUNDED` | 643 | a `gtdb_classification` is present |
 | `UNRESOLVED` | 293 | the tool produced no grounding; **why is not established** |
-| `AMBIGUOUS` | 81 | GTDB splits the NCBI taxon with no majority; `gtdb_candidates` carries every contender |
+| `AMBIGUOUS` | 85 | GTDB splits the NCBI taxon with no majority; `gtdb_candidates` carries every contender |
 | `NOT_ATTEMPTED` | 9 | the tool *would* ground it and the KB does not — unambiguously outstanding work |
 | `WITHHELD` | 2 | the tool can ground it and a curator decided it must not (#292) |
 | `NO_GTDB_EQUIVALENT` | 0 | **curator-assigned only** — the tool cannot establish it (#393) |
@@ -186,8 +186,11 @@ taxonomy entries and their id anchors do not line up.
   `0.99` the true count spans ~170. A thin grounding is not automatically wrong;
   a small genus is legitimately small. The point is that you can now tell.
 
-  A fraction of exactly **0.5** is a two-way tie, not a majority — it is broken by
-  name so the answer is reproducible, but it is still a coin flip (#382).
+  A fraction of exactly **0.5** never grounds: a tie is not a majority, so the
+  tool reports AMBIGUOUS and records both contenders (#382). The name tie-break
+  survives, but only to make the *option list* reproducible — it no longer
+  decides an answer. `--withdraw-ambiguous` removes a stored grounding that has
+  become ambiguous, which `--refresh` deliberately cannot do.
 
   A grounding the majority vote gets *wrong* can be pinned in `CURATED` in
   `tests/test_gtdb_withheld_groundings.py`; the tool has no memory of such a

--- a/kb/communities/Ensifer_YF2_Sphingobacterium_Y2_Polyethylene_Degrading_Consortium.yaml
+++ b/kb/communities/Ensifer_YF2_Sphingobacterium_Y2_Polyethylene_Degrading_Consortium.yaml
@@ -23,17 +23,10 @@ taxonomy:
     term:
       id: NCBITaxon:106591
       label: Ensifer
-    gtdb_grounding_status: GROUNDED
-    gtdb_classification:
-      gtdb_id: GTDB:g__Ensifer
-      gtdb_taxon: Ensifer
-      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Ensifer
-      ncbi_source_id: NCBITaxon:106591
-      majority_fraction: 0.5
-      support_genomes: 19
-      total_genomes: 38
-      is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Ensifer
+    - Sinorhizobium
     notes: Strain YF2 identified only to genus Ensifer in the source; grounded at genus rank.
   strain_designation:
     strain_name: YF2

--- a/kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml
+++ b/kb/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.yaml
@@ -149,15 +149,12 @@ taxonomy:
     term:
       id: NCBITaxon:429
       label: Methylobacter
-    gtdb_grounding_status: GROUNDED
-    gtdb_classification:
-      gtdb_id: GTDB:g__Methylobacter_A
-      gtdb_taxon: Methylobacter_A
-      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;f__Methylomonadaceae;g__Methylobacter_A
-      ncbi_source_id: NCBITaxon:429
-      majority_fraction: 0.662
-      is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 4 GTDB taxa under the NCBI taxon]
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Methylobacter_A
+    - Methylobacter
+    - Methylobacter_B
+    - Methylobacter_C
     notes: Low-oxygen methanotrophic genus in Lake Washington methane-fed microcosms.
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/Medicago_Nodule_Biofertilizer_SynCom.yaml
+++ b/kb/communities/Medicago_Nodule_Biofertilizer_SynCom.yaml
@@ -38,17 +38,10 @@ taxonomy:
     term:
       id: NCBITaxon:106591
       label: Ensifer
-    gtdb_grounding_status: GROUNDED
-    gtdb_classification:
-      gtdb_id: GTDB:g__Ensifer
-      gtdb_taxon: Ensifer
-      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Rhizobiaceae;g__Ensifer
-      ncbi_source_id: NCBITaxon:106591
-      majority_fraction: 0.5
-      support_genomes: 19
-      total_genomes: 38
-      is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Ensifer
+    - Sinorhizobium
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Teosinte_Maize_Biofertilizer_SynCom7.yaml
+++ b/kb/communities/Teosinte_Maize_Biofertilizer_SynCom7.yaml
@@ -37,15 +37,18 @@ taxonomy:
     term:
       id: NCBITaxon:613
       label: Serratia <enterobacteria>
-    gtdb_grounding_status: GROUNDED
-    gtdb_classification:
-      gtdb_id: GTDB:g__Serratia
-      gtdb_taxon: Serratia
-      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Serratia
-      ncbi_source_id: NCBITaxon:613
-      majority_fraction: 0.519
-      is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-06-19) [grounded at g__ rank; 14 GTDB taxa under the NCBI taxon]
+    gtdb_grounding_status: AMBIGUOUS
+    gtdb_candidates:
+    - Serratia
+    - Serratia_J
+    - Serratia_L
+    - Serratia_F
+    - Serratia_A
+    - Serratia_B
+    - Chania
+    - Serratia_K
+    - Serratia_G
+    - Serratia_D
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -407,7 +407,13 @@ def resolve_higher(clean_lc, source_id, label, by_higher, denominator="aggregate
         # (#382); this only makes the answer reproducible.
         top, tw = sorted(weights.items(), key=lambda kv: (-kv[1], kv[0]))[0]
         frac = tw / total
-        if frac >= 0.5:
+        # Strictly greater. An exact 50/50 split is not a majority, and grounding
+        # it meant the answer came from the tie-break rather than the evidence:
+        # two live KB blocks sat on `19/38`, decided alphabetically between
+        # `g__Ensifer` and `g__Sinorhizobium` (#382). The tie-break stays — it is
+        # what makes the AMBIGUOUS option list reproducible — but it no longer
+        # decides a grounding.
+        if frac > 0.5:
             return {
                 "ncbi_source_id": source_id,
                 "gtdb_id": _curie(top, prefix),
@@ -828,6 +834,82 @@ def apply_to_community(
     return added
 
 
+def withdraw_ambiguous(path: Path, by_id, by_name, by_higher, **kwargs) -> int:
+    """Remove groundings the tool now calls AMBIGUOUS (#382, #376).
+
+    `--refresh` is deliberately unable to drop a block: an ungrounded taxon may
+    be ungrounded on purpose, so a refresh that could remove would be able to
+    overturn a curation decision silently (#378). Withdrawal is therefore its
+    own mode, and a narrow one — it removes only where the recompute is
+    *explicitly* ambiguous, never where it merely fails, so a taxon whose rows
+    have gone missing keeps its stored answer rather than losing it to a bad
+    mapping build.
+
+    Curated pins are skipped, as everywhere else.
+    """
+    doc = yaml.safe_load(path.read_text())
+    entries = doc.get("taxonomy", []) or []
+
+    drop_entry: list[bool] = []
+    for tc in entries:
+        tt = (tc or {}).get("taxon_term", {}) or {}
+        term = tt.get("term", {}) or {}
+        tid = str(term.get("id", ""))
+        if (path.name, tid) in CURATED_GROUNDINGS or "gtdb_classification" not in tt:
+            drop_entry.append(False)
+            continue
+        if not tid.startswith("NCBITaxon:"):
+            drop_entry.append(False)
+            continue
+        result = resolve_target(
+            tid.split(":", 1)[1], term.get("label", ""), by_id, by_name, by_higher, **kwargs
+        )
+        drop_entry.append(bool(result and result.get("ambiguous")))
+    if not any(drop_entry):
+        return 0
+
+    lines = path.read_text().splitlines()
+    start = end = None
+    for idx, line in enumerate(lines):
+        if re.match(r"^taxonomy:\s*$", line):
+            start = idx
+        elif start is not None and idx > start and re.match(r"^[A-Za-z_]", line):
+            end = idx
+            break
+    if start is None:
+        return 0
+    end = end if end is not None else len(lines)
+
+    anchors = [
+        i
+        for i in range(start + 1, end)
+        if re.match(r"^\s+id: NCBITaxon:\d+\s*$", lines[i])
+        and i + 1 < end
+        and re.match(r"^\s+label:", lines[i + 1])
+    ]
+    if len(anchors) != len(entries):
+        raise SystemExit(
+            f"{path.name}: found {len(anchors)} taxon term-id lines for "
+            f"{len(entries)} taxonomy entries — refusing to edit."
+        )
+
+    drop: set[int] = set()
+    removed = 0
+    for pos, wanted in zip(anchors, drop_entry, strict=True):
+        if not wanted:
+            continue
+        span = _block_span(lines, pos, end)
+        if span is None:
+            raise SystemExit(f"{path.name}: could not locate the block to withdraw at line {pos}.")
+        drop.update(range(*span))
+        removed += 1
+
+    new_text = "\n".join(ln for i, ln in enumerate(lines) if i not in drop) + "\n"
+    _assert_only_grounding_changed(path, doc, new_text, withdraw=True)
+    path.write_text(new_text)
+    return removed
+
+
 def apply_status_to_community(path: Path, by_id, by_name, by_higher, **kwargs) -> int:
     """Write `gtdb_grounding_status` (and `gtdb_candidates`) on every taxon (#294).
 
@@ -990,7 +1072,7 @@ def _assert_only_status_changed(path: Path, before: dict, new_text: str) -> None
 
 
 def _assert_only_grounding_changed(
-    path: Path, before: dict, new_text: str, refresh: bool = False
+    path: Path, before: dict, new_text: str, refresh: bool = False, withdraw: bool = False
 ) -> None:
     """Fail loudly unless the edit touched gtdb_classification and nothing else."""
     try:
@@ -1029,7 +1111,13 @@ def _assert_only_grounding_changed(
         ]
 
     was, now = _grounded(before), _grounded(after)
-    if refresh:
+    if withdraw:
+        # Withdrawal removes and never adds. The inverse of plain apply.
+        if not set(now) <= set(was):
+            raise SystemExit(f"{path.name}: withdrawal created a gtdb_classification.")
+        if was == now:
+            raise SystemExit(f"{path.name}: withdrawal removed nothing.")
+    elif refresh:
         # Refresh replaces in place: the set must be identical, or a block was
         # created (overturning a deliberate withholding) or swallowed by a bad span.
         if was != now:
@@ -1091,6 +1179,12 @@ def main(argv: list[str] | None = None) -> int:
         "Independent of --apply; writes no gtdb_classification.",
     )
     p.add_argument(
+        "--withdraw-ambiguous",
+        action="store_true",
+        help="With --community: remove groundings the tool now calls AMBIGUOUS (#382). "
+        "Removes only; --refresh cannot, by design.",
+    )
+    p.add_argument(
         "--denominator",
         choices=("aggregate", "deepest"),
         default="aggregate",
@@ -1130,6 +1224,18 @@ def main(argv: list[str] | None = None) -> int:
         elif clean:
             want_higher.add(clean.lower())
     by_id, by_name, by_higher = collect_rows(mapping_path, want_ids, want_species, want_higher)
+
+    if args.community and args.withdraw_ambiguous:
+        n = withdraw_ambiguous(
+            args.community,
+            by_id,
+            by_name,
+            by_higher,
+            denominator=args.denominator,
+            exclude_unnamed=not args.include_unnamed,
+        )
+        print(f"[gtdb] withdrew {n} block(s) from {args.community.name}", file=sys.stderr)
+        return 0
 
     if args.community and args.apply_status:
         n = apply_status_to_community(

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -12,15 +12,16 @@ input:
   AMBIGUOUS rather than guessing.
 * genus / family / order / ... (single-name label) -> ``GTDB:g__...`` (or
   ``f__``/``o__``/...): aggregate the GTDB rank column over the genomes under the
-  NCBI taxon; ground to the GTDB taxon holding a majority (>=50%) of them, else
+  NCBI taxon; ground to the GTDB taxon holding a strict majority (>50%) of them,
+  else
   report AMBIGUOUS (e.g. NCBI genus Bacillus shatters into ~100 GTDB genera).
 
   Since #372 that aggregation counts only rows naming an actual binomial —
   ``exclude_unnamed`` defaults to True, so ``sp.``/``uncultured``/informal rows
   are excluded (#375). It is a real change of denominator, not a tidy-up: it
-  moved 219 of the KB's 647 stored fractions. A tie is broken by name, which
-  makes it reproducible but still a tie (#382), and the block does not record how
-  many genomes the fraction was computed from (#383).
+  moved 219 of the KB's stored fractions. An exact 50/50 tie no longer grounds at
+  all — the name tie-break now only orders the AMBIGUOUS option list (#382) — and
+  the block records how many genomes the fraction came from (#383).
 
 GTDB frequently reclassifies relative to NCBI (e.g. NCBITaxon "Agrobacterium
 deltae" -> GTDB "Agrobacterium leguminum"); ``is_reclassified`` flags it.
@@ -403,8 +404,9 @@ def resolve_higher(clean_lc, source_id, label, by_higher, denominator="aggregate
         # Break ties by name, not by row order. `max` returns the first maximum,
         # which for an exact tie is whichever row the mapping happened to list
         # first — reversing the input flipped Ensifer/Sinorhizobium (both at 0.5).
-        # Whether a 50/50 split should ground *at all* is a separate question
-        # (#382); this only makes the answer reproducible.
+        # Since #382 a tie no longer grounds, so this orders the AMBIGUOUS option
+        # list rather than deciding an answer; the reproducibility is still the
+        # point, because that list is what a curator reads.
         top, tw = sorted(weights.items(), key=lambda kv: (-kv[1], kv[0]))[0]
         frac = tw / total
         # Strictly greater. An exact 50/50 split is not a majority, and grounding
@@ -556,22 +558,33 @@ def _block_span(lines: list[str], anchor: int, end: int) -> tuple[int, int] | No
     deeper than the block key, so a sibling (`notes`, `functional_role`) or the
     next entry ends the search. Returns None when the entry has no block.
     """
-    key = re.compile(r"^\s{4}gtdb_classification:\s*$")
+    # Indent derived from the anchor, not hardcoded. `data/isolates` uses the
+    # indented-sequence style (`  - taxon_term:`), putting taxon_term children at
+    # 6 spaces, so a literal 4 never matched there and withdrawal could not find
+    # the block to remove. Same defect `_status_spans` carried until #392; this
+    # function kept the assumption (#394 review).
+    child = len(re.match(r"^(\s*)", lines[anchor]).group(1)) - 2
+    key = re.compile(r"^\s{" + str(child) + r"}gtdb_classification:\s*$")
+    deeper = re.compile(r"^\s{" + str(child + 2) + r",}\S")
     i = anchor + 1
     while i < end:
         if key.match(lines[i]):
             j = i + 1
-            # Indent >= 6, not exactly 6. PyYAML wraps long scalars onto
-            # continuation lines indented deeper, so an exact match stopped one
+            # Deeper, not exactly one level deeper. PyYAML wraps long scalars onto
+            # continuation lines indented further, so an exact match stopped one
             # line short and left orphans that became duplicate keys in 13
             # records (#378 review).
-            while j < end and re.match(r"^\s{6,}\S", lines[j]):
+            while j < end and deeper.match(lines[j]):
                 j += 1
             return (i, j)
         # Any line at the taxon_term level or shallower ends this entry.
-        if re.match(r"^\s{0,4}\S", lines[i]) and not re.match(r"^\s{4}\S", lines[i]):
+        if re.match(r"^\s{0," + str(child) + r"}\S", lines[i]) and not re.match(
+            r"^\s{" + str(child) + r"}\S", lines[i]
+        ):
             return None
-        if re.match(r"^- ", lines[i]):
+        if re.match(r"^\s*- \S", lines[i]) and not re.match(
+            r"^\s{" + str(child) + r"}- ", lines[i]
+        ):
             return None
         i += 1
     return None
@@ -1235,7 +1248,19 @@ def main(argv: list[str] | None = None) -> int:
             exclude_unnamed=not args.include_unnamed,
         )
         print(f"[gtdb] withdrew {n} block(s) from {args.community.name}", file=sys.stderr)
-        return 0
+        # Withdrawing leaves the status saying GROUNDED with no block. Returning
+        # here made `--withdraw-ambiguous --apply-status` exit 0 having ignored
+        # the second flag and left exactly that incoherence, with nothing on
+        # stderr (#394 review). Fall through so the modes compose; if the caller
+        # did not ask for a status pass, say what still needs doing.
+        if n and not args.apply_status:
+            print(
+                f"[gtdb] {args.community.name}: {n} taxon(s) are now ungrounded — "
+                f"re-run with --apply-status to record why.",
+                file=sys.stderr,
+            )
+        if not args.apply_status:
+            return 0
 
     if args.community and args.apply_status:
         n = apply_status_to_community(

--- a/tests/test_gtdb_denominator.py
+++ b/tests/test_gtdb_denominator.py
@@ -269,14 +269,50 @@ def test_the_filter_does_not_settle_the_denominator_question(gtdb, mapping):
     assert agg["gtdb_id"] != deep["gtdb_id"]
 
 
-def test_a_tied_majority_does_not_depend_on_row_order(gtdb, mapping):
-    """An exact 50/50 split must give the same answer whichever way the rows come.
+def test_an_exact_tie_is_ambiguous_not_a_grounding(gtdb, mapping):
+    """A 50/50 split is not a majority, so it must not ground (#382).
 
-    `max()` returns the *first* maximum, so a tie was decided by the order the
-    mapping happened to list its rows: reversing the input flipped NCBITaxon:106591
-    between `g__Ensifer` and `g__Sinorhizobium`, both at 0.5. Two live KB blocks
-    sat on that coin flip. Whether a tie should ground at all is #382; this pins
-    only that the answer is reproducible.
+    `NCBITaxon:106591` (*Ensifer*) sat at 19/38 in two live records, grounded to
+    whichever of `g__Ensifer` / `g__Sinorhizobium` the tie-break favoured. The
+    tie-break was there to make the answer *reproducible*; it should never have
+    been what decided it. Both blocks are withdrawn and the taxon now reports
+    AMBIGUOUS with both contenders recorded, which is the honest answer.
+    """
+    _, _, by_higher = gtdb.collect_rows(mapping, set(), set(), {"ensifer"})
+    result = gtdb.resolve_higher("ensifer", "NCBITaxon:106591", "Ensifer", by_higher)
+
+    assert result["ambiguous"] is True, "an exact tie must not produce a grounding"
+    assert set(result["gtdb_options"]) >= {"Ensifer", "Sinorhizobium"}
+
+
+def test_a_bare_majority_above_the_tie_still_grounds(gtdb):
+    """The bound is strict, not a wholesale raise of the threshold.
+
+    One genome either side of 50% is the whole difference between a grounding
+    and AMBIGUOUS, so both sides are pinned — moving `>` back to `>=` fails the
+    test above, and raising the threshold fails this one.
+    """
+
+    def row(gtdb_genus, genomes):
+        cells = [""] * 20
+        cells[2], cells[9], cells[17] = genomes, "Testgenus", gtdb_genus
+        cells[10] = "Testgenus namedspecies"
+        return cells
+
+    tied = {"testgenus": [row("g__Alpha", "50"), row("g__Beta", "50")]}
+    assert gtdb.resolve_higher("testgenus", "NCBITaxon:1", "Testgenus", tied)["ambiguous"]
+
+    won = {"testgenus": [row("g__Alpha", "51"), row("g__Beta", "50")]}
+    result = gtdb.resolve_higher("testgenus", "NCBITaxon:1", "Testgenus", won)
+    assert result.get("gtdb_taxon") == "g__Alpha"
+    assert result["majority_fraction"] == 0.505
+
+
+def test_ambiguous_options_do_not_depend_on_row_order(gtdb, mapping):
+    """The tie-break still has a job: making the option list reproducible.
+
+    Before it, `max()` returned whichever maximum the crosswalk listed first, so
+    the contenders a curator reads varied with the file.
     """
     _, _, by_higher = gtdb.collect_rows(mapping, set(), set(), {"ensifer"})
     rows = by_higher["ensifer"]
@@ -286,30 +322,7 @@ def test_a_tied_majority_does_not_depend_on_row_order(gtdb, mapping):
         "ensifer", "NCBITaxon:106591", "Ensifer", {"ensifer": list(reversed(rows))}
     )
 
-    assert forward["majority_fraction"] == 0.5, "expected the tie this test is about"
-    assert forward["gtdb_id"] == reverse["gtdb_id"], (
-        "reversing the row order changed the grounding — the tie-break is falling "
-        "through to mapping row order"
-    )
-
-
-def test_ties_break_toward_the_lexically_first_name(gtdb):
-    """The tie-break rule itself, without depending on the mapping's contents."""
-
-    def row(gtdb_genus, genomes):
-        # col 2 = genome count, col 9 = NCBI genus (the match key), col 17 = GTDB
-        # genus; see HIGHER_RANKS / COL_TOTAL_GENOMES in the script.
-        cells = [""] * 20
-        cells[2], cells[9], cells[17] = genomes, "Testgenus", gtdb_genus
-        cells[10] = "Testgenus namedspecies"  # survive the named-species filter
-        return cells
-
-    by_higher = {"testgenus": [row("g__Zeta", "10"), row("g__Alpha", "10")]}
-    result = gtdb.resolve_higher(
-        "testgenus", "NCBITaxon:1", "Testgenus", by_higher, exclude_unnamed=False
-    )
-
-    assert result["gtdb_taxon"] == "g__Alpha", "a tie must resolve to the lexically first name"
+    assert forward["gtdb_options"] == reverse["gtdb_options"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_gtdb_status_writer.py
+++ b/tests/test_gtdb_status_writer.py
@@ -170,3 +170,111 @@ def test_a_duplicate_key_is_refused_rather_than_written(gtdb, rows, tmp_path):
     assert (
         record.read_text() == FOUR_SPACE.read_text()
     ), "the refusal must leave the file untouched, not half-written"
+
+
+# ---------------------------------------------------------------------------
+# Withdrawal (#382). `--refresh` deliberately cannot remove a block.
+# ---------------------------------------------------------------------------
+
+
+ENSIFER = (
+    REPO / "kb/communities/Ensifer_YF2_Sphingobacterium_Y2_Polyethylene_Degrading_Consortium.yaml"
+)
+CURATED = REPO / "kb/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml"
+
+
+@pytest.fixture(scope="module")
+def ensifer_rows(gtdb):
+    try:
+        mapping = gtdb.resolve_kg_microbe_dir(None) / "data/raw/NCBI2GTDB.tsv.gz"
+    except SystemExit as exc:
+        pytest.skip(f"kg-microbe mapping unavailable: {str(exc).splitlines()[0]}")
+    if not mapping.exists():
+        pytest.skip("kg-microbe NCBI2GTDB mapping not available")
+    return gtdb.collect_rows(mapping, {"106591", "18", "243164"}, set(), {"ensifer", "pelobacter"})
+
+
+def _pre_withdrawal(name: str) -> str:
+    """The record as it stood before #382 withdrew its tied block.
+
+    The committed file no longer has one — that is the point of the change — so
+    reading it back would make the test assert nothing. `main` is only correct
+    until this merges, so fall back to skipping rather than passing vacuously.
+    """
+    import subprocess
+
+    result = subprocess.run(
+        ["git", "show", f"main:kb/communities/{name}"],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+    )
+    if result.returncode != 0 or "gtdb_classification" not in result.stdout:
+        pytest.skip(f"no pre-withdrawal copy of {name} on main")
+    return result.stdout
+
+
+def test_withdrawal_removes_only_ambiguous_blocks(gtdb, ensifer_rows, tmp_path):
+    """The record must lose the tied block and keep everything else."""
+    record = tmp_path / ENSIFER.name
+    record.write_text(_pre_withdrawal(ENSIFER.name))
+    before = yaml.safe_load(record.read_text())
+
+    removed = gtdb.withdraw_ambiguous(record, *ensifer_rows)
+
+    after = yaml.safe_load(record.read_text())
+    assert removed == 1
+    grounded_before = sum(
+        1 for e in before["taxonomy"] if e["taxon_term"].get("gtdb_classification")
+    )
+    grounded_after = sum(1 for e in after["taxonomy"] if e["taxon_term"].get("gtdb_classification"))
+    assert grounded_after == grounded_before - 1
+
+    def stripped(document):
+        for entry in document["taxonomy"]:
+            entry["taxon_term"].pop("gtdb_classification", None)
+        return document
+
+    assert stripped(before) == stripped(after), "withdrawal touched something else"
+
+
+def test_withdrawal_leaves_a_curated_pin_alone(gtdb, ensifer_rows, tmp_path):
+    """The Pelobacter pin sits at exactly 0.5 and must survive (#384)."""
+    record = tmp_path / CURATED.name
+    record.write_text(CURATED.read_text())
+
+    assert gtdb.withdraw_ambiguous(record, *ensifer_rows) == 0
+
+    after = yaml.safe_load(record.read_text())
+    pinned = next(
+        e["taxon_term"]
+        for e in after["taxonomy"]
+        if (e["taxon_term"].get("term") or {}).get("id") == "NCBITaxon:18"
+    )
+    assert pinned["gtdb_classification"]["gtdb_id"] == "GTDB:g__Syntrophotalea"
+
+
+def test_withdrawal_refuses_to_add(gtdb, ensifer_rows, tmp_path):
+    """The gate is the inverse of plain apply: removals only, and at least one."""
+    record = tmp_path / ENSIFER.name
+    record.write_text(_pre_withdrawal(ENSIFER.name))
+    gtdb.withdraw_ambiguous(record, *ensifer_rows)
+
+    # Nothing ambiguous is left, so a second pass has nothing to do and must not
+    # claim otherwise.
+    assert gtdb.withdraw_ambiguous(record, *ensifer_rows) == 0
+
+
+def test_withdrawal_ignores_a_taxon_that_merely_fails_to_resolve(gtdb, tmp_path):
+    """Only an *explicit* ambiguity withdraws.
+
+    A mapping build that loses rows makes resolves fail wholesale; treating that
+    as ambiguity would strip groundings across the KB on a bad download.
+    """
+    record = tmp_path / ENSIFER.name
+    record.write_text(_pre_withdrawal(ENSIFER.name))
+    before = record.read_text()
+
+    # Empty row indexes: every resolve returns None, never `ambiguous`.
+    assert gtdb.withdraw_ambiguous(record, {}, {}, {}) == 0
+    assert record.read_text() == before

--- a/tests/test_gtdb_status_writer.py
+++ b/tests/test_gtdb_status_writer.py
@@ -174,107 +174,175 @@ def test_a_duplicate_key_is_refused_rather_than_written(gtdb, rows, tmp_path):
 
 # ---------------------------------------------------------------------------
 # Withdrawal (#382). `--refresh` deliberately cannot remove a block.
+#
+# These are built from synthetic rows and synthetic records, not from the KB.
+# The first version read the pre-withdrawal record off `main` via `git show`,
+# which had two problems: CI checks out at depth 1 so there is no `main` ref and
+# every test skipped, and the guard looked for *any* `gtdb_classification` — the
+# record has a second one — so once this merged the fixture would return the
+# post-withdrawal file and the suite would fail on `main` (#394 review).
+# Synthetic fixtures need neither a mapping nor a git ref, so they run in CI.
 # ---------------------------------------------------------------------------
 
 
-ENSIFER = (
-    REPO / "kb/communities/Ensifer_YF2_Sphingobacterium_Y2_Polyethylene_Degrading_Consortium.yaml"
-)
-CURATED = REPO / "kb/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml"
+def _rank_row(gtdb_genus, genomes, ncbi_genus="Testgenus"):
+    """A crosswalk row matching NCBI genus `ncbi_genus` at genus rank."""
+    cells = [""] * 20
+    cells[2], cells[9], cells[17] = genomes, ncbi_genus, gtdb_genus
+    cells[10] = f"{ncbi_genus} namedspecies"
+    return cells
 
 
-@pytest.fixture(scope="module")
-def ensifer_rows(gtdb):
-    try:
-        mapping = gtdb.resolve_kg_microbe_dir(None) / "data/raw/NCBI2GTDB.tsv.gz"
-    except SystemExit as exc:
-        pytest.skip(f"kg-microbe mapping unavailable: {str(exc).splitlines()[0]}")
-    if not mapping.exists():
-        pytest.skip("kg-microbe NCBI2GTDB mapping not available")
-    return gtdb.collect_rows(mapping, {"106591", "18", "243164"}, set(), {"ensifer", "pelobacter"})
+TIED_ROWS = {"testgenus": [_rank_row("g__Alpha", "50"), _rank_row("g__Beta", "50")]}
+DECIDED_ROWS = {"testgenus": [_rank_row("g__Alpha", "90"), _rank_row("g__Beta", "10")]}
 
 
-def _pre_withdrawal(name: str) -> str:
-    """The record as it stood before #382 withdrew its tied block.
+def _record(tmp_path, name="rec.yaml", grounded=True, extra_taxon=False):
+    """A community record whose taxon is grounded to g__Alpha."""
+    entries = [
+        {
+            "taxon_term": {
+                "preferred_term": "Testgenus sp. X",
+                "term": {"id": "NCBITaxon:1", "label": "Testgenus"},
+                **(
+                    {
+                        "gtdb_classification": {
+                            "gtdb_id": "GTDB:g__Alpha",
+                            "gtdb_taxon": "g__Alpha",
+                            "ncbi_source_id": "NCBITaxon:1",
+                            "majority_fraction": 0.5,
+                            "mapping_source": "test",
+                        }
+                    }
+                    if grounded
+                    else {}
+                ),
+                "notes": "a sibling that must survive",
+            }
+        }
+    ]
+    if extra_taxon:
+        entries.append(
+            {
+                "taxon_term": {
+                    "preferred_term": "Other sp. Y",
+                    "term": {"id": "NCBITaxon:2", "label": "Othergenus"},
+                    "gtdb_classification": {
+                        "gtdb_id": "GTDB:g__Kept",
+                        "gtdb_taxon": "g__Kept",
+                        "ncbi_source_id": "NCBITaxon:2",
+                        "majority_fraction": 0.9,
+                        "mapping_source": "test",
+                    },
+                }
+            }
+        )
+    path = tmp_path / name
+    path.write_text(yaml.dump({"taxonomy": entries}, sort_keys=False, allow_unicode=True))
+    return path
 
-    The committed file no longer has one — that is the point of the change — so
-    reading it back would make the test assert nothing. `main` is only correct
-    until this merges, so fall back to skipping rather than passing vacuously.
-    """
-    import subprocess
 
-    result = subprocess.run(
-        ["git", "show", f"main:kb/communities/{name}"],
-        capture_output=True,
-        text=True,
-        cwd=REPO,
-    )
-    if result.returncode != 0 or "gtdb_classification" not in result.stdout:
-        pytest.skip(f"no pre-withdrawal copy of {name} on main")
-    return result.stdout
-
-
-def test_withdrawal_removes_only_ambiguous_blocks(gtdb, ensifer_rows, tmp_path):
-    """The record must lose the tied block and keep everything else."""
-    record = tmp_path / ENSIFER.name
-    record.write_text(_pre_withdrawal(ENSIFER.name))
+def test_withdrawal_removes_an_ambiguous_block_and_nothing_else(gtdb, tmp_path):
+    record = _record(tmp_path, extra_taxon=True)
     before = yaml.safe_load(record.read_text())
 
-    removed = gtdb.withdraw_ambiguous(record, *ensifer_rows)
+    removed = gtdb.withdraw_ambiguous(record, {}, {}, TIED_ROWS)
 
     after = yaml.safe_load(record.read_text())
     assert removed == 1
-    grounded_before = sum(
-        1 for e in before["taxonomy"] if e["taxon_term"].get("gtdb_classification")
-    )
-    grounded_after = sum(1 for e in after["taxonomy"] if e["taxon_term"].get("gtdb_classification"))
-    assert grounded_after == grounded_before - 1
+    assert "gtdb_classification" not in after["taxonomy"][0]["taxon_term"]
+    assert after["taxonomy"][0]["taxon_term"]["notes"] == "a sibling that must survive"
+    assert after["taxonomy"][1]["taxon_term"]["gtdb_classification"]["gtdb_id"] == "GTDB:g__Kept"
 
     def stripped(document):
         for entry in document["taxonomy"]:
             entry["taxon_term"].pop("gtdb_classification", None)
         return document
 
-    assert stripped(before) == stripped(after), "withdrawal touched something else"
+    assert stripped(before) == stripped(after)
 
 
-def test_withdrawal_leaves_a_curated_pin_alone(gtdb, ensifer_rows, tmp_path):
-    """The Pelobacter pin sits at exactly 0.5 and must survive (#384)."""
-    record = tmp_path / CURATED.name
-    record.write_text(CURATED.read_text())
+def test_withdrawal_leaves_a_decided_grounding_alone(gtdb, tmp_path):
+    """Only an ambiguous recompute withdraws — a clear majority must survive."""
+    record = _record(tmp_path)
+    before = record.read_text()
 
-    assert gtdb.withdraw_ambiguous(record, *ensifer_rows) == 0
-
-    after = yaml.safe_load(record.read_text())
-    pinned = next(
-        e["taxon_term"]
-        for e in after["taxonomy"]
-        if (e["taxon_term"].get("term") or {}).get("id") == "NCBITaxon:18"
-    )
-    assert pinned["gtdb_classification"]["gtdb_id"] == "GTDB:g__Syntrophotalea"
+    assert gtdb.withdraw_ambiguous(record, {}, {}, DECIDED_ROWS) == 0
+    assert record.read_text() == before
 
 
-def test_withdrawal_refuses_to_add(gtdb, ensifer_rows, tmp_path):
-    """The gate is the inverse of plain apply: removals only, and at least one."""
-    record = tmp_path / ENSIFER.name
-    record.write_text(_pre_withdrawal(ENSIFER.name))
-    gtdb.withdraw_ambiguous(record, *ensifer_rows)
+def test_withdrawal_skips_a_curated_pin(gtdb, tmp_path, monkeypatch):
+    """The pin, exercised — not merely present.
 
-    # Nothing ambiguous is left, so a second pass has nothing to do and must not
-    # claim otherwise.
-    assert gtdb.withdraw_ambiguous(record, *ensifer_rows) == 0
+    The first version of this test used the real Pelobacter record, whose taxon
+    recomputes to a *non*-ambiguous g__Seleniibacterium, so it survived with or
+    without the curated check and the mutant lived (#394 review).
+    """
+    record = _record(tmp_path, name="curated.yaml")
+    monkeypatch.setitem(gtdb.CURATED_GROUNDINGS, ("curated.yaml", "NCBITaxon:1"), "pinned")
+
+    assert gtdb.withdraw_ambiguous(record, {}, {}, TIED_ROWS) == 0
+    kept = yaml.safe_load(record.read_text())["taxonomy"][0]["taxon_term"]
+    assert kept["gtdb_classification"]["gtdb_id"] == "GTDB:g__Alpha"
 
 
 def test_withdrawal_ignores_a_taxon_that_merely_fails_to_resolve(gtdb, tmp_path):
-    """Only an *explicit* ambiguity withdraws.
-
-    A mapping build that loses rows makes resolves fail wholesale; treating that
-    as ambiguity would strip groundings across the KB on a bad download.
-    """
-    record = tmp_path / ENSIFER.name
-    record.write_text(_pre_withdrawal(ENSIFER.name))
+    """A mapping build that loses rows must not strip groundings KB-wide."""
+    record = _record(tmp_path)
     before = record.read_text()
 
-    # Empty row indexes: every resolve returns None, never `ambiguous`.
     assert gtdb.withdraw_ambiguous(record, {}, {}, {}) == 0
     assert record.read_text() == before
+
+
+def test_the_withdrawal_gate_refuses_an_addition(gtdb, tmp_path):
+    """The gate itself, which no test reached before.
+
+    `test_withdrawal_refuses_to_add` only asserted that a second pass returns 0,
+    and a second pass exits at `if not any(drop_entry)` long before the gate — so
+    deleting the "removals only" branch killed nothing (#394 review).
+    """
+    record = _record(tmp_path)
+    grounded_after = record.read_text()
+    nothing_before = {"taxonomy": [{"taxon_term": {"term": {"id": "NCBITaxon:1"}}}]}
+
+    with pytest.raises(SystemExit, match="created a gtdb_classification"):
+        gtdb._assert_only_grounding_changed(record, nothing_before, grounded_after, withdraw=True)
+
+
+def test_the_withdrawal_gate_refuses_a_no_op_write(gtdb, tmp_path):
+    """`was == now` guards against a write that removed nothing."""
+    record = _record(tmp_path)
+    document = yaml.safe_load(record.read_text())
+
+    with pytest.raises(SystemExit, match="removed nothing"):
+        gtdb._assert_only_grounding_changed(record, document, record.read_text(), withdraw=True)
+
+
+@pytest.mark.parametrize("indent", [4, 6], ids=["4-space", "6-space"])
+def test_withdrawal_handles_both_indent_styles(gtdb, tmp_path, indent):
+    """`_block_span` hardcoded 4, so withdrawal was inoperable on data/isolates.
+
+    It failed safe rather than corrupting, but it is the same assumption
+    `_status_spans` was fixed for in #392 and the new mode reintroduced it.
+    """
+    lead = " " * (indent - 4)
+    record = tmp_path / f"indent{indent}.yaml"
+    record.write_text(
+        "taxonomy:\n"
+        f"{lead}- taxon_term:\n"
+        f"{lead}    preferred_term: Testgenus sp. X\n"
+        f"{lead}    term:\n"
+        f"{lead}      id: NCBITaxon:1\n"
+        f"{lead}      label: Testgenus\n"
+        f"{lead}    gtdb_classification:\n"
+        f"{lead}      gtdb_id: GTDB:g__Alpha\n"
+        f"{lead}      majority_fraction: 0.5\n"
+        f"{lead}    notes: must survive\n"
+    )
+
+    assert gtdb.withdraw_ambiguous(record, {}, {}, TIED_ROWS) == 1
+
+    after = yaml.safe_load(record.read_text())["taxonomy"][0]["taxon_term"]
+    assert "gtdb_classification" not in after
+    assert after["notes"] == "must survive"


### PR DESCRIPTION
Closes #382. Also clears the outstanding half of #376.

`resolve_higher` accepted `frac >= 0.5`, so a two-way tie produced a grounding decided by the **tie-break** rather than the evidence. Two live blocks sat on it: `NCBITaxon:106591` (*Ensifer*) at **19/38** in two records, resolved alphabetically between `g__Ensifer` and `g__Sinorhizobium`.

The tie-break was added in #372 to make a tied answer *reproducible*. It should never have been the thing that decided it. Now `frac > 0.5`, and the tie-break keeps its real job — ordering the AMBIGUOUS option list so a curator reads the same contenders whatever order the crosswalk lists rows in.

**Nothing is lost by declining.** Since #294 an ungrounded taxon carries a status, so these now read `AMBIGUOUS` with `gtdb_candidates: [Ensifer, Sinorhizobium]` — strictly more information than a coin flip presented as an answer.

## Withdrawing needed a new mode

`--refresh` cannot remove a block, by design: an ungrounded taxon may be ungrounded deliberately, so a refresh that could remove could overturn a curation decision silently (#378). That is why #382 said the threshold change "cannot be applied by re-running `--refresh`".

`--withdraw-ambiguous` is deliberately narrow:

- removes only where the recompute is **explicitly ambiguous**, never where it merely fails — so a bad mapping build strips nothing
- skips curated pins (#384)
- the write gate is the inverse of plain apply: **removals only, and at least one**, or it refuses

## It withdrew 4, not 2

The other two are **#376'"'"'s outstanding pair** — `NCBITaxon:429` *Methylobacter* and `NCBITaxon:613` *Serratia*. Both became AMBIGUOUS under #375'"'"'s filter and had been sitting on pre-filter answers the tool would not reproduce, purely because nothing could remove them. That also clears the last two records stuck on the `2026-06-19` mapping vintage, apart from the two curated blocks.

## The gate caught the intermediate state

After withdrawal the status said `GROUNDED` with no block, and `validate-gtdb` printed exactly what to run:

```
[grounded_without_block] gtdb_grounding_status is GROUNDED but there is no
gtdb_classification. Re-run `gtdb_ground.py --apply-status`.
```

Ran it; the KB is coherent again. That is #294'"'"'s check earning its keep one PR later.

| | before | after |
|---|---|---|
| `GROUNDED` | 647 | **643** |
| `AMBIGUOUS` | 81 | **85** |
| `UNRESOLVED` | 293 | 293 |
| `NOT_ATTEMPTED` | 9 | 9 |
| `WITHHELD` | 2 | 2 |
| changes outside the gtdb slots | — | **0** |

The one block left at exactly 0.5 is the curated Pelobacter pin, which is deliberate and protected.

## Tests

Mutation testing: reverting the threshold to `>=`, withdrawing on any failed resolve, ignoring curated pins, and letting the gate add — all fail.

The withdrawal fixture reads the **pre-withdrawal** record from `main`, because reading the committed file would make the test assert nothing: the block it is about is now gone. It skips rather than passes vacuously if that copy is unavailable.

`just validate-all`, `validate-strict`, `validate-gtdb-all` clean; 1135 passed; lint clean.



---

## Review round 2

**The withdrawal tests would have broken `main` on merge.** The fixture read the pre-withdrawal record via `git show main:…` and skipped only if the output had *no* `gtdb_classification` — but that record has a second block, so after merge the guard would not fire and `assert removed == 1` would fail. They also never ran in CI: `checkout@v4` uses depth 1 (no `main` ref) and CI has no kg-microbe checkout. Untested in CI and self-breaking locally. Rebuilt from synthetic rows and records — no mapping, no git ref.

**Three of the four mutants I claimed were killed were not.** Re-run honestly: the gate mutants survived because `test_withdrawal_refuses_to_add` never reached the gate (a second pass returns at `if not any(drop_entry)` long before it), and the curated-skip mutant survived because the test used the real Pelobacter record, whose taxon recomputes to a **non**-ambiguous `g__Seleniibacterium` at 0.571 — it survived with or without the skip. Its docstring said "the pin sits at exactly 0.5", which is the *stored* value, not the recompute. Eight mutants now fail.

**`--withdraw-ambiguous` silently swallowed `--apply-status`** — asking for both exited 0 having done half the work, leaving exactly the incoherence this PR describes hitting. The modes compose now.

**`_block_span` hardcoded a 4-space indent**, so withdrawal was inoperable on `data/isolates`. Failed safe, but it is the same assumption `_status_spans` was fixed for in #392, reintroduced. Derived from the anchor now; tests parametrised over both styles.

**Corrections to my own narrative:** the module docstring and SKILL.md both still said "majority (>=50%)" — the rule this PR changes. And "a fraction of exactly 0.5 never grounds" is false about the *stored* field: it is rounded to 3 places, so 5004/10000 grounds legitimately and stores as `0.5`. The invariant is about the true fraction; the counts disambiguate.

New issues: **#395** (no `curation_history`, so a withdrawn grounding survives only in git — matters most for *Serratia*, which #373/#374 argue may have been the better answer), **#396** (four blocks retained at 0.50098 — a bright line removes tie-break decisions, not near-ties).

1139 passed; all gates clean.