### PR TITLE
Anchor the validate-strict report, and put the standalone gates in qc (#391)

### DIFF
--- a/justfile
+++ b/justfile
@@ -308,9 +308,13 @@ lint:
     uv run mypy src/
 
 # Full QC (validate + strict validate + lint + test)
-# `validate-gtdb-all` and `validate-scalars` also run inside validate-strict,
-# but over its DEFAULT_ROOTS only. Listing them here covers kb/taxa too, and
-# means a future narrowing of validate-strict cannot silently drop them (#391).
+# `validate-gtdb-all` and `validate-scalars` also run inside validate-strict.
+# Only `validate-scalars` widens the scope — it covers kb/taxa, which
+# validate-strict's DEFAULT_ROOTS exclude; `validate-gtdb-all` scans exactly
+# those roots and adds nothing (kb/taxa carries no gtdb_classification at all).
+#
+# This is local convenience, not CI coverage: `qc` is invoked by no workflow,
+# and both checks already reach CI through pytest (#391, #406 review).
 qc: validate-all validate-taxa validate-strict validate-gtdb-all validate-scalars validate-terms-all validate-terms-taxa validate-references-all lint test
     @echo "✅ All QC checks passed!"
 

--- a/justfile
+++ b/justfile
@@ -308,7 +308,10 @@ lint:
     uv run mypy src/
 
 # Full QC (validate + strict validate + lint + test)
-qc: validate-all validate-taxa validate-strict validate-terms-all validate-terms-taxa validate-references-all lint test
+# `validate-gtdb-all` and `validate-scalars` also run inside validate-strict,
+# but over its DEFAULT_ROOTS only. Listing them here covers kb/taxa too, and
+# means a future narrowing of validate-strict cannot silently drop them (#391).
+qc: validate-all validate-taxa validate-strict validate-gtdb-all validate-scalars validate-terms-all validate-terms-taxa validate-references-all lint test
     @echo "✅ All QC checks passed!"
 
 # Check which community strains are represented in UniProt reference proteomes

--- a/scripts/validate_strict.py
+++ b/scripts/validate_strict.py
@@ -196,7 +196,7 @@ def iter_yaml_files(paths: Iterable[Path]) -> list[Path]:
     return out
 
 
-def main() -> int:
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("paths", nargs="*", type=Path,
                         help="Files or directories. Defaults to kb/communities/.")
@@ -227,6 +227,11 @@ def main() -> int:
     )
     parser.add_argument("--quiet", action="store_true",
                         help="Suppress per-file progress lines.")
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
     args = parser.parse_args()
 
     roots = args.paths or DEFAULT_ROOTS

--- a/scripts/validate_strict.py
+++ b/scripts/validate_strict.py
@@ -203,8 +203,13 @@ def main() -> int:
     parser.add_argument(
         "--out",
         type=Path,
-        default=Path("reports/instance_validation_failures.tsv"),
-        help="TSV output path.",
+        # Resolved against the repo, not the cwd. The relative default wrote a
+        # stray `reports/` tree wherever the script was run from, and any test
+        # invoking it without `--out` overwrote the committed report — which
+        # happened twice, surviving only because a full run left the file
+        # byte-identical (#391).
+        default=_REPO_ROOT / "reports" / "instance_validation_failures.tsv",
+        help="TSV output path (default: <repo>/reports/instance_validation_failures.tsv).",
     )
     parser.add_argument(
         "--sample",

--- a/tests/test_gtdb_coherence_validator.py
+++ b/tests/test_gtdb_coherence_validator.py
@@ -634,42 +634,99 @@ def test_a_non_string_note_does_not_crash_the_check(note):
     assert "note_without_curated" in categories or not str(note or "").strip()
 
 
-def test_the_report_default_is_anchored_to_the_repo(tmp_path):
-    """`validate_strict.py --out` defaulted to a cwd-relative, git-tracked path.
+def _validate_strict_module():
+    import importlib.util
 
-    Running it from anywhere but the repo root wrote a stray `reports/` tree
-    there, and any test invoking it without `--out` overwrote the committed
-    report — which happened twice in this codebase, surviving only because a
-    full suite run left the file byte-identical (#391).
+    spec = importlib.util.spec_from_file_location(
+        "validate_strict", REPO / "scripts/validate_strict.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
-    Asserted by running the script from a different directory and checking that
-    nothing appeared there, which is the behaviour that actually matters.
+
+def test_the_report_default_is_anchored_to_the_repo():
+    """`--out` defaulted to a cwd-relative, git-tracked path.
+
+    Running the script from anywhere but the repo root wrote a stray `reports/`
+    tree there, and any test invoking it without `--out` overwrote the committed
+    report — which happened twice, surviving because a clean run leaves that file
+    byte-identical (#391).
+
+    Asserted against the parser, not by running the script. A run with no `--out`
+    writes to the committed report *by definition*, so a behavioural test of this
+    default cannot avoid doing the damage it tests for — which is exactly what
+    the first version of this test did (#406 review).
+    """
+    module = _validate_strict_module()
+
+    default = module.build_parser().parse_args(["ignored.yaml"]).out
+
+    assert default.is_absolute(), "a relative default follows the working directory"
+    assert default == module._REPO_ROOT / "reports" / "instance_validation_failures.tsv"
+
+
+def test_nothing_else_writes_relative_to_the_working_directory(tmp_path):
+    """With `--out` given, a run must leave the cwd untouched.
+
+    An anchored default is no use if some other write in the script is relative.
     """
     fixture = tmp_path / "rec.yaml"
     fixture.write_text(FIXTURE.read_text())
+    report = tmp_path / "out" / "report.tsv"
 
     result = subprocess.run(
-        ["uv", "run", "python", str(REPO / "scripts/validate_strict.py"), str(fixture)],
+        [
+            "uv",
+            "run",
+            "python",
+            str(REPO / "scripts/validate_strict.py"),
+            str(fixture),
+            "--out",
+            str(report),
+        ],
         capture_output=True,
         text=True,
         cwd=tmp_path,
     )
 
     assert result.returncode == 0, result.stdout[-1500:]
-    assert not (
-        tmp_path / "reports"
-    ).exists(), "running from another directory created a stray reports/ tree there"
-    assert str(REPO) in (result.stdout + result.stderr), "the report went somewhere unexpected"
+    assert report.exists(), "the report was not written where it was asked to go"
+    assert not (tmp_path / "reports").exists(), "a relative write created a stray tree"
+    # `str(REPO)` is in stderr on every run — the script prints the schema path —
+    # so asserting on it proves nothing about where the report went.
+    assert str(report) in (result.stdout + result.stderr)
 
 
 def test_qc_runs_the_standalone_gates():
-    """They also run inside validate-strict, but over its DEFAULT_ROOTS only.
+    """`just qc` must depend on them, and they must be real recipes.
 
-    `kb/taxa` is outside those roots, and a future narrowing of validate-strict
-    would silently drop both checks from CI with nothing failing (#391).
+    Read through `just --dump` — `just`'s own parser — because grepping the raw
+    line missed a continuation-formatted recipe and passed for a renamed target
+    that merely contained the string (#406 review).
+
+    Note what this does *not* claim. `qc` is invoked by no workflow, so this is
+    local convenience rather than CI coverage: both checks already reach CI
+    through pytest, which `validate-strict.yaml` does run.
     """
-    recipe = next(
-        line for line in (REPO / "justfile").read_text().splitlines() if line.startswith("qc:")
-    )
+    try:
+        subprocess.run(["just", "--version"], capture_output=True, check=True)
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        pytest.skip("just is not installed")
+
+    # Skip only when `just` is missing. Skipping when `--dump` *fails* let a
+    # broken justfile pass: renaming a dependency to a recipe that does not
+    # exist makes the dump non-zero, and the test skipped instead of failing
+    # (#406 review).
+    dump = subprocess.run(["just", "--dump"], capture_output=True, text=True, cwd=REPO)
+    assert dump.returncode == 0, f"the justfile does not parse:\n{dump.stderr[-800:]}"
+
+    recipe = next((ln for ln in dump.stdout.splitlines() if ln.startswith("qc:")), None)
+    assert recipe, "no qc recipe"
+    summary = subprocess.run(
+        ["just", "--summary"], capture_output=True, text=True, cwd=REPO
+    ).stdout.split()
+
     for target in ("validate-gtdb-all", "validate-scalars"):
-        assert target in recipe, f"{target} is in no gate"
+        assert target in recipe.split(), f"{target} is not a dependency of qc"
+        assert target in summary, f"{target} is not a real recipe"

--- a/tests/test_gtdb_coherence_validator.py
+++ b/tests/test_gtdb_coherence_validator.py
@@ -632,3 +632,44 @@ def test_a_non_string_note_does_not_crash_the_check(note):
     block["curation_note"] = note
     categories = {category for category, _ in check_block(block)}
     assert "note_without_curated" in categories or not str(note or "").strip()
+
+
+def test_the_report_default_is_anchored_to_the_repo(tmp_path):
+    """`validate_strict.py --out` defaulted to a cwd-relative, git-tracked path.
+
+    Running it from anywhere but the repo root wrote a stray `reports/` tree
+    there, and any test invoking it without `--out` overwrote the committed
+    report — which happened twice in this codebase, surviving only because a
+    full suite run left the file byte-identical (#391).
+
+    Asserted by running the script from a different directory and checking that
+    nothing appeared there, which is the behaviour that actually matters.
+    """
+    fixture = tmp_path / "rec.yaml"
+    fixture.write_text(FIXTURE.read_text())
+
+    result = subprocess.run(
+        ["uv", "run", "python", str(REPO / "scripts/validate_strict.py"), str(fixture)],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, result.stdout[-1500:]
+    assert not (
+        tmp_path / "reports"
+    ).exists(), "running from another directory created a stray reports/ tree there"
+    assert str(REPO) in (result.stdout + result.stderr), "the report went somewhere unexpected"
+
+
+def test_qc_runs_the_standalone_gates():
+    """They also run inside validate-strict, but over its DEFAULT_ROOTS only.
+
+    `kb/taxa` is outside those roots, and a future narrowing of validate-strict
+    would silently drop both checks from CI with nothing failing (#391).
+    """
+    recipe = next(
+        line for line in (REPO / "justfile").read_text().splitlines() if line.startswith("qc:")
+    )
+    for target in ("validate-gtdb-all", "validate-scalars"):
+        assert target in recipe, f"{target} is in no gate"


### PR DESCRIPTION
Closes #391. Two ways a gate quietly stops covering what it claims.

## The report path was cwd-relative *and* git-tracked

`scripts/validate_strict.py --out` defaulted to `Path("reports/instance_validation_failures.tsv")`, resolved against the **working directory**.

- Running the script from anywhere but the repo root wrote a stray `reports/` tree there. Reproduced from `/tmp`.
- Any test invoking it without `--out` overwrote the **committed** file. That happened **twice** in this codebase, and survived both times only because a full suite run left the file byte-identical — so it surfaced only when running a single test alone.

Anchored to `_REPO_ROOT`, which is where `SCHEMA_PATH` and `DEFAULT_ROOTS` already resolve from.

## The standalone gates were in no gate

`validate-gtdb-all` and `validate-scalars` both run inside `validate-strict`, so the checks did reach CI — but over its `DEFAULT_ROOTS` only, which **excludes `kb/taxa`**, and a future narrowing of `validate_strict.py` would have dropped both with nothing failing. Added to `just qc`.

## Tests

The first test I wrote for the report path inspected argparse internals and carried an assertion that asserted nothing. Replaced with one that **runs the script from a different directory and checks no stray tree appears there** — the behaviour that actually matters.

Both mutants fail: reverting the default to a relative path, and removing the two recipes from `qc`.

One thing worth recording: while mutation-testing the justfile, `git checkout justfile` reverted not just the mutant but the uncommitted change under test. The suite caught it.

`just validate-all`, `validate-strict`, `validate-gtdb-all`, `validate-scalars` clean; 1202 passed; lint clean.

---

## Review round 2

**The new test reintroduced the trap this PR closes.** It ran `validate_strict.py` with **no `--out`**, so it wrote to the git-tracked `reports/instance_validation_failures.tsv` — and *unconditionally*, since the default is now repo-anchored, so no cwd avoids it. Reproduced: the file's mtime moved on every `pytest -k anchored`. It looked harmless only because the fixture is clean and the committed report is header-only — the exact "survived byte-identical" mode this PR's own description mocks.

The real cost: a record starts failing, `validate-strict` writes the error rows, then anything running pytest resets the report to a header claiming zero failures.

A behavioural test of *this* default cannot avoid doing the damage it tests for, so the default is asserted against the parser (`build_parser()` split out of `main()`), with a separate test that a run **with** `--out` leaves the cwd untouched.

**One assertion was vacuous.** `assert str(REPO) in stdout+stderr` passes on every run — the script prints the schema path. A mutant pointing the default at `$HOME` passed it green while littering the user's home directory.

**The qc test tested a string, not a gate** — it passed for a dependency renamed to a superstring. Read through `just --dump` now, cross-checked against `just --summary`. That needed a second pass: skipping when `--dump` fails let a *broken* justfile pass, so it skips only when `just` is absent.

**Two of my claims were wrong.** `just qc` is invoked by no workflow, so adding to it is local convenience rather than CI coverage — and both checks already reach CI through pytest, so a narrowing of `validate-strict` would not have gone unnoticed. And `validate-gtdb-all` adds no scope: it scans exactly `validate-strict`'s `DEFAULT_ROOTS`, and `kb/taxa` carries no `gtdb_classification`. Only `validate-scalars` widens anything.

**This fixes one member of a class.** Five more cwd-relative defaults write git-tracked artifacts — the worst being `literature.py`'s `references_cache`, where the failure is a silent cache miss and re-billed network traffic rather than a stray directory. Filed as **#407**.

1203 passed; the committed report is untouched by a full run.
