### PR TITLE
Re-ground the four ORT taxa to the families their own notes name (#416)

### DIFF
--- a/history/records/KBase_ORT_Workflow_Community_Model/2026-08-05T162059Z-claude-code-b3f015.yaml
+++ b/history/records/KBase_ORT_Workflow_Community_Model/2026-08-05T162059Z-claude-code-b3f015.yaml
@@ -1,0 +1,40 @@
+history_version: 1
+target:
+  kind: record
+  path: kb/communities/KBase_ORT_Workflow_Community_Model.yaml
+  slug: KBase_ORT_Workflow_Community_Model
+session:
+  id: 2026-08-05T162059Z-claude-code-b3f015
+  timestamp: '2026-08-05T16:20:59Z'
+  actors:
+  - type: ai_agent
+    name: claude-code
+    model: claude-opus-5
+    agent_tool: claude-code
+links:
+  issues:
+  - https://github.com/CultureBotAI/CommunityMech/issues/416
+events:
+- type: EDIT
+  outcome: needs_followup
+  sections:
+  - members
+  summary: Re-ground four taxa from ancestor NCBITaxon ids to the families their notes name
+  details: 'All four taxon_terms carried an NCBITaxon id far above the taxon their preferred_term
+    and notes named: ''Nitrososphaeraceae archaeon'' and ''Nitrospiraceae bacterium'' on domain/class
+    ids, and both ''Steroidobacteraceae denitrifier'' entries on NCBITaxon:1236 (class Gammaproteobacteria).
+    Each record note names the family explicitly, sourced from PMID:34726691 (Columbia River
+    sediment MAGs), so the family assignment is the record''s own claim and not a new one.
+    Changed: Nitrososphaeraceae archaeon NCBITaxon:2157 -> NCBITaxon:1033997; Nitrospiraceae
+    bacterium NCBITaxon:1236 -> NCBITaxon:189779; both Steroidobacteraceae denitrifiers NCBITaxon:1236
+    -> NCBITaxon:2689614, resolved with runoak against sqlite:obo:ncbitaxon. GTDB blocks were
+    then regenerated with gtdb_ground.py --apply --refresh, moving three groundings off tautological
+    ranks: d__Archaea -> f__Nitrososphaeraceae (51/51 genomes, majority 1.0) and c__Gammaproteobacteria
+    -> f__Steroidobacteraceae (15/15, 1.0) twice. Outcome is needs_followup, not changed,
+    because the fourth taxon is deliberately still ungrounded: GTDB''s majority for NCBI Nitrospiraceae
+    is f__Leptospirillaceae at 0.534 (31/58), a near-tie of the kind issue #396 covers, and
+    Leptospirillum is an iron oxidizer whereas this genome is the record''s nitrite oxidizer.
+    Taking that vote would assign the wrong physiology, so the WITHHELD pin in gtdb_ground.py
+    is kept with its reason rewritten; the old reason (the bad NCBITaxon:1236 id) no longer
+    applies. A curator still has to pick. Validated: just validate, validate-terms, validate-gtdb,
+    validate-scalars all pass on the record.'

--- a/kb/communities/KBase_ORT_Workflow_Community_Model.yaml
+++ b/kb/communities/KBase_ORT_Workflow_Community_Model.yaml
@@ -45,19 +45,19 @@ taxonomy:
 - taxon_term:
     preferred_term: Nitrososphaeraceae archaeon
     term:
-      id: NCBITaxon:2157
-      label: Archaea
+      id: NCBITaxon:1033997
+      label: Nitrososphaeraceae
     gtdb_grounding_status: GROUNDED
     gtdb_classification:
-      gtdb_id: GTDB:d__Archaea
-      gtdb_taxon: Archaea
-      gtdb_lineage: d__Archaea
-      ncbi_source_id: NCBITaxon:2157
+      gtdb_id: GTDB:f__Nitrososphaeraceae
+      gtdb_taxon: Nitrososphaeraceae
+      gtdb_lineage: d__Archaea;p__Thermoproteota;c__Nitrososphaeria;o__Nitrososphaerales;f__Nitrososphaeraceae
+      ncbi_source_id: NCBITaxon:1033997
       majority_fraction: 1.0
-      support_genomes: 7446
-      total_genomes: 7448
+      support_genomes: 51
+      total_genomes: 51
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at d__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at f__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Archaeal genome classified as Nitrososphaeraceae (family level), genus TA-21, from Columbia
       River sediments. Functions as ammonium oxidizer in the nitrogen cycle.
   functional_role:
@@ -71,8 +71,8 @@ taxonomy:
 - taxon_term:
     preferred_term: Nitrospiraceae bacterium
     term:
-      id: NCBITaxon:1236
-      label: Gammaproteobacteria
+      id: NCBITaxon:189779
+      label: Nitrospiraceae
     gtdb_grounding_status: WITHHELD
     notes: Bacterial member of Nitrospiraceae family from Columbia River sediments. Functions as nitrite
       oxidizer in the nitrogen cycle.
@@ -87,19 +87,19 @@ taxonomy:
 - taxon_term:
     preferred_term: Steroidobacteraceae denitrifier 1
     term:
-      id: NCBITaxon:1236
-      label: Gammaproteobacteria
+      id: NCBITaxon:2689614
+      label: Steroidobacteraceae
     gtdb_grounding_status: GROUNDED
     gtdb_classification:
-      gtdb_id: GTDB:c__Gammaproteobacteria
-      gtdb_taxon: Gammaproteobacteria
-      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria
-      ncbi_source_id: NCBITaxon:1236
+      gtdb_id: GTDB:f__Steroidobacteraceae
+      gtdb_taxon: Steroidobacteraceae
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Steroidobacterales;f__Steroidobacteraceae
+      ncbi_source_id: NCBITaxon:2689614
       majority_fraction: 1.0
-      support_genomes: 744655
-      total_genomes: 744658
+      support_genomes: 15
+      total_genomes: 15
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at f__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Gammaproteobacterial genome within family Steroidobacteraceae from Columbia River sediments.
       Functions as denitrifier reducing nitrate to nitrogen gas.
   functional_role:
@@ -113,19 +113,19 @@ taxonomy:
 - taxon_term:
     preferred_term: Steroidobacteraceae denitrifier 2
     term:
-      id: NCBITaxon:1236
-      label: Gammaproteobacteria
+      id: NCBITaxon:2689614
+      label: Steroidobacteraceae
     gtdb_grounding_status: GROUNDED
     gtdb_classification:
-      gtdb_id: GTDB:c__Gammaproteobacteria
-      gtdb_taxon: Gammaproteobacteria
-      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria
-      ncbi_source_id: NCBITaxon:1236
+      gtdb_id: GTDB:f__Steroidobacteraceae
+      gtdb_taxon: Steroidobacteraceae
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Steroidobacterales;f__Steroidobacteraceae
+      ncbi_source_id: NCBITaxon:2689614
       majority_fraction: 1.0
-      support_genomes: 744655
-      total_genomes: 744658
+      support_genomes: 15
+      total_genomes: 15
       is_reclassified: false
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 2 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at f__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Second gammaproteobacterial genome within family Steroidobacteraceae from Columbia River sediments.
       Functions as denitrifier reducing nitrate to nitrogen gas.
   functional_role:

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -778,7 +778,13 @@ WITHHELD_GROUNDINGS = {
         "NCBITaxon:821 is Phocaeicola vulgatus; B. ovatus is NCBITaxon:28116."
     ),
     ("KBase_ORT_Workflow_Community_Model.yaml", "Nitrospiraceae bacterium"): (
-        "NCBITaxon:1236 is class Gammaproteobacteria, not a Nitrospiraceae bacterium."
+        "GTDB's majority for NCBI Nitrospiraceae is f__Leptospirillaceae at 0.534 "
+        "(31/58 genomes), and Leptospirillum is an iron oxidizer while this genome "
+        "is the record's nitrite oxidizer — so the majority vote would assign the "
+        "wrong physiology. A near-tie of this kind is #396's class. Withheld until "
+        "a curator picks. (Was withheld because the id was NCBITaxon:1236, class "
+        "Gammaproteobacteria; that is fixed — it is now NCBITaxon:189779 — but the "
+        "grounding is still not safe to take automatically, #416.)"
     ),
 }
 


### PR DESCRIPTION
Closes #416.

## Scope grew from one taxon to four, in the same record

#416 was filed for *Nitrososphaeraceae archaeon*. Reading
`KBase_ORT_Workflow_Community_Model.yaml`, all four taxa have the same defect —
`preferred_term` names a family, `term.id` is an ancestor two to five ranks up:

| preferred_term | was | is now |
|---|---|---|
| Nitrososphaeraceae archaeon | `NCBITaxon:2157` Archaea | `NCBITaxon:1033997` Nitrososphaeraceae |
| Nitrospiraceae bacterium | `NCBITaxon:1236` Gammaproteobacteria | `NCBITaxon:189779` Nitrospiraceae |
| Steroidobacteraceae denitrifier 1 | `NCBITaxon:1236` Gammaproteobacteria | `NCBITaxon:2689614` Steroidobacteraceae |
| Steroidobacteraceae denitrifier 2 | `NCBITaxon:1236` Gammaproteobacteria | `NCBITaxon:2689614` Steroidobacteraceae |

Fixing them one at a time would touch the same file four times, so they are here
together.

## One was a wrong organism, not just an imprecise one

*Nitrospiraceae* is in **Nitrospirota**. A Nitrospiraceae bacterium was carrying
a **Pseudomonadota** class id — a different phylum, not an ancestor.

The id↔label gate cannot catch this: `NCBITaxon:1236` really is labelled
`Gammaproteobacteria`, so the pair is internally consistent. Only
`preferred_term` disagrees, and nothing compares those. That is #292's class.

## Evidence

Every one of the four `notes` names its family outright, citing PMID:34726691
(Columbia River sediment MAGs) — e.g. *"Archaeal genome classified as
Nitrososphaeraceae (family level), genus TA-21"*. So the family assignment is
the record's existing claim; this PR makes `term.id` agree with it rather than
asserting anything new. Ids resolved with `runoak` against
`sqlite:obo:ncbitaxon`. Genus TA-21 has no NCBITaxon term (it is a GTDB
placeholder), so family is the finest rank available.

## GTDB, regenerated

`gtdb_ground.py --apply --refresh` moved three groundings off tautological
ranks, both at full support:

```
d__Archaea             -> f__Nitrososphaeraceae   51/51 genomes, majority 1.0
c__Gammaproteobacteria -> f__Steroidobacteraceae  15/15 genomes, majority 1.0  (x2)
```

The diff touches only `gtdb_id`, `gtdb_taxon`, `gtdb_lineage`, `ncbi_source_id`,
the genome counts and `mapping_source` — verified line by line.

## The fourth stays ungrounded, deliberately

GTDB's majority for NCBI *Nitrospiraceae* is `f__Leptospirillaceae` at **0.534**
(31/58 genomes) — a near-tie of exactly the kind #396 is about. And
*Leptospirillum* is an **iron** oxidizer, whereas this genome is the record's
**nitrite** oxidizer. Taking the majority vote would assign the wrong physiology
with a plausible-looking confidence number attached.

So the `WITHHELD` pin stays, with its reason rewritten — the old one cited the
bad `NCBITaxon:1236` id, which this PR fixes, and would otherwise have become a
stale justification for a still-correct decision.

## Provenance

Recorded as a curation-history record (#325, #395), outcome **`needs_followup`**
rather than `changed`, because that fourth taxon still needs a curator.

## Verification

`just qc` exits 0 over the whole tree — lint, 1361 tests, and every offline
validator, including `validate-terms` on the four new id↔label pairs.

## Filed, not fixed here

**#419** — I swept all 715 grounded blocks for this defect shape. Most hits are
**correct** and must not be touched (`EET-capable Rifle aquifer Firmicutes` on
`NCBITaxon:1239` is an honest phylum-level group name; `rhizosphere
Actinobacteria` on Actinomycetota is a synonym, not a mismatch). After filtering
those, exactly one clear case remains — *Candidatus Accumulibacter phosphatis*
on `NCBITaxon:28216` (class Betaproteobacteria) where the genus is
`NCBITaxon:327159`. It needs a curator because "and related PAOs" makes the entry
a group, so narrowing the id would make the scope claim wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)