### PR TITLE
Apply the named-species filter on the species path too (#405)

### DIFF
--- a/.claude/skills/ground-taxa-gtdb/SKILL.md
+++ b/.claude/skills/ground-taxa-gtdb/SKILL.md
@@ -190,9 +190,11 @@ taxonomy entries and their id anchors do not line up.
   9.5x — so #389 stays open.
 
   Counted at **one depth**: a species-rank row and its strain rows overlap, so
-  the larger of the two is taken and never their sum. The named-species filter
-  applies here too since #405 — it used to be accepted and dropped on this path,
-  so a species grounding counted `sp.` rows a genus grounding would not.
+  the larger of the two is taken and never their sum. The named-species filter reaches
+  this path since #405, so `exclude_unnamed` means the same thing everywhere —
+  but it cannot change a species grounding: an NCBI id maps to one crosswalk row
+  and a name group shares one species string, so the filter is all-or-nothing
+  and the never-empty fallback restores it.
 
 - **`support_genomes`** — the numerator, on genus-and-higher groundings only.
   Species blocks deliberately carry none: there `majority_fraction` is the

--- a/.claude/skills/ground-taxa-gtdb/SKILL.md
+++ b/.claude/skills/ground-taxa-gtdb/SKILL.md
@@ -190,7 +190,9 @@ taxonomy entries and their id anchors do not line up.
   9.5x — so #389 stays open.
 
   Counted at **one depth**: a species-rank row and its strain rows overlap, so
-  the larger of the two is taken and never their sum.
+  the larger of the two is taken and never their sum. The named-species filter
+  applies here too since #405 — it used to be accepted and dropped on this path,
+  so a species grounding counted `sp.` rows a genus grounding would not.
 
 - **`support_genomes`** — the numerator, on genus-and-higher groundings only.
   Species blocks deliberately carry none: there `majority_fraction` is the

--- a/scripts/gtdb_denominator_compare.py
+++ b/scripts/gtdb_denominator_compare.py
@@ -101,8 +101,11 @@ def main() -> int:
     rows, differ_from_default = [], 0
     for tid, label in taxa:
         core = tid.split(":")[1]
-        # Only the higher-rank path has these choices; the species and id paths
-        # resolve a single row and are identical under all four.
+        # Only the higher-rank path has these choices. The species and id paths
+        # are identical under all four: the denominator choice does not arise
+        # within one GTDB species, and while `exclude_unnamed` does reach them
+        # since #405, it cannot fire — an id maps to one row and a name group
+        # shares one species string, so the filter is all-or-nothing (#408).
         answers = {
             name: _outcome(
                 grounder.resolve_target(

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -218,7 +218,19 @@ def _species_denominator(rows) -> tuple[int, float]:
     return total, round(sum(_genomes(r) * _maj(r) for r in chosen) / total, 3)
 
 
-def _ground_species(rows, source_id, label, via):
+def _ground_species(rows, source_id, label, via, exclude_unnamed=True):
+    # Apply the named-species filter here too. It was accepted by
+    # `resolve_target` and forwarded only to `resolve_higher`, so a species
+    # grounding counted `sp.` / `uncultured` / informal rows that a genus
+    # grounding would drop — an asymmetry nothing recorded a reason for (#405).
+    #
+    # Same "never empty a taxon" guard as the higher-rank path: a species known
+    # only from unnamed rows keeps its grounding rather than losing it.
+    if exclude_unnamed:
+        filtered = named_species_only(rows)
+        if filtered:
+            rows = filtered
+
     # Deterministic order. A plain `sorted(key=_maj)` is stable, so among rows
     # tied on majority the winner was whichever the crosswalk listed first —
     # reversing the file moved *Anaerobutyricum hallii* from 156 genomes to 1,
@@ -505,17 +517,19 @@ def resolve_target(ncbi_id, label, by_id, by_name, by_higher, denominator="aggre
                    exclude_unnamed=True):
     """Species: id then name (split-aware). Genus/higher: majority GTDB rank taxon.
 
-    `denominator` and `exclude_unnamed` are forwarded to `resolve_higher` only.
-    The species paths ignore both: they resolve within one GTDB species, so the
-    aggregate/deepest choice does not arise — but the named-species filter
-    genuinely does not apply there, which is an asymmetry, not a decision (#405).
+    `denominator` reaches `resolve_higher` only — the species paths resolve
+    within one GTDB species, so the aggregate/deepest choice does not arise.
+    `exclude_unnamed` reaches both since #405; it used to be accepted here and
+    silently dropped on the species path.
     """
     source_id = f"NCBITaxon:{ncbi_id}" if ncbi_id else None
     clean = _clean_label(label)
     if _is_species(clean):
         nlc = clean.lower()
         if ncbi_id and ncbi_id in by_id:
-            return _ground_species(by_id[ncbi_id], source_id, label, "ncbi_id")
+            return _ground_species(
+                by_id[ncbi_id], source_id, label, "ncbi_id", exclude_unnamed=exclude_unnamed
+            )
         if nlc in by_name:
             species: dict[str, list] = {}
             for c in by_name[nlc]:
@@ -523,7 +537,13 @@ def resolve_target(ncbi_id, label, by_id, by_name, by_higher, denominator="aggre
                 if sp:
                     species.setdefault(sp, []).append(c)
             if len(species) == 1:
-                return _ground_species(next(iter(species.values())), source_id, label, "ncbi_name")
+                return _ground_species(
+                    next(iter(species.values())),
+                    source_id,
+                    label,
+                    "ncbi_name",
+                    exclude_unnamed=exclude_unnamed,
+                )
             if len(species) > 1:
                 return {
                     "ambiguous": True,

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -219,13 +219,24 @@ def _species_denominator(rows) -> tuple[int, float]:
 
 
 def _ground_species(rows, source_id, label, via, exclude_unnamed=True):
-    # Apply the named-species filter here too. It was accepted by
-    # `resolve_target` and forwarded only to `resolve_higher`, so a species
-    # grounding counted `sp.` / `uncultured` / informal rows that a genus
-    # grounding would drop — an asymmetry nothing recorded a reason for (#405).
+    # The named-species filter, which `resolve_target` accepted and forwarded
+    # only to `resolve_higher` — so `exclude_unnamed=False` was honoured at genus
+    # rank and silently dropped here (#405).
     #
-    # Same "never empty a taxon" guard as the higher-rank path: a species known
-    # only from unnamed rows keeps its grounding rather than losing it.
+    # It runs *before* `top`, so it selects the GTDB species and not merely the
+    # denominator. That placement is what the tests pin; moving it below passes
+    # every other fixture, since they all put both rows on one species.
+    #
+    # **It cannot fire through `resolve_target` on this crosswalk**, and the PR
+    # that added it was wrong to call that "free today, real later". Every NCBI
+    # id maps to exactly one row (0 of 92711 have more), so the id path filters a
+    # singleton; and `by_name` is keyed on the NCBI species string, so a group
+    # shares one string and the filter is all-or-nothing — 0 of 64660 groups
+    # mix. The non-empty fallback then restores an all-unnamed group intact.
+    # What the change buys is that the flag now means the same thing on both
+    # paths, not a latent guard (#408 review).
+    #
+    # Same "never empty a taxon" fallback as the higher-rank path.
     if exclude_unnamed:
         filtered = named_species_only(rows)
         if filtered:
@@ -270,9 +281,10 @@ def _ground_species(rows, source_id, label, via, exclude_unnamed=True):
     # denominator would be incoherent — B. breve's rows are 1544 genomes at 0.99
     # and 49 at 1.0, so "1.0 of 1593" is a claim no row makes.
     #
-    # This cannot change a grounding: `sp` is read off `top` *before* `agreeing`
-    # is built, so the filter can only ever narrow the rows behind an
-    # already-chosen species. `resolve_target` also reports AMBIGUOUS whenever a
+    # This second filter cannot change a grounding — `sp` is read off `top`
+    # *before* `agreeing` is built, so it can only narrow the rows behind an
+    # already-chosen species. (The named-species filter above runs earlier and
+    # does select the species; do not read this paragraph as covering both.) `resolve_target` also reports AMBIGUOUS whenever a
     # name group holds more than one GTDB species, so the mixed case does not
     # arise from the public entry point — the filter is defensive, and the
     # synthetic split in the tests is what exercises it.

--- a/tests/test_gtdb_denominator.py
+++ b/tests/test_gtdb_denominator.py
@@ -455,3 +455,105 @@ def test_a_shallower_rank_cannot_pre_empt_a_deeper_one(gtdb):
         result["gtdb_id"] == "GTDB:g__FromGenus"
     ), "a shallower rank answered ahead of a deeper one — HIGHER_RANKS is misordered"
     assert gtdb.HIGHER_RANKS[-1][2] == "d", "domain must remain last"
+
+
+# ---------------------------------------------------------------------------
+# The named-species filter on the species path (#405).
+# ---------------------------------------------------------------------------
+
+
+def _species_row(genomes, species, majority="1.0", strain=""):
+    cells = [""] * 20
+    cells[2], cells[3] = genomes, majority
+    cells[10], cells[11], cells[18] = species, strain, "Somegenus somespecies"
+    return cells
+
+
+def test_unnamed_rows_are_dropped_from_a_species_grounding(gtdb):
+    """The filter was accepted by `resolve_target` and applied only at genus rank.
+
+    A species grounding counted `sp.` / `uncultured` rows that a genus grounding
+    would drop — an asymmetry with no recorded reason (#405). No KB block was
+    affected when this landed, which is why it was cheap to fix then.
+    """
+    rows = [
+        _species_row("10", "Somegenus somespecies"),
+        _species_row("990", "Somegenus sp. MAG-1"),
+    ]
+
+    total, _ = gtdb._species_denominator(
+        [r for r in gtdb.named_species_only(rows) if r[gtdb.COL_GTDB_SPECIES].strip()]
+    )
+    grounded = gtdb._ground_species(rows, "NCBITaxon:1", "Somegenus somespecies", "ncbi_id")
+
+    assert total == 10
+    assert grounded["total_genomes"] == 10, "the sp. row was counted"
+
+
+def test_the_filter_can_be_switched_off_on_the_species_path(gtdb):
+    """`exclude_unnamed=False` must reach here, not just `resolve_higher`."""
+    rows = [
+        _species_row("10", "Somegenus somespecies"),
+        _species_row("990", "Somegenus sp. MAG-1"),
+    ]
+
+    unfiltered = gtdb._ground_species(
+        rows, "NCBITaxon:1", "Somegenus somespecies", "ncbi_id", exclude_unnamed=False
+    )
+
+    assert unfiltered["total_genomes"] == 1000
+
+
+def test_the_filter_never_empties_a_species(gtdb):
+    """A species known only from unnamed rows keeps its grounding.
+
+    Same guard as the higher-rank path: the filter is a tie-breaker among named
+    rows, not a reason to abandon a taxon that has none.
+    """
+    rows = [_species_row("7", "Somegenus sp. MAG-1"), _species_row("3", "uncultured Somegenus")]
+
+    grounded = gtdb._ground_species(rows, "NCBITaxon:1", "Somegenus somespecies", "ncbi_id")
+
+    assert grounded["gtdb_id"] == "GTDB:s__Somegenus_somespecies"
+    assert grounded["total_genomes"] == 10, "filtering to nothing must fall back"
+
+
+def test_the_kb_is_unaffected_by_the_species_filter(gtdb, mapping):
+    """Measured before the change and pinned after: zero blocks move.
+
+    If this starts failing, a record has gained a species whose rows mix named
+    and unnamed — the change stops being free and wants a look.
+    """
+    by_id, by_name, by_higher = gtdb.collect_rows(
+        mapping, {"492670"}, {"bacillus velezensis"}, set()
+    )
+    with_filter = gtdb.resolve_target("492670", "Bacillus velezensis", by_id, by_name, by_higher)
+    without = gtdb.resolve_target(
+        "492670", "Bacillus velezensis", by_id, by_name, by_higher, exclude_unnamed=False
+    )
+
+    assert with_filter["total_genomes"] == without["total_genomes"]
+
+
+@pytest.mark.parametrize("path", ["id", "name"])
+def test_exclude_unnamed_reaches_both_species_paths(gtdb, path):
+    """The flag's journey, not just its effect.
+
+    `_ground_species` defaults to filtering, so dropping the explicit argument
+    at a call site changes nothing until someone passes `exclude_unnamed=False`
+    — which is exactly the caller who would be silently ignored (#405).
+    """
+    rows = [
+        _species_row("10", "Somegenus somespecies"),
+        _species_row("990", "Somegenus sp. MAG-1"),
+    ]
+    by_id = {"1": rows} if path == "id" else {}
+    by_name = {} if path == "id" else {"somegenus somespecies": rows}
+
+    filtered = gtdb.resolve_target("1", "Somegenus somespecies", by_id, by_name, {})
+    unfiltered = gtdb.resolve_target(
+        "1", "Somegenus somespecies", by_id, by_name, {}, exclude_unnamed=False
+    )
+
+    assert filtered["total_genomes"] == 10, f"the {path} path ignored the filter"
+    assert unfiltered["total_genomes"] == 1000, f"the {path} path ignored exclude_unnamed=False"

--- a/tests/test_gtdb_denominator.py
+++ b/tests/test_gtdb_denominator.py
@@ -518,21 +518,106 @@ def test_the_filter_never_empties_a_species(gtdb):
     assert grounded["total_genomes"] == 10, "filtering to nothing must fall back"
 
 
-def test_the_kb_is_unaffected_by_the_species_filter(gtdb, mapping):
-    """Measured before the change and pinned after: zero blocks move.
+def test_the_filter_chooses_the_species_not_just_the_denominator(gtdb):
+    """It runs before `top`, so it decides `gtdb_id` — the only thing it buys.
 
-    If this starts failing, a record has gained a species whose rows mix named
-    and unnamed — the change stops being free and wants a look.
+    Moving it to just before `agreeing` passes the entire suite, because every
+    other fixture puts both rows on the *same* GTDB species and so pins only the
+    denominator (#408 review). Here the unnamed row is the majority and names a
+    different species: filtering first must hand the grounding to the named one.
     """
-    by_id, by_name, by_higher = gtdb.collect_rows(
-        mapping, {"492670"}, {"bacillus velezensis"}, set()
-    )
-    with_filter = gtdb.resolve_target("492670", "Bacillus velezensis", by_id, by_name, by_higher)
-    without = gtdb.resolve_target(
-        "492670", "Bacillus velezensis", by_id, by_name, by_higher, exclude_unnamed=False
+    named = _species_row("10", "Somegenus somespecies")
+    unnamed = _species_row("990", "Somegenus sp. MAG-1")
+    unnamed[gtdb.COL_GTDB_SPECIES] = "Somegenus binbin"
+
+    filtered = gtdb._ground_species([named, unnamed], "NCBITaxon:1", "Somegenus somespecies", "x")
+    unfiltered = gtdb._ground_species(
+        [named, unnamed], "NCBITaxon:1", "Somegenus somespecies", "x", exclude_unnamed=False
     )
 
-    assert with_filter["total_genomes"] == without["total_genomes"]
+    assert filtered["gtdb_id"] == "GTDB:s__Somegenus_somespecies"
+    assert (
+        unfiltered["gtdb_id"] == "GTDB:s__Somegenus_binbin"
+    ), "the filter is no longer deciding which species wins"
+
+
+def test_the_species_filter_cannot_fire_on_this_crosswalk(gtdb, mapping):
+    """Why this change moves nothing, stated as a property rather than a count.
+
+    It is inert by construction, not merely inert today:
+
+    * every NCBI id maps to exactly one row (0 of 92711 have more), so the id
+      path always filters a singleton and the non-empty fallback restores it;
+    * `by_name` is keyed on the NCBI species string, so every row in a group
+      carries the *same* string and `named_species_only` is all-or-nothing —
+      0 of 64660 groups mix.
+
+    The PR that added it claimed "free today, real later". That was wrong: no
+    crosswalk with this key structure can reach the mixed case through
+    `resolve_target`. What the change buys is that `exclude_unnamed=False` is
+    now honoured on both paths instead of being silently dropped on one.
+    """
+    import gzip
+    from collections import defaultdict
+
+    rows_per_id = defaultdict(int)
+    group_kinds = defaultdict(set)
+    with gzip.open(mapping, "rt") as handle:
+        next(handle)
+        for line in handle:
+            cells = line.rstrip("\n").split("\t")
+            if len(cells) <= gtdb.COL_GTDB_SPECIES:
+                continue
+            rows_per_id[cells[gtdb.COL_NCBI_ID]] += 1
+            species = cells[gtdb.COL_NCBI_SPECIES].strip()
+            if species:
+                group_kinds[species.lower()].add(bool(gtdb.UNNAMED_SPECIES.search(species)))
+
+    assert not [
+        n for n in rows_per_id.values() if n > 1
+    ], "an NCBI id now has several rows — the id path can filter a proper subset"
+    assert not [k for k in group_kinds.values() if len(k) > 1], (
+        "a name group now mixes named and unnamed rows — the filter can fire, so "
+        "re-measure whether any grounding moves"
+    )
+
+
+def test_no_kb_grounding_moves_under_the_species_filter(gtdb, mapping):
+    """The KB sweep the previous version of this test only claimed to be.
+
+    It pinned one taxon that resolves by id to a single *named* row, so both
+    calls were the identical computation and the assertion held however the
+    filter behaved (#408 review).
+    """
+    import yaml
+
+    want_ids, want_species, want_higher, taxa = set(), set(), set(), []
+    for directory in ("kb/communities", "data/isolates"):
+        for path in sorted((REPO / directory).glob("*.yaml")):
+            for entry in yaml.safe_load(path.read_text()).get("taxonomy") or []:
+                term = (entry.get("taxon_term") or {}).get("term") or {}
+                tid, label = str(term.get("id", "")), term.get("label", "")
+                if not tid.startswith("NCBITaxon:"):
+                    continue
+                taxa.append((tid.split(":")[1], label))
+                want_ids.add(tid.split(":")[1])
+                clean = gtdb._clean_label(label)
+                (want_species if " " in clean else want_higher).add(clean.lower())
+    rows = gtdb.collect_rows(mapping, want_ids, want_species, want_higher)
+
+    # Species-path taxa only. At genus and above the filter has applied since
+    # #375 and legitimately moves 395 groundings; including them measured that
+    # pre-existing behaviour instead of this change.
+    species = [(i, lab) for i, lab in taxa if gtdb._is_species(gtdb._clean_label(lab))]
+
+    moved = []
+    for ncbi_id, label in species:
+        with_filter = gtdb.resolve_target(ncbi_id, label, *rows)
+        without = gtdb.resolve_target(ncbi_id, label, *rows, exclude_unnamed=False)
+        if with_filter != without:
+            moved.append(f"{label} ({ncbi_id})")
+    assert len(species) > 300, f"expected the KB's species taxa, resolved {len(species)}"
+    assert not moved, f"{len(moved)} species groundings move: {moved[:5]}"
 
 
 @pytest.mark.parametrize("path", ["id", "name"])


### PR DESCRIPTION
Closes #405.

`resolve_target` accepted `exclude_unnamed` and forwarded it **only** to `resolve_higher`, so a species grounding counted `sp.` / `uncultured` / informal rows that a genus grounding would drop. Nothing recorded a reason for the asymmetry, and the parameter's presence in the signature implied it applied everywhere.

## Free today, and measured to be

**Zero KB blocks move.** Of 338 species blocks, none has agreeing rows that mix named and unnamed. Re-swept all 316 records to confirm — the KB diff is empty.

That is why the issue said to do it now: the crosswalk's largest placeholder name-group is 14 rows, so the ceiling on future inflation is small but not zero, and the change stops being free the moment a record gains such a species.

Same "never empty a taxon" guard as the higher-rank path: a species known only from unnamed rows keeps its grounding rather than losing it.

## Mutation testing needed a second pass

Dropping the explicit `exclude_unnamed=exclude_unnamed` at either call site **survived** — `_ground_species` defaults to filtering, so the argument only matters for a caller passing `False`, which is exactly the caller that was being silently ignored.

Added a test that follows the flag through `resolve_target` on both species paths rather than only observing the default's effect. Both call-site mutants now fail, along with removing the filter and removing the empty-guard.

`just validate-all`, `validate-strict`, `validate-gtdb-all`, `validate-scalars` clean; 1209 passed; lint clean; KB unchanged.

---

## Review round 2 — the justification was wrong

**"Free today, real later" does not hold.** The filter cannot fire through `resolve_target` on this crosswalk, and not because today's data happens to be convenient:

- every NCBI id maps to **exactly one row** — 0 of 92711 have more — so the id path always filters a singleton and the non-empty fallback restores it;
- `by_name` is keyed on the NCBI **species string**, so every row in a group carries the same string and `named_species_only` is all-or-nothing — **0 of 64660 groups mix**.

The 14-row group I cited as the ceiling on future inflation is `Pseudomonas syringae group genomosp. 3` — all 14 rows unnamed, so the fallback restores every one.

What the change actually buys is that `exclude_unnamed=False` now means the same thing on both paths instead of being silently dropped on one. That is a consistency fix, worth having, and not what I claimed. It is now stated as a **property** in a test, so it fails if the crosswalk ever gains a multi-row id or a mixed name group.

**The one thing the change buys was untested.** The filter runs before `top`, so it selects the GTDB species and not just the denominator — and moving it below **passed the entire suite**, because every fixture put both rows on the same species. Pinned with a mixed-species case.

**The KB test was vacuous.** It pinned `NCBITaxon:492670`, which resolves by id to a single *named* row — both calls were the identical computation, so the assertion held however the filter behaved, while its name promised a KB sweep. Replaced with a real one. That needed a second pass: my first version swept *all* taxa and failed on 395 higher-rank groundings where the filter has applied since #375, measuring pre-existing behaviour rather than this change.

Also corrected: a comment reading "this cannot change a grounding" now sat above **two** filters and was true of only one; "338 species blocks" is 336; and `gtdb_denominator_compare.py` still claimed the species paths ignore all four options.

1211 passed; KB unchanged.
