### PR TITLE
Take validate-references-all out of qc so lint and test actually run (#417)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,11 +16,17 @@ just test                 # Run pytest
 just validate FILE        # Validate one YAML against schema
 just validate-all         # Validate all community YAMLs
 just validate-references FILE  # Check evidence references (PubMed snippets)
-just qc                   # Full QC: validate-all + lint + test
+just qc                   # Full QC: lint + test + every offline validator
+just qc-references        # qc + the literature sweep (network; fails on main, #417)
 just gen-python           # Regenerate datamodel from schema
 just format               # black + ruff --fix
 just lint                 # black --check + ruff + mypy
 ```
+
+`validate-references` is not a CI gate and does not pass on `main` — most cited
+DOIs resolve to no fetchable content (#259) and some snippets paraphrase rather
+than quote (#347). It is out of `qc` on purpose: `just` stops at the first
+failing dependency, so having it there meant `lint` and `test` never ran (#417).
 
 Single test: `uv run pytest tests/test_datamodel.py::test_name -v`
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -82,7 +82,7 @@ just validate FILE                      # Verify
 just suggest-network-repairs            # Generate ($3-12)
 # Review offline, set approved: true
 just apply-batch-repairs REPORT         # Apply
-just qc                                 # Full validation
+just qc                                 # lint + tests + offline validators
 ```
 
 ### Workflow 3: Testing

--- a/justfile
+++ b/justfile
@@ -307,7 +307,6 @@ lint:
     uv run ruff check src/ tests/ scripts/
     uv run mypy src/
 
-# Full QC (lint + test + every offline validator)
 # `validate-gtdb-all` and `validate-scalars` also run inside validate-strict.
 # Only `validate-scalars` widens the scope — it covers kb/taxa, which
 # validate-strict's DEFAULT_ROOTS exclude; `validate-gtdb-all` scans exactly
@@ -328,10 +327,10 @@ lint:
 qc: lint test validate-all validate-taxa validate-strict validate-gtdb-all validate-scalars validate-terms-all validate-terms-taxa
     @echo "✅ All QC checks passed!"
 
-# `qc` plus the literature sweep. Separate because it is the one check that
-# cannot pass: it needs the network, and it reports ~320 errors on a clean `main`
-# for reasons already tracked — #259 (no DOI full-text cache path, so most cited
-# DOIs resolve to no content) and #347 (snippets paraphrase rather than quote).
+# Separate from `qc` because it is the one check that cannot pass: it needs the
+# network, and it reports ~320 errors on a clean `main` for reasons already
+# tracked — #259 (no DOI full-text cache path, so most cited DOIs resolve to no
+# content) and #347 (snippets paraphrase rather than quote).
 #
 # Having it inside `qc` meant `just qc` stopped there and never reached `lint` or
 # `test`, so the command named "check everything" silently skipped the only two

--- a/justfile
+++ b/justfile
@@ -307,7 +307,7 @@ lint:
     uv run ruff check src/ tests/ scripts/
     uv run mypy src/
 
-# Full QC (validate + strict validate + lint + test)
+# Full QC (lint + test + every offline validator)
 # `validate-gtdb-all` and `validate-scalars` also run inside validate-strict.
 # Only `validate-scalars` widens the scope — it covers kb/taxa, which
 # validate-strict's DEFAULT_ROOTS exclude; `validate-gtdb-all` scans exactly
@@ -315,8 +315,32 @@ lint:
 #
 # This is local convenience, not CI coverage: `qc` is invoked by no workflow,
 # and both checks already reach CI through pytest (#391, #406 review).
-qc: validate-all validate-taxa validate-strict validate-gtdb-all validate-scalars validate-terms-all validate-terms-taxa validate-references-all lint test
+#
+# Ordering is load-bearing. `just` stops at the first failing dependency, so
+# whatever runs last only runs on an otherwise-green tree. `lint` and `test`
+# come first because they are the gates CI enforces and the fastest to fail
+# (~40s and ~2min, against 5-7min for the strict and term sweeps) — a broken
+# build should say so before a seven-minute validator does.
+#
+# `validate-references-all` is deliberately NOT here; see `qc-references` (#417).
+#
+# Full QC: lint + test + every offline validator
+qc: lint test validate-all validate-taxa validate-strict validate-gtdb-all validate-scalars validate-terms-all validate-terms-taxa
     @echo "✅ All QC checks passed!"
+
+# `qc` plus the literature sweep. Separate because it is the one check that
+# cannot pass: it needs the network, and it reports ~320 errors on a clean `main`
+# for reasons already tracked — #259 (no DOI full-text cache path, so most cited
+# DOIs resolve to no content) and #347 (snippets paraphrase rather than quote).
+#
+# Having it inside `qc` meant `just qc` stopped there and never reached `lint` or
+# `test`, so the command named "check everything" silently skipped the only two
+# checks CI runs (#417). Reference validation is also not a CI gate, so a red
+# line here says nothing about whether a PR will pass.
+#
+# qc + the literature sweep (needs network; fails on main, see #259/#347)
+qc-references: qc validate-references-all
+    @echo "✅ QC + reference validation complete!"
 
 # Check which community strains are represented in UniProt reference proteomes
 uniprot-reference COMMUNITY_PATH="kb/communities":

--- a/prompts/backlog-loop.goal.md
+++ b/prompts/backlog-loop.goal.md
@@ -22,8 +22,8 @@ sibling repos (CultureMech/MIM/TraitMech), even for cross-Mech sync — report i
    a CI gate: a temporary commit **on your branch, never `main`** breaking one record;
    confirm it reddens at the right step; revert, and confirm that before merging.
 
-6. **Verify side effects, not exit codes.** `just qc` reddens for unrelated reasons;
-   scope to what you touched. Mutation-test new checks: substitute a wrong
+6. **Verify side effects, not exit codes.** `just qc` is green on `main`, so a red
+   one is yours; `qc-references` is not (#417). Mutation-test new checks: substitute a wrong
    implementations, confirm a test fails. Cover **both** sides of two-sided checks. A
    relative-path test can pass auditing nothing — assert the sweep was non-empty.
 

--- a/tests/test_qc_recipe_ordering.py
+++ b/tests/test_qc_recipe_ordering.py
@@ -1,0 +1,116 @@
+"""`just qc` must reach `lint` and `test` (#417).
+
+`just` stops at the first failing dependency. `qc` listed
+`validate-references-all` eighth of ten, and that recipe **cannot pass**: it
+needs the network, and it reports ~320 errors on a clean `main` for reasons
+already tracked (#259, no DOI full-text cache path; #347, snippets that
+paraphrase rather than quote).
+
+So the command named "check everything" stopped there every time and never ran
+`lint` or `test` — the only two checks CI actually enforces. It failed loudly
+enough to look like it had done its job, which is the worst way for a check to
+be broken.
+
+These tests read the recipe text rather than running it. Running `qc` takes
+~15 minutes and needs the kg-microbe checkout; the property worth guarding is a
+statement about the dependency list, and that is cheap to read.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).parent.parent
+JUSTFILE = REPO / "justfile"
+
+# Recipes that cannot pass offline or do not pass on `main` today. Keeping one
+# of these ahead of a gate hides the gate.
+_CANNOT_PASS = ("validate-references-all",)
+
+# What CI enforces. These must be reachable in a local `qc`.
+_CI_GATES = ("lint", "test")
+
+
+def _recipe_dependencies(name: str) -> list[str]:
+    """The dependency list of `name`, in order.
+
+    A just recipe header is `name: dep1 dep2` (or `name param="x": deps`), so
+    the dependencies are whatever follows the first unquoted colon on the line
+    that starts the recipe.
+    """
+    for line in JUSTFILE.read_text().splitlines():
+        match = re.match(rf"^{re.escape(name)}(?:\s+[^:]*)?:(?P<deps>.*)$", line)
+        if match:
+            return match.group("deps").split()
+    raise AssertionError(f"no `{name}` recipe in the justfile")
+
+
+def test_the_helper_finds_a_real_recipe():
+    """Guards every assertion below: a helper that found nothing would pass them."""
+    dependencies = _recipe_dependencies("qc")
+
+    assert len(dependencies) > 5, f"`qc` parsed as {dependencies}, which is not its dependency list"
+    assert "validate-all" in dependencies
+
+    with pytest.raises(AssertionError):
+        _recipe_dependencies("no-such-recipe-anywhere")
+
+
+@pytest.mark.parametrize("gate", _CI_GATES)
+def test_qc_runs_the_checks_ci_enforces(gate):
+    assert gate in _recipe_dependencies("qc"), (
+        f"`just qc` no longer runs `{gate}` — the gate CI enforces. A local QC "
+        f"command that skips it reports green on a build that will fail (#417)."
+    )
+
+
+@pytest.mark.parametrize("recipe", _CANNOT_PASS)
+def test_qc_does_not_depend_on_a_recipe_that_cannot_pass(recipe):
+    """The actual regression: one of these back in `qc` re-breaks it."""
+    assert recipe not in _recipe_dependencies("qc"), (
+        f"`{recipe}` is back in `qc`. It fails on a clean `main` (#259, #347) and "
+        f"needs the network, so `just` stops there and never reaches lint or test "
+        f"(#417). Put it in `qc-references` instead."
+    )
+
+
+@pytest.mark.parametrize("gate", _CI_GATES)
+def test_the_ci_gates_come_before_the_slow_validators(gate):
+    """Ordering, not just membership.
+
+    Being in the list is not enough — `lint` and `test` last would still mean a
+    seven-minute validator decides whether they run at all. They are also the
+    fastest things in the chain (~40s, ~2min against 5-7min), so failing early
+    is free.
+    """
+    dependencies = _recipe_dependencies("qc")
+    slow = [d for d in dependencies if d.startswith("validate-")]
+    assert slow, "no validators in `qc`; this test is stale"
+
+    assert dependencies.index(gate) < min(dependencies.index(s) for s in slow), (
+        f"`{gate}` runs after {slow[0]} in `qc`; a failure there would stop the "
+        f"run before the gate CI enforces (#417)"
+    )
+
+
+def test_the_reference_sweep_is_still_reachable():
+    """Removed from `qc`, not from the repo.
+
+    Dropping the check entirely would trade one silent gap for another — the
+    point is that it runs deliberately, not that it stops running.
+    """
+    dependencies = _recipe_dependencies("qc-references")
+
+    assert "validate-references-all" in dependencies
+    assert "qc" in dependencies, "`qc-references` should be a superset of `qc`"
+
+
+def test_the_docs_do_not_promise_qc_checks_references():
+    """CLAUDE.md is what a contributor reads before running anything."""
+    text = (REPO / "CLAUDE.md").read_text()
+
+    assert "just qc-references" in text, "CLAUDE.md does not mention the reference sweep"
+    assert "#417" in text, "CLAUDE.md does not explain why references are out of `qc`"


### PR DESCRIPTION
Closes #417.

## The bug

`just` stops at the first failing dependency:

```
qc: validate-all validate-taxa validate-strict validate-gtdb-all validate-scalars \
    validate-terms-all validate-terms-taxa validate-references-all lint test
                                           ^^^^^^^^^^^^^^^^^^^^^^^ always fails
```

`validate-references-all` **cannot pass**. It needs the network, and it reports
**320 errors and 35 warnings** on a clean `main`:

| class | already tracked |
|---|---|
| `No content available for reference: doi:...` | #259 — no DOI full-text cache path |
| `Text part not found ... only abstract available` | #347 — snippets paraphrase rather than quote |
| `Could not fetch reference` (35) | environmental |

So `just qc` stopped at check eight of ten and **never ran `lint` or `test`** —
the only two checks CI enforces. It ended in a red line, so it looked like it had
worked. I found it running QC for #414: the 1353-test suite had not executed.

## The fix

```
qc: lint test validate-all validate-taxa validate-strict validate-gtdb-all \
    validate-scalars validate-terms-all validate-terms-taxa

qc-references: qc validate-references-all
```

CI's gates run first, and they are also the fastest to fail — ~40s and ~2min
against 5-7min for the strict and term sweeps, so failing early is free. The
reference sweep is moved, not deleted: `qc-references` is a superset of `qc`, so
it stays one command away and runs deliberately.

Of the three options in #417 this is number 2. Option 3 (make it non-fatal) would
leave a permanently red line inside a green run, which trains people to ignore it.

## Verification

`just qc` **exits 0** — the first time it has completed:

```
Success: no issues found in 43 source files        <- mypy, ~40s in
1361 passed, 14 skipped, 7 deselected in 112.78s   <- pytest, ~2min in
✅ All QC checks passed!
```

Both markers appear in the first two minutes, which is precisely what the old
ordering prevented.

## Regression guard

`tests/test_qc_recipe_ordering.py` reads the recipe rather than running it (a
real run is ~15 min and needs the kg-microbe checkout). Mutation-tested against
all three ways this comes back:

| mutant | result |
|---|---|
| `validate-references-all` back in `qc` | **fails** |
| `lint test` moved to the end (the original shape) | **fails** |
| reference sweep dropped entirely | **fails** |
| unmutated | passes (8) |

It also pins CLAUDE.md, since that is what a contributor reads before running
anything, and `just --list` now renders a real description for both recipes
rather than the trailing fragment of a comment block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)