### PR TITLE
Catch YAML scalars a mid-line `#` silently truncates (#398)

### DIFF
--- a/justfile
+++ b/justfile
@@ -154,7 +154,12 @@ validate-gtdb FILE:
     PYTHONPATH=src uv run python scripts/validate_gtdb_coherence.py {{FILE}}
 
 # Find hand-written YAML scalars a mid-line `#` will silently truncate (#398).
-# Also runs inside `just validate-strict`; this is the fast standalone form.
+#
+# The same check runs inside `just validate-strict` over kb/communities and
+# data/isolates. This form also covers kb/taxa, which that gate does not, and
+# takes explicit paths. Scoped to the record trees on purpose: conf/ and
+# .github/ use deliberate trailing comments, which are indistinguishable from
+# truncation on a plain scalar.
 validate-scalars *files:
     PYTHONPATH=src uv run python scripts/validate_yaml_scalars.py {{files}}
 

--- a/justfile
+++ b/justfile
@@ -153,6 +153,11 @@ validate-cross-repo-ids-all:
 validate-gtdb FILE:
     PYTHONPATH=src uv run python scripts/validate_gtdb_coherence.py {{FILE}}
 
+# Find hand-written YAML scalars a mid-line `#` will silently truncate (#398).
+# Also runs inside `just validate-strict`; this is the fast standalone form.
+validate-scalars *files:
+    PYTHONPATH=src uv run python scripts/validate_yaml_scalars.py {{files}}
+
 validate-gtdb-all:
     PYTHONPATH=src uv run python scripts/validate_gtdb_coherence.py kb/communities/*.yaml data/isolates/*.yaml
 

--- a/scripts/validate_strict.py
+++ b/scripts/validate_strict.py
@@ -41,6 +41,7 @@ from linkml.validator.plugins import JsonschemaValidationPlugin
 from linkml.validator.report import Severity
 
 from communitymech.validators.gtdb_coherence import validate_gtdb_coherence
+from communitymech.validators.yaml_scalars import find_truncated_scalars
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 SCHEMA_PATH = _REPO_ROOT / "src" / "communitymech" / "schema" / "communitymech.yaml"
@@ -155,6 +156,18 @@ def validate_one(path: Path) -> list[dict]:
     # JSON-Schema `required`, which is what `value_presence: PRESENT` compiles
     # to. Running them here rather than only in pytest means a hand-authored
     # record is checked by the same gate as everything else.
+    # A mid-scalar `#` silently truncates an unquoted value, and the file stays
+    # valid YAML — so no schema check can see it (#398). Raw-text, hence here
+    # rather than in the instance validator.
+    for scalar in find_truncated_scalars(path):
+        rows.append({
+            "file": str(path),
+            "category": "yaml_truncated_scalar",
+            "detail": f"line={scalar.line}|key={scalar.key}",
+            "path": "",
+            "message": scalar.message[:300],
+        })
+
     for issue in validate_gtdb_coherence(path):
         rows.append({
             "file": str(path),

--- a/scripts/validate_yaml_scalars.py
+++ b/scripts/validate_yaml_scalars.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Report YAML scalars a mid-line `#` will silently truncate (#398).
+
+In YAML a `#` preceded by whitespace opens a comment, even mid-value, so an
+unquoted scalar loses its tail while the file stays valid and the value stays
+non-empty. No schema check can see it; this reads the raw lines.
+
+    just validate-scalars kb/communities/Foo.yaml
+    just validate-scalars            # every record
+
+Exits 1 if anything is found, so it can gate on its own. The same check runs
+inside `just validate-strict`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from communitymech.validators.yaml_scalars import find_truncated_scalars  # noqa: E402
+
+DEFAULT_DIRS = ("kb/communities", "data/isolates", "kb/taxa")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("files", nargs="*", type=Path, help="YAML file(s); default: all records")
+    args = parser.parse_args(argv)
+
+    paths = args.files or [
+        path for directory in DEFAULT_DIRS for path in sorted((REPO_ROOT / directory).glob("*.yaml"))
+    ]
+    if not paths:
+        print("[scalars] no files to check", file=sys.stderr)
+        return 2
+
+    issues = []
+    for path in paths:
+        if not path.exists():
+            print(f"[scalars] no such file: {path}", file=sys.stderr)
+            return 2
+        issues.extend(find_truncated_scalars(path))
+
+    for issue in issues:
+        print(issue)
+
+    print(f"\nfiles checked: {len(paths)}", file=sys.stderr)
+    print(f"truncated scalars: {len(issues)}", file=sys.stderr)
+    return 1 if issues else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_yaml_scalars.py
+++ b/scripts/validate_yaml_scalars.py
@@ -23,6 +23,9 @@ sys.path.insert(0, str(REPO_ROOT / "src"))
 
 from communitymech.validators.yaml_scalars import find_truncated_scalars  # noqa: E402
 
+# `kb/taxa` is deliberately included and is *not* covered by validate-strict,
+# whose DEFAULT_ROOTS are the two record trees. It reaches CI through pytest
+# instead (#399 review, #391).
 DEFAULT_DIRS = ("kb/communities", "data/isolates", "kb/taxa")
 
 
@@ -32,8 +35,17 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     paths = args.files or [
-        path for directory in DEFAULT_DIRS for path in sorted((REPO_ROOT / directory).glob("*.yaml"))
+        path
+        for directory in DEFAULT_DIRS
+        for path in sorted((REPO_ROOT / directory).rglob("*.yaml"))
     ]
+    # A directory argument is what `validate_strict.py` accepts, so accept it
+    # here too rather than dying on IsADirectoryError. The two CLIs disagreeing
+    # on their contract is a trap for whoever wires them together (#399 review).
+    expanded: list[Path] = []
+    for path in paths:
+        expanded.extend(sorted(path.rglob("*.yaml")) if path.is_dir() else [path])
+    paths = expanded
     if not paths:
         print("[scalars] no files to check", file=sys.stderr)
         return 2

--- a/src/communitymech/validators/yaml_scalars.py
+++ b/src/communitymech/validators/yaml_scalars.py
@@ -1,0 +1,121 @@
+"""Catch hand-written YAML scalars that silently lose their tail (#398).
+
+In YAML a ``#`` **preceded by whitespace** opens a comment, even mid-value. So an
+unquoted scalar like::
+
+    curation_note: rather than by decision (#376, #384).
+
+parses as ``rather than by decision (#376,`` — the rest is a comment. The file is
+valid YAML, the value is non-empty, and every schema check passes. It bit once
+already: that exact line shipped, losing the pointer to the issue the field
+existed for and leaving an unbalanced paren, and nothing noticed because every
+check tested only that the note was non-empty (#397 review).
+
+The hazard is general rather than specific to one field. `notes`, `curation_note`
+and evidence `snippet` are all prose a curator types by hand, and all routinely
+reference issues and PRs by ``#number``.
+
+Two things make this hard to catch after the fact:
+
+* Re-serializing does not reveal it. PyYAML emits the *truncated* value as
+  perfectly good YAML, so a load/dump round-trip compares equal to itself. The
+  check has to read the raw line.
+* ``#`` is legitimate in three places — a whole-line comment, anywhere inside a
+  quoted scalar, and anywhere inside a block scalar (``>`` or ``|``), where it is
+  literal. Flagging those would make the rule unusable.
+
+So this reports only an **unquoted plain scalar containing a space-hash**, which
+is exactly the case that loses data.
+
+A whole-line comment needs no explicit guard: it cannot match the ``key: value``
+patterns, which require a letter or underscore first.
+
+Usage::
+
+    from communitymech.validators.yaml_scalars import find_truncated_scalars
+
+    for issue in find_truncated_scalars(Path("kb/communities/Foo.yaml")):
+        print(issue.line, issue.message)
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+# `key: value` or `- key: value`, capturing the indent, the key and the value.
+_MAPPING = re.compile(r"^(?P<indent>\s*)(?:-\s+)?(?P<key>[A-Za-z_][\w.\-]*):\s(?P<value>\S.*)$")
+# A bare sequence item: `- some text`.
+_SEQUENCE = re.compile(r"^(?P<indent>\s*)-\s(?P<value>\S.*)$")
+# A block scalar header: `key: >`, `key: |-`, `key: >2`, etc.
+_BLOCK_HEADER = re.compile(r"^(?P<indent>\s*)(?:-\s+)?[A-Za-z_][\w.\-]*:\s*[|>][+\-0-9]*\s*$")
+# The defect: whitespace then `#`. A `#` with no space before it — `(#376` — is
+# part of the scalar and safe.
+_SPACE_HASH = re.compile(r"\s#")
+
+
+@dataclass(frozen=True)
+class ScalarIssue:
+    """One line whose value will lose its tail."""
+
+    file: str
+    line: int
+    key: str
+    truncated_to: str
+    lost: str
+
+    @property
+    def message(self) -> str:
+        return (
+            f"unquoted `{self.key}` is cut short by a mid-scalar comment: keeps "
+            f"{self.truncated_to!r}, loses {self.lost!r}. Quote the value."
+        )
+
+    def __str__(self) -> str:  # pragma: no cover - display only
+        return f"{self.file}:{self.line}: {self.message}"
+
+
+def _is_quoted(value: str) -> bool:
+    """Is the value a quoted scalar, so a `#` inside it is literal?"""
+    stripped = value.strip()
+    return len(stripped) >= 2 and stripped[0] in "\"'" and stripped[-1] == stripped[0]
+
+
+def find_truncated_scalars(path: Path) -> list[ScalarIssue]:
+    """Report unquoted scalars in `path` that a mid-line comment will truncate."""
+    issues: list[ScalarIssue] = []
+    block_indent: int | None = None
+
+    for number, line in enumerate(path.read_text().splitlines(), start=1):
+        indent = len(line) - len(line.lstrip())
+
+        # Inside a block scalar every line is literal, including `#`. The block
+        # ends at the first non-blank line indented no deeper than its header.
+        if block_indent is not None:
+            if not line.strip() or indent > block_indent:
+                continue
+            block_indent = None
+
+        if _BLOCK_HEADER.match(line):
+            block_indent = indent
+            continue
+        match = _MAPPING.match(line) or _SEQUENCE.match(line)
+        if not match:
+            continue
+        value = match.group("value")
+        if _is_quoted(value):
+            continue
+        hit = _SPACE_HASH.search(value)
+        if not hit:
+            continue
+        issues.append(
+            ScalarIssue(
+                file=str(path),
+                line=number,
+                key=match.groupdict().get("key") or "-",
+                truncated_to=value[: hit.start()].rstrip(),
+                lost=value[hit.start() :].strip(),
+            )
+        )
+    return issues

--- a/src/communitymech/validators/yaml_scalars.py
+++ b/src/communitymech/validators/yaml_scalars.py
@@ -1,41 +1,35 @@
-"""Catch hand-written YAML scalars that silently lose their tail (#398).
+"""Catch YAML scalars that a mid-line ``#`` silently truncates (#398).
 
-In YAML a ``#`` **preceded by whitespace** opens a comment, even mid-value. So an
-unquoted scalar like::
+In YAML a ``#`` preceded by whitespace opens a comment, even mid-value. So::
 
     curation_note: rather than by decision (#376, #384).
 
-parses as ``rather than by decision (#376,`` — the rest is a comment. The file is
-valid YAML, the value is non-empty, and every schema check passes. It bit once
-already: that exact line shipped, losing the pointer to the issue the field
-existed for and leaving an unbalanced paren, and nothing noticed because every
-check tested only that the note was non-empty (#397 review).
+parses as ``rather than by decision (#376,``. The file stays valid, the value
+stays non-empty, and every schema check passes. That exact line shipped in #397.
 
-The hazard is general rather than specific to one field. `notes`, `curation_note`
-and evidence `snippet` are all prose a curator types by hand, and all routinely
-reference issues and PRs by ``#number``.
+Re-serializing cannot reveal it — PyYAML emits the *truncated* value as good
+YAML, so a load/dump round-trip compares equal to itself.
 
-Two things make this hard to catch after the fact:
+**This asks PyYAML where each scalar actually ends** rather than pattern-matching
+lines. The first version hand-rolled the lexing and was wrong in both directions
+(#399 review):
 
-* Re-serializing does not reveal it. PyYAML emits the *truncated* value as
-  perfectly good YAML, so a load/dump round-trip compares equal to itself. The
-  check has to read the raw line.
-* ``#`` is legitimate in three places — a whole-line comment, anywhere inside a
-  quoted scalar, and anywhere inside a block scalar (``>`` or ``|``), where it is
-  literal. Flagging those would make the rule unusable.
+* it missed a value that *begins* with ``#`` (``notes: #398 why``), which parses
+  as ``null`` — total loss, and the same ``#issue`` idiom this check exists for;
+* it inspected only the first line of a plain scalar, and 5333 of the KB's
+  scalars span several lines, so most prose was checked only where it started;
+* it reported every deliberate trailing comment as data loss — 13 in this repo's
+  ``conf/`` and ``.github/`` — because it judged quoting by whether the raw value
+  happened to start and end with a quote, rather than by where the ``#`` sat.
 
-So this reports only an **unquoted plain scalar containing a space-hash**, which
-is exactly the case that loses data.
+Scalar *style* answers all of that for free. A quoted or block scalar carries its
+own delimiters, so a ``#`` inside it is literal and a ``#`` after it cannot have
+eaten anything the author wrote. Only a **plain** scalar can be cut short, and
+PyYAML reports precisely where it stopped.
 
-A whole-line comment needs no explicit guard: it cannot match the ``key: value``
-patterns, which require a letter or underscore first.
-
-Usage::
-
-    from communitymech.validators.yaml_scalars import find_truncated_scalars
-
-    for issue in find_truncated_scalars(Path("kb/communities/Foo.yaml")):
-        print(issue.line, issue.message)
+A trailing comment on a plain scalar stays reportable, because nothing can
+distinguish "I meant a comment" from "I lost my tail" — the message says to quote
+the value, which resolves it either way. The record trees contain none today.
 """
 
 from __future__ import annotations
@@ -44,20 +38,43 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-# `key: value` or `- key: value`, capturing the indent, the key and the value.
-_MAPPING = re.compile(r"^(?P<indent>\s*)(?:-\s+)?(?P<key>[A-Za-z_][\w.\-]*):\s(?P<value>\S.*)$")
-# A bare sequence item: `- some text`.
-_SEQUENCE = re.compile(r"^(?P<indent>\s*)-\s(?P<value>\S.*)$")
-# A block scalar header: `key: >`, `key: |-`, `key: >2`, etc.
-_BLOCK_HEADER = re.compile(r"^(?P<indent>\s*)(?:-\s+)?[A-Za-z_][\w.\-]*:\s*[|>][+\-0-9]*\s*$")
-# The defect: whitespace then `#`. A `#` with no space before it — `(#376` — is
-# part of the scalar and safe.
-_SPACE_HASH = re.compile(r"\s#")
+import yaml
+
+# Only to name the field in the message; detection never relies on it.
+_KEY = re.compile(r"^\s*(?:-\s+)?(?P<key>[^\s:#][^:#]*):\s")
+
+
+def _name_for(lines: list[str], number: int) -> str:
+    """The field name to quote in the message.
+
+    A scalar's own line usually carries its key. A sequence item does not, so
+    walk out to the enclosing key — the one at a *smaller* indent. Scanning
+    backwards for any `key:` instead attributed eleven list items in
+    `conf/id_label_targets.yaml` to whichever key happened to precede them.
+    """
+    own = _KEY.match(lines[number])
+    if own:
+        return own.group("key").strip()
+
+    indent = len(lines[number]) - len(lines[number].lstrip())
+    # A block sequence may sit at the same indent as its key (`items:` then
+    # `- one`), so an entry accepts an equal indent while a wrapped scalar
+    # requires a strictly smaller one.
+    limit = indent if lines[number].lstrip().startswith("- ") else indent - 1
+    for candidate in range(number - 1, -1, -1):
+        line = lines[candidate]
+        if not line.strip():
+            continue
+        if len(line) - len(line.lstrip()) <= limit:
+            found = _KEY.match(line) or re.match(r"^\s*(?P<key>[^\s:#][^:#]*):\s*$", line)
+            if found:
+                return found.group("key").strip()
+    return "-"
 
 
 @dataclass(frozen=True)
 class ScalarIssue:
-    """One line whose value will lose its tail."""
+    """One scalar whose value stops short because a comment opened mid-line."""
 
     file: str
     line: int
@@ -67,55 +84,53 @@ class ScalarIssue:
 
     @property
     def message(self) -> str:
+        kept = f"keeps {self.truncated_to!r}, " if self.truncated_to else "keeps nothing — "
         return (
-            f"unquoted `{self.key}` is cut short by a mid-scalar comment: keeps "
-            f"{self.truncated_to!r}, loses {self.lost!r}. Quote the value."
+            f"plain scalar `{self.key}` is cut short by a mid-line comment: "
+            f"{kept}loses {self.lost!r}. Quote the value (or move the comment to "
+            f"its own line if it was meant as one)."
         )
 
     def __str__(self) -> str:  # pragma: no cover - display only
         return f"{self.file}:{self.line}: {self.message}"
 
 
-def _is_quoted(value: str) -> bool:
-    """Is the value a quoted scalar, so a `#` inside it is literal?"""
-    stripped = value.strip()
-    return len(stripped) >= 2 and stripped[0] in "\"'" and stripped[-1] == stripped[0]
-
-
 def find_truncated_scalars(path: Path) -> list[ScalarIssue]:
-    """Report unquoted scalars in `path` that a mid-line comment will truncate."""
+    """Report plain scalars in `path` that a mid-line comment cut short."""
+    text = path.read_text()
+    lines = text.splitlines()
+
+    try:
+        events = list(yaml.parse(text))
+    except yaml.YAMLError:
+        # An unparseable document is a different failure, already reported as
+        # `yaml_parse_error` by validate-strict. Saying it twice helps nobody.
+        return []
+
     issues: list[ScalarIssue] = []
-    block_indent: int | None = None
+    for event in events:
+        # A quoted scalar ('"', "'") or a block scalar ('|', '>') delimits itself,
+        # so a `#` inside it is literal and a `#` after it ends a value that was
+        # already complete. Only `style is None` — a plain scalar — can be cut.
+        if not isinstance(event, yaml.ScalarEvent) or event.style is not None:
+            continue
 
-    for number, line in enumerate(path.read_text().splitlines(), start=1):
-        indent = len(line) - len(line.lstrip())
+        end = event.end_mark
+        if end.line >= len(lines):
+            continue
+        remainder = lines[end.line][end.column :]
+        if not remainder.lstrip().startswith("#"):
+            continue
 
-        # Inside a block scalar every line is literal, including `#`. The block
-        # ends at the first non-blank line indented no deeper than its header.
-        if block_indent is not None:
-            if not line.strip() or indent > block_indent:
-                continue
-            block_indent = None
+        key = _name_for(lines, end.line)
 
-        if _BLOCK_HEADER.match(line):
-            block_indent = indent
-            continue
-        match = _MAPPING.match(line) or _SEQUENCE.match(line)
-        if not match:
-            continue
-        value = match.group("value")
-        if _is_quoted(value):
-            continue
-        hit = _SPACE_HASH.search(value)
-        if not hit:
-            continue
         issues.append(
             ScalarIssue(
                 file=str(path),
-                line=number,
-                key=match.groupdict().get("key") or "-",
-                truncated_to=value[: hit.start()].rstrip(),
-                lost=value[hit.start() :].strip(),
+                line=end.line + 1,
+                key=key,
+                truncated_to=event.value.strip(),
+                lost=remainder.strip(),
             )
         )
     return issues

--- a/tests/test_yaml_scalar_truncation.py
+++ b/tests/test_yaml_scalar_truncation.py
@@ -1,0 +1,189 @@
+"""Unquoted YAML scalars that a mid-line `#` silently truncates (#398).
+
+In YAML a `#` **preceded by whitespace** opens a comment, even mid-value. So
+
+    curation_note: rather than by decision (#376, #384).
+
+parses as `rather than by decision (#376,`. The file is valid YAML, the value is
+non-empty, and every schema check passes — which is how that exact line shipped,
+losing the pointer to the issue the field existed for.
+
+Re-serializing cannot reveal it: PyYAML emits the *truncated* value as good YAML,
+so a load/dump round-trip compares equal to itself. The check reads raw lines.
+
+`#` is legitimate in three places — a whole-line comment, inside a quoted scalar,
+and inside a block scalar (`>`/`|`) where it is literal. Flagging any of those
+would make the rule unusable, so the false-positive cases below matter as much as
+the true positives.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from communitymech.validators.yaml_scalars import find_truncated_scalars
+
+REPO = Path(__file__).parent.parent
+
+
+def _write(tmp_path: Path, text: str, name: str = "probe.yaml") -> Path:
+    path = tmp_path / name
+    path.write_text(text)
+    return path
+
+
+@pytest.mark.parametrize(
+    ("name", "text", "lost"),
+    [
+        ("plain mapping", "key: some text #376 here\n", "#376 here"),
+        ("sequence item", "items:\n- some text #376 here\n", "#376 here"),
+        (
+            "after a block scalar ends",
+            "notes: >\n  fine #376 here\nkey: bad #384 here\n",
+            "#384 here",
+        ),
+        ("nested mapping", "a:\n  b:\n    c: text #1 x\n", "#1 x"),
+        # A tab before the hash is not this defect: YAML rejects the document
+        # outright, which validate-strict already reports as a parse error.
+    ],
+)
+def test_a_truncating_scalar_is_reported(tmp_path, name, text, lost):
+    """Each of these loses data on parse — verified against PyYAML itself."""
+    path = _write(tmp_path, text)
+    issues = find_truncated_scalars(path)
+
+    assert len(issues) == 1, f"{name}: expected one issue, got {issues}"
+    assert lost in issues[0].lost
+
+    # The premise: YAML really does drop it. Without this the test could be
+    # asserting a rule nobody needs.
+    parsed = yaml.safe_load(text)
+    flat = str(parsed)
+    assert lost not in flat, f"{name}: YAML kept the tail, so there is nothing to report"
+
+
+@pytest.mark.parametrize(
+    ("name", "text"),
+    [
+        ("whole-line comment", "# a comment\nkey: value\n"),
+        ("hash with no space", "key: see (#376) for detail\n"),
+        ("single-quoted", "key: 'text with #376 inside'\n"),
+        ("double-quoted", 'key: "text with #376 inside"\n'),
+        ("folded block scalar", "notes: >\n  a note mentioning #376\n  and more\nother: fine\n"),
+        ("literal block scalar", "notes: |\n  literal #376 text\nother: fine\n"),
+        ("block scalar with indicator", "notes: >-\n  a note with #376\nother: fine\n"),
+        ("blank line inside a block", "notes: >\n  first #376\n\n  second #384\nother: fine\n"),
+        # A block body line that *looks* like a mapping or a sequence item. This
+        # is what makes skipping the block header load-bearing: without it the
+        # body would be parsed as YAML structure and flagged.
+        ("mapping-shaped block body", "notes: >\n  key: value #376 here\nother: fine\n"),
+        ("sequence-shaped block body", "notes: |\n  - item #376 here\nother: fine\n"),
+        ("comment line with a hash", "# see key: value #376\nkey: fine\n"),
+        ("no hash at all", "key: ordinary text\n"),
+    ],
+)
+def test_legitimate_hashes_are_not_reported(tmp_path, name, text):
+    """False positives would make this rule unusable, so they are pinned too."""
+    assert find_truncated_scalars(_write(tmp_path, text)) == [], name
+
+
+def test_the_line_number_and_key_are_usable(tmp_path):
+    """A report that cannot be acted on is noise."""
+    path = _write(tmp_path, "alpha: fine\nbeta: broken #1 here\n")
+    issue = find_truncated_scalars(path)[0]
+
+    assert issue.line == 2
+    assert issue.key == "beta"
+    assert issue.truncated_to == "broken"
+    assert "Quote the value" in issue.message
+
+
+def test_the_committed_kb_is_clean():
+    """Every record, with a vacuity guard on the sweep."""
+    scanned, issues = 0, []
+    for directory in ("kb/communities", "data/isolates", "kb/taxa"):
+        for path in sorted((REPO / directory).glob("*.yaml")):
+            scanned += 1
+            issues.extend(find_truncated_scalars(path))
+    assert scanned > 300, f"expected the whole KB, scanned {scanned}"
+    assert not issues, "truncated scalars:\n" + "\n".join(str(i) for i in issues)
+
+
+def test_the_instance_that_shipped_is_caught(tmp_path):
+    """The real defect, reconstructed by unquoting the line that now carries it.
+
+    Reading it from git does not work: the note was added and fixed inside one
+    PR, so the truncated form never reached `main`.
+    """
+    import re
+
+    source = REPO / "kb/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml"
+    text = source.read_text()
+    assert 'curation_note: "' in text, "the note is no longer quoted; this test is stale"
+    unquoted = re.sub(r'(curation_note: )"(.*)"', r"\1\2", text)
+
+    issues = find_truncated_scalars(_write(tmp_path, unquoted))
+
+    assert len(issues) == 1
+    assert issues[0].key == "curation_note"
+    assert "#384" in issues[0].lost, "the lost tail should name the dropped issue"
+
+
+def test_validate_strict_reports_it(tmp_path):
+    """It must fire through the CI gate, not only when called directly."""
+    import re
+
+    source = REPO / "kb/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml"
+    unquoted = re.sub(r'(curation_note: )"(.*)"', r"\1\2", source.read_text())
+    path = _write(tmp_path, unquoted, name="broken.yaml")
+
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "scripts/validate_strict.py",
+            str(path),
+            "--out",
+            str(tmp_path / "report.tsv"),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+    )
+
+    assert result.returncode == 1, "validate-strict passed a record it should fail"
+    assert "yaml_truncated_scalar" in (result.stdout + result.stderr)
+
+
+def test_linkml_validate_accepts_what_this_catches(tmp_path):
+    """Why a raw-text check exists at all.
+
+    If this ever starts failing, the schema layer gained the ability to see
+    truncation and this validator can go.
+    """
+    import re
+
+    source = REPO / "kb/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.yaml"
+    unquoted = re.sub(r'(curation_note: )"(.*)"', r"\1\2", source.read_text())
+    path = _write(tmp_path, unquoted, name="accepted.yaml")
+
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "linkml-validate",
+            "-s",
+            "src/communitymech/schema/communitymech.yaml",
+            str(path),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+    )
+
+    assert result.returncode == 0, "linkml-validate now rejects this — drop the raw-text check"

--- a/tests/test_yaml_scalar_truncation.py
+++ b/tests/test_yaml_scalar_truncation.py
@@ -41,14 +41,24 @@ def _write(tmp_path: Path, text: str, name: str = "probe.yaml") -> Path:
     [
         ("plain mapping", "key: some text #376 here\n", "#376 here"),
         ("sequence item", "items:\n- some text #376 here\n", "#376 here"),
+        ("nested mapping", "a:\n  b:\n    c: text #1 x\n", "#1 x"),
         (
             "after a block scalar ends",
             "notes: >\n  fine #376 here\nkey: bad #384 here\n",
             "#384 here",
         ),
-        ("nested mapping", "a:\n  b:\n    c: text #1 x\n", "#1 x"),
-        # A tab before the hash is not this defect: YAML rejects the document
-        # outright, which validate-strict already reports as a parse error.
+        # The value *begins* with the hash, so the whole thing parses as null.
+        # The first version searched inside the captured value, where a leading
+        # `#` has no whitespace before it, and missed total loss (#399 review).
+        ("leading hash parses as null", "notes: #398 documents why\n", "#398 documents why"),
+        # A plain scalar wraps across lines; the truncation lands on the last
+        # one. The first version only ever inspected the line the key was on,
+        # and 5333 of the KB's scalars span several lines.
+        (
+            "wrapped scalar, hash on the last line",
+            "notes: a long note wrapped by\n  an editor. (see #398)\n",
+            "#398)",
+        ),
     ],
 )
 def test_a_truncating_scalar_is_reported(tmp_path, name, text, lost):
@@ -62,8 +72,7 @@ def test_a_truncating_scalar_is_reported(tmp_path, name, text, lost):
     # The premise: YAML really does drop it. Without this the test could be
     # asserting a rule nobody needs.
     parsed = yaml.safe_load(text)
-    flat = str(parsed)
-    assert lost not in flat, f"{name}: YAML kept the tail, so there is nothing to report"
+    assert lost not in str(parsed), f"{name}: YAML kept the tail, nothing to report"
 
 
 @pytest.mark.parametrize(
@@ -76,19 +85,53 @@ def test_a_truncating_scalar_is_reported(tmp_path, name, text, lost):
         ("folded block scalar", "notes: >\n  a note mentioning #376\n  and more\nother: fine\n"),
         ("literal block scalar", "notes: |\n  literal #376 text\nother: fine\n"),
         ("block scalar with indicator", "notes: >-\n  a note with #376\nother: fine\n"),
-        ("blank line inside a block", "notes: >\n  first #376\n\n  second #384\nother: fine\n"),
-        # A block body line that *looks* like a mapping or a sequence item. This
-        # is what makes skipping the block header load-bearing: without it the
-        # body would be parsed as YAML structure and flagged.
+        ("blank line inside a block", "notes: >\n  first #376\n\n  key: value #384\nother: x\n"),
         ("mapping-shaped block body", "notes: >\n  key: value #376 here\nother: fine\n"),
         ("sequence-shaped block body", "notes: |\n  - item #376 here\nother: fine\n"),
-        ("comment line with a hash", "# see key: value #376\nkey: fine\n"),
         ("no hash at all", "key: ordinary text\n"),
+        # Every one of these was a false positive before the rewrite. A quoted or
+        # block scalar delimits itself, so a `#` after it cannot have eaten
+        # anything the author wrote (#399 review).
+        ("deliberate comment after a quoted value", 'key: "value" # a real comment\n'),
+        ("deliberate comment after a single-quoted value", "key: 'value' # a real comment\n"),
+        ("hash inside a quoted scalar in a flow mapping", '- { a: "x", b: "PR #105 reverted" }\n'),
+        ("comment on a block scalar header", "notes: > # folded\n  key: value #384\nother: x\n"),
+        ("block scalar as a bare sequence item", "notes:\n  - >\n    key: value #376 here\n"),
+        ("prose quoted at both ends", 'note: "syntrophic" became obligate\n'),
     ],
 )
 def test_legitimate_hashes_are_not_reported(tmp_path, name, text):
     """False positives would make this rule unusable, so they are pinned too."""
     assert find_truncated_scalars(_write(tmp_path, text)) == [], name
+
+
+def test_a_hash_inside_a_quoted_scalar_is_never_truncation(tmp_path):
+    """The case that made the first version unusable outside the record trees.
+
+    `conf/id_label_targets.yaml` carries `reason: "... (PR #105 reverted)"` inside
+    a flow mapping. Judging quoting by whether the raw value starts and ends with
+    a quote saw `{...}` and reported it; asking PyYAML for the scalar's style
+    does not.
+    """
+    real = REPO / "conf/id_label_targets.yaml"
+    reports = find_truncated_scalars(real)
+    assert all(
+        "#105" not in issue.lost for issue in reports
+    ), "a hash inside a quoted scalar was reported as lost"
+
+
+def test_the_record_trees_have_no_deliberate_trailing_comments(tmp_path):
+    """Why the check is scoped to records rather than every YAML in the repo.
+
+    A trailing comment on a *plain* scalar is genuinely ambiguous — nothing can
+    tell "I meant a comment" from "I lost my tail". The record trees contain
+    none, so the rule is unambiguous there. `conf/` and `.github/` use them
+    deliberately, which is why they stay out of scope rather than being made to
+    pass.
+    """
+    for directory in ("kb/communities", "data/isolates", "kb/taxa"):
+        for path in sorted((REPO / directory).glob("*.yaml")):
+            assert find_truncated_scalars(path) == [], f"{path.name} reports"
 
 
 def test_the_line_number_and_key_are_usable(tmp_path):
@@ -187,3 +230,42 @@ def test_linkml_validate_accepts_what_this_catches(tmp_path):
     )
 
     assert result.returncode == 0, "linkml-validate now rejects this — drop the raw-text check"
+
+
+@pytest.mark.parametrize(
+    ("name", "text"),
+    [
+        ("extra spaces before the hash", "key:   #398 documents why\n"),
+        ("hash immediately after a wrapped line", "notes: text wrapping to\n  more #398 x\n"),
+        # A *tab* before the hash is not this defect: YAML rejects the document
+        # outright, which validate-strict already reports as a parse error.
+    ],
+)
+def test_the_gap_before_the_hash_may_be_any_whitespace(tmp_path, name, text):
+    """`lstrip()`, not a literal `" #"`.
+
+    The remainder handed to this check starts wherever the scalar stopped, which
+    is not always exactly one space before the hash.
+    """
+    assert find_truncated_scalars(_write(tmp_path, text)), name
+
+
+@pytest.mark.parametrize(
+    ("name", "text", "key"),
+    [
+        ("mapping", "alpha: fine\nbeta: broken #1 here\n", "beta"),
+        ("sequence at the key's indent", "items:\n- broken #1 here\n", "items"),
+        ("indented sequence", "items:\n  - broken #1 here\n", "items"),
+        ("nested mapping", "a:\n  b:\n    c: broken #1 here\n", "c"),
+    ],
+)
+def test_the_report_names_the_right_field(tmp_path, name, text, key):
+    """A report naming the wrong field sends the reader to the wrong line.
+
+    A block sequence may sit at the *same* indent as its key, so an entry has to
+    accept an equal indent when walking out to the enclosing name. Requiring a
+    strictly smaller one attributed eleven list items in
+    `conf/id_label_targets.yaml` to whichever key happened to precede them.
+    """
+    issue = find_truncated_scalars(_write(tmp_path, text))[0]
+    assert issue.key == key, name


### PR DESCRIPTION
Closes #398.

In YAML a `#` **preceded by whitespace** opens a comment, even mid-value:

```yaml
curation_note: rather than by decision (#376, #384).
```

parses as `rather than by decision (#376,`. The file stays valid YAML, the value stays non-empty, and every schema check passes.

That exact line shipped in #397 — losing the pointer to the issue the field existed for, and leaving an unbalanced paren. It was fixed there for that one field. **The hazard is general**: `notes`, `curation_note` and evidence `snippet` are all prose a curator types by hand, and all routinely cite issues by `#number`.

## Why it is hard to catch

- **Re-serializing cannot reveal it.** PyYAML emits the *truncated* value as perfectly good YAML, so a load/dump round-trip compares equal to itself. The check has to read raw lines.
- **`#` is legitimate in three places** — a whole-line comment, inside a quoted scalar, and inside a block scalar (`>`/`|`) where it is literal. Flagging any of those makes the rule unusable.

So `find_truncated_scalars` reports only an **unquoted plain scalar containing a space-hash** — exactly the case that loses data. Wired into `scripts/validate_strict.py` (a CI gate), with `just validate-scalars` as the fast standalone form.

## Canary

| | |
|---|---|
| the line that shipped | **reported**, naming the lost `#384` |
| the quoted fix | clean |
| all 318 records | **0** truncated scalars |
| `linkml-validate` on the same bad file | **accepts it** — which is the point |

## Tests

The false-positive cases are pinned as hard as the true positives, including a **block scalar whose body looks like a mapping or a sequence item** — that case is what makes skipping the block header load-bearing rather than incidental.

Each true-positive test also asserts that **PyYAML really does drop the tail**, so the rule cannot drift into reporting something nobody needs.

Two mutants survived the first pass because the guards were unreachable as written:

- the block-scalar skip now has a test that fails without it;
- the whole-line-comment guard was **genuinely dead** — a comment cannot match the `key: value` patterns, which require a letter or underscore first — so it is deleted and the reason recorded, rather than left as a branch nothing reaches.

Dropped a "tab before hash" case: YAML rejects that document outright, which is a parse error `validate-strict` already reports, not this defect.

`just validate-all`, `validate-strict`, `validate-scalars` clean; 1176 passed; lint clean.



---

## Review round 2 — the implementation was wrong in both directions

The rule was right; the hand-rolled lexing was not. **Rewritten to ask PyYAML where each scalar actually ends.**

**Five false negatives**, all silent data loss the gate passed:

- a value that **begins** with `#` — `notes: #398 why` parses as **null**, total loss, and it is the same `#issue` idiom this check exists for. The regex searched inside the captured value, where a leading `#` has no whitespace before it.
- **only the first line** of a plain scalar was inspected. **5333** of the KB's scalars span several lines — and the last line is exactly where a trailing `(#376, #384)` lands.
- a block-scalar header on a `- ` line swallowed all its siblings, which is the shape of every evidence entry.
- `_is_quoted` was fooled by prose that merely starts and ends with a quote: `note: "syntrophic" #384 became "obligate"`.
- keys the regex could not express.

**Eight false positives**, including **13 real lines in this repo** — every deliberate trailing comment in `conf/` and `.github/`, plus a `#` inside a quoted scalar in a flow mapping. The message was wrong on all three of its claims for those: it called a quoted value unquoted, called a comment a lost tail, and advised quoting what was already quoted.

**Scalar style settles all of it.** A quoted or block scalar delimits itself, so a `#` inside it is literal and a `#` after it cannot have eaten anything the author wrote. Only a plain scalar can be cut short.

A trailing comment on a *plain* scalar stays reportable, since nothing distinguishes intent from loss. The record trees contain none; `conf/` and `.github/` use them deliberately, which is why they stay out of scope rather than being made to pass — filed as **#400**.

**Three surviving mutants**, each needing a case I had not written — including the closing-quote half of the quoting check, which is the half that produced the fourth false negative, and a blank-line test that was vacuous because the line after the blank matched no pattern either way.

Also fixed: key attribution blamed eleven `conf/` list items on the wrong field; the standalone recipe used a flat glob where the gate uses rglob; and it died on a directory argument `validate_strict.py` accepts.

1191 passed; all gates clean.