### PR TITLE
Anchor output paths on the repo, not the working directory (#407)

### DIFF
--- a/scripts/add_evidence_source.py
+++ b/scripts/add_evidence_source.py
@@ -45,7 +45,7 @@ class EvidenceSourceAdder:
         # fetch_paper surface (plus a richer DOI fallback chain through
         # CrossRef / PMC / OpenAlex / Semantic Scholar / Europe PMC) which
         # is what these scripts actually need.
-        self.fetcher = LiteratureFetcher(cache_dir=".literature_cache")
+        self.fetcher = LiteratureFetcher()
         self.stats = {
             'total_evidence': 0,
             'already_has_source': 0,

--- a/scripts/apply_suggested_fixes.py
+++ b/scripts/apply_suggested_fixes.py
@@ -20,6 +20,9 @@ from typing import Dict, List, Optional, Tuple
 
 import yaml
 
+# Repo-anchored: a relative default follows the cwd (#407).
+_REPORTS = Path(__file__).resolve().parent.parent / "reports"
+
 # Add scripts to path for imports
 sys.path.insert(0, str(Path(__file__).parent))
 
@@ -302,7 +305,7 @@ def main():
     )
     parser.add_argument(
         "--report",
-        default="evidence_curation_report.txt",
+        default=_REPORTS / "evidence_curation_report.txt",
         help="Path to curation report (default: evidence_curation_report.txt)",
     )
     parser.add_argument(

--- a/scripts/apply_suggested_snippets.py
+++ b/scripts/apply_suggested_snippets.py
@@ -17,6 +17,9 @@ from pathlib import Path
 from typing import Dict, List, Tuple, Optional
 import yaml
 
+# Repo-anchored: a relative default follows the cwd (#407).
+_REPORTS = Path(__file__).resolve().parent.parent / "reports"
+
 
 class SnippetFix:
     """Represents a suggested snippet fix from the curation report."""
@@ -287,7 +290,7 @@ def main():
     )
     parser.add_argument(
         '--report',
-        default='evidence_curation_report.txt',
+        default=_REPORTS / "evidence_curation_report.txt",
         help='Path to curation report (default: evidence_curation_report.txt)'
     )
     parser.add_argument(

--- a/scripts/evidence_snippet_audit.py
+++ b/scripts/evidence_snippet_audit.py
@@ -27,7 +27,9 @@ from collections import defaultdict
 import yaml
 
 COMM = Path("kb/communities")
-CACHE = Path("references_cache")
+# Repo-anchored (#407). Tests override this attribute; a relative default also
+# resolved against the cwd, so importing the module from elsewhere read nothing.
+CACHE = Path(__file__).resolve().parent.parent / "references_cache"
 LIST_MM = "--list-mismatch" in sys.argv
 LIST_NC = "--list-nocontent" in sys.argv
 LIST_RD = "--list-rendering" in sys.argv

--- a/scripts/generate_validation_report.py
+++ b/scripts/generate_validation_report.py
@@ -322,8 +322,12 @@ See `{output_path.parent / 'validation_results.tsv'}` for per-community breakdow
 
 
 def main():
-    communities_dir = Path("kb/communities")
-    output_dir = Path("reports")
+    # Repo-anchored: both targets are git-tracked, so a run from another
+    # directory wrote a stray tree there and a run from the repo root could
+    # overwrite committed files without meaning to (#407).
+    repo_root = Path(__file__).resolve().parent.parent
+    communities_dir = repo_root / "kb" / "communities"
+    output_dir = repo_root / "reports"
     output_dir.mkdir(exist_ok=True)
 
     print("🔬 Generating validation report for all communities...")

--- a/scripts/generate_validation_report.py
+++ b/scripts/generate_validation_report.py
@@ -322,9 +322,12 @@ See `{output_path.parent / 'validation_results.tsv'}` for per-community breakdow
 
 
 def main():
-    # Repo-anchored: both targets are git-tracked, so a run from another
-    # directory wrote a stray tree there and a run from the repo root could
-    # overwrite committed files without meaning to (#407).
+    # Repo-anchored so the output lands in one predictable place. Note the
+    # trade this makes rather than removes: both targets are git-tracked, so a
+    # run from another directory used to leave a stray tree and now rewrites the
+    # committed files instead. That is the intended behaviour for a report
+    # generator whose output is committed — but it is a trade, not a fix, and an
+    # earlier version of this comment had it backwards (#409 review).
     repo_root = Path(__file__).resolve().parent.parent
     communities_dir = repo_root / "kb" / "communities"
     output_dir = repo_root / "reports"

--- a/scripts/gtdb_integration.py
+++ b/scripts/gtdb_integration.py
@@ -44,6 +44,9 @@ from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+# Repo-anchored: a relative default follows the cwd (#407).
+_REPORTS = Path(__file__).resolve().parent.parent / "reports"
+
 try:
     import duckdb
 except ImportError:
@@ -630,7 +633,7 @@ class GTDBIntegration:
 
     def generate_comparison_report(self,
                                    yaml_dir: Path,
-                                   output_dir: Path = Path(__file__).resolve().parent.parent):
+                                   output_dir: Path = _REPORTS):
         """
         Generate comprehensive GTDB vs NCBI comparison report.
 
@@ -917,7 +920,7 @@ def main():
     parser.add_argument(
         '--output-dir',
         type=Path,
-        default=Path('./'),
+        default=_REPORTS,
         help='Output directory for reports'
     )
 

--- a/scripts/gtdb_integration.py
+++ b/scripts/gtdb_integration.py
@@ -630,7 +630,7 @@ class GTDBIntegration:
 
     def generate_comparison_report(self,
                                    yaml_dir: Path,
-                                   output_dir: Path = Path("./")):
+                                   output_dir: Path = Path(__file__).resolve().parent.parent):
         """
         Generate comprehensive GTDB vs NCBI comparison report.
 

--- a/scripts/kgm_strain_lookup.py
+++ b/scripts/kgm_strain_lookup.py
@@ -21,6 +21,9 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 import time
 
+# Repo-anchored: a relative default follows the cwd (#407).
+_REPORTS = Path(__file__).resolve().parent.parent / "reports"
+
 try:
     import duckdb
 except ImportError:
@@ -606,7 +609,7 @@ class KGMStrainLookup:
         return results
 
     def generate_corrections_report(self,
-                                   output_dir=Path(__file__).resolve().parent.parent,
+                                   output_dir=_REPORTS,
                                    yaml_dir="/Users/marcin/Documents/VIMSS/ontology/KG-Hub/KG-Microbe/CommunityMech/CommunityMech/kb/communities"):
         """
         Generate comprehensive correction recommendations based on kg-microbe.
@@ -792,7 +795,7 @@ def main():
     parser.add_argument(
         "--output-dir",
         type=str,
-        default="./",
+        default=_REPORTS,
         help="Output directory for reports (default: current directory)"
     )
     parser.add_argument(

--- a/scripts/kgm_strain_lookup.py
+++ b/scripts/kgm_strain_lookup.py
@@ -606,7 +606,7 @@ class KGMStrainLookup:
         return results
 
     def generate_corrections_report(self,
-                                   output_dir="./",
+                                   output_dir=Path(__file__).resolve().parent.parent,
                                    yaml_dir="/Users/marcin/Documents/VIMSS/ontology/KG-Hub/KG-Microbe/CommunityMech/CommunityMech/kb/communities"):
         """
         Generate comprehensive correction recommendations based on kg-microbe.

--- a/scripts/review_literature.py
+++ b/scripts/review_literature.py
@@ -32,6 +32,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from communitymech.literature_enhanced import EnhancedLiteratureFetcher
 
+# Repo-anchored: a relative default follows the cwd (#407).
+_REPORTS = Path(__file__).resolve().parent.parent / "reports"
+
 # Color codes
 class Colors:
     HEADER = '\033[95m'
@@ -420,7 +423,7 @@ def main():
     parser.add_argument('--community', help="Review specific community file")
     parser.add_argument('--download-pdfs', action='store_true', help="Download full PDFs")
     parser.add_argument('--no-fallback', action='store_true', help="Disable scihub fallback")
-    parser.add_argument('--output', default='literature_review_report.txt', help="Output report file")
+    parser.add_argument('--output', default=_REPORTS / "literature_review_report.txt", help="Output report file")
 
     args = parser.parse_args()
 

--- a/src/communitymech/cli.py
+++ b/src/communitymech/cli.py
@@ -13,6 +13,7 @@ from communitymech.network.auditor import (
     EXIT_WARNINGS,
     NetworkIntegrityAuditor,
 )
+from communitymech.paths import DOCS
 
 # Try to import rich for beautiful output
 try:
@@ -585,7 +586,8 @@ def _apply_batch_report(report_path: Path):
 @click.option(
     "--output",
     type=click.Path(dir_okay=False, path_type=Path),
-    default="docs/community_umap.html",
+    # Repo-anchored; the target is git-tracked (#407).
+    default=str(DOCS / "community_umap.html"),
     help="Output HTML path",
 )
 @click.option(

--- a/src/communitymech/cli.py
+++ b/src/communitymech/cli.py
@@ -13,7 +13,7 @@ from communitymech.network.auditor import (
     EXIT_WARNINGS,
     NetworkIntegrityAuditor,
 )
-from communitymech.paths import DOCS
+from communitymech.paths import DOCS, REPO_ROOT, REPORTS
 
 # Try to import rich for beautiful output
 try:
@@ -386,7 +386,7 @@ def _display_repair_summary_plain(result: dict):
 @click.option(
     "--output",
     type=click.Path(dir_okay=False, path_type=Path),
-    default="reports/network_repair_suggestions.yaml",
+    default=str(REPORTS / "network_repair_suggestions.yaml"),
     help="Output path for report",
 )
 @click.option(
@@ -586,14 +586,16 @@ def _apply_batch_report(report_path: Path):
 @click.option(
     "--output",
     type=click.Path(dir_okay=False, path_type=Path),
-    # Repo-anchored; the target is git-tracked (#407).
+    # Repo-anchored so the default lands in one predictable place. The target is
+    # git-tracked, so this makes a run from elsewhere rewrite the committed file
+    # rather than leave a stray one — deliberate for a committed artifact (#407).
     default=str(DOCS / "community_umap.html"),
     help="Output HTML path",
 )
 @click.option(
     "--cache-dir",
     type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
-    default=".umap_cache",
+    default=str(REPO_ROOT / ".umap_cache"),
     help="Directory for embedding cache",
 )
 @click.option(

--- a/src/communitymech/embedding/loader.py
+++ b/src/communitymech/embedding/loader.py
@@ -8,11 +8,13 @@ from pathlib import Path
 import numpy as np
 from tqdm import tqdm
 
+from communitymech.paths import REPO_ROOT
+
 
 class EmbeddingLoader:
     """Load and cache node embeddings from KG-Microbe TSV.gz file."""
 
-    def __init__(self, embeddings_path: str, cache_dir: str = ".umap_cache"):
+    def __init__(self, embeddings_path: str, cache_dir: str | Path = REPO_ROOT / ".umap_cache"):
         """Initialize loader.
 
         Args:

--- a/src/communitymech/export/browser_export.py
+++ b/src/communitymech/export/browser_export.py
@@ -10,6 +10,8 @@ from typing import Any
 
 import yaml
 
+from communitymech.paths import DOCS
+
 
 class BrowserExporter:
     """Export community YAMLs to browser-ready JSON."""
@@ -18,7 +20,7 @@ class BrowserExporter:
         self.communities_dir = communities_dir
         self.communities: list[dict[str, Any]] = []
 
-    def export_all(self, output_path: Path = Path("docs/data.js")) -> None:
+    def export_all(self, output_path: Path = DOCS / "data.js") -> None:
         """
         Export all community files to browser JSON.
 

--- a/src/communitymech/export/browser_export.py
+++ b/src/communitymech/export/browser_export.py
@@ -302,7 +302,7 @@ def main():
     )
     parser.add_argument(
         "--output",
-        default="docs/data.js",
+        default=str(DOCS / "data.js"),
         help="Output JavaScript file path",
     )
 

--- a/src/communitymech/literature.py
+++ b/src/communitymech/literature.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import requests
 
+from communitymech.paths import REFERENCES_CACHE
+
 # ---------------------------------------------------------------------------
 # Citation / first-author derivation
 # ---------------------------------------------------------------------------
@@ -211,8 +213,12 @@ def format_citation(text: str, *, author_string: str | None = None) -> str | Non
 class LiteratureFetcher:
     """Fetch and cache scientific literature."""
 
-    def __init__(self, cache_dir: str = "references_cache"):
-        self.cache_dir = Path(cache_dir)
+    def __init__(self, cache_dir: str | Path | None = None):
+        # Repo-anchored, not cwd-relative. The old default created a second,
+        # empty cache wherever the process happened to be running and re-fetched
+        # from PubMed/CrossRef — a silent cache miss and billed traffic, which
+        # also defeats the reproducibility the committed cache exists for (#407).
+        self.cache_dir = Path(cache_dir) if cache_dir is not None else REFERENCES_CACHE
         self.cache_dir.mkdir(exist_ok=True)
         self.session = requests.Session()
         self.session.headers.update(

--- a/src/communitymech/network/auditor.py
+++ b/src/communitymech/network/auditor.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 import yaml
 
+from communitymech.paths import REPO_ROOT
+
 
 class IssueType(str, Enum):
     """Types of network integrity issues."""
@@ -627,7 +629,7 @@ class NetworkIntegrityAuditor:
         """
         return json.dumps(self.issues, indent=2, default=str)
 
-    def write_report(self, output_path: Path = Path("network_integrity_audit.txt")):
+    def write_report(self, output_path: Path = REPO_ROOT / "network_integrity_audit.txt"):
         """
         Write detailed report to file.
 

--- a/src/communitymech/network/batch_reporter.py
+++ b/src/communitymech/network/batch_reporter.py
@@ -12,7 +12,7 @@ from communitymech.llm.anthropic_client import AnthropicClient
 from communitymech.network.auditor import NetworkIntegrityAuditor
 from communitymech.network.repair_strategies import StrategySelector
 from communitymech.network.validators import SuggestionValidator
-from communitymech.paths import REPORTS
+from communitymech.paths import REPO_ROOT, REPORTS
 
 logger = logging.getLogger(__name__)
 
@@ -276,7 +276,7 @@ class BatchReporter:
             }
 
     def apply_approved_suggestions(
-        self, report_path: Path, backup_dir: Path = Path(".backups")
+        self, report_path: Path, backup_dir: Path = REPO_ROOT / ".backups"
     ) -> dict[str, Any]:
         """
         Apply suggestions from a report that have been approved.

--- a/src/communitymech/network/batch_reporter.py
+++ b/src/communitymech/network/batch_reporter.py
@@ -12,6 +12,7 @@ from communitymech.llm.anthropic_client import AnthropicClient
 from communitymech.network.auditor import NetworkIntegrityAuditor
 from communitymech.network.repair_strategies import StrategySelector
 from communitymech.network.validators import SuggestionValidator
+from communitymech.paths import REPORTS
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +47,7 @@ class BatchReporter:
 
     def generate_report(
         self,
-        output_path: Path = Path("reports/network_repair_suggestions.yaml"),
+        output_path: Path = REPORTS / "network_repair_suggestions.yaml",
         max_communities: int | None = None,
         max_issues_per_community: int | None = None,
     ) -> dict[str, Any]:

--- a/src/communitymech/network/llm_repair.py
+++ b/src/communitymech/network/llm_repair.py
@@ -12,6 +12,7 @@ from communitymech.llm.anthropic_client import AnthropicClient
 from communitymech.network.auditor import NetworkIntegrityAuditor
 from communitymech.network.repair_strategies import StrategySelector
 from communitymech.network.validators import SuggestionValidator
+from communitymech.paths import REPO_ROOT
 from communitymech.validation.write_validated import (
     ValidationFailedError,
     write_validated_community,
@@ -25,7 +26,7 @@ class LLMNetworkRepairer:
         self,
         llm_client: AnthropicClient | None = None,
         validator: SuggestionValidator | None = None,
-        backup_dir: Path = Path(".backups"),
+        backup_dir: Path = REPO_ROOT / ".backups",
     ):
         """
         Initialize LLM network repairer.

--- a/src/communitymech/network/validators.py
+++ b/src/communitymech/network/validators.py
@@ -76,7 +76,7 @@ class SuggestionValidator:
 
         # Initialize literature fetcher for evidence validation
         if validate_evidence:
-            self.literature_fetcher = LiteratureFetcher(cache_dir="references_cache")
+            self.literature_fetcher = LiteratureFetcher()
 
     def validate(
         self, suggestion: dict[str, Any], community_data: dict[str, Any]

--- a/src/communitymech/paths.py
+++ b/src/communitymech/paths.py
@@ -11,11 +11,17 @@ a second, empty cache and re-fetched from PubMed and CrossRef — a silent cache
 miss and billed network traffic, not merely an untidy tree. The committed cache
 exists for reproducibility; a miss defeats it quietly.
 
-Anchoring on ``__file__`` assumes the package is imported from a source checkout,
-which is how this repo is installed (editable) and how `scripts/` already
-resolves its own paths. A wheel installed into site-packages would compute a
-nonsense root — acceptable here because nothing ships that way, and stated so the
-assumption is visible rather than discovered.
+Anchoring on ``__file__`` assumes the package is imported from a source checkout.
+That is how this repo installs today (editable) and how `scripts/` already
+resolves its own paths — but `pyproject.toml` does declare a setuptools build and
+a console script, so a wheel install is a supported build even if nobody uses it.
+Under one, ``parents[2]`` lands in ``site-packages``' parent and every constant
+here would point somewhere nobody looks, which for the literature cache means a
+silent re-fetch into a directory destroyed on the next venv rebuild.
+
+`looks_like_a_checkout()` makes that loud rather than silent; callers that care
+can check it. It is deliberately not raised at import time, because importing a
+path module should not be able to break an otherwise working install.
 """
 
 from __future__ import annotations
@@ -29,3 +35,8 @@ REFERENCES_CACHE = REPO_ROOT / "references_cache"
 REPORTS = REPO_ROOT / "reports"
 DOCS = REPO_ROOT / "docs"
 KB_COMMUNITIES = REPO_ROOT / "kb" / "communities"
+
+
+def looks_like_a_checkout() -> bool:
+    """Is `REPO_ROOT` really the repo, or did a wheel install fool `__file__`?"""
+    return (REPO_ROOT / "pyproject.toml").is_file() and (REPO_ROOT / "kb").is_dir()

--- a/src/communitymech/paths.py
+++ b/src/communitymech/paths.py
@@ -1,0 +1,31 @@
+"""Repo-anchored locations for the artifacts this package reads and writes (#407).
+
+Several defaults were plain relative strings — ``Path("reports")``,
+``"references_cache"``, ``"docs/communities"`` — resolved against the *working
+directory*. Run from anywhere but the repo root they wrote stray trees, and the
+targets are git-tracked, so a caller could also overwrite committed files.
+
+The sharpest case was the literature cache. `LiteratureFetcher` defaulted to
+``references_cache`` and `mkdir`-ed it, so running from another directory created
+a second, empty cache and re-fetched from PubMed and CrossRef — a silent cache
+miss and billed network traffic, not merely an untidy tree. The committed cache
+exists for reproducibility; a miss defeats it quietly.
+
+Anchoring on ``__file__`` assumes the package is imported from a source checkout,
+which is how this repo is installed (editable) and how `scripts/` already
+resolves its own paths. A wheel installed into site-packages would compute a
+nonsense root — acceptable here because nothing ships that way, and stated so the
+assumption is visible rather than discovered.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# src/communitymech/paths.py -> src/communitymech -> src -> <repo>
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+REFERENCES_CACHE = REPO_ROOT / "references_cache"
+REPORTS = REPO_ROOT / "reports"
+DOCS = REPO_ROOT / "docs"
+KB_COMMUNITIES = REPO_ROOT / "kb" / "communities"

--- a/src/communitymech/render.py
+++ b/src/communitymech/render.py
@@ -10,6 +10,8 @@ from pathlib import Path
 import yaml
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
+from communitymech.paths import DOCS
+
 
 class CommunityRenderer:
     """Render community YAML files to HTML pages."""
@@ -70,15 +72,18 @@ class CommunityRenderer:
     def render_all(
         self,
         communities_dir: Path = Path("kb/communities"),
-        output_dir: Path = Path("docs/communities"),
+        output_dir: Path | None = None,
     ) -> None:
         """
         Render all community YAML files to HTML.
 
         Args:
             communities_dir: Directory containing community YAML files
-            output_dir: Directory for output HTML files
+            output_dir: Directory for output HTML files. Defaults to the repo's
+                `docs/communities`, which is git-tracked — a cwd-relative default
+                wrote a stray tree wherever the process ran (#407).
         """
+        output_dir = output_dir if output_dir is not None else DOCS / "communities"
         yaml_files = sorted(communities_dir.glob("*.yaml"))
 
         print(f"\nRendering {len(yaml_files)} communities to HTML...")

--- a/src/communitymech/render.py
+++ b/src/communitymech/render.py
@@ -172,7 +172,7 @@ def main():
     )
     parser.add_argument(
         "--output-dir",
-        default="docs/communities",
+        default=str(DOCS / "communities"),
         help="Output directory for HTML files",
     )
     parser.add_argument(

--- a/src/communitymech/utils/media_linker.py
+++ b/src/communitymech/utils/media_linker.py
@@ -13,6 +13,8 @@ from pathlib import Path
 import requests
 import yaml
 
+from communitymech.paths import REPO_ROOT
+
 
 class MediaFetcher:
     """Fetch and cache CultureMech + MediaIngredientMech YAML from local or remote sources."""
@@ -33,7 +35,7 @@ class MediaFetcher:
 
     def __init__(
         self,
-        cache_dir: str = "media_cache",
+        cache_dir: str | Path = REPO_ROOT / "media_cache",
         cache_ttl: int = 86400,
         culturemech_index_path: str | None = None,
         culturemech_data_path: str | None = None,

--- a/src/communitymech/visualization/umap_generator.py
+++ b/src/communitymech/visualization/umap_generator.py
@@ -12,6 +12,7 @@ from communitymech.embedding import (
     EmbeddingLoader,
     UMAPReducer,
 )
+from communitymech.paths import DOCS, REPO_ROOT
 
 
 class UMAPVisualizationGenerator:
@@ -24,9 +25,9 @@ class UMAPVisualizationGenerator:
             "data/embeddings/"
             "DeepWalkSkipGramEnsmallen_degreenorm_embedding_512_v3_2026-06-26_12_55_27.tsv.gz"
         ),
-        output_path: str = "docs/community_umap.html",
+        output_path: str | Path | None = None,
         template_dir: str | None = None,
-        cache_dir: str = ".umap_cache",
+        cache_dir: str | Path = REPO_ROOT / ".umap_cache",
         force_reload: bool = False,
         method: str = "pacmap",
         n_neighbors: int = 15,
@@ -39,7 +40,9 @@ class UMAPVisualizationGenerator:
         Args:
             communities_dir: Directory containing community YAML files
             embeddings_path: Path to KG-Microbe embeddings TSV.gz
-            output_path: Output HTML file path
+            output_path: Output HTML file path. Defaults to the repo's
+                `docs/community_umap.html`, which is git-tracked — a cwd-relative
+                default wrote a stray tree wherever the process ran (#407).
             template_dir: Template directory (auto-detected if None)
             cache_dir: Cache directory for embeddings
             force_reload: Force reload embeddings from TSV.gz
@@ -49,6 +52,7 @@ class UMAPVisualizationGenerator:
             min_coverage: Minimum embedding coverage for communities
             exclude_hosts: Exclude non-microbial taxa (hosts) from representation
         """
+        output_path = Path(output_path) if output_path is not None else DOCS / "community_umap.html"
         print("=" * 60)
         print("🔬 CommunityMech UMAP Visualization Generator")
         print("=" * 60)
@@ -171,7 +175,7 @@ class UMAPVisualizationGenerator:
     def _render_html(
         self,
         community_data: list[dict[str, Any]],
-        output_path: str,
+        output_path: str | Path,
         template_dir: str | None = None,
         projection_label: str = "PaCMAP",
     ):

--- a/tests/test_output_paths_are_anchored.py
+++ b/tests/test_output_paths_are_anchored.py
@@ -27,7 +27,18 @@ REPO = Path(__file__).parent.parent
 
 # Parameters whose value is somewhere the process writes. `cache_dir` counts:
 # a wrong cache is a re-fetch, which is the most expensive failure of the set.
-_OUTPUT_PARAMS = ("output_dir", "output_path", "cache_dir", "out_dir", "out_path", "report_path")
+_OUTPUT_PARAMS = (
+    "output_dir",
+    "output_path",
+    "cache_dir",
+    "out_dir",
+    "out_path",
+    "report_path",
+    # Same relative-default-plus-mkdir shape as the literature cache, and worse
+    # in consequence: a repair run rewrites tracked YAML while dropping its only
+    # pre-edit backup in the caller's cwd, so a later restore cannot find it.
+    "backup_dir",
+)
 
 # Files that legitimately take a relative default because they never write —
 # none today; kept so an exemption has to be named rather than assumed.
@@ -65,44 +76,139 @@ def _relative_string_default(node: ast.AST) -> str | None:
     return text
 
 
-def test_no_output_parameter_defaults_to_a_relative_path():
-    """A default that follows the cwd writes wherever the process happens to be."""
-    offenders = []
-    for path in _python_files():
+# argparse/click flags whose value is a location the process writes.
+_OUTPUT_FLAGS = ("--out", "--output", "--output-dir", "--output-path", "--cache-dir", "--report")
+
+
+def _label(path: Path) -> str:
+    """Repo-relative when it is a repo file, bare name for a tmp probe."""
+    try:
+        return str(path.relative_to(REPO))
+    except ValueError:
+        return path.name
+
+
+def _offenders(files: list[Path]) -> list[str]:
+    """Every relative output default in `files`, as `path:line description`."""
+    found = []
+    for path in files:
         if path.name in _EXEMPT:
             continue
         tree = ast.parse(path.read_text())
         for node in ast.walk(tree):
-            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                continue
-            args = node.args
-            defaults = list(args.defaults)
-            positional = (args.posonlyargs + args.args)[
-                len(args.args) + len(args.posonlyargs) - len(defaults) :
-            ]
-            for arg, default in list(zip(positional, defaults, strict=False)) + list(
-                zip(args.kwonlyargs, args.kw_defaults, strict=False)
-            ):
-                if default is None or arg.arg not in _OUTPUT_PARAMS:
+            # Function and method parameter defaults.
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                args = node.args
+                defaults = list(args.defaults)
+                positional = (args.posonlyargs + args.args)[
+                    len(args.args) + len(args.posonlyargs) - len(defaults) :
+                ]
+                pairs = list(zip(positional, defaults, strict=False)) + list(
+                    zip(args.kwonlyargs, args.kw_defaults, strict=False)
+                )
+                for arg, default in pairs:
+                    if default is None or arg.arg not in _OUTPUT_PARAMS:
+                        continue
+                    literal = _relative_string_default(default)
+                    if literal:
+                        found.append(
+                            f"{_label(path)}:{default.lineno} "
+                            f"{node.name}({arg.arg}={literal!r})"
+                        )
+            # `add_argument("--out", default=...)`. This is the class that
+            # started the whole thing — #391 was an argparse default, and the
+            # first version of this guard could not see one, so six anchored
+            # parameter defaults sat behind flags that still followed the cwd
+            # (#409 review).
+            elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+                if node.func.attr not in ("add_argument", "option", "argument"):
                     continue
-                literal = _relative_string_default(default)
-                if literal:
-                    offenders.append(
-                        f"{path.relative_to(REPO)}:{default.lineno} "
-                        f"{node.name}({arg.arg}={literal!r})"
-                    )
-    assert not offenders, (
+                flags = [
+                    a.value
+                    for a in node.args
+                    if isinstance(a, ast.Constant) and isinstance(a.value, str)
+                ]
+                if not any(flag in _OUTPUT_FLAGS for flag in flags):
+                    continue
+                for keyword in node.keywords:
+                    if keyword.arg != "default":
+                        continue
+                    literal = _relative_string_default(keyword.value)
+                    if literal:
+                        found.append(
+                            f"{_label(path)}:{keyword.value.lineno} "
+                            f"{'/'.join(flags)} default={literal!r}"
+                        )
+    return found
+
+
+def test_no_output_default_follows_the_working_directory():
+    """A default that follows the cwd writes wherever the process happens to be."""
+    assert not _offenders(_python_files()), (
         "output paths that follow the working directory — anchor them on "
         "`communitymech.paths` or `Path(__file__)` (#407):\n"
-        + "\n".join(f"  {o}" for o in offenders)
+        + "\n".join(f"  {o}" for o in _offenders(_python_files()))
     )
 
 
 def test_the_scan_actually_inspects_the_tree():
-    """Guards the test above: an empty or broken sweep would pass vacuously."""
+    """Guards the sweep above: an empty file list would pass vacuously."""
     files = _python_files()
     assert len(files) > 40, f"expected the source tree, found {len(files)} files"
     assert any(path.name == "literature.py" for path in files)
+
+
+@pytest.mark.parametrize(
+    ("name", "source", "needle"),
+    [
+        ("parameter default", "def f(output_dir='reports'):\n    pass\n", "output_dir="),
+        (
+            "Path() parameter default",
+            "def f(output_dir=Path('reports')):\n    pass\n",
+            "output_dir=",
+        ),
+        ("backup_dir", "def f(backup_dir=Path('.backups')):\n    pass\n", "backup_dir="),
+        (
+            "argparse default",
+            "p.add_argument('--out', default=Path('reports/x.tsv'))\n",
+            "--out default=",
+        ),
+        (
+            "argparse output-dir",
+            "p.add_argument('--output-dir', default='docs/x')\n",
+            "--output-dir default=",
+        ),
+    ],
+)
+def test_the_scan_detects_each_shape_it_claims_to(tmp_path, name, source, needle):
+    """Runs a synthetic offender through the *whole* scan, not just its helper.
+
+    Emptying `_OUTPUT_PARAMS` left the suite green: the old vacuity guard only
+    counted files, and the positive control called `_relative_string_default`
+    directly, so nothing exercised the walk itself (#409 review).
+    """
+    probe = tmp_path / "probe.py"
+    probe.write_text("from pathlib import Path\n" + source)
+
+    found = _offenders([probe])
+
+    assert found, f"the scan misses a {name}"
+    assert any(needle in entry for entry in found), found
+
+
+def test_the_scan_leaves_anchored_forms_alone(tmp_path):
+    """A guard that fires on the fix would get switched off."""
+    probe = tmp_path / "ok.py"
+    probe.write_text(
+        "from pathlib import Path\n"
+        "from communitymech.paths import REPORTS\n"
+        "def f(output_dir=REPORTS):\n    pass\n"
+        "def g(output_dir=Path('/abs/reports')):\n    pass\n"
+        "p.add_argument('--out', default=REPORTS / 'x.tsv')\n"
+        "def h(name='report.txt'):\n    pass\n"
+    )
+
+    assert _offenders([probe]) == []
 
 
 def test_the_scan_would_catch_a_regression(tmp_path):
@@ -124,20 +230,21 @@ def test_the_scan_would_catch_a_regression(tmp_path):
     assert _relative_string_default(other.args.defaults[0]) is None
 
 
-@pytest.mark.parametrize(
-    ("module", "attribute"),
-    [
-        ("communitymech.paths", "REFERENCES_CACHE"),
-        ("communitymech.paths", "REPORTS"),
-        ("communitymech.paths", "DOCS"),
-    ],
-)
-def test_the_anchored_locations_are_absolute_and_real(module, attribute):
+@pytest.mark.parametrize("attribute", ["REFERENCES_CACHE", "REPORTS", "DOCS", "KB_COMMUNITIES"])
+def test_the_anchored_locations_are_under_the_repo(attribute):
+    """`REPO in value.parents`, not "direct child of the repo".
+
+    The first version asserted `value.parent == REPO or value == REPO / name` —
+    two spellings of the same predicate, so the `or` was inert. The tell was that
+    `KB_COMMUNITIES` was the one constant left out of the list: it would have
+    failed, since its parent is `REPO/"kb"` (#409 review).
+    """
     import importlib
 
-    value = getattr(importlib.import_module(module), attribute)
+    value = getattr(importlib.import_module("communitymech.paths"), attribute)
+
     assert value.is_absolute()
-    assert value.parent == REPO or value == REPO / value.name
+    assert REPO in value.parents, f"{attribute} is not under the repo"
 
 
 def test_the_literature_cache_default_finds_the_committed_cache():

--- a/tests/test_output_paths_are_anchored.py
+++ b/tests/test_output_paths_are_anchored.py
@@ -1,0 +1,157 @@
+"""Output locations must not follow the working directory (#407).
+
+Several defaults were plain relative strings — `Path("reports")`,
+`"references_cache"`, `"docs/communities"` — resolved against the *cwd*. Run from
+anywhere but the repo root they wrote stray trees, and because the targets are
+git-tracked a caller could also overwrite committed files.
+
+The literature cache was the sharpest: `LiteratureFetcher` defaulted to
+`references_cache` and `mkdir`-ed it, so running from another directory created a
+second, empty cache and re-fetched from PubMed and CrossRef. That is a silent
+cache miss and billed traffic, not an untidy tree, and it defeats the
+reproducibility the committed cache exists for.
+
+This file guards the class rather than the instances: a grep-style scan for
+relative defaults on output-ish parameters, so the next one fails here instead of
+being found by someone's stray directory.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).parent.parent
+
+# Parameters whose value is somewhere the process writes. `cache_dir` counts:
+# a wrong cache is a re-fetch, which is the most expensive failure of the set.
+_OUTPUT_PARAMS = ("output_dir", "output_path", "cache_dir", "out_dir", "out_path", "report_path")
+
+# Files that legitimately take a relative default because they never write —
+# none today; kept so an exemption has to be named rather than assumed.
+_EXEMPT: set[str] = set()
+
+
+def _python_files() -> list[Path]:
+    return [
+        path
+        for directory in ("src/communitymech", "scripts")
+        for path in sorted((REPO / directory).rglob("*.py"))
+        if "__pycache__" not in path.parts
+    ]
+
+
+def _relative_string_default(node: ast.AST) -> str | None:
+    """The literal if it is a bare relative path, else None."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        text = node.value
+    elif (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "Path"
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+        and isinstance(node.args[0].value, str)
+    ):
+        text = node.args[0].value
+    else:
+        return None
+    if not text or text.startswith("/") or text.startswith("~"):
+        return None
+    # Any relative string counts, with or without a separator. `Path("reports")`
+    # has none and was one of the actual defects.
+    return text
+
+
+def test_no_output_parameter_defaults_to_a_relative_path():
+    """A default that follows the cwd writes wherever the process happens to be."""
+    offenders = []
+    for path in _python_files():
+        if path.name in _EXEMPT:
+            continue
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            args = node.args
+            defaults = list(args.defaults)
+            positional = (args.posonlyargs + args.args)[
+                len(args.args) + len(args.posonlyargs) - len(defaults) :
+            ]
+            for arg, default in list(zip(positional, defaults, strict=False)) + list(
+                zip(args.kwonlyargs, args.kw_defaults, strict=False)
+            ):
+                if default is None or arg.arg not in _OUTPUT_PARAMS:
+                    continue
+                literal = _relative_string_default(default)
+                if literal:
+                    offenders.append(
+                        f"{path.relative_to(REPO)}:{default.lineno} "
+                        f"{node.name}({arg.arg}={literal!r})"
+                    )
+    assert not offenders, (
+        "output paths that follow the working directory — anchor them on "
+        "`communitymech.paths` or `Path(__file__)` (#407):\n"
+        + "\n".join(f"  {o}" for o in offenders)
+    )
+
+
+def test_the_scan_actually_inspects_the_tree():
+    """Guards the test above: an empty or broken sweep would pass vacuously."""
+    files = _python_files()
+    assert len(files) > 40, f"expected the source tree, found {len(files)} files"
+    assert any(path.name == "literature.py" for path in files)
+
+
+def test_the_scan_would_catch_a_regression(tmp_path):
+    """The rule detects the shape it is written for."""
+    probe = tmp_path / "probe.py"
+    probe.write_text(
+        "from pathlib import Path\n"
+        "def f(output_dir: Path = Path('reports')):\n"
+        "    return output_dir\n"
+    )
+    tree = ast.parse(probe.read_text())
+    function = next(n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef))
+
+    assert _relative_string_default(function.args.defaults[0]) == "reports"
+    assert _relative_string_default(ast.parse("f('a/b.html')").body[0].value.args[0]) == "a/b.html"
+    # And it does not fire on the anchored forms actually used in the repo.
+    anchored = ast.parse("def g(output_dir=REPORTS): pass")
+    other = next(n for n in ast.walk(anchored) if isinstance(n, ast.FunctionDef))
+    assert _relative_string_default(other.args.defaults[0]) is None
+
+
+@pytest.mark.parametrize(
+    ("module", "attribute"),
+    [
+        ("communitymech.paths", "REFERENCES_CACHE"),
+        ("communitymech.paths", "REPORTS"),
+        ("communitymech.paths", "DOCS"),
+    ],
+)
+def test_the_anchored_locations_are_absolute_and_real(module, attribute):
+    import importlib
+
+    value = getattr(importlib.import_module(module), attribute)
+    assert value.is_absolute()
+    assert value.parent == REPO or value == REPO / value.name
+
+
+def test_the_literature_cache_default_finds_the_committed_cache():
+    """The failure this issue is really about: a cache miss, not a stray tree."""
+    from communitymech.literature import LiteratureFetcher
+
+    fetcher = LiteratureFetcher()
+
+    assert fetcher.cache_dir.is_absolute()
+    assert fetcher.cache_dir == REPO / "references_cache"
+    assert len(list(fetcher.cache_dir.glob("*"))) > 100, "the default found an empty cache"
+
+
+def test_an_explicit_cache_directory_still_wins(tmp_path):
+    from communitymech.literature import LiteratureFetcher
+
+    assert LiteratureFetcher(cache_dir=tmp_path).cache_dir == tmp_path


### PR DESCRIPTION
Closes #407.

Defaults like `Path("reports")`, `"references_cache"` and `"docs/communities"` resolved against the **working directory**. Run from anywhere but the repo root they wrote stray trees, and because the targets are git-tracked a caller could also overwrite committed files.

## The one with a real cost

`LiteratureFetcher` defaulted to `references_cache` and `mkdir`-ed it, so running from another directory created a **second, empty cache** and re-fetched from PubMed and CrossRef — a silent cache miss and billed traffic, not an untidy tree, and it defeats the reproducibility the committed 677-file cache exists for. `network/validators.py` passed the same relative literal explicitly.

Canaried from `/tmp`: the default now finds all 677 files and creates nothing.

## The issue listed five instances; a scan found thirteen

The extras include two more **git-tracked** targets — `docs/data.js` and `reports/network_repair_suggestions.yaml` — plus `.umap_cache`, `media_cache`, `network_integrity_audit.txt`, and two `output_dir='./'` defaults sitting six lines from an anchored path in the same file.

That ratio is why **the guard is the point**, not the thirteen fixes.

## The guard

`tests/test_output_paths_are_anchored.py` walks the AST of `src/` and `scripts/` and fails on any relative default for an output-ish parameter (`output_dir`, `output_path`, `cache_dir`, …). It carries a vacuity guard, a positive control that the rule detects the shape it is written for, and **no exemptions**.

My first version required a `/` in the literal, reasoning that a bare name is not a location. That would have missed `Path("reports")` — one of the actual defects — so it now flags any relative string.

New `communitymech/paths.py` holds the anchors, with its assumption stated: `__file__`-relative means a source checkout, which is how this repo installs and how `scripts/` already resolves its own paths.

`just validate-all`, `validate-strict`, `validate-gtdb-all`, `validate-scalars` clean; 1219 passed; lint clean (mypy wanted three `str | Path` widenings).

---

## Review round 2 — six of the fixes were dead code

**The anchored parameter defaults sat behind argparse defaults that still followed the cwd.** Six of the thirteen are never reached, because every caller passes the value from a flag whose own default was relative — `--output-dir default="docs/communities"`, `--output default="docs/data.js"`, `--cache-dir default=".umap_cache"`, and two `--output-dir default='./'`. Reproduced post-fix: rendering from another directory still wrote a full `docs/communities/` tree there.

**And the guard could not see them.** It walked function parameters only — so the exact class that started this (#391 was an argparse `--out` default, and #407 explicitly proposed a test for it) passed clean. Extended to `add_argument`/`option` defaults, which found **nine**, three of them not in the review's list.

**The guard was also vacuous.** Emptying `_OUTPUT_PARAMS` left the suite green: the vacuity check only counted files, and the positive control called the helper directly, so nothing exercised the walk. It now pushes synthetic offenders of every shape it claims to catch through `_offenders` itself, plus a negative case so a guard that fired on the fix would also fail.

**`backup_dir` was the same shape and worse in consequence** — `.backups` is not gitignored, and a repair run rewrites tracked YAML while dropping its only pre-edit backup in the caller's cwd, where a later restore cannot find it. Covered now.

### Two of my claims were wrong

- "two more git-tracked targets" — `docs/data.js` is **gitignored** and `reports/network_repair_suggestions.yaml` is **untracked**. The tracked targets actually touched are `docs/community_umap.html` and `reports/validation_results.tsv`/`validation_summary.md`.
- **The rationale was backwards.** Anchoring does not prevent overwriting committed files — it makes that happen from *every* cwd instead of leaving a stray tree. That is the right trade for a committed artifact, but it is a trade, and both comments said the opposite.

Also: the anchored-locations test asserted `value.parent == REPO or value == REPO / value.name` — two spellings of one predicate, and the tell was that `KB_COMMUNITIES` was the single constant omitted, because it would have failed. `paths.py` gains `looks_like_a_checkout()`, since `pyproject.toml` does declare a wheel build under which every constant would point into site-packages silently.

The six scripts passing `cache_dir=".literature_cache"` are left alone: they import `communitymech.literature_enhanced`, which does not exist, so they fail at import. Filed as **#410** rather than making dead code look maintained.

1226 passed; all gates clean.
