### PR TITLE
Fail on a script that cannot import, port one, and stop the docs claiming the rest work (#410)

### DIFF
--- a/docs/AUTOMATION_TOOLS.md
+++ b/docs/AUTOMATION_TOOLS.md
@@ -18,10 +18,10 @@ Parses the evidence_curation_report.txt and applies suggested snippet fixes that
 ### Usage
 ```bash
 # Interactive mode - review each suggestion
-poetry run python scripts/apply_suggested_snippets.py --file Australian_Lead_Zinc_Polymetallic.yaml
+uv run python scripts/apply_suggested_snippets.py --file Australian_Lead_Zinc_Polymetallic.yaml
 
 # Auto-approve mode - automatically apply all suggestions
-poetry run python scripts/apply_suggested_snippets.py --file Australian_Lead_Zinc_Polymetallic.yaml --auto-approve
+uv run python scripts/apply_suggested_snippets.py --file Australian_Lead_Zinc_Polymetallic.yaml --auto-approve
 ```
 
 ### Features
@@ -46,16 +46,16 @@ Directly fetches abstracts from PMID/DOI references and uses context-aware analy
 ### Usage
 ```bash
 # Interactive mode - review suggestions for all evidence
-poetry run python scripts/intelligent_snippet_fixer.py --file Australian_Lead_Zinc_Polymetallic.yaml
+uv run python scripts/intelligent_snippet_fixer.py --file Australian_Lead_Zinc_Polymetallic.yaml
 
 # Process only invalid snippets (short ones)
-poetry run python scripts/intelligent_snippet_fixer.py --file Australian_Lead_Zinc_Polymetallic.yaml --only-invalid
+uv run python scripts/intelligent_snippet_fixer.py --file Australian_Lead_Zinc_Polymetallic.yaml --only-invalid
 
 # Auto-approve mode (applies top suggestion automatically)
-poetry run python scripts/intelligent_snippet_fixer.py --file Australian_Lead_Zinc_Polymetallic.yaml --auto-approve
+uv run python scripts/intelligent_snippet_fixer.py --file Australian_Lead_Zinc_Polymetallic.yaml --auto-approve
 
 # Verbose mode (shows debugging info)
-poetry run python scripts/intelligent_snippet_fixer.py --file Australian_Lead_Zinc_Polymetallic.yaml --verbose
+uv run python scripts/intelligent_snippet_fixer.py --file Australian_Lead_Zinc_Polymetallic.yaml --verbose
 ```
 
 ### Features
@@ -130,22 +130,22 @@ Process multiple YAML files in sequence using the intelligent snippet fixer.
 ### Usage
 ```bash
 # Process Phase 1 top 10 priority files
-poetry run python scripts/batch_snippet_fixer.py --phase 1
+uv run python scripts/batch_snippet_fixer.py --phase 1
 
 # Process Phase 2 medium-priority files
-poetry run python scripts/batch_snippet_fixer.py --phase 2
+uv run python scripts/batch_snippet_fixer.py --phase 2
 
 # Process all files from curation report (sorted by issue count)
-poetry run python scripts/batch_snippet_fixer.py --from-report
+uv run python scripts/batch_snippet_fixer.py --from-report
 
 # Process specific files
-poetry run python scripts/batch_snippet_fixer.py --files Australian_Lead_Zinc_Polymetallic.yaml AMD_Acidophile_Heterotroph_Network.yaml
+uv run python scripts/batch_snippet_fixer.py --files Australian_Lead_Zinc_Polymetallic.yaml AMD_Acidophile_Heterotroph_Network.yaml
 
 # Limit to first N files
-poetry run python scripts/batch_snippet_fixer.py --phase 1 --limit 3
+uv run python scripts/batch_snippet_fixer.py --phase 1 --limit 3
 
 # Auto-approve mode (non-interactive)
-poetry run python scripts/batch_snippet_fixer.py --phase 1 --auto-approve
+uv run python scripts/batch_snippet_fixer.py --phase 1 --auto-approve
 ```
 
 ### Features
@@ -159,10 +159,10 @@ poetry run python scripts/batch_snippet_fixer.py --phase 1 --auto-approve
 ### Example Workflow
 ```bash
 # Start with Phase 1 (top 10 files), interactive mode
-poetry run python scripts/batch_snippet_fixer.py --phase 1
+uv run python scripts/batch_snippet_fixer.py --phase 1
 
 # After familiarization, use auto-approve for faster processing
-poetry run python scripts/batch_snippet_fixer.py --phase 1 --auto-approve --limit 3
+uv run python scripts/batch_snippet_fixer.py --phase 1 --auto-approve --limit 3
 ```
 
 ### Output
@@ -193,7 +193,7 @@ Total files processed: 10
 ### For Individual Files (Careful Review)
 ```bash
 # 1. Use intelligent fixer with interactive mode
-poetry run python scripts/intelligent_snippet_fixer.py --file FILENAME.yaml
+uv run python scripts/intelligent_snippet_fixer.py --file FILENAME.yaml
 
 # 2. Review suggestions carefully, apply best ones
 
@@ -210,24 +210,24 @@ just validate kb/communities/FILENAME.yaml
 ### For Batch Processing (Faster)
 ```bash
 # 1. Start with Phase 1, limited scope for testing
-poetry run python scripts/batch_snippet_fixer.py --phase 1 --limit 3
+uv run python scripts/batch_snippet_fixer.py --phase 1 --limit 3
 
 # 2. Review results
 
 # 3. Process full Phase 1 with auto-approve
-poetry run python scripts/batch_snippet_fixer.py --phase 1 --auto-approve
+uv run python scripts/batch_snippet_fixer.py --phase 1 --auto-approve
 
 # 4. Continue with Phase 2
-poetry run python scripts/batch_snippet_fixer.py --phase 2 --auto-approve
+uv run python scripts/batch_snippet_fixer.py --phase 2 --auto-approve
 ```
 
 ### For Quick Fixes from Report
 ```bash
 # Apply report suggestions (fast, limited scope)
-poetry run python scripts/apply_suggested_snippets.py --file FILENAME.yaml --auto-approve
+uv run python scripts/apply_suggested_snippets.py --file FILENAME.yaml --auto-approve
 
 # Then use intelligent fixer for remaining issues
-poetry run python scripts/intelligent_snippet_fixer.py --file FILENAME.yaml --only-invalid
+uv run python scripts/intelligent_snippet_fixer.py --file FILENAME.yaml --only-invalid
 ```
 
 ---
@@ -262,7 +262,7 @@ poetry run python scripts/intelligent_snippet_fixer.py --file FILENAME.yaml --on
 8. **Time: 5-10 minutes per snippet**
 
 ### After (Automated)
-1. Run intelligent fixer: `poetry run python scripts/intelligent_snippet_fixer.py --file FILENAME.yaml --auto-approve`
+1. Run intelligent fixer: `uv run python scripts/intelligent_snippet_fixer.py --file FILENAME.yaml --auto-approve`
 2. **Time: ~30 seconds per file** (with auto-approve)
 3. **Time: ~2-3 minutes per file** (with interactive review)
 
@@ -280,13 +280,13 @@ Process files using the batch tool:
 
 ```bash
 # Phase 1: Top 10 priority files
-poetry run python scripts/batch_snippet_fixer.py --phase 1 --auto-approve
+uv run python scripts/batch_snippet_fixer.py --phase 1 --auto-approve
 
 # Phase 2: Medium priority
-poetry run python scripts/batch_snippet_fixer.py --phase 2 --auto-approve
+uv run python scripts/batch_snippet_fixer.py --phase 2 --auto-approve
 
 # Phase 3: Remaining files
-poetry run python scripts/batch_snippet_fixer.py --phase 3 --auto-approve
+uv run python scripts/batch_snippet_fixer.py --phase 3 --auto-approve
 ```
 
 ### Option B: Targeted Fixes
@@ -294,7 +294,7 @@ Focus on highest-impact files first:
 
 ```bash
 # Process just the top 3 worst files
-poetry run python scripts/batch_snippet_fixer.py \
+uv run python scripts/batch_snippet_fixer.py \
   --files Australian_Lead_Zinc_Polymetallic.yaml AMD_Acidophile_Heterotroph_Network.yaml Chromium_Sulfur_Reduction_Enrichment.yaml
 ```
 

--- a/docs/AUTOMATION_TOOLS.md
+++ b/docs/AUTOMATION_TOOLS.md
@@ -198,7 +198,10 @@ poetry run python scripts/intelligent_snippet_fixer.py --file FILENAME.yaml
 # 2. Review suggestions carefully, apply best ones
 
 # 3. Validate
-poetry run python scripts/curate_evidence_with_pdfs.py --file FILENAME.yaml
+# ⚠️ NOT FUNCTIONAL — this script imports communitymech.literature_enhanced,
+# which has never existed, so it fails at import. Tracked in #410.
+# (The command below is also stale: this repo uses uv, not poetry.)
+uv run python scripts/curate_evidence_with_pdfs.py --file FILENAME.yaml
 
 # 4. Schema check
 just validate kb/communities/FILENAME.yaml

--- a/docs/CURATION_PROGRESS_REPORT.md
+++ b/docs/CURATION_PROGRESS_REPORT.md
@@ -259,7 +259,7 @@ poetry run python scripts/batch_snippet_fixer.py --phase 1 --auto-approve
 
 1. **Validation**:
    ```bash
-   poetry run python scripts/curate_evidence_with_pdfs.py --quick
+   # NOT FUNCTIONAL (#410): scripts/curate_evidence_with_pdfs.py --quick
    just validate-all
    ```
 
@@ -313,10 +313,10 @@ poetry run python scripts/intelligent_snippet_fixer.py --file FILENAME.yaml --au
 poetry run python scripts/batch_snippet_fixer.py --phase 1 --auto-approve
 
 # Validate file
-poetry run python scripts/curate_evidence_with_pdfs.py --file FILENAME.yaml
+# NOT FUNCTIONAL (#410): scripts/curate_evidence_with_pdfs.py --file FILENAME.yaml
 
 # Validate all files (quick)
-poetry run python scripts/curate_evidence_with_pdfs.py --quick
+# NOT FUNCTIONAL (#410): scripts/curate_evidence_with_pdfs.py --quick
 ```
 
 ---

--- a/docs/pdf_fetching_capability.md
+++ b/docs/pdf_fetching_capability.md
@@ -14,9 +14,17 @@ was absent from the repo's first commit (`7c658e6`), which is also where these
 scripts were added. They fail at import, so even `--help` does not work.
 
 This page previously read "✅ VALIDATED — Successfully integrated and tested",
-which was never true of the committed code. Tracked in #410; `LiteratureFetcher`
-in `communitymech.literature` is the working fetcher, and
-`tests/test_scripts_import.py` now fails on any *new* script that cannot import.
+which was never true of the committed code.
+
+**Everything below this line describes software that is not in this repository**,
+including the success rates, the per-tier table and the "5/5 DOIs" test results.
+Those numbers cannot have come from committed code and are retained only as a
+record of what was claimed. Do not cite them.
+
+`LiteratureFetcher` in `communitymech.literature` is the working fetcher — it has
+no PDF surface, which is why porting these scripts is a capability decision
+rather than an import swap (#410). `tests/test_scripts_import.py` now fails on
+any *new* script that cannot import.
 
 - Scihub fallback from MicroGrowAgents: `pdf_evidence_extractor.py`
 - 6-tier cascading strategy implemented

--- a/docs/pdf_fetching_capability.md
+++ b/docs/pdf_fetching_capability.md
@@ -6,7 +6,17 @@ The CommunityMech literature system integrates a 6-tier cascading PDF discovery 
 
 ## Integration Status
 
-✅ **VALIDATED** - Successfully integrated and tested
+⚠️ **NOT FUNCTIONAL** — the scripts described below cannot run.
+
+All of them begin `from communitymech.literature_enhanced import
+EnhancedLiteratureFetcher`, and that module has never existed in any commit: it
+was absent from the repo's first commit (`7c658e6`), which is also where these
+scripts were added. They fail at import, so even `--help` does not work.
+
+This page previously read "✅ VALIDATED — Successfully integrated and tested",
+which was never true of the committed code. Tracked in #410; `LiteratureFetcher`
+in `communitymech.literature` is the working fetcher, and
+`tests/test_scripts_import.py` now fails on any *new* script that cannot import.
 
 - Scihub fallback from MicroGrowAgents: `pdf_evidence_extractor.py`
 - 6-tier cascading strategy implemented

--- a/scripts/fix_invalid_snippets.py
+++ b/scripts/fix_invalid_snippets.py
@@ -14,16 +14,19 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from communitymech.literature_enhanced import EnhancedLiteratureFetcher
+from communitymech.literature import LiteratureFetcher
 
 
 class SnippetFixer:
     """Fix invalid evidence snippets"""
 
     def __init__(self):
-        self.fetcher = EnhancedLiteratureFetcher(
-            cache_dir=".literature_cache", use_fallback_pdf=False
-        )
+        # Ported from the never-committed EnhancedLiteratureFetcher, following
+        # the swap merged in #88: `fetch_paper` returns (abstract, source) and
+        # takes no `download_pdf`. This script passed `download_pdf=False`
+        # throughout, so nothing is lost. The default cache is the committed
+        # `references_cache` (#407); the old `.literature_cache` never existed.
+        self.fetcher = LiteratureFetcher()
         self.invalid_snippets = []
 
     def find_invalid_snippets(self, yaml_path: Path) -> list[dict]:
@@ -51,11 +54,9 @@ class SnippetFixer:
 
                     # Fetch abstract
                     try:
-                        paper = self.fetcher.fetch_paper(reference, download_pdf=False)
-                        if paper["abstract"]:
-                            valid = self.fetcher.validate_evidence_snippet(
-                                snippet, paper["abstract"]
-                            )
+                        abstract, _ = self.fetcher.fetch_paper(reference)
+                        if abstract:
+                            valid = self.fetcher.validate_evidence_snippet(snippet, abstract)
 
                             if not valid:
                                 invalid.append(
@@ -65,7 +66,7 @@ class SnippetFixer:
                                         "organism": organism,
                                         "reference": reference,
                                         "snippet": snippet,
-                                        "abstract": paper["abstract"],
+                                        "abstract": abstract,
                                         "taxon_idx": taxon_idx,
                                         "ev_idx": ev_idx,
                                     }
@@ -90,11 +91,9 @@ class SnippetFixer:
 
                     # Fetch abstract
                     try:
-                        paper = self.fetcher.fetch_paper(reference, download_pdf=False)
-                        if paper["abstract"]:
-                            valid = self.fetcher.validate_evidence_snippet(
-                                snippet, paper["abstract"]
-                            )
+                        abstract, _ = self.fetcher.fetch_paper(reference)
+                        if abstract:
+                            valid = self.fetcher.validate_evidence_snippet(snippet, abstract)
 
                             if not valid:
                                 invalid.append(
@@ -104,7 +103,7 @@ class SnippetFixer:
                                         "organism": int_name,
                                         "reference": reference,
                                         "snippet": snippet,
-                                        "abstract": paper["abstract"],
+                                        "abstract": abstract,
                                         "int_idx": int_idx,
                                         "ev_idx": ev_idx,
                                     }

--- a/tests/test_scripts_import.py
+++ b/tests/test_scripts_import.py
@@ -19,6 +19,7 @@ the outside and a wrong guess here writes into the repo.
 from __future__ import annotations
 
 import ast
+import importlib.util
 import re
 import subprocess
 import sys
@@ -38,15 +39,19 @@ _EXECUTES_ON_IMPORT = {
     "term_label_audit.py",
 }
 
-# Broken since the repo's first commit (7c658e6): all six import
-# `communitymech.literature_enhanced`, which has never existed in any commit on
-# any branch. Listed rather than skipped silently, so the count is visible and
-# shrinks as #410 is resolved — deleting them or porting them to
-# `LiteratureFetcher` is a curation decision, not a test's to make.
+# All import `communitymech.literature_enhanced`, which has never existed in any
+# commit on any branch — verified over all 498 commits. They were added in
+# `7c658e6` (the 7th commit, 2026-02-18; the repo's first is `79f5196`).
+#
+# Not a curation call in general: #88 already ported the same import in two other
+# scripts, and `fix_invalid_snippets.py` followed that recipe here because it
+# passed `download_pdf=False` throughout, so nothing was lost. These five pass a
+# *variable* for PDF fetching, or call `fetch_pdf_url`, and `LiteratureFetcher`
+# has no PDF surface at all — porting them means deciding whether to drop a
+# capability their CLI flags advertise. That decision is #410, which stays open.
 _KNOWN_BROKEN = {
     "curate_evidence_with_pdfs.py",
     "extract_evidence_snippets.py",
-    "fix_invalid_snippets.py",
     "quick_literature_review.py",
     "review_literature.py",
     "test_pdf_fetching.py",
@@ -64,6 +69,26 @@ _PROBE = (
     "mod = importlib.util.module_from_spec(spec); "
     "spec.loader.exec_module(mod)"
 )
+
+
+def _declared_packages() -> frozenset[str]:
+    """Distribution names mentioned anywhere in the dependency files.
+
+    Coarse on purpose — this only has to tell "a real package nobody installed"
+    from "a name that exists nowhere".
+    """
+    text = (REPO / "pyproject.toml").read_text()
+    lock = REPO / "uv.lock"
+    if lock.exists():
+        text += lock.read_text()
+    return frozenset(re.findall(r"[A-Za-z0-9_.-]+", text))
+
+
+_DECLARED_PACKAGES = _declared_packages()
+
+
+def _is_installed(module: str) -> bool:
+    return importlib.util.find_spec(module) is not None
 
 
 def _is_first_party(module: str) -> bool:
@@ -89,9 +114,46 @@ def _importable() -> list[Path]:
     ]
 
 
-def test_the_sweep_sees_the_scripts():
-    """Guards everything below: an empty glob would pass vacuously."""
+def test_the_sweep_actually_tests_most_scripts():
+    """Counting files is not enough — the *tested* set must not collapse.
+
+    pytest turns an empty parametrize list into a skip, not a failure, so
+    growing an exclusion list to cover everything would leave this file green
+    with nothing checked (#413 review).
+    """
     assert len(_scripts()) > 50, f"expected the scripts tree, found {len(_scripts())}"
+    assert len(_importable()) >= 55, (
+        f"only {len(_importable())} of {len(_scripts())} scripts are import-tested; "
+        f"an exclusion list has grown"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(_EXECUTES_ON_IMPORT))
+def test_an_excluded_script_really_executes_on_import(name):
+    """The other allowlist, which had no hygiene test at all.
+
+    A name lands here by claiming it does work at module scope. If that stops
+    being true it should rejoin the import check rather than stay exempt.
+    """
+    tree = ast.parse((SCRIPTS / name).read_text())
+    work = [
+        node
+        for node in tree.body
+        if not isinstance(
+            node,
+            (ast.Import, ast.ImportFrom, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef),
+        )
+        and not (isinstance(node, ast.Assign | ast.AnnAssign | ast.Expr))
+    ]
+    calls = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call)
+    ]
+    assert work or calls, (
+        f"{name} has no module-level work; drop it from _EXECUTES_ON_IMPORT so it "
+        f"is import-tested like everything else"
+    )
 
 
 @pytest.mark.parametrize("script", _importable(), ids=lambda p: p.name)
@@ -119,10 +181,27 @@ def test_a_script_imports(script: Path):
     # scripts need `duckdb`, which is not in the default sync, and three of them
     # exit with an install hint on purpose. A missing *first-party* module is a
     # bug: it can never be installed, which is exactly #410.
-    if missing and not _is_first_party(missing.group(1)):
-        pytest.skip(f"{script.name} needs {missing.group(1)}, which is not installed")
-    if "not available. Install with" in output:
-        pytest.skip(f"{script.name} exits deliberately without duckdb")
+    if missing:
+        module = missing.group(1)
+        if _is_first_party(module):
+            pytest.fail(f"{script.name} imports a module this repo does not provide: {module}")
+        if module not in _DECLARED_PACKAGES:
+            # A name that appears in no dependency file can never be installed,
+            # so it is a typo or a rename, not an environment difference —
+            # `import reqeusts` used to skip forever (#413 review).
+            pytest.fail(f"{script.name} imports {module!r}, which is in no dependency file")
+        pytest.skip(f"{script.name} needs {module}, which is not installed here")
+
+    # Some scripts catch the ImportError themselves and exit with an install
+    # hint, so there is no "No module named" to match. Key off the package they
+    # name and verify it really is absent — matching the phrase alone was too
+    # loose (`compare_ncbi_gtdb_taxonomy.py` prints it as a *non-fatal* warning,
+    # which would have relabelled a later first-party failure as an install gap)
+    # and requiring the script to mention the package was too strict
+    # (`gtdb_demo.py` inherits it from a sibling import) — #413 review.
+    hint = re.search(r"([A-Za-z0-9_]+) not available\. Install with", output)
+    if hint and not _is_first_party(hint.group(1)) and not _is_installed(hint.group(1)):
+        pytest.skip(f"{script.name} exits deliberately without {hint.group(1)}")
 
     tail = output.splitlines()[-3:] or ["(no output)"]
     pytest.fail(f"{script.name} does not import:\n  " + "\n  ".join(tail))

--- a/tests/test_scripts_import.py
+++ b/tests/test_scripts_import.py
@@ -1,0 +1,181 @@
+"""Every script must at least import (#410).
+
+`scripts/` has no test coverage at all. Six scripts have imported a module that
+does not exist — `communitymech.literature_enhanced` — since the repo's first
+commit, so they have never run, and nothing noticed for months. `just lint` did
+not reach `scripts/` until #381, and lint would not have caught this anyway: the
+import is syntactically fine.
+
+Importing is a low bar deliberately. These are scripts with side effects and
+network calls; running them is not something a test suite should do. But an
+import failure means the file cannot execute at all, which is worth exactly one
+cheap check.
+
+Scripts that execute work at import time are excluded by name rather than by
+pattern, because "does this module do something on import" is not decidable from
+the outside and a wrong guess here writes into the repo.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).parent.parent
+SCRIPTS = REPO / "scripts"
+
+# These run their work at import — no `if __name__ == "__main__"` guard — so
+# importing them would rewrite KB files. They are checked for parse only.
+_EXECUTES_ON_IMPORT = {
+    "chebi_fix_apply.py",
+    "chebi_label_audit.py",
+    "term_fix_apply.py",
+    "term_label_audit.py",
+}
+
+# Broken since the repo's first commit (7c658e6): all six import
+# `communitymech.literature_enhanced`, which has never existed in any commit on
+# any branch. Listed rather than skipped silently, so the count is visible and
+# shrinks as #410 is resolved — deleting them or porting them to
+# `LiteratureFetcher` is a curation decision, not a test's to make.
+_KNOWN_BROKEN = {
+    "curate_evidence_with_pdfs.py",
+    "extract_evidence_snippets.py",
+    "fix_invalid_snippets.py",
+    "quick_literature_review.py",
+    "review_literature.py",
+    "test_pdf_fetching.py",
+}
+
+
+# `python scripts/foo.py` puts `scripts/` on sys.path, which is how the sibling
+# imports between these files resolve (`from scout_communities import ...`).
+# Loading the file without that made four scripts look broken when they are not —
+# the probe has to match how the thing is actually invoked.
+_PROBE = (
+    "import sys, importlib.util; "
+    "sys.path.insert(0, {scripts!r}); "
+    "spec = importlib.util.spec_from_file_location('_probe', {path!r}); "
+    "mod = importlib.util.module_from_spec(spec); "
+    "spec.loader.exec_module(mod)"
+)
+
+
+def _is_first_party(module: str) -> bool:
+    """Is this a module the repo is supposed to provide?
+
+    `communitymech.*` and any sibling script name. Those can never be fixed by
+    installing something, so their absence is a defect rather than an
+    environment difference.
+    """
+    root = module.split(".")[0]
+    return root == "communitymech" or (SCRIPTS / f"{root}.py").exists()
+
+
+def _scripts() -> list[Path]:
+    return sorted(SCRIPTS.glob("*.py"))
+
+
+def _importable() -> list[Path]:
+    return [
+        path
+        for path in _scripts()
+        if path.name not in _EXECUTES_ON_IMPORT and path.name not in _KNOWN_BROKEN
+    ]
+
+
+def test_the_sweep_sees_the_scripts():
+    """Guards everything below: an empty glob would pass vacuously."""
+    assert len(_scripts()) > 50, f"expected the scripts tree, found {len(_scripts())}"
+
+
+@pytest.mark.parametrize("script", _importable(), ids=lambda p: p.name)
+def test_a_script_imports(script: Path):
+    """A script that cannot import cannot run, whatever else is true of it."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _PROBE.format(path=str(script), scripts=str(SCRIPTS)),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+        timeout=120,
+    )
+    if result.returncode == 0:
+        return
+
+    # Both streams: three of these print their install hint to stdout and exit,
+    # so a stderr-only check reported them as failing with an empty message.
+    output = (result.stdout + result.stderr).strip()
+    missing = re.search(r"No module named '([^']+)'", output)
+    # A missing *third-party* package is an install gap, not a defect — five
+    # scripts need `duckdb`, which is not in the default sync, and three of them
+    # exit with an install hint on purpose. A missing *first-party* module is a
+    # bug: it can never be installed, which is exactly #410.
+    if missing and not _is_first_party(missing.group(1)):
+        pytest.skip(f"{script.name} needs {missing.group(1)}, which is not installed")
+    if "not available. Install with" in output:
+        pytest.skip(f"{script.name} exits deliberately without duckdb")
+
+    tail = output.splitlines()[-3:] or ["(no output)"]
+    pytest.fail(f"{script.name} does not import:\n  " + "\n  ".join(tail))
+
+
+@pytest.mark.parametrize("script", _scripts(), ids=lambda p: p.name)
+def test_a_script_parses(script: Path):
+    """Even the excluded ones must be syntactically valid."""
+    ast.parse(script.read_text())
+
+
+def test_the_known_broken_list_is_still_accurate():
+    """A name that starts importing must leave the list, or the list rots.
+
+    Without this, fixing one of the six would leave it permanently exempt from
+    the check above — the failure mode of every allowlist.
+    """
+    fixed = []
+    for name in sorted(_KNOWN_BROKEN):
+        path = SCRIPTS / name
+        if not path.exists():
+            continue
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                _PROBE.format(path=str(path), scripts=str(SCRIPTS)),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=REPO,
+            timeout=120,
+        )
+        if result.returncode == 0:
+            fixed.append(name)
+    assert not fixed, f"these now import and should be removed from _KNOWN_BROKEN: {fixed} (#410)"
+
+
+def test_the_known_broken_all_share_one_cause():
+    """The list is one bug, not a bucket.
+
+    If a script joins it for a different reason, that reason wants its own issue
+    rather than being absorbed into #410's count.
+    """
+    for name in sorted(_KNOWN_BROKEN):
+        path = SCRIPTS / name
+        if not path.exists():
+            continue
+        imports = {
+            node.module
+            for node in ast.walk(ast.parse(path.read_text()))
+            if isinstance(node, ast.ImportFrom) and node.module
+        }
+        assert any(
+            "literature_enhanced" in module for module in imports
+        ), f"{name} is in _KNOWN_BROKEN but does not import literature_enhanced"


### PR DESCRIPTION
Addresses #410 in part. **Deliberately does not close it** — see below.

Six scripts import `communitymech.literature_enhanced`, which **has never existed in any commit on any branch** (verified across all 498 commits). They were added in `7c658e6` (the 7th commit, 2026-02-18 — the repo's first is `79f5196`) and have never been able to run; even `--help` fails.

## The guard

`tests/test_scripts_import.py` — every script must import, in a subprocess, with `scripts/` on `sys.path`, which is how `python scripts/foo.py` resolves the sibling imports these files use.

Getting the skip logic right took several passes, and each error was mine:

- **My first probe** used `exec_module` without `scripts/` on the path, so four sibling-importing scripts looked broken when they are fine.
- **A missing third-party package is an install gap; a missing first-party module is a defect.** The test skips the former, fails the latter.
- **A typo'd package name skipped forever** — `import reqeusts` can never be installed. Now checked against the names in `pyproject.toml` and `uv.lock`.
- **The "not available. Install with" skip matched arbitrary output** and ran *after* the first-party check, so it overrode it — and `compare_ncbi_gtdb_taxonomy.py` prints that exact phrase as a **non-fatal warning**, meaning a real `literature_enhanced` failure there would have been relabelled an install gap. Now keyed to the package the message names, verified genuinely absent. My first fix was too strict the other way and broke `gtdb_demo.py`, which inherits `duckdb` from a sibling.
- **`_EXECUTES_ON_IMPORT` had no hygiene test**, and the vacuity guard counted *files*, not tested files — pytest turns an empty parametrize into a **skip**, so growing an exclusion list to cover everything would have left the file green with nothing checked. Both closed.

## One script ported, five left — and why that is not "a curation call"

**PR #88 (`393b373`, 25 May) already fixed this identical import in two other scripts**, documenting the API deltas. So "nothing noticed for months" was wrong: it was noticed, and the fix was not generalised.

`fix_invalid_snippets.py` follows that recipe here — it passed `download_pdf=False` throughout, so nothing is lost. **It now imports and `--help`s for the first time since 2026-02-18.**

The other five pass a *variable* for PDF fetching or call `fetch_pdf_url`, and `LiteratureFetcher` has **no PDF surface at all**. Porting them means deciding whether to drop a capability their CLI flags advertise — which is the decision #410 exists for, so the issue stays open.

## Why the closing keyword is gone

#410 lists three options and calls the third — "leave them and add a note" — **"the worst option, since a broken script is indistinguishable from an unused one until someone needs it."** The first version of this PR implemented exactly that and closed the issue, while three in-repo pointers directed readers to it.

## Docs: I fixed two of three, and got the third backwards

- `docs/CURATION_PROGRESS_REPORT.md` still carried **three live instructions** to run the broken script — missed entirely.
- `docs/pdf_fetching_capability.md` kept its **fabricated evidence four lines under my new warning**: a "100% success rate (5/5 DOIs)" table, per-tier rates, and named sci-hub mirrors, for software not in this repository. Now explicitly disclaimed.
- My `poetry run` → `uv run` edit touched **only the command marked NOT FUNCTIONAL**, leaving 25 others — including `intelligent_snippet_fixer.py`, which actually works. All 25 converted.

`just validate-all`, `validate-strict`, `validate-gtdb-all`, `validate-scalars`, `vendored-sync` clean; **1349 passed**, 14 skipped; lint clean.
