### PR TITLE
Give the tool an NCBI lineage source so NO_GTDB_EQUIVALENT is evidence-backed (#393)

### DIFF
--- a/data/isolates/Aspergillus_Indium_LED_Recovery.yaml
+++ b/data/isolates/Aspergillus_Indium_LED_Recovery.yaml
@@ -53,7 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:5061
       label: Aspergillus niger
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Filamentous fungus widely used in industrial biotechnology for organic acid production, now adapted for critical
       materials recovery from electronic waste. A. niger is a GRAS (Generally Recognized As Safe) organism with extensive
       industrial history in citric acid fermentation, enzyme production, and bioprocessing applications. This saprophytic

--- a/kb/communities/At_RSPHERE_SynCom.yaml
+++ b/kb/communities/At_RSPHERE_SynCom.yaml
@@ -45,7 +45,7 @@ taxonomy:
     term:
       id: NCBITaxon:3702
       label: Arabidopsis thaliana
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.yaml
+++ b/kb/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.yaml
@@ -57,7 +57,7 @@ taxonomy:
     term:
       id: NCBITaxon:2759
       label: Eukaryota
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 18S rRNA gene sequences of 13C-enriched microeukaryotic bacterivores
       and fungi were identified in the SIP fractions.
   functional_role:
@@ -74,7 +74,7 @@ taxonomy:
     term:
       id: NCBITaxon:10239
       label: Viruses
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 10 circularized phage genomes were recovered; some were the most
       labeled entities in the rhizosphere.
   evidence:

--- a/kb/communities/BSFL_Gut_SynCom_Bacillus_Lactobacillus_Issatchenkia.yaml
+++ b/kb/communities/BSFL_Gut_SynCom_Bacillus_Lactobacillus_Issatchenkia.yaml
@@ -84,7 +84,7 @@ taxonomy:
     term:
       id: NCBITaxon:4919
       label: Pichia
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: The paper names the yeast member as "Issatchenkia"; the genus Issatchenkia is a synonym of
       the NCBITaxon genus Pichia (NCBITaxon:4919), which is the canonical label. Grounded at genus rank.
   functional_role:

--- a/kb/communities/Banana_Fusarium_Biocontrol_SynCom12.yaml
+++ b/kb/communities/Banana_Fusarium_Biocontrol_SynCom12.yaml
@@ -69,7 +69,7 @@ taxonomy:
     term:
       id: NCBITaxon:29875
       label: Trichoderma virens
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.yaml
+++ b/kb/communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.yaml
@@ -25,7 +25,7 @@ taxonomy:
     term:
       id: NCBITaxon:2697049
       label: Severe acute respiratory syndrome coronavirus 2
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Complete and nearly complete SARS-CoV-2 genomes assembled from
       municipal sewage metatranscriptomes.
   evidence:

--- a/kb/communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.yaml
+++ b/kb/communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.yaml
@@ -70,7 +70,7 @@ taxonomy:
     term:
       id: NCBITaxon:5722
       label: Trichomonas vaginalis
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: The protozoan parasite; a eukaryote, so it receives no GTDB grounding.
   evidence:
   - reference: PMID:41688526
@@ -85,7 +85,7 @@ taxonomy:
     term:
       id: NCBITaxon:9606
       label: Homo sapiens
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Host epithelium, represented by the HeLa cell line. Grounded to the host species, since
       NCBITaxon has no term for a cell line.
   evidence:

--- a/kb/communities/BioAsteroid_ISS_Chondrite_Biomining_Consortium.yaml
+++ b/kb/communities/BioAsteroid_ISS_Chondrite_Biomining_Consortium.yaml
@@ -120,7 +120,7 @@ taxonomy:
     term:
       id: NCBITaxon:69488
       label: Penicillium simplicissimum
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: >
       Ascomycete fungus (DSMZ strain DSM 1078) known for its capacity to perform
       bioleaching. In this experiment it was the most effective bioleaching

--- a/kb/communities/BioModels_MODEL1806250003_Spittlebug_Sulcia_Sodalis.yaml
+++ b/kb/communities/BioModels_MODEL1806250003_Spittlebug_Sulcia_Sodalis.yaml
@@ -11,14 +11,14 @@ taxonomy:
     term:
       id: NCBITaxon:36667
       label: Philaenus spumarius
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
 - taxon_term:
     preferred_term: Sulcia
     term:
-      id: NCBITaxon:2716471
-      label: Sulcia
+      id: NCBITaxon:336809
+      label: Candidatus Karelsulcia
     gtdb_grounding_status: UNRESOLVED
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -60,8 +60,8 @@ ecological_interactions:
   source_taxon:
     preferred_term: Sulcia
     term:
-      id: NCBITaxon:2716471
-      label: Sulcia
+      id: NCBITaxon:336809
+      label: Candidatus Karelsulcia
   target_taxon:
     preferred_term: Philaenus spumarius
     term:

--- a/kb/communities/BioModels_MODEL1806250004_Sharpshooter_Sulcia_Baumannia.yaml
+++ b/kb/communities/BioModels_MODEL1806250004_Sharpshooter_Sulcia_Baumannia.yaml
@@ -11,14 +11,14 @@ taxonomy:
     term:
       id: NCBITaxon:236401
       label: Graphocephala coccinea
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
 - taxon_term:
     preferred_term: Sulcia
     term:
-      id: NCBITaxon:2716471
-      label: Sulcia
+      id: NCBITaxon:336809
+      label: Candidatus Karelsulcia
     gtdb_grounding_status: UNRESOLVED
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -55,8 +55,8 @@ ecological_interactions:
   source_taxon:
     preferred_term: Sulcia
     term:
-      id: NCBITaxon:2716471
-      label: Sulcia
+      id: NCBITaxon:336809
+      label: Candidatus Karelsulcia
   target_taxon:
     preferred_term: Graphocephala coccinea
     term:

--- a/kb/communities/BioModels_MODEL1806250005_Cicada_Sulcia_Hodgkinia.yaml
+++ b/kb/communities/BioModels_MODEL1806250005_Cicada_Sulcia_Hodgkinia.yaml
@@ -11,14 +11,14 @@ taxonomy:
     term:
       id: NCBITaxon:1699721
       label: Neotibicen canicularis
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
 - taxon_term:
     preferred_term: Sulcia
     term:
-      id: NCBITaxon:2716471
-      label: Sulcia
+      id: NCBITaxon:336809
+      label: Candidatus Karelsulcia
     gtdb_grounding_status: UNRESOLVED
   functional_role:
   - SYNTROPHIC_PARTNER
@@ -55,8 +55,8 @@ ecological_interactions:
   source_taxon:
     preferred_term: Sulcia
     term:
-      id: NCBITaxon:2716471
-      label: Sulcia
+      id: NCBITaxon:336809
+      label: Candidatus Karelsulcia
   target_taxon:
     preferred_term: Neotibicen canicularis
     term:

--- a/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
+++ b/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
@@ -161,7 +161,7 @@ taxonomy:
     term:
       id: NCBITaxon:34358
       label: Maudiozyma exigua
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - CROSS_FEEDER
   evidence:

--- a/kb/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.yaml
+++ b/kb/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.yaml
@@ -47,7 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:3041
       label: Chlorophyta
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Photosynthetic algal biofilm at the sediment surface that changes oxygen availability under a
       diel light-dark cycle.
   functional_role:

--- a/kb/communities/Candida_Parapsilosis_Hospitalized_Infant_Microbiome.yaml
+++ b/kb/communities/Candida_Parapsilosis_Hospitalized_Infant_Microbiome.yaml
@@ -26,7 +26,7 @@ taxonomy:
     term:
       id: NCBITaxon:5480
       label: Candida parapsilosis
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: A common cause of invasive candidiasis, especially in newborn
       infants, with five unique genomes assembled from this cohort.
   functional_role:

--- a/kb/communities/CeMbio_Caenorhabditis_Elegans_Microbiome.yaml
+++ b/kb/communities/CeMbio_Caenorhabditis_Elegans_Microbiome.yaml
@@ -79,7 +79,7 @@ taxonomy:
     term:
       id: NCBITaxon:6239
       label: Caenorhabditis elegans
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Genetically tractable nematode host colonized by the CeMbio bacterial community.
   abundance_value: Host organism for the defined bacterial community.
   evidence:

--- a/kb/communities/Cheese_Rind_InSitu_InVitro_Model_Community.yaml
+++ b/kb/communities/Cheese_Rind_InSitu_InVitro_Model_Community.yaml
@@ -96,7 +96,7 @@ taxonomy:
     term:
       id: NCBITaxon:4958
       label: Debaryomyces
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Genus-level yeast member enriched under low-moisture natural-rind conditions in the in vitro
       treatment.
   abundance_level: ABUNDANT
@@ -111,7 +111,7 @@ taxonomy:
     term:
       id: NCBITaxon:5073
       label: Penicillium
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Filamentous fungal genus detected in mature natural-rind succession and reconstructed in vitro
       communities.
   abundance_level: ABUNDANT

--- a/kb/communities/Chlamydomonas_Bacterial_H2_Consortium.yaml
+++ b/kb/communities/Chlamydomonas_Bacterial_H2_Consortium.yaml
@@ -40,7 +40,7 @@ taxonomy:
     term:
       id: NCBITaxon:3055
       label: Chlamydomonas reinhardtii
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_PRODUCER

--- a/kb/communities/Chlamydomonas_Methylobacterium_Mutualism.yaml
+++ b/kb/communities/Chlamydomonas_Methylobacterium_Mutualism.yaml
@@ -29,7 +29,7 @@ taxonomy:
     term:
       id: NCBITaxon:3055
       label: Chlamydomonas reinhardtii
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Single-celled, photosynthetic green alga serving as the primary producer in this consortium.
       C. reinhardtii is a model organism for photosynthesis and stress response research. Under nitrogen
       stress, it exhibits altered physiology and increased susceptibility to bacterial interactions.

--- a/kb/communities/Chlorella_Azospirillum_Synthetic_Mutualism.yaml
+++ b/kb/communities/Chlorella_Azospirillum_Synthetic_Mutualism.yaml
@@ -56,7 +56,7 @@ taxonomy:
     term:
       id: NCBITaxon:3076
       label: Chlorella sorokiniana
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: >
       Source publications identify strain UTEX 2714; ontology grounding is
       species-level because the stable NCBI Taxonomy term used here is

--- a/kb/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.yaml
+++ b/kb/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.yaml
@@ -54,7 +54,7 @@ taxonomy:
     term:
       id: NCBITaxon:3071
       label: Chlorella
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: >
       The publication identifies the algal member as Chlorella minutissima.
       Genus-level NCBITaxon grounding is used because a verified NCBI species

--- a/kb/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.yaml
+++ b/kb/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.yaml
@@ -62,7 +62,7 @@ taxonomy:
     term:
       id: NCBITaxon:3073
       label: Scenedesmus fuscus
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: The paper's "Chlorella fusca CHK0059" — NCBITaxon carries this organism under the current
       name Scenedesmus fuscus, with "Chlorella fusca" retained as a synonym. The strain is the
       biofertilizer microalga whose phytomicrobiome supplied the keystone taxa; it is not itself a
@@ -166,7 +166,7 @@ taxonomy:
     term:
       id: NCBITaxon:5507
       label: Fusarium oxysporum
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Soilborne fungal pathogen challenged by the SynCom; the antagonism target rather than a
       SynCom member. Included in taxonomy so the antagonistic interactions resolve, matching the
       house pattern used for pathogens in Maize_Root_Simplified_Community.
@@ -181,7 +181,7 @@ taxonomy:
     term:
       id: NCBITaxon:3747
       label: Fragaria x ananassa
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Plant host in which SynCom disease suppression was assayed.
   evidence:
   - reference: PMID:41937467
@@ -194,7 +194,7 @@ taxonomy:
     term:
       id: NCBITaxon:4081
       label: Solanum lycopersicum
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Plant host in which SynCom disease suppression was assayed.
   evidence:
   - reference: PMID:41937467

--- a/kb/communities/Chlorella_Rhizobium_Bioflocculation.yaml
+++ b/kb/communities/Chlorella_Rhizobium_Bioflocculation.yaml
@@ -45,7 +45,7 @@ taxonomy:
     term:
       id: NCBITaxon:3077
       label: Chlorella vulgaris
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Unicellular green microalgae serving as the primary producer in this consortium. Axenic cultures
       exhibit poor flocculation efficiency (0.2%) but form dense flocs when co-cultured with bioflocculant-producing
       bacteria.

--- a/kb/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.yaml
@@ -91,7 +91,7 @@ taxonomy:
     term:
       id: NCBITaxon:4932
       label: Saccharomyces cerevisiae
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Engineered S. cerevisiae cdt-1 is a cellodextrin-fermenting yeast used
       as the ethanologenic partner in the curated exact coculture.
   strain_designation:

--- a/kb/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.yaml
+++ b/kb/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.yaml
@@ -53,7 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:1571157
       label: Coniochaeta sp. 2T2.1
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: JGI-sequenced fungal member isolated from a lignocellulose-degrading consortium.
   abundance_level: COMMON
   functional_role:

--- a/kb/communities/Coscinodiscus_Synthetic_Community.yaml
+++ b/kb/communities/Coscinodiscus_Synthetic_Community.yaml
@@ -46,7 +46,7 @@ taxonomy:
     term:
       id: NCBITaxon:33642
       label: Coscinodiscus radiatus
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Large centric diatom serving as the primary producer in this synthetic community. C. radiatus
       is a cosmopolitan marine phytoplankton species important for carbon cycling and primary production.
       Its large size and well-characterized physiology make it an ideal model for studying diatom-bacteria

--- a/kb/communities/Dangl_SynComm_35.yaml
+++ b/kb/communities/Dangl_SynComm_35.yaml
@@ -48,7 +48,7 @@ taxonomy:
     term:
       id: NCBITaxon:3702
       label: Arabidopsis thaliana
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.yaml
+++ b/kb/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.yaml
@@ -108,7 +108,7 @@ taxonomy:
     term:
       id: NCBITaxon:7227
       label: Drosophila melanogaster
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Fruit-fly host colonized with the defined bacterial community.
   abundance_value: Host organism for the defined gut microbiota.
   evidence:

--- a/kb/communities/Emiliania_Phaeobacter_Dynamic_Interaction.yaml
+++ b/kb/communities/Emiliania_Phaeobacter_Dynamic_Interaction.yaml
@@ -40,7 +40,7 @@ taxonomy:
     term:
       id: NCBITaxon:2903
       label: Emiliania huxleyi
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Calcifying coccolithophore algal strain used as the host phototroph in the co-culture.
   strain_designation:
     strain_name: CCMP3266

--- a/kb/communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.yaml
+++ b/kb/communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.yaml
@@ -192,7 +192,7 @@ taxonomy:
     term:
       id: NCBITaxon:3932
       label: Eucalyptus
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Host tree. Three clonal genotypes were inoculated; the consortium's effect on seedling
       quality and mortality differed between them.
   evidence:

--- a/kb/communities/Grassland_Soil_WetUp_Virus_Host_Community.yaml
+++ b/kb/communities/Grassland_Soil_WetUp_Virus_Host_Community.yaml
@@ -27,7 +27,7 @@ taxonomy:
     term:
       id: NCBITaxon:10239
       label: Viruses
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: A diverse but low-biomass reservoir of soil virions; a subset thrives
       following wet-up.
   evidence:

--- a/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
+++ b/kb/communities/Iberian_Pit_Lake_Stratified_Community.yaml
@@ -337,7 +337,7 @@ taxonomy:
     term:
       id: NCBITaxon:1125364
       label: Coccomyxa onubensis
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Dominant acidophilic green alga that drives primary production in the upper layer and chemocline,
       representing 95% ± 2.5% of eukaryotic sequences. C. onubensis performs oxygenic photosynthesis at
       extremely low pH (2.2-3.1) and high metal concentrations, fixing CO₂ via the Calvin-Benson-Bassham

--- a/kb/communities/Infant_Gut_DNA_Phage_Succession_Community.yaml
+++ b/kb/communities/Infant_Gut_DNA_Phage_Succession_Community.yaml
@@ -29,7 +29,7 @@ taxonomy:
     term:
       id: NCBITaxon:10239
       label: Viruses
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Early DNA phage colonizers, ~9 percent of which persist for 3 years
       and most of which are maternally transmitted and infect Bacteroides.
   evidence:

--- a/kb/communities/Ion_Adsorption_REE_Indigenous_Community.yaml
+++ b/kb/communities/Ion_Adsorption_REE_Indigenous_Community.yaml
@@ -257,7 +257,7 @@ taxonomy:
     term:
       id: NCBITaxon:4890
       label: Ascomycota
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Dominant fungal phylum (47.8% average abundance) contributing to REE mineralization through
       production of organic acids, siderophores, and extracellular enzymes. Ascomycetes accelerate granite
       weathering through mechanical hyphal penetration and chemical dissolution, releasing REE from silicate
@@ -284,7 +284,7 @@ taxonomy:
     term:
       id: NCBITaxon:5204
       label: Basidiomycota
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Second dominant fungal phylum (40.4% average abundance) contributing to bioweathering and
       REE mobilization. Basidiomycetes produce extracellular enzymes (laccases, peroxidases) and organic
       acids that facilitate mineral dissolution and REE release. Together with Ascomycota, Basidiomycetes

--- a/kb/communities/Kombucha_KMC_IMBG1_Fermentation_Community.yaml
+++ b/kb/communities/Kombucha_KMC_IMBG1_Fermentation_Community.yaml
@@ -75,7 +75,7 @@ taxonomy:
     term:
       id: NCBITaxon:4919
       label: Pichia
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Dominant yeast genus in the KMC-IMBG1 core community under tested growth conditions.
   abundance_level: DOMINANT
   functional_role:
@@ -91,7 +91,7 @@ taxonomy:
     term:
       id: NCBITaxon:13366
       label: Brettanomyces
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Source article reports the yeast lineage as Brettanomyces/Dekkera; NCBI genus Brettanomyces is
       used for ontology grounding.
   abundance_level: DOMINANT

--- a/kb/communities/Lotus_LjSC3.yaml
+++ b/kb/communities/Lotus_LjSC3.yaml
@@ -235,7 +235,7 @@ taxonomy:
     term:
       id: NCBITaxon:34305
       label: Lotus japonicus
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Maize_Root_Simplified_Community.yaml
+++ b/kb/communities/Maize_Root_Simplified_Community.yaml
@@ -218,7 +218,7 @@ taxonomy:
     term:
       id: NCBITaxon:4577
       label: Zea mays
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_PRODUCER
   evidence:
@@ -235,7 +235,7 @@ taxonomy:
     term:
       id: NCBITaxon:117187
       label: Fusarium verticillioides
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Target phytopathogenic fungus — NOT a SynCom member; included here as the antagonism
       target of the community's biocontrol activity. Both the whole 7-member consortium and the
       keystone member E. cloacae individually inhibit F. verticillioides growth in planta and in

--- a/kb/communities/Mars_Regolith_Cyanobacteria_Biofertilizer_Panel.yaml
+++ b/kb/communities/Mars_Regolith_Cyanobacteria_Biofertilizer_Panel.yaml
@@ -127,7 +127,7 @@ taxonomy:
     term:
       id: NCBITaxon:3077
       label: Chlorella vulgaris
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: >
       A green microalga (not a cyanobacterium); ontology grounding is species-level. It
       did not thrive on the regolith extract.

--- a/kb/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.yaml
+++ b/kb/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.yaml
@@ -81,7 +81,7 @@ taxonomy:
     term:
       id: NCBITaxon:2530459
       label: Galdieria sp.
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Strain-level NCBI Taxonomy for RTK37.1 was not found; the broader Galdieria sp. taxon is
       used with the source-backed strain designation.
   strain_designation:

--- a/kb/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.yaml
+++ b/kb/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.yaml
@@ -98,7 +98,7 @@ taxonomy:
     term:
       id: NCBITaxon:2675547
       label: Chlorella sp. HS2
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: >
       NCBI Taxonomy records Chlorella sp. HS2 as a species-level unclassified
       Chlorella entry with homotypic synonym Chlorella sp. HS-2.

--- a/kb/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.yaml
+++ b/kb/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.yaml
@@ -140,7 +140,7 @@ taxonomy:
     term:
       id: NCBITaxon:4952
       label: Yarrowia lipolytica
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Oleaginous yeast included in some consortium variants; this record distinguishes that
       conditional role from the bacterial formaldehyde cross-feeding core.
   abundance_level: COMMON

--- a/kb/communities/Neocallimastix_Methanobrevibacter_Xylan_Coculture.yaml
+++ b/kb/communities/Neocallimastix_Methanobrevibacter_Xylan_Coculture.yaml
@@ -41,7 +41,7 @@ taxonomy:
     term:
       id: NCBITaxon:4757
       label: Neocallimastix frontalis
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: PNK2 strain used as one of the anaerobic ruminal fungal partners; this record focuses on the
       N. frontalis-M. smithii coculture subset.
   abundance_level: COMMON

--- a/kb/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.yaml
+++ b/kb/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.yaml
@@ -45,7 +45,7 @@ taxonomy:
     term:
       id: NCBITaxon:70448
       label: Ostreococcus tauri
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: OTH95 strain used as the photosynthetic algal partner.
   abundance_level: COMMON
   functional_role:

--- a/kb/communities/Parachlorella_Saccharomyces_Mutualistic_Coculture.yaml
+++ b/kb/communities/Parachlorella_Saccharomyces_Mutualistic_Coculture.yaml
@@ -24,7 +24,7 @@ taxonomy:
     term:
       id: NCBITaxon:3074
       label: Parachlorella kessleri
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Green microalga; the lipid-producing partner in the co-culture.
   functional_role:
   - PRIMARY_PRODUCER
@@ -42,7 +42,7 @@ taxonomy:
     term:
       id: NCBITaxon:4932
       label: Saccharomyces cerevisiae
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Yeast partner; consumes glucose and provides CO2 to the microalga.
   functional_role:
   - CROSS_FEEDER

--- a/kb/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.yaml
+++ b/kb/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.yaml
@@ -118,7 +118,7 @@ taxonomy:
     term:
       id: NCBITaxon:10239
       label: Viruses
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Viral populations are curated as broad wetland sediment viruses
       because most viral populations were novel and unclassified.
   abundance_level: COMMON

--- a/kb/communities/Pseudonitzschia_Sulfitobacter_Association.yaml
+++ b/kb/communities/Pseudonitzschia_Sulfitobacter_Association.yaml
@@ -21,7 +21,7 @@ taxonomy:
     term:
       id: NCBITaxon:37319
       label: Pseudo-nitzschia multiseries
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_PRODUCER

--- a/kb/communities/SMutans_CAlbicans_ECC_Biofilm.yaml
+++ b/kb/communities/SMutans_CAlbicans_ECC_Biofilm.yaml
@@ -71,7 +71,7 @@ taxonomy:
     term:
       id: NCBITaxon:5476
       label: Candida albicans
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   evidence:
   - reference: PMID:24566629
     supports: SUPPORT

--- a/kb/communities/SPRUCE_Peatland_Warming_Community.yaml
+++ b/kb/communities/SPRUCE_Peatland_Warming_Community.yaml
@@ -79,7 +79,7 @@ taxonomy:
     term:
       id: NCBITaxon:4751
       label: Fungi
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Fungal communities characterized by ITS amplicon sequencing. Two major functional guilds show divergent climate responses: (1) Saprophytic fungi increase under warming, promoting organic matter decomposition in root zones; (2) Ectomycorrhizal (ECM) fungi increase under elevated CO2, forming enhanced associations with tree roots (Picea mariana). ECM fungi under eCO2 employ short-distance exploration strategies, preferentially accessing labile nitrogen pools in soil. This functional differentiation has critical implications for carbon and nutrient cycling under climate change. Warming-enhanced saprotrophs accelerate carbon mineralization, while eCO2-enhanced ECM fungi improve plant nutrient acquisition and potentially enhance carbon sequestration through plant-microbe symbiosis.
 
       '
@@ -104,7 +104,7 @@ taxonomy:
     term:
       id: NCBITaxon:10239
       label: Viruses
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Viral communities (viromes) extensively characterized, recovering 4,326 viral operational taxonomic units (vOTUs). Viral community composition correlated significantly with peat depth, water content, and carbon chemistry (methane and CO2 concentrations), but not with temperature during the first 2 years of warming. Viruses exhibit strong niche partitioning: aquatic-like viruses enriched in waterlogged surface peat, while terrestrial viruses dominate deeper zones. No marine or freshwater vOTUs detected, confirming terrestrial specialization. Predicted viral hosts show narrow ranges (generally within a single bacterial genus), suggesting limited host flexibility. Virome enrichment recovered 32x more vOTUs per sample than total metagenomes, demonstrating utility of viral particle concentration methods for soil virome research.
 
       '

--- a/kb/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.yaml
+++ b/kb/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.yaml
@@ -52,7 +52,7 @@ taxonomy:
     term:
       id: NCBITaxon:4932
       label: Saccharomyces cerevisiae
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Engineered strain producing lactic acid as the target product from
       lignocellulosic hydrolysate sugars.
   functional_role:

--- a/kb/communities/Saccharomyces_Chlamydomonas_Fungal_Algal_Mutualism.yaml
+++ b/kb/communities/Saccharomyces_Chlamydomonas_Fungal_Algal_Mutualism.yaml
@@ -43,7 +43,7 @@ taxonomy:
     term:
       id: NCBITaxon:4932
       label: Saccharomyces cerevisiae
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Budding yeast model organism used as the fungal partner in the engineered mutualism.
   functional_role:
   - CROSS_FEEDER
@@ -59,7 +59,7 @@ taxonomy:
     term:
       id: NCBITaxon:3055
       label: Chlamydomonas reinhardtii
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Green algal model organism used as the photosynthetic partner in the engineered mutualism.
   functional_role:
   - PRIMARY_PRODUCER

--- a/kb/communities/Sorghum_SRC1_Subset.yaml
+++ b/kb/communities/Sorghum_SRC1_Subset.yaml
@@ -174,7 +174,7 @@ taxonomy:
     term:
       id: NCBITaxon:4558
       label: Sorghum bicolor
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
+++ b/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
@@ -125,7 +125,7 @@ taxonomy:
     term:
       id: NCBITaxon:3847
       label: Glycine max
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom.yaml
+++ b/kb/communities/Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom.yaml
@@ -51,7 +51,7 @@ taxonomy:
     term:
       id: NCBITaxon:1904413
       label: Suillus clintonianus
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Ectomycorrhizal fungus and thiamine (B1) recipient; cannot effectively obtain or
       synthesize thiamine and recruits a bacterial partner to supply it.
   abundance_level: DOMINANT
@@ -109,7 +109,7 @@ taxonomy:
     term:
       id: NCBITaxon:88730
       label: Pinus massoniana
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Host tree (Masson pine); ectomycorrhizal colonization by S. clintonianus increases as a
       downstream outcome of the bacterial thiamine supply.
   abundance_level: DOMINANT

--- a/kb/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.yaml
+++ b/kb/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.yaml
@@ -150,7 +150,7 @@ taxonomy:
     term:
       id: NCBITaxon:5059
       label: Aspergillus flavus
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: The aflatoxin-producing fungal pathogen the community suppresses; the antagonism target
       rather than a member.
   evidence:
@@ -165,7 +165,7 @@ taxonomy:
     term:
       id: NCBITaxon:3818
       label: Arachis hypogaea
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Host legume in which both functions were assayed.
   evidence:
   - reference: PMID:42099455

--- a/kb/communities/SynCom_Chlorella_sorokiniana_Biogas_Slurry_Coupling_System.yaml
+++ b/kb/communities/SynCom_Chlorella_sorokiniana_Biogas_Slurry_Coupling_System.yaml
@@ -23,7 +23,7 @@ taxonomy:
     term:
       id: NCBITaxon:3076
       label: Chlorella sorokiniana
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Autochthonous microalga isolated from the biogas slurry; the downstream member of the
       coupling system.
   functional_role:

--- a/kb/communities/SynCom_MetG2_Rhizobacteria_Sugarcane_Stress_Resilience.yaml
+++ b/kb/communities/SynCom_MetG2_Rhizobacteria_Sugarcane_Stress_Resilience.yaml
@@ -24,7 +24,7 @@ taxonomy:
     term:
       id: NCBITaxon:4547
       label: Saccharum officinarum
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Plant host of the rhizosphere community. The abstract refers only to "sugarcane"; commercial
       sugarcane is typically Saccharum officinarum or an interspecific hybrid, grounded here at
       S. officinarum.

--- a/kb/communities/SynCom_Sesame_Flavor_Baijiu_Fuqu_13Genus.yaml
+++ b/kb/communities/SynCom_Sesame_Flavor_Baijiu_Fuqu_13Genus.yaml
@@ -24,7 +24,7 @@ taxonomy:
     term:
       id: NCBITaxon:5052
       label: Aspergillus <genus>
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Genus-level identification (core Fuqu microbiota); no species resolved in the abstract.
       NCBITaxon canonical label carries a "<genus>" disambiguation suffix.
   functional_role:
@@ -156,7 +156,7 @@ taxonomy:
     term:
       id: NCBITaxon:4919
       label: Pichia
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Genus-level identification (core Fuqu microbiota); yeast.
   functional_role:
   - SECONDARY_FERMENTER
@@ -174,7 +174,7 @@ taxonomy:
     term:
       id: NCBITaxon:4930
       label: Saccharomyces
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Genus-level identification (core Fuqu microbiota); yeast.
   functional_role:
   - SECONDARY_FERMENTER
@@ -192,7 +192,7 @@ taxonomy:
     term:
       id: NCBITaxon:5552
       label: Trichosporon
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Genus-level identification (core Fuqu microbiota); yeast-like fungus.
   functional_role:
   - SECONDARY_FERMENTER
@@ -238,7 +238,7 @@ taxonomy:
     term:
       id: NCBITaxon:5475
       label: Candida
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Genus-level identification (core Fuqu microbiota); yeast (fungal genus Candida).
   functional_role:
   - SECONDARY_FERMENTER
@@ -256,7 +256,7 @@ taxonomy:
     term:
       id: NCBITaxon:4948
       label: Torulaspora
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Genus-level identification (core Fuqu microbiota); yeast.
   functional_role:
   - SECONDARY_FERMENTER
@@ -274,7 +274,7 @@ taxonomy:
     term:
       id: NCBITaxon:36910
       label: Clavispora
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Genus-level identification (core Fuqu microbiota); yeast.
   functional_role:
   - SECONDARY_FERMENTER
@@ -292,7 +292,7 @@ taxonomy:
     term:
       id: NCBITaxon:599737
       label: Wickerhamomyces
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Genus-level identification (core Fuqu microbiota); yeast.
   functional_role:
   - SECONDARY_FERMENTER

--- a/kb/communities/Synechococcus_Yarrowia_SPC.yaml
+++ b/kb/communities/Synechococcus_Yarrowia_SPC.yaml
@@ -68,7 +68,7 @@ taxonomy:
     term:
       id: NCBITaxon:4952
       label: Yarrowia lipolytica
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: ABUNDANT
   functional_role:
   - CROSS_FEEDER

--- a/kb/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.yaml
+++ b/kb/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.yaml
@@ -70,7 +70,7 @@ taxonomy:
     term:
       id: NCBITaxon:5535
       label: Rhodotorula glutinis
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Oleaginous yeast heterotroph that adapted to the coculture medium and utilized sucrose from S.
       elongatus.
   strain_designation:

--- a/kb/communities/Synthetic_Periphyton_Freshwater_Biofilm.yaml
+++ b/kb/communities/Synthetic_Periphyton_Freshwater_Biofilm.yaml
@@ -37,7 +37,7 @@ taxonomy:
     term:
       id: NCBITaxon:2836
       label: Bacillariophyta
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_PRODUCER
   evidence:
@@ -47,7 +47,7 @@ taxonomy:
     term:
       id: NCBITaxon:3041
       label: Chlorophyta
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.yaml
+++ b/kb/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.yaml
@@ -57,7 +57,7 @@ taxonomy:
     term:
       id: NCBITaxon:1577725
       label: Conticribra weissflogii
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: >
       Sources use the name Thalassiosira weissflogii. NCBI Taxonomy currently
       treats Thalassiosira weissflogii as a homotypic synonym of Conticribra

--- a/kb/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.yaml
+++ b/kb/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.yaml
@@ -50,7 +50,7 @@ taxonomy:
     term:
       id: NCBITaxon:296543
       label: Thalassiosira pseudonana CCMP1335
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Diatom strain CCMP1335, the photosynthetic member of the pairwise coculture.
   abundance_value: One of two members in the defined coculture.
   functional_role:

--- a/kb/communities/Thermophilic_Lignocellulose_Composting_SynCom_Biosanitization.yaml
+++ b/kb/communities/Thermophilic_Lignocellulose_Composting_SynCom_Biosanitization.yaml
@@ -120,7 +120,7 @@ taxonomy:
     term:
       id: NCBITaxon:5498
       label: Cladosporium
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Fungal member; species not specified in the source, grounded at the genus rank confirmed by
       OAK.
   functional_role:
@@ -138,7 +138,7 @@ taxonomy:
     term:
       id: NCBITaxon:5544
       label: Trichoderma harzianum
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Fungal member of the thermophilic lignocellulose-degrading SynCom.
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/Tinto_River_Iron_Cycling_Community.yaml
+++ b/kb/communities/Tinto_River_Iron_Cycling_Community.yaml
@@ -142,7 +142,7 @@ taxonomy:
     term:
       id: NCBITaxon:33849
       label: Bacillariophyceae
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Diatoms (photosynthetic microalgae) contributing to primary production in Rio Tinto. Diatoms
       are eukaryotic algae with silica cell walls that photosynthesize at low pH, providing organic carbon
       to the heterotrophic community. Their presence demonstrates that oxygenic photosynthesis is compatible
@@ -166,7 +166,7 @@ taxonomy:
     term:
       id: NCBITaxon:3041
       label: Chlorophyta
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Green algae including acidophilic genera Chlamydomonas, Klebsormidium, and Zignema that contribute
       to photosynthetic primary production. Chlorophytes are eukaryotic algae with chloroplasts adapted
       to acidic conditions, producing organic matter and oxygen that support the heterotrophic-oxidative
@@ -188,7 +188,7 @@ taxonomy:
     term:
       id: NCBITaxon:5204
       label: Basidiomycota
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: 'Acidophilic fungi including Hortaea werneckii (black yeast) detected in Rio Tinto sediments
       and water. Fungi contribute to organic matter degradation, biofilm formation, and nutrient cycling
       through extracellular enzyme secretion.

--- a/kb/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.yaml
+++ b/kb/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.yaml
@@ -48,7 +48,7 @@ taxonomy:
     term:
       id: NCBITaxon:51453
       label: Trichoderma reesei
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Cellulolytic fungal member; source abstract supports species-level identity.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Trichoderma_Lactate_Platform.yaml
+++ b/kb/communities/Trichoderma_Lactate_Platform.yaml
@@ -40,7 +40,7 @@ taxonomy:
     term:
       id: NCBITaxon:51453
       label: Trichoderma reesei
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   abundance_level: DOMINANT
   functional_role:
   - PRIMARY_DEGRADER

--- a/kb/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.yaml
+++ b/kb/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.yaml
@@ -54,7 +54,7 @@ taxonomy:
     term:
       id: NCBITaxon:1344414
       label: Trichoderma reesei RUT C-30
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: Cellulolytic fungal member supplying cellulases and hydrolysate sugars.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.yaml
+++ b/kb/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.yaml
@@ -119,7 +119,7 @@ taxonomy:
     term:
       id: NCBITaxon:5206
       label: Cryptococcus <basidiomycete fungi>
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
     notes: The study identifies a Cryptococcus yeast that produces the B-vitamin
       pantothenate; species-level identity is not resolved in the abstract.
   functional_role:

--- a/kb/communities/Wheat_Consortium_C1.yaml
+++ b/kb/communities/Wheat_Consortium_C1.yaml
@@ -77,7 +77,7 @@ taxonomy:
     term:
       id: NCBITaxon:4565
       label: Triticum aestivum
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Wheat_Consortium_C6.yaml
+++ b/kb/communities/Wheat_Consortium_C6.yaml
@@ -70,7 +70,7 @@ taxonomy:
     term:
       id: NCBITaxon:4565
       label: Triticum aestivum
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_PRODUCER
   evidence:

--- a/kb/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.yaml
+++ b/kb/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.yaml
@@ -82,7 +82,7 @@ taxonomy:
     term:
       id: NCBITaxon:5547
       label: Trichoderma viride
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_DEGRADER
   evidence:
@@ -92,7 +92,7 @@ taxonomy:
     term:
       id: NCBITaxon:5061
       label: Aspergillus niger
-    gtdb_grounding_status: UNRESOLVED
+    gtdb_grounding_status: NO_GTDB_EQUIVALENT
   functional_role:
   - PRIMARY_DEGRADER
   evidence:

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -57,6 +57,11 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MAPPING_REL = Path("data/raw/NCBI2GTDB.tsv.gz")
 
+# `scripts/` is on sys.path when this runs as `python scripts/gtdb_ground.py`,
+# so reach the package the same way the other scripts do.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from communitymech.validators.ncbi_domain import outside_gtdb_scope  # noqa: E402
+
 # NCBI2GTDB.tsv column indices (0-based); see header row.
 COL_NCBI_ID = 0
 COL_TOTAL_GENOMES = 2
@@ -739,6 +744,48 @@ def _block_span(lines: list[str], anchor: int, end: int) -> tuple[int, int] | No
 STATUS_KEYS = ("gtdb_grounding_status", "gtdb_candidates")
 
 
+# Why a resolve failed, from what the tool already holds at that moment (#393).
+#
+# #294 wanted UNRESOLVED told apart from NO_GTDB_EQUIVALENT ("GTDB has no
+# counterpart and never will"). #392 made the tool emit only the weak state,
+# because inferring the strong one from "the resolve failed" was wrong for at
+# least 82 of 293 entries.
+#
+# This does not restore the strong claim — that needs an NCBI lineage source
+# this script does not have, since GTDB is bacteria/archaea only (#393 option 1).
+# It records the *reason*, which the tool knew and discarded, and which splits
+# the population into two genuinely different piles:
+#
+#   ROWS_FILTERED    the crosswalk has rows under this taxon and the
+#                    named-species filter (#375) removed all of them —
+#                    `Pseudomonas sp.`, `Streptomyces sp.`. A curator could
+#                    recover these by relaxing the filter; nothing is missing.
+#   NOT_IN_CROSSWALK the id and name appear nowhere in the mapping. Two very
+#                    different things live here and this deliberately does not
+#                    guess between them: a eukaryote or virus, which really is
+#                    final (GTDB will never classify Saccharomyces), and a clade
+#                    the crosswalk spells differently (NCBI *Sulcia* is
+#                    `Candidatus Karelsulcia`), which is a lookup failure.
+#
+# So NOT_IN_CROSSWALK is the population #393 option 1 would resolve, and naming
+# it is what makes that work schedulable instead of a re-derivation.
+UNRESOLVED_REASONS = ("ROWS_FILTERED", "NOT_IN_CROSSWALK")
+
+
+def unresolved_reason(tid: str, label: str, by_id, by_name, by_higher) -> str:
+    """Which of the two failure modes applied.
+
+    Read off the indexes rather than re-deriving: `collect_rows` only indexes
+    taxa that were asked for, so a non-empty entry means the crosswalk really
+    does carry rows for this taxon and the filter is what emptied them.
+    """
+    number = tid.split(":", 1)[1] if ":" in tid else tid
+    name = (label or "").strip().lower()
+    if by_id.get(number) or by_name.get(name) or by_higher.get(name):
+        return "ROWS_FILTERED"
+    return "NOT_IN_CROSSWALK"
+
+
 def classify_status(
     record_name,
     tid,
@@ -799,8 +846,22 @@ def classify_status(
         # Matching NCBI names against the table was tried and does not settle it
         # either — a rename defeats it. Establishing "GTDB will never classify
         # this" needs an NCBI lineage source, since GTDB is bacteria/archaea
-        # only, which this script does not have. So NO_GTDB_EQUIVALENT is
-        # curator-assigned and the tool never writes it (#393).
+        # only. That source is now wired in (#393): `outside_gtdb_scope` asks the
+        # NCBITaxon ontology for the taxon's domain, and a eukaryote or virus is
+        # final rather than merely unresolved.
+        #
+        # Of the KB's 220 UNRESOLVED taxa, 92 are Eukaryota and 6 Viruses — so
+        # 98 were never outstanding work, and the backlog overstated itself by
+        # about 45%. The other 106 are genuinely bacteria and archaea the tool
+        # failed to match, and stay UNRESOLVED.
+        #
+        # One-directional on purpose. `outside_gtdb_scope` returns False when it
+        # cannot tell — no adapter, a lookup failure, a taxon above every domain
+        # like `cellular organisms` — so an unavailable NCBITaxon database
+        # degrades to the weaker status and never to a false claim of finality.
+        # That is what keeps this script runnable without a large download.
+        if outside_gtdb_scope(tid):
+            return "NO_GTDB_EQUIVALENT", []
         return "UNRESOLVED", []
     # The tool would ground this and the KB does not. That is the only value
     # here that represents outstanding work.

--- a/src/communitymech/validators/ncbi_domain.py
+++ b/src/communitymech/validators/ncbi_domain.py
@@ -1,0 +1,91 @@
+"""Is a taxon outside GTDB's scope entirely? (#393)
+
+GTDB classifies **bacteria and archaea only**. So a taxon under Eukaryota or
+Viruses can never be grounded — not "the tool failed", but "there is nothing to
+find, now or later". That is the distinction #294 wanted and #392 could not make.
+
+Why this needs an ontology and not the crosswalk: a eukaryote does not appear in
+NCBI2GTDB at all, so the crosswalk cannot tell "absent because out of scope" from
+"absent because the name is spelled differently" (NCBI *Sulcia* is `Candidatus
+Karelsulcia`). Both look identical from there. #393 tried settling it by name
+matching and withdrew the attempt for exactly this reason.
+
+Measured over the KB's 220 UNRESOLVED taxa:
+
+    Eukaryota            92   final
+    Viruses               6   final
+    Bacteria             90   genuinely outstanding
+    Archaea              16   genuinely outstanding
+    other/above-domain   16   `cellular organisms` and similar
+
+So 98 of 220 are not work at all. Without this, the count of outstanding
+grounding work overstates itself by about 45%.
+
+**Degrades rather than guesses.** If the adapter cannot be built or a lookup
+fails, `outside_gtdb_scope()` returns False — "I could not tell" collapses to the
+weaker, safer status, never to a false claim of finality. That keeps
+`gtdb_ground.py` runnable without the NCBITaxon database, which is a large
+download that the grounding path did not previously need.
+"""
+
+from __future__ import annotations
+
+import functools
+
+# NCBI's top-level divisions. A taxon at or under one of the first two is in
+# GTDB's scope; at or under one of the last two it is permanently outside it.
+BACTERIA = "NCBITaxon:2"
+ARCHAEA = "NCBITaxon:2157"
+EUKARYOTA = "NCBITaxon:2759"
+VIRUSES = "NCBITaxon:10239"
+
+OUT_OF_SCOPE = (EUKARYOTA, VIRUSES)
+
+
+@functools.lru_cache(maxsize=1)
+def _adapter():
+    """The NCBITaxon adapter, or None if it cannot be built.
+
+    Cached because building it opens a large SQLite database, and a grounding run
+    asks about a few hundred taxa.
+    """
+    try:
+        # oaklib ships no py.typed marker; same ignore as
+        # `cross_repo_environment.py`, which imports it the same way.
+        from oaklib import get_adapter  # type: ignore[import-untyped]
+
+        return get_adapter("sqlite:obo:ncbitaxon")
+    except Exception:
+        return None
+
+
+@functools.lru_cache(maxsize=4096)
+def domain_of(curie: str) -> str | None:
+    """`NCBITaxon:2` / `:2157` / `:2759` / `:10239`, or None if undetermined.
+
+    None covers three different situations on purpose — no adapter, a lookup
+    failure, and a taxon above every domain (`cellular organisms`, `root`). All
+    three mean "cannot claim finality", which is the only thing callers act on.
+    """
+    if not curie or not curie.startswith("NCBITaxon:"):
+        return None
+    adapter = _adapter()
+    if adapter is None:
+        return None
+    try:
+        ancestors = set(adapter.ancestors([curie], predicates=["rdfs:subClassOf"]))
+    except Exception:
+        return None
+    for domain in (BACTERIA, ARCHAEA, EUKARYOTA, VIRUSES):
+        if curie == domain or domain in ancestors:
+            return domain
+    return None
+
+
+def outside_gtdb_scope(curie: str) -> bool:
+    """True only when the taxon is provably a eukaryote or a virus.
+
+    Deliberately one-directional: False means "not established", not "in scope".
+    A caller may downgrade on False but must never upgrade on it.
+    """
+    return domain_of(curie) in OUT_OF_SCOPE

--- a/tests/test_gtdb_coherence_validator.py
+++ b/tests/test_gtdb_coherence_validator.py
@@ -474,6 +474,13 @@ def test_the_status_distribution_is_what_was_measured():
     *Bacteria* or *Archaea* at all, so it recorded "no grounding produced" for
     the two roots of GTDB. They are grounded now, which is why GROUNDED and
     UNRESOLVED both moved by 72 while NOT_ATTEMPTED returned to 9.
+
+    #393's second half moved 96 more out of UNRESOLVED (221 -> 125) and into
+    NO_GTDB_EQUIVALENT. Those are eukaryotes and viruses, which GTDB will never
+    classify — the tool can say so now that it consults an NCBI lineage source
+    rather than inferring finality from its own failure. So UNRESOLVED's floor
+    drops sharply here on purpose: what is left is bacteria and archaea the
+    lookup genuinely missed, which is the number that should drive curation.
     """
     from collections import Counter
 
@@ -484,7 +491,16 @@ def test_the_status_distribution_is_what_was_measured():
                 counts[(entry.get("taxon_term") or {}).get("gtdb_grounding_status")] += 1
 
     assert counts["GROUNDED"] > 700
-    assert counts["UNRESOLVED"] > 180, "the ungrounded-but-unexplained bucket vanished"
+    assert counts["UNRESOLVED"] > 90, "the ungrounded-but-unexplained bucket vanished"
+    # Two-sided: without a ceiling, losing the domain lookup and dumping all 96
+    # eukaryotes back into UNRESOLVED would pass (#393).
+    assert counts["UNRESOLVED"] < 160, (
+        "UNRESOLVED has grown back toward its pre-#393 size; the NCBI domain "
+        "lookup may be silently unavailable, which degrades to this bucket"
+    )
+    assert (
+        counts["NO_GTDB_EQUIVALENT"] > 50
+    ), "the eukaryote/virus population stopped being recognised as final (#393)"
     assert counts["AMBIGUOUS"] > 50
     assert counts["WITHHELD"] == 2, "the #292 withholds must still be marked"
     # A floor as well as a ceiling: `< 50` alone is satisfied by zero, so
@@ -493,9 +509,16 @@ def test_the_status_distribution_is_what_was_measured():
         "NOT_ATTEMPTED is the only value meaning outstanding work; 0 almost "
         "certainly means it is being mislabelled, not that the work is done"
     )
-    assert (
-        counts["NO_GTDB_EQUIVALENT"] == 0
-    ), "the tool must not assert NO_GTDB_EQUIVALENT — it cannot establish it (#393)"
+    # Was `== 0`: #392 forbade the tool from ever asserting this, because it
+    # inferred finality from its own failure and got 82 of 293 wrong. #393
+    # removes the reason for the ban rather than the ban's intent — the value is
+    # now backed by an NCBI domain lookup, and every instance is checked against
+    # that lookup in tests/test_ncbi_domain_scope.py. The property that matters
+    # is no longer "never claim it" but "never claim it for a prokaryote".
+    assert counts["NO_GTDB_EQUIVALENT"] > 50, (
+        "the eukaryote/virus population stopped being recognised as final; the "
+        "NCBI domain lookup may be unavailable (#393)"
+    )
 
 
 def test_the_withholds_are_marked_withheld_not_grounded():

--- a/tests/test_ncbi_domain_scope.py
+++ b/tests/test_ncbi_domain_scope.py
@@ -1,0 +1,129 @@
+"""NO_GTDB_EQUIVALENT is now evidence-backed, not inferred from failure (#393).
+
+GTDB classifies bacteria and archaea only, so a eukaryote or virus can never be
+grounded. #294 wanted that said; #392 had to withdraw it, because inferring
+"final" from "the resolve failed" was wrong for at least 82 of 293 entries.
+
+The missing piece was an NCBI lineage source, which `outside_gtdb_scope()` now
+supplies from the NCBITaxon ontology OAK already configures. Of the KB's 220
+UNRESOLVED taxa, 95 turn out to be eukaryotes or viruses — the backlog of
+outstanding grounding work overstated itself by roughly 43%.
+
+The direction matters more than the count. `outside_gtdb_scope()` returns False
+whenever it cannot tell — no adapter, a failed lookup, a taxon above every domain
+— so an unavailable database degrades to the weaker status and never to a false
+claim of finality.
+"""
+
+from __future__ import annotations
+
+import collections
+import pathlib
+
+import pytest
+import yaml
+
+from communitymech.validators.ncbi_domain import BACTERIA, EUKARYOTA, domain_of, outside_gtdb_scope
+
+REPO = pathlib.Path(__file__).parent.parent
+
+
+@pytest.mark.parametrize(
+    ("curie", "expected"),
+    [
+        ("NCBITaxon:4932", True),  # Saccharomyces cerevisiae
+        ("NCBITaxon:3702", True),  # Arabidopsis thaliana
+        ("NCBITaxon:2759", True),  # Eukaryota itself
+        ("NCBITaxon:10239", True),  # Viruses itself
+        ("NCBITaxon:2", False),  # Bacteria
+        ("NCBITaxon:2157", False),  # Archaea
+        ("NCBITaxon:1239", False),  # Bacillota
+        ("NCBITaxon:336809", False),  # Candidatus Karelsulcia — see below
+        # Above every domain: "cannot tell" must read as not-final.
+        ("NCBITaxon:131567", False),  # cellular organisms
+        ("NCBITaxon:1", False),  # root
+        # Malformed input must never claim finality.
+        ("", False),
+        ("GTDB:s__Bacillus_velezensis", False),
+        ("not-a-curie", False),
+    ],
+)
+def test_scope_is_decided_only_when_it_can_be(curie, expected):
+    assert outside_gtdb_scope(curie) is expected
+
+
+def test_an_unavailable_adapter_degrades_rather_than_guesses(monkeypatch):
+    """The property that makes this safe to depend on.
+
+    Without it, running `gtdb_ground.py` on a machine lacking the NCBITaxon
+    database would silently relabel every unresolved taxon as final.
+    """
+    import communitymech.validators.ncbi_domain as module
+
+    real_adapter = module._adapter
+    # `domain_of` is lru_cached, so a real answer from an earlier test would be
+    # returned without ever consulting the patched adapter.
+    module.domain_of.cache_clear()
+    monkeypatch.setattr(module, "_adapter", lambda: None)
+    try:
+        assert module.domain_of("NCBITaxon:4932") is None
+        assert module.outside_gtdb_scope("NCBITaxon:4932") is False
+    finally:
+        # Clear again before the real adapter is restored, or every later test
+        # inherits the None answers cached here. `real_adapter` is the lru_cached
+        # original — the patched stand-in has no `cache_clear`.
+        module.domain_of.cache_clear()
+        real_adapter.cache_clear()
+
+
+def _statuses():
+    counts = collections.Counter()
+    offenders = []
+    for path in sorted((REPO / "kb/communities").glob("*.yaml")):
+        for entry in (yaml.safe_load(path.read_text()) or {}).get("taxonomy") or []:
+            term_block = entry.get("taxon_term") or {}
+            status = term_block.get("gtdb_grounding_status")
+            if not status:
+                continue
+            counts[status] += 1
+            term = term_block.get("term") or {}
+            curie = term.get("id") if isinstance(term, dict) else None
+            if status == "NO_GTDB_EQUIVALENT" and curie and not outside_gtdb_scope(curie):
+                offenders.append(f"{path.name}: {curie} {term.get('label')!r}")
+    return counts, offenders
+
+
+def test_every_final_status_is_backed_by_a_domain_lookup():
+    """The claim #392 could not make, now checkable rather than asserted.
+
+    A NO_GTDB_EQUIVALENT whose taxon is a bacterium is the exact failure that
+    made 57 KB entries read "GTDB has no counterpart" for *Bacteria*, the root
+    of GTDB.
+    """
+    counts, offenders = _statuses()
+
+    assert not offenders, "NO_GTDB_EQUIVALENT on an in-scope taxon:\n" + "\n".join(offenders[:10])
+    assert counts["NO_GTDB_EQUIVALENT"] > 50, (
+        f"only {counts['NO_GTDB_EQUIVALENT']} final statuses; the domain lookup "
+        f"may have stopped working (#393)"
+    )
+    assert counts["UNRESOLVED"] > 0, "nothing unresolved at all — suspiciously clean"
+
+
+def test_sulcia_is_a_bacterium_not_a_spider():
+    """`NCBITaxon:2716471` is a spider genus, and three records used it.
+
+    Found because the domain lookup called a bacterial endosymbiont a eukaryote.
+    NCBI renamed *Candidatus Sulcia* to *Candidatus Karelsulcia*
+    (`NCBITaxon:336809`); GTDB still calls it `g__Sulcia`, which is why the
+    crosswalk lookup misses and it stays UNRESOLVED rather than becoming final.
+
+    The id↔label gate cannot catch this class: `NCBITaxon:2716471` really is
+    labelled "Sulcia" (#292).
+    """
+    for path in sorted((REPO / "kb/communities").glob("*.yaml")):
+        text = path.read_text()
+        assert "NCBITaxon:2716471" not in text, f"{path.name} still uses the spider id"
+
+    assert domain_of("NCBITaxon:336809") == BACTERIA
+    assert domain_of("NCBITaxon:2716471") == EUKARYOTA


### PR DESCRIPTION
Closes #393.

## The measurement #393 asked for

GTDB classifies **bacteria and archaea only**, so a eukaryote or virus can never
be grounded. #294 wanted that said; #392 had to withdraw it, because inferring
finality from a failed resolve was wrong for at least 82 of 293 entries — 57 read
"GTDB has no counterpart" for *Bacteria*, the root of GTDB.

Classifying the 220 UNRESOLVED taxa by NCBI domain:

| domain | n | |
|---|---|---|
| Eukaryota | 92 | **final** |
| Viruses | 6 | **final** |
| Bacteria | 90 | genuinely outstanding |
| Archaea | 16 | genuinely outstanding |
| other / above-domain | 16 | `cellular organisms` and similar |

**The outstanding-work backlog overstated itself by ~43%.**

After backfilling both record roots:

```
UNRESOLVED          221 -> 125
NO_GTDB_EQUIVALENT    0 ->  96
```

## Why this is option 1 and not a new dependency

#393 priced this as "a dependency in the grounding path and a downloaded
database". It turns out OAK already configures NCBITaxon for the id↔label gate,
so the adapter and the database are both present.

## The safety property

`outside_gtdb_scope()` is deliberately **one-directional**: False means "not
established", never "in scope". No adapter, a failed lookup, or a taxon above
every domain all collapse to False, so a machine without the NCBITaxon database
degrades to the weaker status rather than to a false claim of finality — which is
exactly what #392's blanket ban was protecting. The ban is replaced by a test
that checks every stored `NO_GTDB_EQUIVALENT` against the lookup, so the property
is enforced rather than avoided.

| mutant | result |
|---|---|
| treat "undetermined" as out-of-scope | **6 fail** |
| never report out-of-scope | **5 fail** |
| unmutated | passes (16) |

## The canary found a wrong organism

Marking *Sulcia* final looked wrong, so I checked — and it was:

```
NCBITaxon:2716471  ancestors: Leptonetidae, Ecdysozoa, Metazoa, Eukaryota
```

**It is a spider genus**, used in three records for a bacterial endosymbiont.
NCBI renamed *Candidatus Sulcia* → *Candidatus Karelsulcia*
(`NCBITaxon:336809`); GTDB still calls it `g__Sulcia`, which is why the crosswalk
lookup misses it.

The id↔label gate cannot catch this — `NCBITaxon:2716471` really *is* labelled
"Sulcia", so the pair is internally consistent and only the biology disagrees.
Same class as #292 and #416. Fixed across all three records; they now read
`UNRESOLVED`, which is honest, instead of a confident falsehood.

Note this is the second time in this batch that a cross-check found a
wrong-organism id no existing gate could see.

## Two things I got wrong

**The first backfill covered only `kb/communities`** and missed the four records
in `data/isolates`. An existing test that reads both roots caught it, not me.

**Two existing tests encoded #392's ban** (`NO_GTDB_EQUIVALENT == 0`,
`UNRESOLVED > 180`). Updated, with the reasoning recorded — and the UNRESOLVED
bound is now two-sided, so silently losing the domain lookup (which would dump
all 96 back into UNRESOLVED) fails rather than passes.

`just qc` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)