### PR TITLE
Ground taxa at domain rank (#393)

### DIFF
--- a/.claude/skills/ground-taxa-gtdb/SKILL.md
+++ b/.claude/skills/ground-taxa-gtdb/SKILL.md
@@ -131,18 +131,23 @@ unambiguously outstanding work (#276).
 
 | status | count | meaning |
 |---|---|---|
-| `GROUNDED` | 643 | a `gtdb_classification` is present |
-| `UNRESOLVED` | 293 | the tool produced no grounding; **why is not established** |
+| `GROUNDED` | 715 | a `gtdb_classification` is present |
+| `UNRESOLVED` | 221 | the tool produced no grounding; **why is not established** |
 | `AMBIGUOUS` | 85 | GTDB splits the NCBI taxon with no majority; `gtdb_candidates` carries every contender |
 | `NOT_ATTEMPTED` | 9 | the tool *would* ground it and the KB does not — unambiguously outstanding work |
 | `WITHHELD` | 2 | the tool can ground it and a curator decided it must not (#292) |
 | `NO_GTDB_EQUIVALENT` | 0 | **curator-assigned only** — the tool cannot establish it (#393) |
 
 `UNRESOLVED` deliberately does not claim finality. Some of it is final (viruses,
-eukaryotes — GTDB is bacteria/archaea only) and some is this tool's limits: it
-attempts genus through phylum only, so *Bacteria* never resolves even though
-`d__Bacteria` is the root of GTDB. Reading it as "no GTDB equivalent" is the
-substitution #294 exists to stop.
+eukaryotes — GTDB is bacteria/archaea only) and some is this tool's limits, e.g.
+a clade the crosswalk spells differently (NCBI *Sulcia* is `Candidatus
+Karelsulcia`). Reading it as "no GTDB equivalent" is the substitution #294 exists
+to stop; what remains unseparated is #393.
+
+Rank support runs **domain through genus**. Domain was added in #393, which
+moved 72 entries out of `UNRESOLVED`: *Bacteria* and *Archaea* had recorded "no
+grounding produced" for the two roots of GTDB. Domain is tried last, so a genus
+is never answered at a shallower rank.
 
 `GROUNDED` is redundant with the block's presence on purpose: a consumer should
 read a state, not infer one from whether a field exists. The two must agree, and

--- a/.claude/skills/ground-taxa-gtdb/SKILL.md
+++ b/.claude/skills/ground-taxa-gtdb/SKILL.md
@@ -126,7 +126,7 @@ Grounding happens at the **rank of the input**:
 Every `taxonomy[].taxon_term` carries `gtdb_grounding_status`, written by
 `gtdb_ground.py --community <file> --apply-status`. Absence of a
 `gtdb_classification` cannot say *why* it is absent, and the reasons are not
-comparable: a missing block implied 389 open items, of which only 9 are
+comparable: a missing block implies 317 open items, of which only 9 are
 unambiguously outstanding work (#276).
 
 | status | count | meaning |
@@ -146,8 +146,14 @@ to stop; what remains unseparated is #393.
 
 Rank support runs **domain through genus**. Domain was added in #393, which
 moved 72 entries out of `UNRESOLVED`: *Bacteria* and *Archaea* had recorded "no
-grounding produced" for the two roots of GTDB. Domain is tried last, so a genus
-is never answered at a shallower rank.
+grounding produced" for the two roots of GTDB. Domain is tried last so a
+shallower rank can never pre-empt a deeper one — defensive rather than load
+bearing, since no name occupies two rank columns in this crosswalk today.
+
+Those 72 are **10% of all grounded blocks and carry no information beyond the
+NCBITaxon id** — *Bacteria* → `d__Bacteria` is a tautology. Filter on
+`mapping_source`, which records `[grounded at d__ rank]`, before quoting a
+grounding-coverage figure (#403).
 
 `GROUNDED` is redundant with the block's presence on purpose: a consumer should
 read a state, not infer one from whether a field exists. The two must agree, and

--- a/kb/communities/ANME_SRB_Marine_Methane_Seep_Consortium.yaml
+++ b/kb/communities/ANME_SRB_Marine_Methane_Seep_Consortium.yaml
@@ -21,7 +21,17 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Archaea
+      gtdb_taxon: Archaea
+      gtdb_lineage: d__Archaea
+      ncbi_source_id: NCBITaxon:2157
+      majority_fraction: 1.0
+      support_genomes: 7446
+      total_genomes: 7448
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Environmental ANME clades are represented conservatively at domain level because marine ANME
       lineages are polyphyletic and not available as pure isolates.
   functional_role:

--- a/kb/communities/Aalborg_East_Full_Scale_EBPR_Community.yaml
+++ b/kb/communities/Aalborg_East_Full_Scale_EBPR_Community.yaml
@@ -141,7 +141,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: The flanking community includes fermenters, hydrolytic bacteria, nitrifiers, and denitrifiers
       that support the phosphorus-removing process.
   functional_role:

--- a/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
+++ b/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
@@ -81,7 +81,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Community members that perform reductive dechlorination of TCE and
       PCE. Previous synthetic-coculture work used Dehalococcoides mccartyi
       strains 195 and BAV1; the abstract does not explicitly enumerate the

--- a/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
+++ b/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
@@ -82,7 +82,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Core community bacteria capable of dissimilatory nitrate reduction
       to ammonium; their replication outcompetes anammox during destabilization.
   functional_role:

--- a/kb/communities/Anammox_Granule_Metabolic_Interaction_Community.yaml
+++ b/kb/communities/Anammox_Granule_Metabolic_Interaction_Community.yaml
@@ -99,7 +99,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Aggregated representation for Bacteroidetes, Chloroflexi, Proteobacteria, and other heterotrophic
       MAGs recovered from the anammox granules.
   functional_role:

--- a/kb/communities/Arabidopsis_Coumarin_Root_SynCom.yaml
+++ b/kb/communities/Arabidopsis_Coumarin_Root_SynCom.yaml
@@ -35,7 +35,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Arabidopsis_Phyllosphere_SynCom7.yaml
+++ b/kb/communities/Arabidopsis_Phyllosphere_SynCom7.yaml
@@ -37,7 +37,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.yaml
+++ b/kb/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.yaml
@@ -61,7 +61,17 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Archaea
+      gtdb_taxon: Archaea
+      gtdb_lineage: d__Archaea
+      ncbi_source_id: NCBITaxon:2157
+      majority_fraction: 1.0
+      support_genomes: 7446
+      total_genomes: 7448
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Co-resident methanogenic archaea whose substrate availability is
       modulated by the Asgard-mediated metabolic activity inferred from this
       study.

--- a/kb/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.yaml
+++ b/kb/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.yaml
@@ -30,7 +30,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 55 bacterial genomes at least 70 percent complete were recovered from
       density-fractionated SIP samples.
   functional_role:

--- a/kb/communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.yaml
+++ b/kb/communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.yaml
@@ -31,7 +31,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: The aggregate soil decomposer community recovered by
       metatranscriptomics; the abstract does not enumerate specific taxa per
       guild, but transcripts were binned using a reference database from soil

--- a/kb/communities/BioModels_MODEL2407300002_Sponge_Holobiont_Network.yaml
+++ b/kb/communities/BioModels_MODEL2407300002_Sponge_Holobiont_Network.yaml
@@ -49,7 +49,17 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Archaea
+      gtdb_taxon: Archaea
+      gtdb_lineage: d__Archaea
+      ncbi_source_id: NCBITaxon:2157
+      majority_fraction: 1.0
+      support_genomes: 7446
+      total_genomes: 7448
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Ammonia-oxidizing archaeon from Stylissa holobiont. Specific species identification requires
       supplementary materials from doi:10.1038/s41467-024-55222-w. Likely Nitrosopumilus-like based on
       typical sponge microbiome composition.
@@ -66,7 +76,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Nitrite-oxidizing bacterium from Stylissa holobiont. Specific species identification requires
       supplementary materials. Likely Nitrospira-like based on typical sponge microbiome composition.
   functional_role:
@@ -82,7 +102,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Newly discovered bacterial taxon with key role in cross-feeding activities. Dynamically adjusts
       metabolism with nutrient inputs. Specific taxonomic identification requires supplementary materials
       from doi:10.1038/s41467-024-55222-w.

--- a/kb/communities/CRC_Fusobacterium_Control_SynCom.yaml
+++ b/kb/communities/CRC_Fusobacterium_Control_SynCom.yaml
@@ -38,7 +38,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.yaml
+++ b/kb/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.yaml
@@ -63,7 +63,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Taxonomically unresolved sediment bacteria that maintain high sulfate reduction and sulfide
       supply in the reduced sediment horizon.
   functional_role:

--- a/kb/communities/California_Grassland_Precipitation_Legacy_Soil_Community.yaml
+++ b/kb/communities/California_Grassland_Precipitation_Legacy_Soil_Community.yaml
@@ -35,7 +35,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Bacterial members of the grassland soil community recovered by 16S
       rRNA amplicon sequencing and meta-omics; specific taxa are not enumerated
       in the abstract.

--- a/kb/communities/CeMbio_Caenorhabditis_Elegans_Microbiome.yaml
+++ b/kb/communities/CeMbio_Caenorhabditis_Elegans_Microbiome.yaml
@@ -45,7 +45,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Defined twelve-strain bacterial consortium containing Enterobacter, Lelliottia, Acinetobacter,
       Sphingomonas, Stenotrophomonas, Pseudomonas, Comamonas, Pantoea, Ochrobactrum, Sphingobacterium,
       and Chryseobacterium isolates.

--- a/kb/communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.yaml
+++ b/kb/communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.yaml
@@ -54,7 +54,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Sulfate-reducing bacteria are represented broadly because the source
       tests sulfate reducer responses without reporting a concise exact species
       composition.

--- a/kb/communities/Desert_Tomato_Salt_Stress_SynCom5.yaml
+++ b/kb/communities/Desert_Tomato_Salt_Stress_SynCom5.yaml
@@ -37,7 +37,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/GLBRC_Exometabolite_Transwell_SynCom.yaml
+++ b/kb/communities/GLBRC_Exometabolite_Transwell_SynCom.yaml
@@ -35,7 +35,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Grassland_Soil_WetUp_Virus_Host_Community.yaml
+++ b/kb/communities/Grassland_Soil_WetUp_Virus_Host_Community.yaml
@@ -43,7 +43,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Soil bacterial hosts resuscitated and lysed during wet-up; specific
       taxa are not enumerated in the abstract.
   functional_role:

--- a/kb/communities/Hanford_300_Area_Unconfined_Aquifer_Community.yaml
+++ b/kb/communities/Hanford_300_Area_Unconfined_Aquifer_Community.yaml
@@ -109,7 +109,17 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Archaea
+      gtdb_taxon: Archaea
+      gtdb_lineage: d__Archaea
+      ncbi_source_id: NCBITaxon:2157
+      majority_fraction: 1.0
+      support_genomes: 7446
+      total_genomes: 7448
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Archaea were a low-abundance component of the aquifer community, with higher representation
       in shallow depths and putative ammonia oxidizers reported among functional groups.
   functional_role:

--- a/kb/communities/Honeybee_Core20_Defined_Microbiota.yaml
+++ b/kb/communities/Honeybee_Core20_Defined_Microbiota.yaml
@@ -37,7 +37,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Infant_Gut_Strain_Persistence_Maternal_Community.yaml
+++ b/kb/communities/Infant_Gut_Strain_Persistence_Maternal_Community.yaml
@@ -83,7 +83,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Maternal gut strains transferred to the infant; significantly more
       likely to persist in the infant gut than other strains.
   functional_role:

--- a/kb/communities/KBase_ORT_Workflow_Community_Model.yaml
+++ b/kb/communities/KBase_ORT_Workflow_Community_Model.yaml
@@ -47,7 +47,17 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Archaea
+      gtdb_taxon: Archaea
+      gtdb_lineage: d__Archaea
+      ncbi_source_id: NCBITaxon:2157
+      majority_fraction: 1.0
+      support_genomes: 7446
+      total_genomes: 7448
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Archaeal genome classified as Nitrososphaeraceae (family level), genus TA-21, from Columbia
       River sediments. Functions as ammonium oxidizer in the nitrogen cycle.
   functional_role:

--- a/kb/communities/LBNL_Brachypodium_Drought_SynCom15.yaml
+++ b/kb/communities/LBNL_Brachypodium_Drought_SynCom15.yaml
@@ -36,7 +36,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/LBNL_Human_Gut_Interaction_SynCom.yaml
+++ b/kb/communities/LBNL_Human_Gut_Interaction_SynCom.yaml
@@ -37,7 +37,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/LBNL_Switchgrass_Soil_SynCom16.yaml
+++ b/kb/communities/LBNL_Switchgrass_Soil_SynCom16.yaml
@@ -38,7 +38,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Lac_Pavin_Stratified_Lake_Community.yaml
+++ b/kb/communities/Lac_Pavin_Stratified_Lake_Community.yaml
@@ -64,7 +64,17 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Archaea
+      gtdb_taxon: Archaea
+      gtdb_lineage: d__Archaea
+      ncbi_source_id: NCBITaxon:2157
+      majority_fraction: 1.0
+      support_genomes: 7446
+      total_genomes: 7448
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Diverse sediment methanogens vary on the centimeter scale and drive
       depth-stratified methane production.
   functional_role:

--- a/kb/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.yaml
+++ b/kb/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.yaml
@@ -52,7 +52,17 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Archaea
+      gtdb_taxon: Archaea
+      gtdb_lineage: d__Archaea
+      ncbi_source_id: NCBITaxon:2157
+      majority_fraction: 1.0
+      support_genomes: 7446
+      total_genomes: 7448
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Methanogenic archaea are curated broadly because the study emphasizes
       methanogen networks and conserved methane-cycling genera across many
       wetlands rather than one fixed species composition.
@@ -109,7 +119,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Methanotrophic bacteria are represented broadly because the abstract
       reports methanogen-methanotroph network relationships across wetlands.
   functional_role:

--- a/kb/communities/Maize_Benzoxazinoid_Metabolizing_SynComs.yaml
+++ b/kb/communities/Maize_Benzoxazinoid_Metabolizing_SynComs.yaml
@@ -34,7 +34,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Maize_Drought_Response_SynCom.yaml
+++ b/kb/communities/Maize_Drought_Response_SynCom.yaml
@@ -38,7 +38,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Mediterranean_Grassland_qSIP_Rainfall_Community.yaml
+++ b/kb/communities/Mediterranean_Grassland_qSIP_Rainfall_Community.yaml
@@ -26,7 +26,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Active soil bacterial members identified by qSIP-driven incorporation
       of 18O into newly synthesized DNA.
   functional_role:
@@ -43,7 +53,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Flagellar motile microorganisms whose activity and growth rates
       increase with year-round precipitation.
   functional_role:

--- a/kb/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.yaml
+++ b/kb/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.yaml
@@ -84,7 +84,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: A reproducible 25-species core noncyanobacterial microbiome was recovered
       across consortia; species-level identities are not enumerated in the
       abstract.

--- a/kb/communities/Multiomics_Corn_Straw_Degradation_SynCom.yaml
+++ b/kb/communities/Multiomics_Corn_Straw_Degradation_SynCom.yaml
@@ -35,7 +35,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - PRIMARY_DEGRADER
   evidence:

--- a/kb/communities/NCycle_Bioflocculation_Model_Consortium.yaml
+++ b/kb/communities/NCycle_Bioflocculation_Model_Consortium.yaml
@@ -36,7 +36,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Ngawha_Geothermal_Mercury_Cycling_Community.yaml
+++ b/kb/communities/Ngawha_Geothermal_Mercury_Cycling_Community.yaml
@@ -30,7 +30,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Acidophilic and mesophilic sulfur- and iron-cycling bacteria
       dominate the geothermal microbiome.
   abundance_level: DOMINANT
@@ -47,7 +57,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Mercury- and arsenic-resistant bacteria persist under ultrahigh
       mercury and arsenic exposure.
   functional_role:
@@ -63,7 +83,17 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Archaea
+      gtdb_taxon: Archaea
+      gtdb_lineage: d__Archaea
+      ncbi_source_id: NCBITaxon:2157
+      majority_fraction: 1.0
+      support_genomes: 7446
+      total_genomes: 7448
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Thermophilic and acidophilic archaeal members of the geothermal
       community.
   functional_role:

--- a/kb/communities/OMM12_Gnotobiotic_Mouse_Gut_Community.yaml
+++ b/kb/communities/OMM12_Gnotobiotic_Mouse_Gut_Community.yaml
@@ -46,7 +46,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Defined 12-strain bacterial community containing Firmicutes/Bacillota, Bacteroidota, Actinomycetota,
       Verrucomicrobiota, and Proteobacteria/Pseudomonadota representatives from the mouse intestine.
   functional_role:

--- a/kb/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.yaml
+++ b/kb/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.yaml
@@ -60,7 +60,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Assembled genomes of rhizosphere H2-oxidizing bacteria enriched in
       gluconeogenic-acid utilization genes; specific species are not enumerated
       in the abstract.
@@ -80,7 +90,17 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Archaea
+      gtdb_taxon: Archaea
+      gtdb_lineage: d__Archaea
+      ncbi_source_id: NCBITaxon:2157
+      majority_fraction: 1.0
+      support_genomes: 7446
+      total_genomes: 7448
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Hydrogenotrophic methanogenic archaea whose CH4 production gene
       activities decrease relative to consumption under PSY transgenic
       conditions; specific genera are not enumerated in the abstract.
@@ -99,7 +119,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Rhizosphere bacterial members whose H2-producing gene activity
       decreases under PSY transgenic conditions, contrasting with the
       H2-oxidizing counterparts.

--- a/kb/communities/Peanut_Seed_Bacterial_CS_SynCom.yaml
+++ b/kb/communities/Peanut_Seed_Bacterial_CS_SynCom.yaml
@@ -38,7 +38,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Pepper_Growth_Rhizosphere_SynCom.yaml
+++ b/kb/communities/Pepper_Growth_Rhizosphere_SynCom.yaml
@@ -36,7 +36,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Phenol_Carboxylation_Consortium.yaml
+++ b/kb/communities/Phenol_Carboxylation_Consortium.yaml
@@ -21,7 +21,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER
@@ -36,7 +46,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/Populus_Salt_Tolerant_SynComs.yaml
+++ b/kb/communities/Populus_Salt_Tolerant_SynComs.yaml
@@ -37,7 +37,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.yaml
+++ b/kb/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.yaml
@@ -50,7 +50,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Candidate sulfate-reducing microorganisms are represented broadly
       because the study recovered diverse candidate SRB genomes across multiple
       phyla rather than a fixed culture composition.
@@ -74,7 +84,17 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Archaea
+      gtdb_taxon: Archaea
+      gtdb_lineage: d__Archaea
+      ncbi_source_id: NCBITaxon:2157
+      majority_fraction: 1.0
+      support_genomes: 7446
+      total_genomes: 7448
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Methanogens are represented at archaeal domain level because the
       paper reports diverse mcrA sequences and putative methanogen genomes
       across multiple orders.

--- a/kb/communities/Rice_Acid_Soil_Bioinoculant_SynCom.yaml
+++ b/kb/communities/Rice_Acid_Soil_Bioinoculant_SynCom.yaml
@@ -36,7 +36,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/SPRUCE_Peatland_Methane_Cycling_Community.yaml
+++ b/kb/communities/SPRUCE_Peatland_Methane_Cycling_Community.yaml
@@ -22,7 +22,17 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Archaea
+      gtdb_taxon: Archaea
+      gtdb_lineage: d__Archaea
+      ncbi_source_id: NCBITaxon:2157
+      majority_fraction: 1.0
+      support_genomes: 7446
+      total_genomes: 7448
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: The 2025 metagenomic and metatranscriptomic analysis reports Candidatus Methanoflorens as the
       dominant active methanogen at the SPRUCE bog surface.
   functional_role:
@@ -68,7 +78,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Deep peat MAGs include acetogenic bacteria with Wood-Ljungdahl pathway potential and high acetate
       concentrations, linking primary fermentation products to methanogenesis.
   functional_role:

--- a/kb/communities/SPRUCE_Peatland_Warming_Community.yaml
+++ b/kb/communities/SPRUCE_Peatland_Warming_Community.yaml
@@ -20,7 +20,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: 'Bacterial communities characterized by 16S rRNA amplicon sequencing. Warming promotes chemoorganoheterotrophic bacteria in root zones, particularly those involved in carbon metabolism and organic matter decomposition. Key phyla include Proteobacteria, Acidobacteria, Actinobacteria, and Verrucomicrobia. Bacterial community composition correlates with peat depth, water content, and plant root traits (specific root length, root diameter, tissue chemistry).
 
       '
@@ -40,7 +50,17 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Archaea
+      gtdb_taxon: Archaea
+      gtdb_lineage: d__Archaea
+      ncbi_source_id: NCBITaxon:2157
+      majority_fraction: 1.0
+      support_genomes: 7446
+      total_genomes: 7448
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Archaeal communities present in anoxic peat layers, likely including methanogens given the methanogenesis activity in the system. Characterized through 16S rRNA amplicon sequencing alongside bacteria.
 
       '

--- a/kb/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.yaml
+++ b/kb/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.yaml
@@ -127,7 +127,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: The record keeps the anammox guild taxonomically broad because the cited model uses hzo gene
       profiles and process rates rather than a named organism in the quoted text.
   functional_role:
@@ -145,7 +155,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Nitrous oxide reducers are kept as unidentified bacteria because the study inferred a separate
       nosZ-containing niche not assigned to SUP05 in the quoted text.
   functional_role:

--- a/kb/communities/SkinCom_Synthetic_Skin_Community.yaml
+++ b/kb/communities/SkinCom_Synthetic_Skin_Community.yaml
@@ -35,7 +35,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.yaml
+++ b/kb/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.yaml
@@ -52,7 +52,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Bacterial methylphosphonate degradation genes were correlated with
       methane flux, supporting a bacterial methane-generating mechanism in the
       salt pond sediment community.
@@ -69,7 +79,17 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Archaea
+      gtdb_taxon: Archaea
+      gtdb_lineage: d__Archaea
+      ncbi_source_id: NCBITaxon:2157
+      majority_fraction: 1.0
+      support_genomes: 7446
+      total_genomes: 7448
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Archaeal methanogenesis genes were correlated with methane flux in
       the salt pond and wetland sediment communities.
   functional_role:

--- a/kb/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.yaml
+++ b/kb/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.yaml
@@ -37,7 +37,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.yaml
+++ b/kb/communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.yaml
@@ -61,7 +61,17 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Archaea
+      gtdb_taxon: Archaea
+      gtdb_lineage: d__Archaea
+      ncbi_source_id: NCBITaxon:2157
+      majority_fraction: 1.0
+      support_genomes: 7446
+      total_genomes: 7448
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Methanogenic archaea are curated at domain level because the source
       reports multiple methanogen orders and genome-resolved methylotrophic
       methanogenesis potential across the native methanogen community.
@@ -85,7 +95,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Bacterial MAGs across many phyla encoded and expressed anaerobic
       methylotrophic potential, providing an indirect route that can feed carbon
       cycling and greenhouse gas production in the mire.

--- a/kb/communities/SynComBac10_Chicken_Intestinal_SynCom.yaml
+++ b/kb/communities/SynComBac10_Chicken_Intestinal_SynCom.yaml
@@ -38,7 +38,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/SynCom_Chlorella_sorokiniana_Biogas_Slurry_Coupling_System.yaml
+++ b/kb/communities/SynCom_Chlorella_sorokiniana_Biogas_Slurry_Coupling_System.yaml
@@ -40,7 +40,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: The abstract describes a "synthetic microbial community (SynCom)" pretreatment stage but
       does not name its constituent bacterial taxa; grounded only at the domain rank (Bacteria) as
       a placeholder for the unnamed SynCom.

--- a/kb/communities/Trichodesmium_Alteromonas_Marine_Consortium.yaml
+++ b/kb/communities/Trichodesmium_Alteromonas_Marine_Consortium.yaml
@@ -72,7 +72,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Diverse heterotrophic bacteria that occur with Trichodesmium colonies in field and culture studies.
   functional_role:
   - CROSS_FEEDER

--- a/kb/communities/Watermelon_Rhizosphere_Fusarium_SynCom8.yaml
+++ b/kb/communities/Watermelon_Rhizosphere_Fusarium_SynCom8.yaml
@@ -47,7 +47,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.yaml
+++ b/kb/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.yaml
@@ -50,7 +50,17 @@ taxonomy:
     term:
       id: NCBITaxon:2157
       label: Archaea
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Archaea
+      gtdb_taxon: Archaea
+      gtdb_lineage: d__Archaea
+      ncbi_source_id: NCBITaxon:2157
+      majority_fraction: 1.0
+      support_genomes: 7446
+      total_genomes: 7448
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Methanogenic archaea are curated at domain level because the abstract
       distinguishes hydrogenotrophic and acetoclastic methanogenesis responses
       without providing a compact exact taxon list.
@@ -73,7 +83,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Bacterial guilds are curated broadly because the study reports
       altered microbial guilds and metabolic subnetworks rather than a defined
       synthetic species composition.

--- a/kb/communities/hCom2_Complex_Gut_Microbiome.yaml
+++ b/kb/communities/hCom2_Complex_Gut_Microbiome.yaml
@@ -37,7 +37,17 @@ taxonomy:
     term:
       id: NCBITaxon:2
       label: Bacteria
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:d__Bacteria
+      gtdb_taxon: Bacteria
+      gtdb_lineage: d__Bacteria
+      ncbi_source_id: NCBITaxon:2
+      majority_fraction: 1.0
+      support_genomes: 1603049
+      total_genomes: 1603049
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -65,7 +65,21 @@ COL_NCBI_SPECIES = 10
 COL_NCBI_STRAIN = 11
 COL_GTDB_SPECIES = 18
 # (ncbi_col, gtdb_col, rank_prefix) for higher ranks, finest -> coarsest.
-HIGHER_RANKS = [(9, 17, "g"), (8, 16, "f"), (7, 15, "o"), (6, 14, "c"), (5, 13, "p")]
+# (NCBI column, GTDB column, CURIE prefix), deepest first — `resolve_higher`
+# takes the first rank whose NCBI column carries the requested name.
+#
+# Domain was absent until #393, so *Bacteria* and *Archaea* never resolved and
+# 72 KB entries recorded "the tool produced no grounding" for the two taxa that
+# are the roots of GTDB. It is last because it is the shallowest, and it only
+# ever matches the two names.
+HIGHER_RANKS = [
+    (9, 17, "g"),
+    (8, 16, "f"),
+    (7, 15, "o"),
+    (6, 14, "c"),
+    (5, 13, "p"),
+    (4, 12, "d"),
+]
 # GTDB lineage columns (col, prefix), domain..species.
 GTDB_RANK_COLS = [(12, "d"), (13, "p"), (14, "c"), (15, "o"), (16, "f"), (17, "g"), (18, "s")]
 

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -64,14 +64,18 @@ COL_MAJORITY = 3
 COL_NCBI_SPECIES = 10
 COL_NCBI_STRAIN = 11
 COL_GTDB_SPECIES = 18
-# (ncbi_col, gtdb_col, rank_prefix) for higher ranks, finest -> coarsest.
 # (NCBI column, GTDB column, CURIE prefix), deepest first — `resolve_higher`
 # takes the first rank whose NCBI column carries the requested name.
 #
 # Domain was absent until #393, so *Bacteria* and *Archaea* never resolved and
 # 72 KB entries recorded "the tool produced no grounding" for the two taxa that
-# are the roots of GTDB. It is last because it is the shallowest, and it only
-# ever matches the two names.
+# are the roots of GTDB.
+#
+# Domain is last on principle rather than necessity: `resolve_higher` re-filters
+# by each rank's own NCBI column, and no name occupies two rank columns in this
+# crosswalk, so moving it first changes nothing today — I checked all 1032 KB
+# taxa. Ordering is what would keep it correct if that ever stopped holding
+# (#402 review).
 HIGHER_RANKS = [
     (9, 17, "g"),
     (8, 16, "f"),
@@ -677,10 +681,10 @@ def classify_status(
         # UNRESOLVED, never NO_GTDB_EQUIVALENT. This script cannot tell the two
         # apart, and an earlier version asserted the strong one anyway: 57 KB
         # entries read "GTDB has no counterpart and never will" for *Bacteria*,
-        # which is the root of GTDB — `HIGHER_RANKS` stops at phylum, so domain
-        # rank is never attempted. Others failed because the crosswalk spells
-        # the clade differently (NCBI *Sulcia* is `Candidatus Karelsulcia`) or
-        # because the named-species filter removed their rows.
+        # which is the root of GTDB. That was a gap in `HIGHER_RANKS`, closed in
+        # #393 by adding domain rank. What remains fails for other reasons — the
+        # crosswalk spelling the clade differently (NCBI *Sulcia* is `Candidatus
+        # Karelsulcia`), or the named-species filter removing its rows.
         #
         # Matching NCBI names against the table was tried and does not settle it
         # either — a rename defeats it. Establishing "GTDB will never classify
@@ -780,6 +784,21 @@ def apply_to_community(
         term = tt.get("term", {}) or {}
         tid = str(term.get("id", ""))
         grounded = "gtdb_classification" in tt
+        # A withheld taxon must not be re-grounded. #293 closed this with a CI
+        # pin rather than a guard, so the write still happened and was only
+        # caught afterwards — running the documented `--apply` over the KB
+        # reinstated `NCBITaxon:1236` as c__Gammaproteobacteria, derived from an
+        # id that names a different organism (#402 review). Keyed by
+        # preferred_term because both withheld records use the offending id
+        # correctly elsewhere (#294).
+        if (path.name, tt.get("preferred_term")) in WITHHELD_GROUNDINGS:
+            print(
+                f"[gtdb] skipping withheld {tt.get('preferred_term')!r} in {path.name}: "
+                f"{WITHHELD_GROUNDINGS[(path.name, tt.get('preferred_term'))]}",
+                file=sys.stderr,
+            )
+            wanted.append(None)
+            continue
         if _is_curated(tt) or (path.name, tid) in CURATED_GROUNDINGS:
             # The reason can come from either source, and indexing the list
             # unconditionally raised KeyError whenever the block's own `curated`

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-08-04T22:13:52
+# Generation date: 2026-08-05T00:20:05
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech
@@ -2267,9 +2267,10 @@ class GtdbGroundingStatusEnum(EnumDefinitionImpl):
     Why a taxon does or does not carry a gtdb_classification. Absence alone cannot say: a virus GTDB will never
     classify, an NCBI taxon GTDB splits with no majority, and a taxon nobody has grounded yet all look identical as a
     missing block (#294).
-    Of 1032 taxonomy entries: 647 GROUNDED, 293 UNRESOLVED, 81 AMBIGUOUS, 9 NOT_ATTEMPTED, 2 WITHHELD. Only
-    NOT_ATTEMPTED is unambiguously outstanding work, against the 385 that a missing block implied. How much of
-    UNRESOLVED is final rather than a tool limitation is not yet determined (#393).
+    Only NOT_ATTEMPTED is unambiguously outstanding work — 9 taxa, against the 317 that a missing block implies. How
+    much of UNRESOLVED is final rather than a tool limitation is not yet determined (#393). Exact counts live in
+    `.claude/skills/ground-taxa-gtdb/SKILL.md` and in the tests rather than here, because a description baked into the
+    generated datamodel goes stale every time the KB is swept.
     """
 
     GROUNDED = PermissibleValue(
@@ -2278,7 +2279,8 @@ class GtdbGroundingStatusEnum(EnumDefinitionImpl):
     )
     UNRESOLVED = PermissibleValue(
         text="UNRESOLVED",
-        description="""`gtdb_ground.py` produced no grounding and the reason is not established. Some of these are final — viruses and eukaryotes, since GTDB is bacteria/archaea only — and some are limitations of the tool: it attempts genus through phylum only, so domain-rank taxa such as *Bacteria* never resolve despite `d__Bacteria` being the root of GTDB; others fail because the crosswalk spells the clade differently (NCBI *Sulcia* is `Candidatus Karelsulcia`) or because the named-species filter removed their rows. Separating the two needs an NCBI lineage source the script does not have (#393).""",
+        description="""`gtdb_ground.py` produced no grounding and the reason is not established. Some of these are final — viruses and eukaryotes, since GTDB is bacteria/archaea only — and some are limitations of the tool: the crosswalk may spell the clade differently (NCBI *Sulcia* is `Candidatus Karelsulcia`), or the named-species filter may have removed its rows. Separating the two needs an NCBI lineage source the script does not have (#393).
+Rank support runs domain through genus. Domain was added in #393, which moved 72 entries out of this bucket: *Bacteria* and *Archaea* had recorded \"no grounding produced\" for the two roots of GTDB.""",
     )
     NO_GTDB_EQUIVALENT = PermissibleValue(
         text="NO_GTDB_EQUIVALENT",
@@ -2300,7 +2302,7 @@ class GtdbGroundingStatusEnum(EnumDefinitionImpl):
     _defn = EnumDefinition(
         name="GtdbGroundingStatusEnum",
         description="""Why a taxon does or does not carry a gtdb_classification. Absence alone cannot say: a virus GTDB will never classify, an NCBI taxon GTDB splits with no majority, and a taxon nobody has grounded yet all look identical as a missing block (#294).
-Of 1032 taxonomy entries: 647 GROUNDED, 293 UNRESOLVED, 81 AMBIGUOUS, 9 NOT_ATTEMPTED, 2 WITHHELD. Only NOT_ATTEMPTED is unambiguously outstanding work, against the 385 that a missing block implied. How much of UNRESOLVED is final rather than a tool limitation is not yet determined (#393).""",
+Only NOT_ATTEMPTED is unambiguously outstanding work — 9 taxa, against the 317 that a missing block implies. How much of UNRESOLVED is final rather than a tool limitation is not yet determined (#393). Exact counts live in `.claude/skills/ground-taxa-gtdb/SKILL.md` and in the tests rather than here, because a description baked into the generated datamodel goes stale every time the KB is swept.""",
     )
 
 

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -167,10 +167,12 @@ enums:
       with no majority, and a taxon nobody has grounded yet all look identical
       as a missing block (#294).
 
-      Of 1032 taxonomy entries: 647 GROUNDED, 293 UNRESOLVED, 81 AMBIGUOUS, 9
-      NOT_ATTEMPTED, 2 WITHHELD. Only NOT_ATTEMPTED is unambiguously outstanding
-      work, against the 385 that a missing block implied. How much of UNRESOLVED
-      is final rather than a tool limitation is not yet determined (#393).
+      Only NOT_ATTEMPTED is unambiguously outstanding work — 9 taxa, against the
+      317 that a missing block implies. How much of UNRESOLVED is final rather
+      than a tool limitation is not yet determined (#393). Exact counts live in
+      `.claude/skills/ground-taxa-gtdb/SKILL.md` and in the tests rather than
+      here, because a description baked into the generated datamodel goes stale
+      every time the KB is swept.
     permissible_values:
       GROUNDED:
         description: >-
@@ -182,12 +184,14 @@ enums:
           `gtdb_ground.py` produced no grounding and the reason is not
           established. Some of these are final — viruses and eukaryotes, since
           GTDB is bacteria/archaea only — and some are limitations of the tool:
-          it attempts genus through phylum only, so domain-rank taxa such as
-          *Bacteria* never resolve despite `d__Bacteria` being the root of GTDB;
-          others fail because the crosswalk spells the clade differently (NCBI
-          *Sulcia* is `Candidatus Karelsulcia`) or because the named-species
-          filter removed their rows. Separating the two needs an NCBI lineage
-          source the script does not have (#393).
+          the crosswalk may spell the clade differently (NCBI *Sulcia* is
+          `Candidatus Karelsulcia`), or the named-species filter may have removed
+          its rows. Separating the two needs an NCBI lineage source the script
+          does not have (#393).
+
+          Rank support runs domain through genus. Domain was added in #393,
+          which moved 72 entries out of this bucket: *Bacteria* and *Archaea*
+          had recorded "no grounding produced" for the two roots of GTDB.
       NO_GTDB_EQUIVALENT:
         description: >-
           GTDB has no counterpart and never will — a final state, not a gap.

--- a/tests/test_gtdb_coherence_validator.py
+++ b/tests/test_gtdb_coherence_validator.py
@@ -469,6 +469,11 @@ def test_the_status_distribution_is_what_was_measured():
     An earlier version used only upper/lower bounds so loose that folding
     NOT_ATTEMPTED into UNRESOLVED — the exact confusion this enum exists to
     prevent — passed every assertion. The ratio and the floor are what bite.
+
+    #393 moved 72 domain-rank taxa out of UNRESOLVED: the tool could not reach
+    *Bacteria* or *Archaea* at all, so it recorded "no grounding produced" for
+    the two roots of GTDB. They are grounded now, which is why GROUNDED and
+    UNRESOLVED both moved by 72 while NOT_ATTEMPTED returned to 9.
     """
     from collections import Counter
 
@@ -478,8 +483,8 @@ def test_the_status_distribution_is_what_was_measured():
             for entry in yaml.safe_load(path.read_text()).get("taxonomy") or []:
                 counts[(entry.get("taxon_term") or {}).get("gtdb_grounding_status")] += 1
 
-    assert counts["GROUNDED"] > 600
-    assert counts["UNRESOLVED"] > 250, "the ungrounded-but-unexplained bucket vanished"
+    assert counts["GROUNDED"] > 700
+    assert counts["UNRESOLVED"] > 180, "the ungrounded-but-unexplained bucket vanished"
     assert counts["AMBIGUOUS"] > 50
     assert counts["WITHHELD"] == 2, "the #292 withholds must still be marked"
     # A floor as well as a ceiling: `< 50` alone is satisfied by zero, so

--- a/tests/test_gtdb_denominator.py
+++ b/tests/test_gtdb_denominator.py
@@ -429,16 +429,29 @@ def test_domain_rank_resolves(gtdb, mapping):
     assert not bacteria["is_reclassified"], "GTDB and NCBI agree on the name here"
 
 
-def test_domain_is_the_shallowest_rank_tried(gtdb, mapping):
-    """Order matters: a genus must never be answered at domain rank.
+def test_a_shallower_rank_cannot_pre_empt_a_deeper_one(gtdb):
+    """Order matters — demonstrated, not restated.
 
-    `resolve_higher` takes the first rank whose NCBI column carries the name, so
-    putting domain anywhere but last would let a shallow match pre-empt a
-    specific one.
+    The first version of this test resolved *Acetobacter* and asserted it landed
+    at `g__`. That passed under every mutant, including deleting domain rank
+    entirely, because no real name occupies two rank columns — so the assertion
+    could not distinguish the ordering working from the hazard being absent
+    (#402 review).
+
+    A synthetic row that carries one name at *both* domain and genus rank does
+    distinguish them: with domain last the genus answers, and only then.
     """
-    assert gtdb.HIGHER_RANKS[-1][2] == "d", "domain must be tried last"
+    cells = [""] * 20
+    cells[2] = "10"
+    # Bare names: the crosswalk stores them without a rank prefix and `_curie`
+    # adds one. Writing `g__FromGenus` here yields `GTDB:g__g__FromGenus`.
+    cells[4], cells[12] = "Ambiguous", "FromDomain"  # NCBI domain, GTDB domain
+    cells[9], cells[17] = "Ambiguous", "FromGenus"  # NCBI genus, GTDB genus
+    cells[10] = "Ambiguous namedspecies"
 
-    _, _, by_higher = gtdb.collect_rows(mapping, set(), set(), {"acetobacter"})
-    result = gtdb.resolve_higher("acetobacter", "NCBITaxon:434", "Acetobacter", by_higher)
+    result = gtdb.resolve_higher("ambiguous", "NCBITaxon:1", "Ambiguous", {"ambiguous": [cells]})
 
-    assert result["gtdb_id"].startswith("GTDB:g__"), "a genus must resolve at genus rank"
+    assert (
+        result["gtdb_id"] == "GTDB:g__FromGenus"
+    ), "a shallower rank answered ahead of a deeper one — HIGHER_RANKS is misordered"
+    assert gtdb.HIGHER_RANKS[-1][2] == "d", "domain must remain last"

--- a/tests/test_gtdb_denominator.py
+++ b/tests/test_gtdb_denominator.py
@@ -408,3 +408,37 @@ def test_the_cli_can_reach_both_denominators(gtdb, mapping, capsys):
 
     assert "g__Acetobacter" in default
     assert "g__CAG-267" in alternative, "the flags did not reach the grounding"
+
+
+def test_domain_rank_resolves(gtdb, mapping):
+    """`Bacteria` and `Archaea` are the roots of GTDB and must ground (#393).
+
+    `HIGHER_RANKS` stopped at phylum, so neither resolved and 72 KB entries
+    recorded "the tool produced no grounding" — which an earlier revision of the
+    status enum reported as "GTDB has no counterpart and never will".
+    """
+    _, _, by_higher = gtdb.collect_rows(mapping, set(), set(), {"bacteria", "archaea"})
+
+    bacteria = gtdb.resolve_higher("bacteria", "NCBITaxon:2", "Bacteria", by_higher)
+    archaea = gtdb.resolve_higher("archaea", "NCBITaxon:2157", "Archaea", by_higher)
+
+    assert bacteria["gtdb_id"] == "GTDB:d__Bacteria"
+    assert archaea["gtdb_id"] == "GTDB:d__Archaea"
+    assert bacteria["majority_fraction"] == 1.0
+    assert bacteria["total_genomes"] > 1_000_000, "expected the whole table behind a domain"
+    assert not bacteria["is_reclassified"], "GTDB and NCBI agree on the name here"
+
+
+def test_domain_is_the_shallowest_rank_tried(gtdb, mapping):
+    """Order matters: a genus must never be answered at domain rank.
+
+    `resolve_higher` takes the first rank whose NCBI column carries the name, so
+    putting domain anywhere but last would let a shallow match pre-empt a
+    specific one.
+    """
+    assert gtdb.HIGHER_RANKS[-1][2] == "d", "domain must be tried last"
+
+    _, _, by_higher = gtdb.collect_rows(mapping, set(), set(), {"acetobacter"})
+    result = gtdb.resolve_higher("acetobacter", "NCBITaxon:434", "Acetobacter", by_higher)
+
+    assert result["gtdb_id"].startswith("GTDB:g__"), "a genus must resolve at genus rank"

--- a/tests/test_gtdb_withheld_groundings.py
+++ b/tests/test_gtdb_withheld_groundings.py
@@ -195,3 +195,75 @@ def test_the_withhold_does_not_catch_a_sibling_sharing_the_id(gtdb):
             f"'{term.get('preferred_term')}' shares the withheld id and was "
             f"classified {status} — the withhold list is keyed by id again"
         )
+
+
+def test_apply_does_not_reinstate_a_withheld_grounding(gtdb, tmp_path):
+    """The guard #293 closed with a CI pin rather than a tool-level refusal.
+
+    `WITHHELD_GROUNDINGS` was consulted only by `classify_status`, so the
+    documented `gtdb_ground.py --community <file> --apply` still wrote the block:
+    running it over the KB reinstated `NCBITaxon:1236` as
+    `GTDB:c__Gammaproteobacteria`, derived from an id that names a different
+    organism. CI caught it — after the write, in a diff that looked like every
+    other block in the sweep (#402 review).
+
+    The record keeps its real filename because the withhold is keyed on it.
+    """
+    record, preferred = next(iter(gtdb.WITHHELD_GROUNDINGS))
+    source = COMMUNITIES / record
+    destination = tmp_path / record
+    destination.write_text(source.read_text())
+
+    pairs = [
+        (
+            (e["taxon_term"].get("term") or {}).get("id", ""),
+            (e["taxon_term"].get("term") or {}).get("label", ""),
+        )
+        for e in yaml.safe_load(destination.read_text())["taxonomy"]
+    ]
+    cleaned = [gtdb._clean_label(label) for _, label in pairs]
+    try:
+        mapping = gtdb.resolve_kg_microbe_dir(None) / "data/raw/NCBI2GTDB.tsv.gz"
+    except SystemExit:
+        pytest.skip("kg-microbe mapping unavailable")
+    if not mapping.exists():
+        pytest.skip("kg-microbe mapping unavailable")
+    rows = gtdb.collect_rows(
+        mapping,
+        {i.split(":")[1] for i, _ in pairs if i},
+        {c.lower() for c in cleaned if " " in c},
+        {c.lower() for c in cleaned if " " not in c},
+    )
+
+    gtdb.apply_to_community(destination, *rows, "test-source")
+
+    after = yaml.safe_load(destination.read_text())
+    withheld = next(
+        e["taxon_term"]
+        for e in after["taxonomy"]
+        if e["taxon_term"].get("preferred_term") == preferred
+    )
+    assert (
+        "gtdb_classification" not in withheld
+    ), f"--apply reinstated the withheld grounding for {preferred!r}"
+
+
+def test_the_withhold_does_not_block_a_sibling_sharing_the_id(gtdb, tmp_path):
+    """Both withheld records use the offending id correctly elsewhere.
+
+    Keying the guard on the NCBITaxon id would leave those siblings permanently
+    ungroundable — the same collision that mislabelled three groundings in #294.
+    """
+    record = "BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml"
+    doc = yaml.safe_load((COMMUNITIES / record).read_text())
+    siblings = [
+        e["taxon_term"]
+        for e in doc["taxonomy"]
+        if (e["taxon_term"].get("term") or {}).get("id") == "NCBITaxon:821"
+        and e["taxon_term"].get("preferred_term") != "Bacteroides ovatus"
+    ]
+    assert siblings, "expected another entry on NCBITaxon:821"
+    for term in siblings:
+        assert term.get(
+            "gtdb_classification"
+        ), "a correct grounding sharing the withheld id lost its block"


### PR DESCRIPTION
Addresses #393 in part — see the last section for what stays open.

`HIGHER_RANKS` ran genus through phylum, so **Bacteria** and **Archaea** never resolved. 72 KB entries recorded "the tool produced no grounding" for the two taxa that are **the roots of GTDB**. Until #392 they said worse: "GTDB has no counterpart and never will" — this tool'"'"'s rank support, published as a fact about GTDB.

## The change

Adding `(4, 12, "d")` to `HIGHER_RANKS`. The crosswalk is unambiguous:

| taxon | GTDB | majority | genomes |
|---|---|---|---|
| *Bacteria* | `d__Bacteria` | 1.0 | 1603049 / 1603049 |
| *Archaea* | `d__Archaea` | 1.0 | 7446 / 7448 |

Domain is tried **last** because it is the shallowest — putting it earlier would let a domain match pre-empt a genus. Both the position and the effect are pinned.

| status | before | after |
|---|---|---|
| `GROUNDED` | 643 | **715** |
| `UNRESOLVED` | 293 | **221** |
| `AMBIGUOUS` | 85 | 85 |
| `NOT_ATTEMPTED` | 9 | 9 |
| `WITHHELD` | 2 | 2 |
| changes outside the gtdb slots | — | **0** |

## Only domain-rank taxa were grounded

Nine others sit at `NOT_ATTEMPTED` and the tool would ground them too, but each is a judgement rather than a sweep:

- *Colwellia* → `g__Cognaticolwellia` at **0.548** and Methanobacteriota at **0.531** are renames on a bare majority — exactly what #396 is about.
- Both *Nitrospira* entries are reclassifications to `g__Nitrospira_D`, the type-species question of #373/#374.
- Several carry informal `preferred_term`s — "Nitrospira-like nitrite oxidizer", "Seep-SRB1", "novel multiheme-cytochrome organism" — where grounding asserts an identity the source may not support.

Filed as **#401** rather than swept in.

The restriction was enforced by **passing row indexes built only for the two domain names**, so nothing else could resolve — no new flag, and verifiable rather than trusted. Canaried on a record with a domain taxon *and* on one with a thin non-domain taxon, confirming the latter stayed ungrounded.

## What #393 still wants

This does not close the issue'"'"'s core question. Separating a **final** `NO_GTDB_EQUIVALENT` from an unresolved taxon still needs an NCBI lineage source — GTDB is bacteria/archaea only, so a domain lookup would settle every eukaryote and virus at once. What this removes is the largest population that was never GTDB'"'"'s limitation in the first place; the remaining 221 still say only "the tool produced no grounding".

`just validate-all`, `validate-strict`, `validate-scalars` clean; 1193 passed; lint clean.

---

## Review round 2

**The documented command re-grounds a withheld taxon.** `WITHHELD_GROUNDINGS` was consulted only by `classify_status`, never by `apply_to_community` — so `gtdb_ground.py --community <file> --apply` writes `GTDB:c__Gammaproteobacteria` onto `NCBITaxon:1236`, an id that names a different organism from the taxon carrying it. **#293 closed this with a CI pin rather than a guard**, so the write happened and was caught only afterwards, in a diff indistinguishable from the rest of a sweep.

It surfaced because the reviewer reproduced my sweep with the *shipped* tool and got **73** blocks where I reported 72. My one-off script avoided it by accident — passing row indexes for only the two domain names meant nothing else could resolve. I presented that restriction as rank discipline and missed that it was also load-bearing against #293. The writer now skips withheld taxa, keyed on `preferred_term` so the siblings legitimately sharing those ids are unaffected.

**The schema documented the opposite of the code** — the `UNRESOLVED` description still said the tool "attempts genus through phylum only, so domain-rank taxa such as *Bacteria* never resolve", the sentence this PR falsifies. I had updated the identical text in SKILL.md and left the published contract, which is also the generated datamodel docstring. Its baked-in counts are gone too; they go stale on every sweep.

**My "domain last" justification was false.** I claimed putting it earlier would let a domain match pre-empt a genus, "which the tests pin". Neither half held: `resolve_higher` re-filters by each rank's own NCBI column, and no name occupies two rank columns — moving domain first changes nothing across all 1032 taxa. The ordering is defensive, and now says so.

**The ordering test was vacuous** — its Acetobacter assertion passed under every mutant, including deleting domain rank entirely, because the hazard it claimed to show does not occur in real data. Replaced with a synthetic row carrying one name at both domain and genus rank, which fails when domain moves first.

Also: the 72 `d__` groundings are 10% of GROUNDED and inflate any coverage figure computed from the status enum — filterable via `mapping_source`, now documented and filed as **#403**.

1195 passed; all gates clean.

<sub>(This description was briefly blanked by a tooling error during the review round and has been restored.)</sub>
