### PR TITLE
Mark near-tie groundings in the CLI rather than leaving 0.50098 unremarked (#396)

### DIFF
--- a/.claude/skills/ground-taxa-gtdb/SKILL.md
+++ b/.claude/skills/ground-taxa-gtdb/SKILL.md
@@ -198,6 +198,26 @@ taxonomy entries and their id anchors do not line up.
   on the chosen GTDB taxon. Lower values (e.g. *Bacillus* 0.57) warrant a curator
   glance.
 
+  Below **0.55** the CLI says so outright, printing `⚠ NEAR-TIE` beside the
+  fraction (#396). A strict `> 0.5` threshold (#394) stopped a *tie-break* from
+  deciding a grounding; it did not make the survivors well-supported. Four blocks
+  sit at **0.50098** — 226306 against 225423, a margin of 883 genomes in 451729.
+
+  Take the marker seriously rather than as a formality. NCBI *Nitrospiraceae*
+  grounds to `f__Leptospirillaceae` at 0.534, and *Leptospirillum* is an **iron**
+  oxidizer — in #416 that was about to be attached to a record's **nitrite**
+  oxidizer. A near-tie is not "slightly less certain"; it is often two different
+  organisms with a number in between.
+
+  The distribution is heavily bimodal, so the marker is rare: of 715 groundings,
+  **649 are ≥ 0.90** and only **5 fall below 0.55**. One of those five is
+  `g__Syntrophotalea` at exactly 0.5, which is in the KB only because a curator
+  pinned it against the vote — it carries `curated: true` and a note (#384).
+
+  The marker is advisory: nothing is stored and nothing is withheld. There is no
+  natural cut point, and raising the threshold would withdraw blocks on a policy
+  judgement nobody has made — a 60/40 split is not a strong statement either.
+
 - **`total_genomes`** — how many genomes the majority was computed over, i.e.
   what the fraction is a fraction *of* (#383). Read it *before* trusting a
   fraction: `1.0` on `7/7` and `1.0` on `7000/7000` are the same number and very

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -76,6 +76,36 @@ COL_GTDB_SPECIES = 18
 # crosswalk, so moving it first changes nothing today — I checked all 1032 KB
 # taxa. Ordering is what would keep it correct if that ever stopped holding
 # (#402 review).
+# A grounding this close to the 0.5 line is a coin flip that landed right (#396).
+#
+# 0.55 is a judgement call and is meant to be: there is no natural cut point in
+# the distribution, which is why #396 rejected *raising* the threshold. It sits
+# where it does because the population either side is stable — 5 blocks below
+# 0.55, then a gap to 0.57 — so the marker points at the genuinely marginal ones
+# instead of crying wolf across the 35 blocks between 0.7 and 0.9.
+#
+# Deliberately advisory. It changes no stored value and withholds no grounding;
+# it only makes the tool say so where a curator will see it.
+NEAR_TIE_BELOW = 0.55
+
+
+def _is_near_tie(fraction) -> bool:
+    """Is this grounding close enough to 0.5 to be a coin flip?
+
+    False for a missing fraction: "unknown" is not "marginal".
+
+    A pure function of the number, deliberately — it does not consult `curated`.
+    The KB's one sub-threshold block (`g__Syntrophotalea` at exactly 0.5) really
+    is a coin flip; that a curator chose it anyway (#384) is a separate fact the
+    block records for itself.
+
+    No `isinstance(fraction, bool)` guard. Booleans are ints in Python, so one
+    looked prudent — but `True` is 1, above the bound, and `False` is 0, which
+    fails `0 < fraction`. It was dead code: removing it failed no test.
+    """
+    return isinstance(fraction, (int, float)) and 0 < fraction < NEAR_TIE_BELOW
+
+
 HIGHER_RANKS = [
     (9, 17, "g"),
     (8, 16, "f"),
@@ -1510,7 +1540,19 @@ def main(argv: list[str] | None = None) -> int:
         else:
             of = ""
         thin = "  ⚠ THIN" if total and total < 10 else ""
-        print(f"  majority     : {g['majority_fraction']}{via}{of}{thin}")
+        # A grounding just over the line is a coin flip that happened to land
+        # right. #394 moved the threshold from >=0.5 to >0.5 so a tie-break could
+        # no longer decide a grounding, but it did not make the survivors
+        # well-supported: four blocks sit at 0.50098 — 226306 against 225423,
+        # a margin of 883 genomes in 451729 (#396).
+        #
+        # Marked rather than withheld, because there is no natural cut point and
+        # raising the threshold is a curation policy call. What a curator needs
+        # is to be told at the moment of decision. #416 is the case in point: a
+        # 0.534 majority put an *iron* oxidizer (f__Leptospirillaceae) on the
+        # record's *nitrite* oxidizer. The number alone did not say "look here".
+        near = "  ⚠ NEAR-TIE" if _is_near_tie(g.get("majority_fraction")) else ""
+        print(f"  majority     : {g['majority_fraction']}{via}{of}{thin}{near}")
         if args.emit_yaml:
             print("  --- gtdb_classification block ---")
             for line in emit_block(g, mapping_source).splitlines():

--- a/tests/test_gtdb_near_tie_marker.py
+++ b/tests/test_gtdb_near_tie_marker.py
@@ -1,0 +1,165 @@
+"""A grounding just over 0.5 is a coin flip that landed right (#396).
+
+#394 moved the threshold from `>=0.5` to `>0.5`, so a tie-break can no longer
+*decide* a grounding. That is narrower than it sounds, and #396 was filed so the
+stronger reading does not take hold: it removed the exact ties, not the near
+ones. Four blocks sit at **0.50098** — 226306 against 225423, a margin of 883
+genomes in 451729.
+
+The marker is advisory. It stores nothing and withholds nothing, because there is
+no natural cut point in the distribution and raising the threshold is a curation
+policy call (#396 option 3, rejected there). What it does is tell a curator at
+the moment of decision.
+
+#416 is why that matters. NCBI *Nitrospiraceae* grounds to
+`f__Leptospirillaceae` at 0.534 — and *Leptospirillum* is an **iron** oxidizer
+while the record's genome is its **nitrite** oxidizer. The majority vote would
+have assigned the wrong physiology, wearing a confidence number that looked like
+a decision rather than a coin flip.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).parent.parent
+
+
+def _module():
+    spec = importlib.util.spec_from_file_location("_gtdb", REPO / "scripts/gtdb_ground.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("fraction", "expected"),
+    [
+        (0.50098, True),  # the four Bacillota blocks
+        (0.501, True),
+        (0.534, True),  # the #416 Nitrospiraceae case
+        (0.5449, True),
+        (0.55, False),  # the bound is exclusive
+        (0.57, False),  # g__Bacillus, the next real population up
+        (1.0, False),
+        # "unknown" is not "marginal". (A curated block may still carry a
+        # fraction — the KB's does, at 0.5 — so this is about absence, not
+        # about curation.)
+        (None, False),
+        ("0.5", False),
+        # Booleans are ints in Python. They are excluded by the range rather
+        # than by a type guard: `True` is 1 (above the bound) and `False` is 0
+        # (fails `0 < fraction`). An explicit guard was dead code.
+        (True, False),
+        (False, False),
+        (0, False),
+    ],
+)
+def test_the_predicate_fires_only_on_a_near_tie(fraction, expected):
+    assert _module()._is_near_tie(fraction) is expected
+
+
+def test_the_bound_is_where_the_population_gap_is():
+    """The threshold is a judgement call, so pin what justified it.
+
+    5 blocks below 0.55, then a gap to 0.57. If the KB drifts so the marker
+    covers a crowd, it stops pointing at anything and should be revisited.
+    """
+    fractions = sorted(
+        block["majority_fraction"]
+        for _, block in _grounded()
+        if isinstance(block.get("majority_fraction"), (int, float))
+    )
+    marked = [f for f in fractions if f < _module().NEAR_TIE_BELOW]
+
+    assert len(marked) <= 12, (
+        f"{len(marked)} of {len(fractions)} groundings are now near-ties; the "
+        f"marker is supposed to single out the marginal few (#396)"
+    )
+    assert marked, "no near-ties at all — either the KB changed or the bound is wrong"
+
+
+def _grounded():
+    for path in sorted((REPO / "kb/communities").glob("*.yaml")):
+        for entry in (yaml.safe_load(path.read_text()) or {}).get("taxonomy") or []:
+            block = (entry.get("taxon_term") or {}).get("gtdb_classification")
+            if block:
+                yield path.name, block
+
+
+def test_the_known_near_ties_are_still_there():
+    """The population #396 documents, so it cannot shrink unnoticed.
+
+    Five blocks, and they are two different things:
+
+    * four `p__Bacillota_A` at 0.50098 — the tool's own output, retained because
+      0.50098 > 0.5. These are what #396 is about.
+    * one `g__Syntrophotalea` at exactly 0.5, which the threshold would reject.
+      It is in the KB because a curator pinned it against the vote (#384), and
+      it carries `curated: true` saying so.
+
+    That second one is why the *flag* stays a pure function of the fraction while
+    the *judgement* does not: 0.5 really is a coin flip, and the record already
+    answers "should someone look at this" with a curation note.
+    """
+    near = [
+        (name, block["gtdb_id"], bool(block.get("curated")))
+        for name, block in _grounded()
+        if _module()._is_near_tie(block.get("majority_fraction"))
+    ]
+    uncurated = [(n, g) for n, g, curated in near if not curated]
+
+    assert len(uncurated) >= 4, f"expected the 0.50098 Bacillota blocks, found {near}"
+    assert all(gtdb_id == "GTDB:p__Bacillota_A" for _, gtdb_id in uncurated), uncurated
+    # Every block at or below the strict threshold must be a deliberate override,
+    # or the threshold is not being enforced.
+    for name, block in _grounded():
+        fraction = block.get("majority_fraction")
+        if isinstance(fraction, (int, float)) and fraction <= 0.5:
+            assert block.get("curated") is True, (
+                f"{name}: {block['gtdb_id']} sits at {fraction} with no `curated` "
+                f"flag — a non-majority grounding that nobody chose (#394)"
+            )
+
+
+@pytest.mark.parametrize(
+    ("name", "marked"),
+    [
+        ("Bacillota", True),  # 0.501 -- 226306/451729
+        ("Nitrospiraceae", True),  # 0.534 -- the #416 case
+        ("Bacillus", False),  # 0.57 -- just above
+        ("Steroidobacteraceae", False),  # 1.0
+    ],
+)
+def test_the_cli_marks_the_right_groundings(name, marked):
+    """End to end through the CLI, which is where a curator actually sees it."""
+    result = subprocess.run(
+        ["uv", "run", "python", "scripts/gtdb_ground.py", "--name", name],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+        timeout=900,
+    )
+    lines = [ln for ln in result.stdout.splitlines() if "majority" in ln]
+    if not lines:
+        pytest.skip(f"{name} no longer grounds; this test is stale")
+
+    assert ("NEAR-TIE" in lines[0]) is marked, lines[0]
+
+
+def test_the_marker_does_not_replace_thin():
+    """Two different weaknesses; a block can have either, both, or neither.
+
+    THIN is "too few genomes to say anything"; NEAR-TIE is "plenty of genomes,
+    split down the middle". Collapsing them would hide the 0.50098 blocks, which
+    have 451729 genomes and are anything but thin.
+    """
+    source = (REPO / "scripts/gtdb_ground.py").read_text()
+
+    assert "⚠ THIN" in source and "⚠ NEAR-TIE" in source
+    assert "{thin}{near}" in source, "both markers should be able to appear together"


### PR DESCRIPTION
Closes #396.

## Why not option 1

#396 offered three options and leaned toward the first — close as documentation,
since `support_genomes`/`total_genomes` are stored (#383) and a reader can judge
226306/451729 for themselves.

#416, curated after #396 was filed, is the counter-evidence. NCBI
*Nitrospiraceae* grounds to `f__Leptospirillaceae` at **0.534**. *Leptospirillum*
is an **iron** oxidizer; the record's genome is its **nitrite** oxidizer. Every
number needed to catch that was already in the block, and none of them said
"look here". A near-tie is frequently not "slightly less certain" — it is two
different organisms with a number in between.

Option 3 (raise the threshold) stays rejected for the reason #396 gives: there is
no natural cut point, and a 60/40 split is not a strong statement either.

## What this does — option 2, lightest form

```
  majority     : 0.501  (at p__ rank)  [226306/451729 genomes]  ⚠ NEAR-TIE
  majority     : 0.534  (at f__ rank)  [31/58 genomes]  ⚠ NEAR-TIE
  majority     : 0.57   (at g__ rank)  [4981/8737 genomes]
  majority     : 1.0    (at f__ rank)  [15/15 genomes]
```

Advisory only: **nothing stored, nothing withheld, no threshold moved.** It sits
beside the existing `⚠ THIN`, and the two are independent — the 0.50098 blocks
rest on 451729 genomes and are anything but thin.

## The bound is a judgement, and is documented as one

The distribution is bimodal, which is what makes a marker useful at all:

| band | blocks |
|---|---|
| ≥ 0.90 | 649 |
| 0.70–0.90 | 35 |
| 0.60–0.70 | 11 |
| 0.55–0.60 | 15 |
| **< 0.55** | **5** |

Five below 0.55, then a gap to 0.57. A test pins that the marked population stays
small — if it ever covers a crowd it has stopped pointing at anything.

## Two things the tests turned up

**A block sits *below* the threshold.** `g__Syntrophotalea` at exactly 0.5 —
which `> 0.5` should reject. It is there because a curator pinned it against the
vote (#384) and it carries `curated: true` with a note. My first test asserted
all near-ties were `p__Bacillota_A`, which was simply false. It now asserts the
stronger and more useful property: **every block at or below 0.5 must be a
deliberate override**, or the threshold is not being enforced.

**A guard I wrote was dead code.** `isinstance(fraction, bool)` looked prudent —
booleans are ints in Python — but `True` is 1, above the bound, and `False` is 0,
which fails `0 < fraction`. Removing it failed no test, so it is gone rather than
left looking load-bearing. Mutation testing found this, not review.

| mutant | result |
|---|---|
| bound 0.55 → 0.5001 | **fails** (7 tests) |
| bool guard removed | passes → so it was removed |
| unmutated | passes (19) |

`just qc` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)