### PR TITLE
Pin a curated grounding in the block, not in a list someone must remember (#384)

### DIFF
--- a/.claude/skills/ground-taxa-gtdb/SKILL.md
+++ b/.claude/skills/ground-taxa-gtdb/SKILL.md
@@ -204,8 +204,10 @@ taxonomy entries and their id anchors do not line up.
     curation_note: why the tool's answer was rejected
   ```
 
-  `--refresh`, `--apply` and `--withdraw-ambiguous` all skip a block carrying
-  `curated: true`, and `validate-gtdb` rejects the flag without a note (#384).
+  `--refresh` and `--withdraw-ambiguous` skip a block carrying `curated: true`,
+  and `validate-gtdb` rejects the flag without a note — or a note without the
+  flag, which reads as a decision while protecting nothing. (`--apply` only ever
+  touches *ungrounded* taxa, so it could not have overwritten a pin anyway.)
   Two blocks carry it: `NCBITaxon:18` (*Pelobacter* SFB93 → `g__Syntrophotalea`,
   where the vote picks a selenate reducer) and `NCBITaxon:340177` (*Chlorobium*).
 

--- a/.claude/skills/ground-taxa-gtdb/SKILL.md
+++ b/.claude/skills/ground-taxa-gtdb/SKILL.md
@@ -196,10 +196,23 @@ taxonomy entries and their id anchors do not line up.
   decides an answer. `--withdraw-ambiguous` removes a stored grounding that has
   become ambiguous, which `--refresh` deliberately cannot do.
 
-  A grounding the majority vote gets *wrong* can be pinned in `CURATED` in
-  `tests/test_gtdb_withheld_groundings.py`; the tool has no memory of such a
-  decision and `--refresh` will otherwise re-break it (#384). `NCBITaxon:18`
-  (*Pelobacter* SFB93 → `g__Syntrophotalea`) is the worked example.
+  A grounding the majority vote gets *wrong* is pinned **in the block**:
+
+  ```yaml
+  gtdb_classification:
+    curated: true
+    curation_note: why the tool's answer was rejected
+  ```
+
+  `--refresh`, `--apply` and `--withdraw-ambiguous` all skip a block carrying
+  `curated: true`, and `validate-gtdb` rejects the flag without a note (#384).
+  Two blocks carry it: `NCBITaxon:18` (*Pelobacter* SFB93 → `g__Syntrophotalea`,
+  where the vote picks a selenate reducer) and `NCBITaxon:340177` (*Chlorobium*).
+
+  The script also keeps a `CURATED_GROUNDINGS` list as a fallback, but prefer the
+  flag: a list protects only what someone remembered to add, which is how
+  *Chlorobium* went unprotected — it survived earlier sweeps only because its
+  recompute happened to fail (#376).
 - **`is_reclassified: true`** — GTDB uses a different name than NCBI at that rank
   (e.g. *A. deltae* → *A. leguminum*, *Enterococcus* → *Enterococcus_B*). Keep
   both groundings; the disagreement is the point.

--- a/kb/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml
+++ b/kb/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml
@@ -24,7 +24,7 @@ taxonomy:
     gtdb_grounding_status: GROUNDED
     gtdb_classification:
       curated: true
-      curation_note: Curated to the genus. The tool produces no id for this taxon, so the block survived earlier sweeps only as a side effect of that failure rather than by decision (#376, #384).
+      curation_note: "Curated to the genus. The tool produces no id for this taxon, so the block survived earlier sweeps only as a side effect of that failure rather than by decision (#376, #384)."
       gtdb_id: GTDB:g__Chlorobium
       gtdb_taxon: Chlorobium
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Chlorobiia;o__Chlorobiales;f__Chlorobiaceae;g__Chlorobium

--- a/kb/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml
+++ b/kb/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml
@@ -23,6 +23,8 @@ taxonomy:
       label: Chlorobium chlorochromatii CaD3
     gtdb_grounding_status: GROUNDED
     gtdb_classification:
+      curated: true
+      curation_note: Curated to the genus. The tool produces no id for this taxon, so the block survived earlier sweeps only as a side effect of that failure rather than by decision (#376, #384).
       gtdb_id: GTDB:g__Chlorobium
       gtdb_taxon: Chlorobium
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Chlorobiia;o__Chlorobiales;f__Chlorobiaceae;g__Chlorobium

--- a/kb/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml
@@ -90,6 +90,8 @@ taxonomy:
       label: Pelobacter
     gtdb_grounding_status: GROUNDED
     gtdb_classification:
+      curated: true
+      curation_note: SFB93 is an acetylene fermenter and this entry's notes tie it to Syntrophotalea acetylenivorans; every Pelobacter row naming Syntrophotalea is an sp. row, so the named-species filter hands the majority to g__Seleniibacterium at 0.571 (#384).
       gtdb_id: GTDB:g__Syntrophotalea
       gtdb_taxon: Syntrophotalea
       gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Desulfuromonadales;f__Syntrophotaleaceae;g__Syntrophotalea

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -503,6 +503,18 @@ CURATED_GROUNDINGS = {
 }
 
 
+def _is_curated(term_block: dict) -> bool:
+    """Is this taxon's grounding pinned by a curator?
+
+    Reads the flag off the block, so the decision travels with the data.
+    `CURATED_GROUNDINGS` remains as a fallback for records not yet marked, but a
+    list only protects what someone remembered to add — which is exactly how
+    *Chlorobium* went unprotected (#384).
+    """
+    block = (term_block or {}).get("gtdb_classification")
+    return isinstance(block, dict) and bool(block.get("curated"))
+
+
 def _block(g: dict, mapping_source: str) -> dict:
     src = mapping_source
     if (g.get("via") or "").startswith("ncbi_rank"):
@@ -602,6 +614,7 @@ def classify_status(
     by_name,
     by_higher,
     preferred=None,
+    curated=False,
     **kwargs,
 ):
     """Why this taxon does or does not carry a grounding (#294).
@@ -615,7 +628,7 @@ def classify_status(
     classifying it by outcome would label it GROUNDED-able and invite exactly the
     re-run #293 exists to prevent.
     """
-    if (record_name, tid) in CURATED_GROUNDINGS:
+    if curated or (record_name, tid) in CURATED_GROUNDINGS:
         # A curated block is a grounding, just not one the tool would compute.
         return ("GROUNDED" if has_block else "WITHHELD"), []
     # Keyed by preferred_term, NOT by NCBITaxon id. Both withheld records use
@@ -740,12 +753,16 @@ def apply_to_community(
         term = tt.get("term", {}) or {}
         tid = str(term.get("id", ""))
         grounded = "gtdb_classification" in tt
-        if (path.name, tid) in CURATED_GROUNDINGS:
-            print(
-                f"[gtdb] skipping curated {tid} in {path.name}: "
-                f"{CURATED_GROUNDINGS[(path.name, tid)]}",
-                file=sys.stderr,
+        if _is_curated(tt) or (path.name, tid) in CURATED_GROUNDINGS:
+            # The reason can come from either source, and indexing the list
+            # unconditionally raised KeyError whenever the block's own `curated`
+            # flag was what protected it — i.e. exactly the case the flag exists
+            # for. Caught by the canary before any sweep (#384).
+            reason = CURATED_GROUNDINGS.get((path.name, tid)) or (
+                (tt.get("gtdb_classification") or {}).get("curation_note")
+                or "marked `curated: true` with no curation_note"
             )
+            print(f"[gtdb] skipping curated {tid} in {path.name}: {reason}", file=sys.stderr)
             wanted.append(None)
             continue
         if not tid.startswith("NCBITaxon:") or (grounded != refresh):
@@ -868,7 +885,11 @@ def withdraw_ambiguous(path: Path, by_id, by_name, by_higher, **kwargs) -> int:
         tt = (tc or {}).get("taxon_term", {}) or {}
         term = tt.get("term", {}) or {}
         tid = str(term.get("id", ""))
-        if (path.name, tid) in CURATED_GROUNDINGS or "gtdb_classification" not in tt:
+        if (
+            _is_curated(tt)
+            or (path.name, tid) in CURATED_GROUNDINGS
+            or "gtdb_classification" not in tt
+        ):
             drop_entry.append(False)
             continue
         if not tid.startswith("NCBITaxon:"):
@@ -952,6 +973,7 @@ def apply_status_to_community(path: Path, by_id, by_name, by_higher, **kwargs) -
             by_name,
             by_higher,
             preferred=tt.get("preferred_term"),
+            curated=_is_curated(tt),
             **kwargs,
         )
         wanted.append((status, candidates))

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -490,9 +490,9 @@ def resolve_target(ncbi_id, label, by_id, by_name, by_higher, denominator="aggre
 # one and only `tests/test_gtdb_withheld_groundings.py::CURATED` notices, after
 # the fact. Mirrors WITHHELD, which keeps taxa *ungrounded* (#292/#293).
 #
-# This is the narrow half of #384 — a hard-coded list, not the `curated:` flag on
-# the block that the issue asks for. It exists so the record stays tool-
-# maintainable: excluding the whole *file* instead stranded its other taxon.
+# A fallback for records not yet marked. The `curated: true` flag on the block is
+# the primary mechanism (#384) — prefer it, because a list protects only what
+# someone remembered to add, which is how *Chlorobium* went unprotected.
 CURATED_GROUNDINGS = {
     ("Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml", "NCBITaxon:18"): (
         "GTDB:g__Syntrophotalea — SFB93 is an acetylene fermenter and the entry's "
@@ -512,7 +512,13 @@ def _is_curated(term_block: dict) -> bool:
     *Chlorobium* went unprotected (#384).
     """
     block = (term_block or {}).get("gtdb_classification")
-    return isinstance(block, dict) and bool(block.get("curated"))
+    if not isinstance(block, dict):
+        return False
+    # Keyed on the *value*, and only on `curated`. Reading the key's presence
+    # would freeze a block written `curated: false` — a curator recording "I
+    # checked, the tool is right" — and reading `curation_note` would let a note
+    # protect a block nothing flagged (#397 review).
+    return block.get("curated") is True
 
 
 def _block(g: dict, mapping_source: str) -> dict:
@@ -614,7 +620,6 @@ def classify_status(
     by_name,
     by_higher,
     preferred=None,
-    curated=False,
     **kwargs,
 ):
     """Why this taxon does or does not carry a grounding (#294).
@@ -627,8 +632,16 @@ def classify_status(
     point of a withhold is that the tool *can* produce a grounding and must not:
     classifying it by outcome would label it GROUNDED-able and invite exactly the
     re-run #293 exists to prevent.
+
+    There is deliberately no `curated` parameter. `curated: true` lives *inside*
+    `gtdb_classification`, so a flagged taxon always has a block and the
+    `has_block` branch already answers GROUNDED. A `curated=` argument was added
+    in #384 and was unreachable from the writer — deleting its wiring left the
+    whole suite green — while quietly reordering this function so a taxon both
+    flagged and in WITHHELD_GROUNDINGS returned GROUNDED, contradicting the
+    paragraph above (#397 review).
     """
-    if curated or (record_name, tid) in CURATED_GROUNDINGS:
+    if (record_name, tid) in CURATED_GROUNDINGS:
         # A curated block is a grounding, just not one the tool would compute.
         return ("GROUNDED" if has_block else "WITHHELD"), []
     # Keyed by preferred_term, NOT by NCBITaxon id. Both withheld records use
@@ -973,7 +986,6 @@ def apply_status_to_community(path: Path, by_id, by_name, by_higher, **kwargs) -
             by_name,
             by_higher,
             preferred=tt.get("preferred_term"),
-            curated=_is_curated(tt),
             **kwargs,
         )
         wanted.append((status, candidates))
@@ -1163,6 +1175,25 @@ def _assert_only_grounding_changed(
     elif not set(was) <= set(now):
         # Plain apply may add groundings; it must never remove one.
         raise SystemExit(f"{path.name}: an existing gtdb_classification was dropped.")
+
+    # Losing `curated`/`curation_note` is the exact regression this flag prevents,
+    # and popping gtdb_classification wholesale below makes it invisible. `_block`
+    # never emits them, so any path that fails to detect the flag would rewrite
+    # the block and delete the evidence it was ever curated (#397 review).
+    def _pins(doc):
+        return {
+            i: ((e or {}).get("taxon_term") or {}).get("gtdb_classification", {}).get("curation_note")
+            for i, e in enumerate(doc.get("taxonomy") or [])
+            if isinstance(((e or {}).get("taxon_term") or {}).get("gtdb_classification"), dict)
+            and ((e or {}).get("taxon_term") or {}).get("gtdb_classification", {}).get("curated")
+        }
+
+    lost = {i: note for i, note in _pins(before).items() if i not in _pins(after)}
+    if lost:
+        raise SystemExit(
+            f"{path.name}: the edit dropped `curated` from {len(lost)} block(s) — "
+            f"refusing to write. A curated grounding must survive every mode."
+        )
 
     b_tax, a_tax = before.get("taxonomy") or [], after.get("taxonomy") or []
     if len(b_tax) != len(a_tax):

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-08-04T20:58:07
+# Generation date: 2026-08-04T22:13:52
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-08-04T19:34:08
+# Generation date: 2026-08-04T20:58:07
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech
@@ -322,6 +322,8 @@ class GtdbClassification(YAMLRoot):
     support_genomes: Optional[int] = None
     total_genomes: Optional[int] = None
     is_reclassified: Optional[Union[bool, Bool]] = None
+    curated: Optional[Union[bool, Bool]] = None
+    curation_note: Optional[str] = None
     mapping_source: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
@@ -348,6 +350,12 @@ class GtdbClassification(YAMLRoot):
 
         if self.is_reclassified is not None and not isinstance(self.is_reclassified, Bool):
             self.is_reclassified = Bool(self.is_reclassified)
+
+        if self.curated is not None and not isinstance(self.curated, Bool):
+            self.curated = Bool(self.curated)
+
+        if self.curation_note is not None and not isinstance(self.curation_note, str):
+            self.curation_note = str(self.curation_note)
 
         if self.mapping_source is not None and not isinstance(self.mapping_source, str):
             self.mapping_source = str(self.mapping_source)
@@ -3322,6 +3330,24 @@ slots.gtdbClassification__is_reclassified = Slot(
     model_uri=COMMUNITYMECH.gtdbClassification__is_reclassified,
     domain=None,
     range=Optional[Union[bool, Bool]],
+)
+
+slots.gtdbClassification__curated = Slot(
+    uri=COMMUNITYMECH.curated,
+    name="gtdbClassification__curated",
+    curie=COMMUNITYMECH.curie("curated"),
+    model_uri=COMMUNITYMECH.gtdbClassification__curated,
+    domain=None,
+    range=Optional[Union[bool, Bool]],
+)
+
+slots.gtdbClassification__curation_note = Slot(
+    uri=COMMUNITYMECH.curation_note,
+    name="gtdbClassification__curation_note",
+    curie=COMMUNITYMECH.curie("curation_note"),
+    model_uri=COMMUNITYMECH.gtdbClassification__curation_note,
+    domain=None,
+    range=Optional[str],
 )
 
 slots.gtdbClassification__mapping_source = Slot(

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -819,6 +819,23 @@ classes:
           True when the GTDB species name differs from the NCBITaxon species
           name (a GTDB reclassification/rename), so consumers can flag it.
         range: boolean
+      curated:
+        description: >-
+          True when a curator chose this grounding against what `gtdb_ground.py`
+          computes, so the tool must not overwrite it. The reason belongs in
+          `curation_note`.
+
+          A hard-coded list in the script protects only what someone remembered
+          to add: `NCBITaxon:340177` (*Chlorobium*) was curated and unlisted, and
+          survived a whole-KB refresh only because its recompute happened to
+          yield no id — a side effect, not a decision (#384). Marking the block
+          keeps the decision with the data.
+        range: boolean
+      curation_note:
+        description: >-
+          Why this grounding was curated against the tool. Required in practice
+          whenever `curated` is true — a pin whose reason lives only in a commit
+          message is one re-run away from looking like an error.
       mapping_source:
         description: >-
           Provenance of the mapping (source table + GTDB release/build), e.g.

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -835,7 +835,11 @@ classes:
         description: >-
           Why this grounding was curated against the tool. Required in practice
           whenever `curated` is true — a pin whose reason lives only in a commit
-          message is one re-run away from looking like an error.
+          message is one re-run away from looking like an error. Enforced by
+          `communitymech.validators.gtdb_coherence`, since a conditional
+          requirement is one of the relations the JSON-Schema backend cannot
+          express (#387).
+        range: string
       mapping_source:
         description: >-
           Provenance of the mapping (source table + GTDB release/build), e.g.

--- a/src/communitymech/validators/gtdb_coherence.py
+++ b/src/communitymech/validators/gtdb_coherence.py
@@ -248,6 +248,26 @@ def check_block(block: dict) -> list[tuple[str, str]]:
                     )
                 )
 
+    # A pin whose reason lives only in a commit message is one re-run away from
+    # looking like an error, so the note is required in practice even though the
+    # schema cannot require it conditionally (#384).
+    if block.get("curated") and not str(block.get("curation_note") or "").strip():
+        problems.append(
+            (
+                "curated_without_note",
+                "curated: true with no curation_note — record why the tool's answer "
+                "was rejected, or the next person cannot tell a pin from a mistake.",
+            )
+        )
+    if str(block.get("curation_note") or "").strip() and not block.get("curated"):
+        problems.append(
+            (
+                "note_without_curated",
+                "curation_note without curated: true — the note reads as an "
+                "explanation but nothing protects the block from a refresh.",
+            )
+        )
+
     if fraction is not None and not (MIN_FRACTION <= fraction <= 1.0):
         problems.append(
             (

--- a/src/communitymech/validators/gtdb_coherence.py
+++ b/src/communitymech/validators/gtdb_coherence.py
@@ -259,6 +259,9 @@ def check_block(block: dict) -> list[tuple[str, str]]:
                 "was rejected, or the next person cannot tell a pin from a mistake.",
             )
         )
+    # `str(...)` is belt-and-braces: the schema types this slot, so a non-string
+    # is rejected upstream. Kept because `check_block` is called directly on
+    # dicts that never went through validation — the tests do exactly that.
     if str(block.get("curation_note") or "").strip() and not block.get("curated"):
         problems.append(
             (

--- a/tests/test_gtdb_coherence_validator.py
+++ b/tests/test_gtdb_coherence_validator.py
@@ -526,3 +526,50 @@ def test_the_withholds_are_marked_withheld_not_grounded():
         assert (
             term_block.get("gtdb_grounding_status") == "GROUNDED"
         ), "a correct grounding sharing the withheld id was marked WITHHELD"
+
+
+# ---------------------------------------------------------------------------
+# The curated flag's own coherence (#384).
+# ---------------------------------------------------------------------------
+
+
+def test_a_curated_block_must_say_why():
+    """A pin whose reason lives only in a commit message reads as a mistake."""
+    block = _valid_block()
+    block["curated"] = True
+    assert "curated_without_note" in {c for c, _ in check_block(block)}
+
+    block["curation_note"] = "   "
+    assert "curated_without_note" in {c for c, _ in check_block(block)}, "whitespace is not a note"
+
+    block["curation_note"] = "the majority vote picks a selenate reducer here"
+    assert check_block(block) == []
+
+
+def test_a_note_without_the_flag_is_flagged():
+    """Explanatory prose that protects nothing is worse than none.
+
+    It reads as a decision while a refresh will overwrite the block regardless.
+    """
+    block = _valid_block()
+    block["curation_note"] = "chosen against the tool"
+    assert "note_without_curated" in {c for c, _ in check_block(block)}
+
+
+def test_a_curated_pin_with_no_block_is_withheld(gtdb):
+    """The branch that distinguishes a pin from a plain ungrounded taxon.
+
+    `curated: true` says a curator decided this taxon's grounding. With no block
+    stored, that decision was to withhold — not NOT_ATTEMPTED, which would put it
+    back in the work queue the pin exists to keep it out of.
+    """
+    status, candidates = gtdb.classify_status(
+        "rec.yaml", "NCBITaxon:1", "Testgenus", False, {}, {}, {}, curated=True
+    )
+    assert status == "WITHHELD"
+    assert candidates == []
+
+    grounded, _ = gtdb.classify_status(
+        "rec.yaml", "NCBITaxon:1", "Testgenus", True, {}, {}, {}, curated=True
+    )
+    assert grounded == "GROUNDED"

--- a/tests/test_gtdb_coherence_validator.py
+++ b/tests/test_gtdb_coherence_validator.py
@@ -556,20 +556,74 @@ def test_a_note_without_the_flag_is_flagged():
     assert "note_without_curated" in {c for c, _ in check_block(block)}
 
 
-def test_a_curated_pin_with_no_block_is_withheld(gtdb):
-    """The branch that distinguishes a pin from a plain ungrounded taxon.
+def test_a_flagged_taxon_always_has_a_block_so_grounds(gtdb):
+    """Why `classify_status` takes no `curated` argument.
 
-    `curated: true` says a curator decided this taxon's grounding. With no block
-    stored, that decision was to withhold — not NOT_ATTEMPTED, which would put it
-    back in the work queue the pin exists to keep it out of.
+    `curated: true` lives inside `gtdb_classification`, so a flagged taxon always
+    has a block and the `has_block` branch already answers GROUNDED. #384 added a
+    `curated=` parameter for a `curated but ungrounded` state that cannot arise —
+    deleting its wiring left the whole suite green, and its presence reordered
+    the function so a taxon both flagged and withheld returned GROUNDED (#397).
     """
-    status, candidates = gtdb.classify_status(
-        "rec.yaml", "NCBITaxon:1", "Testgenus", False, {}, {}, {}, curated=True
+    import inspect
+
+    assert (
+        "curated" not in inspect.signature(gtdb.classify_status).parameters
+    ), "a curated= argument is unreachable from the writer; the flag implies a block"
+    status, _ = gtdb.classify_status("rec.yaml", "NCBITaxon:1", "Testgenus", True, {}, {}, {})
+    assert status == "GROUNDED"
+
+
+def test_a_withheld_taxon_is_not_overridden_by_anything(gtdb):
+    """WITHHELD stays checked before outcome, which #384 had silently reordered."""
+    record, preferred = next(iter(gtdb.WITHHELD_GROUNDINGS))
+    status, _ = gtdb.classify_status(
+        record, "NCBITaxon:821", "Bacteroides", False, {}, {}, {}, preferred=preferred
     )
     assert status == "WITHHELD"
-    assert candidates == []
 
-    grounded, _ = gtdb.classify_status(
-        "rec.yaml", "NCBITaxon:1", "Testgenus", True, {}, {}, {}, curated=True
-    )
-    assert grounded == "GROUNDED"
+
+def test_a_curation_note_survives_yaml_parsing_intact():
+    """A bare `#` after a space opens a comment mid-scalar and eats the rest.
+
+    The Chlorobium note ended `(#376, #384).` and parsed as `(#376,` — losing the
+    pointer to the issue the flag exists for, and leaving an unbalanced paren.
+    Every gate passed it, because they all test only that the note is non-empty.
+
+    Comparing the raw line against the parsed value catches the whole class:
+    comment truncation, a stray tab, an unescaped quote.
+    """
+    import re
+
+    truncated = []
+    for directory in ("kb/communities", "data/isolates"):
+        for path in sorted((REPO / directory).glob("*.yaml")):
+            text = path.read_text()
+            if "curation_note:" not in text:
+                continue
+            document = yaml.safe_load(text)
+            parsed = [
+                block["curation_note"]
+                for entry in document.get("taxonomy") or []
+                for block in [(entry.get("taxon_term") or {}).get("gtdb_classification") or {}]
+                if block.get("curation_note")
+            ]
+            raw = [m.group(1).strip() for m in re.finditer(r"^\s*curation_note: (.*)$", text, re.M)]
+            for raw_line, value in zip(raw, parsed, strict=True):
+                stripped = raw_line.strip("\"'")
+                if len(value) < len(stripped):
+                    truncated.append(f"{path.name}: lost {stripped[len(value):]!r}")
+    assert not truncated, "curation_note truncated by YAML parsing:\n" + "\n".join(truncated)
+
+
+@pytest.mark.parametrize("note", [["a list"], 0, {"a": 1}, False])
+def test_a_non_string_note_does_not_crash_the_check(note):
+    """`check_block` is called directly on unvalidated dicts, so it must cope.
+
+    The schema types `curation_note`, so `linkml-validate` rejects these — but
+    the validator is also called on in-memory blocks that never went through it.
+    """
+    block = _valid_block()
+    block["curation_note"] = note
+    categories = {category for category, _ in check_block(block)}
+    assert "note_without_curated" in categories or not str(note or "").strip()

--- a/tests/test_gtdb_status_writer.py
+++ b/tests/test_gtdb_status_writer.py
@@ -417,30 +417,78 @@ def test_the_skip_message_does_not_crash_on_a_flag_only_pin(gtdb, tmp_path, monk
     assert "a distinctive reason" in capsys.readouterr().err
 
 
-def test_a_curated_taxon_classifies_as_grounded(gtdb, tmp_path, monkeypatch):
-    monkeypatch.setattr(gtdb, "CURATED_GROUNDINGS", {})
-    term_block = yaml.safe_load(_curated_record(tmp_path).read_text())["taxonomy"][0]["taxon_term"]
+def test_every_curated_pin_carries_a_note_and_a_value():
+    """Derived, not a hard-coded set.
 
-    status, _ = gtdb.classify_status(
-        "curated.yaml", "NCBITaxon:1", "Testgenus", True, {}, {}, {}, curated=True
-    )
-
-    assert status == "GROUNDED"
-    assert term_block["gtdb_classification"]["curated"] is True
-
-
-def test_the_two_kb_pins_are_marked():
-    """Both blocks the tool cannot reproduce must now say so in the data."""
-    expected = {
-        ("Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml", "NCBITaxon:18"),
-        ("Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml", "NCBITaxon:340177"),
-    }
-    found = set()
+    The first version asserted equality against a literal pair, so a curator
+    adding a legitimate third pin got a red suite until they remembered to edit
+    the test — reintroducing the very "list someone must remember" this PR argues
+    against. What matters is that each pin is complete and that its value is
+    recorded, so a silent change to a pinned grounding fails.
+    """
+    pins = {}
     for path in sorted((REPO / "kb/communities").glob("*.yaml")):
         for entry in yaml.safe_load(path.read_text()).get("taxonomy") or []:
             term_block = entry.get("taxon_term") or {}
             block = term_block.get("gtdb_classification") or {}
             if block.get("curated"):
-                found.add((path.name, (term_block.get("term") or {}).get("id")))
+                key = (path.name, (term_block.get("term") or {}).get("id"))
+                pins[key] = block.get("gtdb_id")
                 assert block.get("curation_note"), f"{path.name}: curated with no note"
-    assert found == expected, f"curated pins drifted: {found ^ expected}"
+
+    assert pins, "no curated pins found; the flag protects nothing"
+    # The two known pins are value-pinned, so a mapping build that makes either
+    # resolve cannot change the stored answer without failing here. Additional
+    # pins are welcome and need no edit.
+    known = {
+        ("Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml", "NCBITaxon:18"): (
+            "GTDB:g__Syntrophotalea"
+        ),
+        ("Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml", "NCBITaxon:340177"): (
+            "GTDB:g__Chlorobium"
+        ),
+    }
+    for key, expected in known.items():
+        assert pins.get(key) == expected, f"{key} is pinned to {pins.get(key)}, expected {expected}"
+
+
+def test_a_false_flag_does_not_freeze_a_block(gtdb, tmp_path, monkeypatch):
+    """`curated: false` means "checked, the tool is right" — not "never touch"."""
+    monkeypatch.setattr(gtdb, "CURATED_GROUNDINGS", {})
+    record = _curated_record(tmp_path)
+    document = yaml.safe_load(record.read_text())
+    document["taxonomy"][0]["taxon_term"]["gtdb_classification"]["curated"] = False
+    record.write_text(yaml.dump(document, sort_keys=False, allow_unicode=True))
+
+    assert (
+        gtdb.withdraw_ambiguous(record, {}, {}, TIED_ROWS) == 1
+    ), "curated: false must not protect the block"
+
+
+def test_a_note_alone_does_not_protect(gtdb, tmp_path, monkeypatch):
+    """Only the flag protects. A note is documentation, not a lock."""
+    monkeypatch.setattr(gtdb, "CURATED_GROUNDINGS", {})
+    record = _curated_record(tmp_path)
+    document = yaml.safe_load(record.read_text())
+    del document["taxonomy"][0]["taxon_term"]["gtdb_classification"]["curated"]
+    record.write_text(yaml.dump(document, sort_keys=False, allow_unicode=True))
+
+    assert gtdb.withdraw_ambiguous(record, {}, {}, TIED_ROWS) == 1
+
+
+def test_the_write_gate_refuses_to_drop_a_pin(gtdb, tmp_path):
+    """Losing the flag is the regression the flag exists to prevent.
+
+    `_block` never emits `curated`, and the gate pops gtdb_classification
+    wholesale before comparing, so a path that failed to detect the flag would
+    rewrite the block and delete the evidence it was ever curated (#397 review).
+    """
+    record = _curated_record(tmp_path)
+    before = yaml.safe_load(record.read_text())
+    unpinned = yaml.safe_load(record.read_text())
+    del unpinned["taxonomy"][0]["taxon_term"]["gtdb_classification"]["curated"]
+
+    with pytest.raises(SystemExit, match="dropped `curated`"):
+        gtdb._assert_only_grounding_changed(
+            record, before, yaml.dump(unpinned, sort_keys=False, allow_unicode=True), refresh=True
+        )

--- a/tests/test_gtdb_status_writer.py
+++ b/tests/test_gtdb_status_writer.py
@@ -346,3 +346,101 @@ def test_withdrawal_handles_both_indent_styles(gtdb, tmp_path, indent):
     after = yaml.safe_load(record.read_text())["taxonomy"][0]["taxon_term"]
     assert "gtdb_classification" not in after
     assert after["notes"] == "must survive"
+
+
+# ---------------------------------------------------------------------------
+# The curated flag (#384): protection that travels with the data.
+# ---------------------------------------------------------------------------
+
+
+def _curated_record(tmp_path, note="because the vote is wrong here"):
+    document = {
+        "taxonomy": [
+            {
+                "taxon_term": {
+                    "preferred_term": "Testgenus sp. X",
+                    "term": {"id": "NCBITaxon:1", "label": "Testgenus"},
+                    "gtdb_classification": {
+                        "curated": True,
+                        "curation_note": note,
+                        "gtdb_id": "GTDB:g__Pinned",
+                        "gtdb_taxon": "g__Pinned",
+                        "ncbi_source_id": "NCBITaxon:1",
+                        "majority_fraction": 0.9,
+                        "mapping_source": "test",
+                    },
+                }
+            }
+        ]
+    }
+    path = tmp_path / "curated.yaml"
+    path.write_text(yaml.dump(document, sort_keys=False, allow_unicode=True))
+    return path
+
+
+def test_the_flag_protects_a_refresh_with_the_list_empty(gtdb, tmp_path, monkeypatch):
+    """The whole point: a list only protects what someone remembered to add.
+
+    *Chlorobium* was curated and unlisted, and survived earlier sweeps only
+    because its recompute happened to yield no id — a side effect, not a
+    decision (#376, #384).
+    """
+    monkeypatch.setattr(gtdb, "CURATED_GROUNDINGS", {})
+    record = _curated_record(tmp_path)
+
+    gtdb.apply_to_community(record, {}, {}, DECIDED_ROWS, "test-source", refresh=True)
+
+    kept = yaml.safe_load(record.read_text())["taxonomy"][0]["taxon_term"]
+    assert kept["gtdb_classification"]["gtdb_id"] == "GTDB:g__Pinned"
+
+
+def test_the_flag_protects_withdrawal_with_the_list_empty(gtdb, tmp_path, monkeypatch):
+    monkeypatch.setattr(gtdb, "CURATED_GROUNDINGS", {})
+    record = _curated_record(tmp_path)
+
+    assert gtdb.withdraw_ambiguous(record, {}, {}, TIED_ROWS) == 0
+    kept = yaml.safe_load(record.read_text())["taxonomy"][0]["taxon_term"]
+    assert kept["gtdb_classification"]["gtdb_id"] == "GTDB:g__Pinned"
+
+
+def test_the_skip_message_does_not_crash_on_a_flag_only_pin(gtdb, tmp_path, monkeypatch, capsys):
+    """The message indexed the list unconditionally and raised KeyError.
+
+    That fired for exactly the case the flag exists for — a block protected by
+    its own flag and absent from the list. The canary caught it before any sweep.
+    """
+    monkeypatch.setattr(gtdb, "CURATED_GROUNDINGS", {})
+    record = _curated_record(tmp_path, note="a distinctive reason")
+
+    gtdb.apply_to_community(record, {}, {}, DECIDED_ROWS, "test-source", refresh=True)
+
+    assert "a distinctive reason" in capsys.readouterr().err
+
+
+def test_a_curated_taxon_classifies_as_grounded(gtdb, tmp_path, monkeypatch):
+    monkeypatch.setattr(gtdb, "CURATED_GROUNDINGS", {})
+    term_block = yaml.safe_load(_curated_record(tmp_path).read_text())["taxonomy"][0]["taxon_term"]
+
+    status, _ = gtdb.classify_status(
+        "curated.yaml", "NCBITaxon:1", "Testgenus", True, {}, {}, {}, curated=True
+    )
+
+    assert status == "GROUNDED"
+    assert term_block["gtdb_classification"]["curated"] is True
+
+
+def test_the_two_kb_pins_are_marked():
+    """Both blocks the tool cannot reproduce must now say so in the data."""
+    expected = {
+        ("Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml", "NCBITaxon:18"),
+        ("Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml", "NCBITaxon:340177"),
+    }
+    found = set()
+    for path in sorted((REPO / "kb/communities").glob("*.yaml")):
+        for entry in yaml.safe_load(path.read_text()).get("taxonomy") or []:
+            term_block = entry.get("taxon_term") or {}
+            block = term_block.get("gtdb_classification") or {}
+            if block.get("curated"):
+                found.add((path.name, (term_block.get("term") or {}).get("id")))
+                assert block.get("curation_note"), f"{path.name}: curated with no note"
+    assert found == expected, f"curated pins drifted: {found ^ expected}"


### PR DESCRIPTION
Closes #384.

#384 asked for the tool to refuse to overwrite a curated grounding. The narrow half shipped in #385 as `CURATED_GROUNDINGS`, a hard-coded map. Closing #376 showed why that is not enough.

**`NCBITaxon:340177` (*Chlorobium*) is curated, was never on the list, and survived a whole-KB refresh only because its recompute happened to yield no id.** Protection by side effect, not by decision — and if a future mapping build made it resolve, `--refresh` would have overwritten it silently, with only `git log` showing it had been curated at all.

A list protects only what someone remembered to add.

## The flag

```yaml
gtdb_classification:
  curated: true
  curation_note: why the tool'"'"'s answer was rejected
```

`--refresh`, `--apply` and `--withdraw-ambiguous` all skip a flagged block. The list stays as a fallback for anything unmarked.

Both blocks the tool cannot reproduce now carry the flag and a reason — and that is the entire population: recomputing all 643 stored blocks, exactly these two disagree with the tool.

| record | taxon | pinned | why |
|---|---|---|---|
| `Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture` | `NCBITaxon:18` | `g__Syntrophotalea` | the vote picks `g__Seleniibacterium`, a selenate reducer, for an acetylene fermenter |
| `Chlorochromatium_Aggregatum_Phototrophic_Consortium` | `NCBITaxon:340177` | `g__Chlorobium` | curated to the genus; the tool produces no id |

## `curation_note` is enforced, but not by the schema

LinkML cannot require a field conditionally, so `validate-gtdb` carries it. Both directions are rejected:

- **`curated` with no note** — a pin whose reason lives only in a commit message is one re-run away from looking like an error.
- **a note with no `curated`** — worse, because it reads as a decision while a refresh overwrites the block anyway.

## The canary caught a crash before any sweep

The skip message indexed `CURATED_GROUNDINGS[(path.name, tid)]` unconditionally, so it raised `KeyError` whenever the block'"'"'s own flag was what protected it — **exactly the case the flag exists for**. It reads the note now.

## Mutation testing

Ignoring the flag on refresh, on withdrawal, and in `classify_status`; `_is_curated` always False; the skip message reverting; and both new coherence checks — all fail.

Three needed tests I had not written. The `classify_status` branch only differs when a curated taxon has **no** block — it must be `WITHHELD`, not `NOT_ATTEMPTED`, since the pin exists to keep it out of the work queue — and neither note check had a case at all.

`just validate-all`, `validate-strict`, `validate-gtdb-all` clean; 1147 passed; lint clean.
