### PR TITLE
Gate one NCBITaxon id reused for two different organisms (#292)

### DIFF
--- a/justfile
+++ b/justfile
@@ -163,6 +163,16 @@ validate-gtdb FILE:
 validate-scalars *files:
     PYTHONPATH=src uv run python scripts/validate_yaml_scalars.py {{files}}
 
+# Find one NCBITaxon id standing in for two different organisms (#292).
+#
+# The id<->label gate cannot see this: `NCBITaxon:821` really is labelled
+# "Phocaeicola vulgatus", so the pair is consistent and only `preferred_term`
+# disagrees. Runs inside `just validate-strict`; this is the single-file form.
+#
+# Find an NCBITaxon id used for two different organisms
+validate-taxon-ids *files:
+    PYTHONPATH=src uv run python scripts/validate_shared_taxon_ids.py {{files}}
+
 validate-gtdb-all:
     PYTHONPATH=src uv run python scripts/validate_gtdb_coherence.py kb/communities/*.yaml data/isolates/*.yaml
 

--- a/justfile
+++ b/justfile
@@ -317,7 +317,8 @@ lint:
     uv run ruff check src/ tests/ scripts/
     uv run mypy src/
 
-# `validate-gtdb-all` and `validate-scalars` also run inside validate-strict.
+# `validate-gtdb-all`, `validate-scalars` and `validate-taxon-ids` also run
+# inside validate-strict.
 # Only `validate-scalars` widens the scope — it covers kb/taxa, which
 # validate-strict's DEFAULT_ROOTS exclude; `validate-gtdb-all` scans exactly
 # those roots and adds nothing (kb/taxa carries no gtdb_classification at all).

--- a/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
+++ b/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
@@ -139,9 +139,18 @@ taxonomy:
 - taxon_term:
     preferred_term: Bacteroides ovatus
     term:
-      id: NCBITaxon:821
-      label: Phocaeicola vulgatus
-    gtdb_grounding_status: WITHHELD
+      id: NCBITaxon:28116
+      label: Bacteroides ovatus
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:s__Bacteroides_ovatus
+      gtdb_taxon: Bacteroides ovatus
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Bacteroides;s__Bacteroides ovatus
+      ncbi_source_id: NCBITaxon:28116
+      majority_fraction: 0.99
+      total_genomes: 3107
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: DSM1896
   functional_role:

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -873,9 +873,6 @@ def classify_status(
 # Mirrors CURATED_GROUNDINGS, which protects a grounding that *is* right.
 # Kept in step with WITHHELD in tests/test_gtdb_withheld_groundings.py (#292).
 WITHHELD_GROUNDINGS = {
-    ("BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml", "Bacteroides ovatus"): (
-        "NCBITaxon:821 is Phocaeicola vulgatus; B. ovatus is NCBITaxon:28116."
-    ),
     ("KBase_ORT_Workflow_Community_Model.yaml", "Nitrospiraceae bacterium"): (
         "GTDB's majority for NCBI Nitrospiraceae is f__Leptospirillaceae at 0.534 "
         "(31/58 genomes), and Leptospirillum is an iron oxidizer while this genome "

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -868,8 +868,11 @@ def classify_status(
     return "NOT_ATTEMPTED", []
 
 
-# Taxa kept ungrounded on purpose because the NCBITaxon id names a different
-# organism, so a derived block would describe the wrong species convincingly.
+# Taxa kept ungrounded on purpose because the block this tool would derive is
+# wrong, so writing it would state the error convincingly in a second field.
+# Two reasons qualify and they need different fixes: a wrong NCBITaxon id (#292,
+# fixed by correcting the id) and a GTDB majority that contradicts the record's
+# own physiology (#416, fixed only by a curator choosing the grounding).
 # Mirrors CURATED_GROUNDINGS, which protects a grounding that *is* right.
 # Kept in step with WITHHELD in tests/test_gtdb_withheld_groundings.py (#292).
 WITHHELD_GROUNDINGS = {
@@ -963,8 +966,8 @@ def apply_to_community(
         # caught afterwards — running the documented `--apply` over the KB
         # reinstated `NCBITaxon:1236` as c__Gammaproteobacteria, derived from an
         # id that names a different organism (#402 review). Keyed by
-        # preferred_term because both withheld records use the offending id
-        # correctly elsewhere (#294).
+        # preferred_term, not by id: a withheld record may use the same id
+        # correctly for one of its other entries (#294).
         if (path.name, tt.get("preferred_term")) in WITHHELD_GROUNDINGS:
             print(
                 f"[gtdb] skipping withheld {tt.get('preferred_term')!r} in {path.name}: "

--- a/scripts/validate_shared_taxon_ids.py
+++ b/scripts/validate_shared_taxon_ids.py
@@ -1,0 +1,40 @@
+"""Report NCBITaxon ids standing in for more than one organism (#292).
+
+Single-file form of the check `validate-strict` runs. See
+`communitymech.validators.shared_taxon_ids` for why the id<->label gate cannot
+see this class of error.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from communitymech.validators.shared_taxon_ids import check_record  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    paths = [Path(p) for p in (argv if argv is not None else sys.argv[1:])]
+    if not paths:
+        print("usage: validate_shared_taxon_ids.py FILE [FILE ...]", file=sys.stderr)
+        return 2
+    problems = 0
+    for path in paths:
+        try:
+            document = yaml.safe_load(path.read_text()) or {}
+        except yaml.YAMLError as error:
+            print(f"{path}: unparseable: {error}", file=sys.stderr)
+            problems += 1
+            continue
+        for message in check_record(document.get("taxonomy") or []):
+            print(f"{path}: {message}")
+            problems += 1
+    print(f"\nfiles checked: {len(paths)}\nreused ids: {problems}")
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_shared_taxon_ids.py
+++ b/scripts/validate_shared_taxon_ids.py
@@ -22,17 +22,31 @@ def main(argv: list[str] | None = None) -> int:
         print("usage: validate_shared_taxon_ids.py FILE [FILE ...]", file=sys.stderr)
         return 2
     problems = 0
+    unreadable = 0
     for path in paths:
+        # An unreadable file is a usage error, not a finding. Counting it as one
+        # would exit 1 and read as "this record reuses an id" (#434); the
+        # sibling validators return 2 for the same reason.
         try:
-            document = yaml.safe_load(path.read_text()) or {}
-        except yaml.YAMLError as error:
-            print(f"{path}: unparseable: {error}", file=sys.stderr)
-            problems += 1
+            text = path.read_text()
+        except OSError as error:
+            print(f"[taxon-ids] cannot read {path}: {error}", file=sys.stderr)
+            unreadable += 1
             continue
-        for message in check_record(document.get("taxonomy") or []):
+        try:
+            document = yaml.safe_load(text)
+        except yaml.YAMLError as error:
+            print(f"[taxon-ids] unparseable {path}: {error}", file=sys.stderr)
+            unreadable += 1
+            continue
+        taxonomy = document.get("taxonomy") if isinstance(document, dict) else None
+        for message in check_record(taxonomy):
             print(f"{path}: {message}")
             problems += 1
     print(f"\nfiles checked: {len(paths)}\nreused ids: {problems}")
+    if unreadable:
+        print(f"unreadable: {unreadable}", file=sys.stderr)
+        return 2
     return 1 if problems else 0
 
 

--- a/scripts/validate_strict.py
+++ b/scripts/validate_strict.py
@@ -41,6 +41,7 @@ from linkml.validator.plugins import JsonschemaValidationPlugin
 from linkml.validator.report import Severity
 
 from communitymech.validators.gtdb_coherence import validate_gtdb_coherence
+from communitymech.validators.shared_taxon_ids import check_record as check_shared_taxon_ids
 from communitymech.validators.yaml_scalars import find_truncated_scalars
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -180,6 +181,20 @@ def validate_one(path: Path) -> list[dict]:
                 "detail": issue.taxon,
                 "path": "",
                 "message": issue.message[:300],
+            }
+        )
+
+    # One specific NCBITaxon id standing in for two different organisms (#292).
+    # Not covered by the id<->label gate: the id and label agree, and only the
+    # `preferred_term` disagrees.
+    for message in check_shared_taxon_ids((instance or {}).get("taxonomy") or []):
+        rows.append(
+            {
+                "file": str(path),
+                "category": "taxon_id_reused_for_another_organism",
+                "detail": message.split(" ", 1)[0],
+                "path": "",
+                "message": message[:300],
             }
         )
     return rows

--- a/scripts/validate_strict.py
+++ b/scripts/validate_strict.py
@@ -187,7 +187,8 @@ def validate_one(path: Path) -> list[dict]:
     # One specific NCBITaxon id standing in for two different organisms (#292).
     # Not covered by the id<->label gate: the id and label agree, and only the
     # `preferred_term` disagrees.
-    for message in check_shared_taxon_ids((instance or {}).get("taxonomy") or []):
+    taxonomy = instance.get("taxonomy") if isinstance(instance, dict) else None
+    for message in check_shared_taxon_ids(taxonomy):
         rows.append(
             {
                 "file": str(path),

--- a/src/communitymech/validators/shared_taxon_ids.py
+++ b/src/communitymech/validators/shared_taxon_ids.py
@@ -26,19 +26,38 @@ organisms is a contradiction: a species is one organism, so two names under it
 cannot both be right. NCBITaxon carries the rank, so this is a lookup rather than
 a guess, and the legitimate cases need no waiver list.
 
-Genus is included as specific. A genus id shared by two entries is a real
-pattern in MAG-based records ("Methylobacter MAG 1" / "MAG 2"), so those are
-allowed through when the names differ only by such a suffix — see
-`_looks_like_the_same_organism`.
+Genus is included as specific, but a genus id shared by two entries is a real
+pattern in MAG-based records (`Variovorax sp. BK119` .. `BK752`), so under a
+genus id only a differing *genus* counts — see `_names_disagree`.
+
+Three ways the KB spells one organism two ways are exempt, because each would
+otherwise be a false positive, and a gate that fires on a legitimate record is
+one a curator learns to ignore:
+
+* an **NCBI rename** — one species id carrying both `Eubacterium rectale` and
+  `Agathobacter rectalis`, which is the very thing `preferred_term` exists to
+  preserve. Both are names NCBITaxon lists for the id (`known_cores`).
+* a **GTDB genus split** — `Olsenella` beside `Olsenella_B`.
+* an **abbreviated genus** — `B. subtilis` beside `Bacillus subtilis`.
+
+The last two are `_same_genus`. All three are lookups or unambiguous string
+facts rather than guesses, so none of them needs a waiver list.
 """
 
 from __future__ import annotations
 
 import functools
 import re
+import sys
 
 # NCBI ranks at or below which one id denotes one organism. Anything broader is
 # a clade that may legitimately host several distinct entries.
+#
+# `species_group`/`species_subgroup` are deliberately absent: each spans several
+# species, so two names under one are not a contradiction. They would be
+# unreachable here anyway — NCBITaxon models those two ranks as
+# `obo:NCBITaxon#_species_group` rather than a `NCBITaxon:` CURIE, so `rank_of`
+# returns None for them.
 SPECIFIC_RANKS = frozenset(
     {
         "species",
@@ -49,7 +68,6 @@ SPECIFIC_RANKS = frozenset(
         "serogroup",
         "biotype",
         "genotype",
-        "species_subgroup",
         "forma_specialis",
         "genus",
         "subgenus",
@@ -63,6 +81,10 @@ _CORE = re.compile(r"^([A-Za-z][A-Za-z0-9_\-]*)\s+([a-z][a-z0-9_\-]*)")
 # GTDB-style placeholder epithets: `sp.`, `sp900119625`, `sp002874965`. All mean
 # "unnamed species", so two of them under one genus are not a contradiction.
 _PLACEHOLDER = re.compile(r"^sp\d*$")
+# GTDB splits one NCBI genus into `Olsenella`, `Olsenella_A`, `Olsenella_B`. NCBI
+# genus names never contain an underscore, so stripping this suffix is
+# unambiguous, and two GTDB splits of one genus are not two different genera.
+_GTDB_GENUS_SUFFIX = re.compile(r"_[a-z]$")
 
 
 def _core(name: str) -> tuple[str, str] | None:
@@ -91,6 +113,27 @@ def _adapter():
         return None
 
 
+_warned_no_adapter = False
+
+
+def _warn_once_if_unavailable() -> None:
+    """Say so when the whole check is being skipped for want of NCBITaxon.
+
+    Without this a green `validate-strict` on a machine with no NCBITaxon
+    database reads as "no id is reused for two organisms", when in fact nothing
+    was looked at (#426). Stderr, not a failure: refusing to run is the right
+    behaviour on a bare checkout, but it should be visible.
+    """
+    global _warned_no_adapter
+    if not _warned_no_adapter and _adapter() is None:
+        _warned_no_adapter = True
+        print(
+            "[taxon-ids] NCBITaxon is unavailable, so the shared-id check (#292) "
+            "was skipped, not passed.",
+            file=sys.stderr,
+        )
+
+
 @functools.lru_cache(maxsize=4096)
 def rank_of(curie: str) -> str | None:
     """The NCBI rank (`species`, `genus`, `class`, ...), or None if undetermined.
@@ -112,7 +155,7 @@ def rank_of(curie: str) -> str | None:
             continue
         for value in values:
             if isinstance(value, str) and value.startswith("NCBITaxon:"):
-                return value.split(":", 1)[1].replace("_", " ").strip().replace(" ", "_")
+                return value.split(":", 1)[1].strip()
     return None
 
 
@@ -121,7 +164,54 @@ def is_specific(curie: str) -> bool:
     return (rank_of(curie) or "") in SPECIFIC_RANKS
 
 
-def _names_disagree(first: str, second: str, rank: str | None) -> bool:
+@functools.lru_cache(maxsize=4096)
+def known_cores(curie: str) -> frozenset:
+    """Binomial cores of every name NCBITaxon itself recognises for this id.
+
+    This is what keeps NCBI renames out of the gate. `preferred_term` preserves
+    the source paper's name, so one species id legitimately carries both
+    `Eubacterium rectale` and `Agathobacter rectalis` — different genus *and*
+    different epithet, which is otherwise the strongest possible clash signal.
+    Both are names NCBITaxon lists for `NCBITaxon:39491`, so both are the same
+    organism and neither is evidence of a wrong id.
+
+    Empty when the adapter is missing, which simply leaves the rank filter to
+    decide as before.
+    """
+    adapter = _adapter()
+    if adapter is None or not curie.startswith("NCBITaxon:"):
+        return frozenset()
+    names = []
+    try:
+        label = adapter.label(curie)
+        if label:
+            names.append(label)
+        names.extend(adapter.entity_aliases(curie) or [])
+    except Exception:
+        return frozenset()
+    return frozenset(core for core in (_core(n) for n in names) if core)
+
+
+def _same_genus(first: str, second: str) -> bool:
+    """Two genus tokens naming one genus.
+
+    Beyond equality this absorbs the two ways the KB spells a genus without
+    meaning a different one: a GTDB split suffix (`Olsenella_B`), and the
+    abbreviation a paper uses after first mention (`B. subtilis` beside
+    `Bacillus subtilis`).
+    """
+    first = _GTDB_GENUS_SUFFIX.sub("", first)
+    second = _GTDB_GENUS_SUFFIX.sub("", second)
+    if first == second:
+        return True
+    if len(first) == 1:
+        return second.startswith(first)
+    if len(second) == 1:
+        return first.startswith(second)
+    return False
+
+
+def _names_disagree(first: str, second: str, rank: str | None, known: frozenset) -> bool:
     """Do two `preferred_term`s under one id name genuinely different taxa?
 
     The rank decides what counts as a disagreement, and this is the whole design:
@@ -133,6 +223,9 @@ def _names_disagree(first: str, second: str, rank: str | None) -> bool:
       a contradiction: `Bacteroides ovatus` and `Bacteroides vulgatus` cannot
       both be `NCBITaxon:821`.
 
+    Two names that NCBITaxon *both* lists for the id are exempt whatever the
+    rank: that is a rename, not a clash — see `known_cores`.
+
     Names that are not binomials at all fall back to "no disagreement". A guild
     label like `rhizosphere Actinobacteria` says nothing this check can use, and
     guessing from it is how a gate becomes noise.
@@ -140,24 +233,42 @@ def _names_disagree(first: str, second: str, rank: str | None) -> bool:
     left, right = _core(first), _core(second)
     if left is None or right is None:
         return False
-    if left[0] != right[0]:
+    if left in known and right in known:
+        return False
+    if not _same_genus(left[0], right[0]):
         return True
-    return rank != "genus" and rank != "subgenus" and left[1] != right[1]
+    return rank not in ("genus", "subgenus") and left[1] != right[1]
 
 
 def check_record(taxonomy: list) -> list[str]:
-    """Messages for each specific id shared by genuinely different organisms."""
+    """Messages for each specific id shared by genuinely different organisms.
+
+    Malformed input is skipped rather than raised on. This runs inside
+    `validate_strict`, whose whole job is to report bad records — a record so
+    malformed that `taxonomy` holds a non-mapping is exactly what the schema
+    validator in that same pass diagnoses properly, and an exception here would
+    abort the run and discard every other file's findings (#429).
+    """
+    if not isinstance(taxonomy, list):
+        return []
     by_id: dict[str, list[str]] = {}
-    for entry in taxonomy or []:
-        term_block = entry.get("taxon_term") or {}
+    for entry in taxonomy:
+        if not isinstance(entry, dict):
+            continue
+        term_block = entry.get("taxon_term")
+        if not isinstance(term_block, dict):
+            continue
         term = term_block.get("term")
         if not isinstance(term, dict):
             continue
         curie = term.get("id") or ""
         name = term_block.get("preferred_term") or term.get("label") or ""
+        if not isinstance(curie, str) or not isinstance(name, str):
+            continue
         if curie and name and name not in by_id.get(curie, []):
             by_id.setdefault(curie, []).append(name)
 
+    _warn_once_if_unavailable()
     problems = []
     for curie, names in sorted(by_id.items()):
         # Cheap test first. Asking NCBITaxon for a rank opens a large SQLite
@@ -166,27 +277,19 @@ def check_record(taxonomy: list) -> list[str]:
         # of ~15, and the scan took minutes rather than seconds.
         if len(names) < 2:
             continue
-        rank = rank_of(curie)
-        if (rank or "") not in SPECIFIC_RANKS:
+        if not is_specific(curie):
             continue
-        clashing = sorted(
-            {
-                names[i]
-                for i in range(len(names))
-                for j in range(i)
-                if _names_disagree(names[i], names[j], rank)
-            }
-            | {
-                names[j]
-                for i in range(len(names))
-                for j in range(i)
-                if _names_disagree(names[i], names[j], rank)
-            }
-        )
-        if len(clashing) < 2:
+        rank = rank_of(curie)
+        known = known_cores(curie)
+        clashing: set[str] = set()
+        for i in range(len(names)):
+            for j in range(i):
+                if _names_disagree(names[i], names[j], rank, known):
+                    clashing.update((names[i], names[j]))
+        if not clashing:
             continue
         problems.append(
             f"{curie} ({rank}) is used for taxa that cannot all be it: "
-            + ", ".join(repr(n) for n in clashing)
+            + ", ".join(repr(n) for n in sorted(clashing))
         )
     return problems

--- a/src/communitymech/validators/shared_taxon_ids.py
+++ b/src/communitymech/validators/shared_taxon_ids.py
@@ -1,0 +1,192 @@
+"""One specific NCBITaxon id standing in for two different organisms (#292).
+
+Two KB records asserted facts about the wrong species. *Bacteroides ovatus*
+carried `NCBITaxon:821`, which is *Phocaeicola vulgatus*; a `Nitrospiraceae
+bacterium` carried `NCBITaxon:1236`, class Gammaproteobacteria — a different
+phylum. Both then acquired a GTDB block derived from the wrong id, which restates
+an error in a second field and makes it look better sourced.
+
+**No existing gate can see this.** `linkml-term-validator` checks that `term.id`
+and `term.label` correspond, and they do: `NCBITaxon:821` really is labelled
+"Phocaeicola vulgatus". The disagreement is between `preferred_term` and the
+grounded term, and comparing *those* is not viable — `preferred_term` differs
+from `term.label` right across the KB on purpose, preserving the source paper's
+name across NCBI renames (*Eubacterium rectale* -> *Agathobacter rectalis*, and
+~50 more). Flagging that would bury the signal.
+
+The usable signal is narrower: **one id reused for two genuinely different named
+organisms inside a single record.** Both defects had that shape, because both
+were copy-paste from a neighbouring entry.
+
+Sharpening it with rank is what makes it a gate rather than a report. A *broad*
+id shared across entries is normal and correct — environmental records
+deliberately put several functional guilds under `NCBITaxon:2` (Bacteria) or
+`NCBITaxon:131567` (cellular organisms). A *species* id shared by two different
+organisms is a contradiction: a species is one organism, so two names under it
+cannot both be right. NCBITaxon carries the rank, so this is a lookup rather than
+a guess, and the legitimate cases need no waiver list.
+
+Genus is included as specific. A genus id shared by two entries is a real
+pattern in MAG-based records ("Methylobacter MAG 1" / "MAG 2"), so those are
+allowed through when the names differ only by such a suffix — see
+`_looks_like_the_same_organism`.
+"""
+
+from __future__ import annotations
+
+import functools
+import re
+
+# NCBI ranks at or below which one id denotes one organism. Anything broader is
+# a clade that may legitimately host several distinct entries.
+SPECIFIC_RANKS = frozenset(
+    {
+        "species",
+        "subspecies",
+        "strain",
+        "isolate",
+        "serotype",
+        "serogroup",
+        "biotype",
+        "genotype",
+        "species_subgroup",
+        "forma_specialis",
+        "genus",
+        "subgenus",
+    }
+)
+
+# A binomial core: genus plus specific epithet, with everything that
+# distinguishes an *isolate* stripped. `Bacillus velezensis OB3` and `... NA3`
+# share a core; `Bacteroides ovatus` and `Bacteroides vulgatus` do not.
+_CORE = re.compile(r"^([A-Za-z][A-Za-z0-9_\-]*)\s+([a-z][a-z0-9_\-]*)")
+# GTDB-style placeholder epithets: `sp.`, `sp900119625`, `sp002874965`. All mean
+# "unnamed species", so two of them under one genus are not a contradiction.
+_PLACEHOLDER = re.compile(r"^sp\d*$")
+
+
+def _core(name: str) -> tuple[str, str] | None:
+    """(genus, epithet) for a Latin binomial, or None if the name is not one.
+
+    Parentheticals and trailing strain codes are dropped before matching, so
+    `Olsenella_B sp. (MAG ATO3)` reduces to `("olsenella_b", "sp")`.
+    """
+    cleaned = re.sub(r"\(.*?\)", " ", name or "").replace(".", " ")
+    match = _CORE.match(cleaned.strip())
+    if not match:
+        return None
+    genus, epithet = match.group(1).lower(), match.group(2).lower()
+    if _PLACEHOLDER.match(epithet):
+        epithet = "sp"
+    return genus, epithet
+
+
+@functools.lru_cache(maxsize=1)
+def _adapter():
+    try:
+        from oaklib import get_adapter  # type: ignore[import-untyped]
+
+        return get_adapter("sqlite:obo:ncbitaxon")
+    except Exception:
+        return None
+
+
+@functools.lru_cache(maxsize=4096)
+def rank_of(curie: str) -> str | None:
+    """The NCBI rank (`species`, `genus`, `class`, ...), or None if undetermined.
+
+    None whenever the adapter is missing or the term carries no rank, which
+    callers must treat as "cannot judge" — never as "specific". A gate that
+    fired when it could not look anything up would be noise on any machine
+    without the NCBITaxon database.
+    """
+    adapter = _adapter()
+    if adapter is None or not curie.startswith("NCBITaxon:"):
+        return None
+    try:
+        metadata = adapter.entity_metadata_map(curie)
+    except Exception:
+        return None
+    for key, values in (metadata or {}).items():
+        if "rank" not in key.lower():
+            continue
+        for value in values:
+            if isinstance(value, str) and value.startswith("NCBITaxon:"):
+                return value.split(":", 1)[1].replace("_", " ").strip().replace(" ", "_")
+    return None
+
+
+def is_specific(curie: str) -> bool:
+    """Does this id denote a single organism? False when undetermined."""
+    return (rank_of(curie) or "") in SPECIFIC_RANKS
+
+
+def _names_disagree(first: str, second: str, rank: str | None) -> bool:
+    """Do two `preferred_term`s under one id name genuinely different taxa?
+
+    The rank decides what counts as a disagreement, and this is the whole design:
+
+    * a **genus** id legitimately hosts many species and many unnamed isolates —
+      `Variovorax sp. BK119` through `BK752`, or a named species beside an
+      `sp.` — so only a differing *genus* is a contradiction there;
+    * a **species**-or-finer id denotes one organism, so a differing *epithet* is
+      a contradiction: `Bacteroides ovatus` and `Bacteroides vulgatus` cannot
+      both be `NCBITaxon:821`.
+
+    Names that are not binomials at all fall back to "no disagreement". A guild
+    label like `rhizosphere Actinobacteria` says nothing this check can use, and
+    guessing from it is how a gate becomes noise.
+    """
+    left, right = _core(first), _core(second)
+    if left is None or right is None:
+        return False
+    if left[0] != right[0]:
+        return True
+    return rank != "genus" and rank != "subgenus" and left[1] != right[1]
+
+
+def check_record(taxonomy: list) -> list[str]:
+    """Messages for each specific id shared by genuinely different organisms."""
+    by_id: dict[str, list[str]] = {}
+    for entry in taxonomy or []:
+        term_block = entry.get("taxon_term") or {}
+        term = term_block.get("term")
+        if not isinstance(term, dict):
+            continue
+        curie = term.get("id") or ""
+        name = term_block.get("preferred_term") or term.get("label") or ""
+        if curie and name and name not in by_id.get(curie, []):
+            by_id.setdefault(curie, []).append(name)
+
+    problems = []
+    for curie, names in sorted(by_id.items()):
+        # Cheap test first. Asking NCBITaxon for a rank opens a large SQLite
+        # database, and only a handful of ids in a record are shared at all —
+        # ordering this the other way meant ~1000 lookups per KB sweep instead
+        # of ~15, and the scan took minutes rather than seconds.
+        if len(names) < 2:
+            continue
+        rank = rank_of(curie)
+        if (rank or "") not in SPECIFIC_RANKS:
+            continue
+        clashing = sorted(
+            {
+                names[i]
+                for i in range(len(names))
+                for j in range(i)
+                if _names_disagree(names[i], names[j], rank)
+            }
+            | {
+                names[j]
+                for i in range(len(names))
+                for j in range(i)
+                if _names_disagree(names[i], names[j], rank)
+            }
+        )
+        if len(clashing) < 2:
+            continue
+        problems.append(
+            f"{curie} ({rank}) is used for taxa that cannot all be it: "
+            + ", ".join(repr(n) for n in clashing)
+        )
+    return problems

--- a/tests/test_gtdb_coherence_validator.py
+++ b/tests/test_gtdb_coherence_validator.py
@@ -502,7 +502,10 @@ def test_the_status_distribution_is_what_was_measured():
         counts["NO_GTDB_EQUIVALENT"] > 50
     ), "the eukaryote/virus population stopped being recognised as final (#393)"
     assert counts["AMBIGUOUS"] > 50
-    assert counts["WITHHELD"] == 2, "the #292 withholds must still be marked"
+    # 2 -> 1: `Bacteroides ovatus` was withheld only because its id was wrong.
+    # #292 corrected it (NCBITaxon:28116) and the grounding followed, so the
+    # withhold was removed rather than left protecting a fixed record.
+    assert counts["WITHHELD"] == 1, "the remaining #416 withhold must still be marked"
     # A floor as well as a ceiling: `< 50` alone is satisfied by zero, so
     # collapsing NOT_ATTEMPTED into another bucket passed.
     assert 1 <= counts["NOT_ATTEMPTED"] < 50, (
@@ -532,7 +535,6 @@ def test_the_withholds_are_marked_withheld_not_grounded():
     from communitymech.validators.gtdb_coherence import _taxon_terms
 
     for record, preferred in [
-        ("BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml", "Bacteroides ovatus"),
         ("KBase_ORT_Workflow_Community_Model.yaml", "Nitrospiraceae bacterium"),
     ]:
         doc = yaml.safe_load((REPO / "kb/communities" / record).read_text())
@@ -543,13 +545,13 @@ def test_the_withholds_are_marked_withheld_not_grounded():
     doc = yaml.safe_load(
         (REPO / "kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml").read_text()
     )
+    # `Bacteroides ovatus` no longer shares 821 — that was the bug (#292). What
+    # this still guards is that the entry which legitimately holds 821 kept its
+    # grounding when its former neighbour was corrected.
     siblings = [
-        t
-        for _, t in _taxon_terms(doc)
-        if (t.get("term") or {}).get("id") == "NCBITaxon:821"
-        and t.get("preferred_term") != "Bacteroides ovatus"
+        t for _, t in _taxon_terms(doc) if (t.get("term") or {}).get("id") == "NCBITaxon:821"
     ]
-    assert siblings, "expected another entry on NCBITaxon:821 in this record"
+    assert siblings, "expected an entry on NCBITaxon:821 in this record"
     for term_block in siblings:
         assert (
             term_block.get("gtdb_grounding_status") == "GROUNDED"

--- a/tests/test_gtdb_withheld_groundings.py
+++ b/tests/test_gtdb_withheld_groundings.py
@@ -1,18 +1,26 @@
 """Keep deliberately-withheld GTDB groundings withheld (#292, #293).
 
-Two taxa carry an ``NCBITaxon`` id belonging to a different organism, so the GTDB
-classification derived from that id describes the wrong species. Restating a wrong
-grounding in a second, independently-derived-looking field makes it harder to
-spot, not easier, so those two entries are left ungrounded until the ids are
-fixed.
+A withheld taxon is one where the block ``gtdb_ground.py`` would derive is wrong,
+so restating it in a second, independently-derived-looking field would make the
+error harder to spot rather than easier.
 
 ``gtdb_ground.py --apply`` has no memory of that decision: it is otherwise
 perfectly idempotent, but a re-run over the whole KB re-adds exactly these
 blocks. Without this test the withhold lasts only until the next person runs the
 tool and commits, and nothing anywhere fails.
 
-Removing an entry from ``WITHHELD`` is part of fixing #292 — correct the id, then
-re-run ``--apply`` and the right block appears on its own.
+Two reasons have put an entry here, and they need different fixes:
+
+* **a wrong id** (#292) — the id named a different organism, so everything
+  derived from it was wrong. Fix the id, re-run ``--apply``, and the right block
+  appears on its own; then drop the entry. That is what happened to
+  *Bacteroides ovatus*, which is why it is no longer listed.
+* **a wrong majority** (#416) — the id is right, but GTDB's majority vote for it
+  lands on a taxon whose physiology contradicts the record. No id edit fixes
+  that; it needs a curator to choose the grounding.
+
+Which one applies is in each entry's reason string, because the remediation
+differs and guessing wrong wastes a maintainer's afternoon.
 """
 
 from __future__ import annotations
@@ -24,7 +32,8 @@ import yaml
 
 COMMUNITIES = Path(__file__).parent.parent / "kb/communities"
 
-# (record, preferred_term) -> why the id is wrong. Tracked in #292.
+# (record, preferred_term) -> why the derived block would be wrong, and so which
+# remediation applies. Tracked in #292 (wrong id) and #416 (wrong majority).
 # `Bacteroides ovatus` was here until #292 was fixed: its id is now
 # NCBITaxon:28116 and `--apply` produced GTDB:s__Bacteroides_ovatus on its own,
 # exactly as the module docstring says it should. The entry is gone rather than
@@ -63,16 +72,18 @@ def test_withheld_taxon_is_still_present(record: str, preferred: str):
     ("record", "preferred"), list(WITHHELD), ids=[f"{r}::{p}" for r, p in WITHHELD]
 )
 def test_withheld_taxon_stays_ungrounded(record: str, preferred: str):
-    """No GTDB block on a taxon whose NCBITaxon id names a different organism."""
+    """No GTDB block on a taxon the tool would ground wrongly."""
     term = _taxon_term(record, preferred)
     assert term is not None
     assert "gtdb_classification" not in term, (
-        f"'{preferred}' in {record} was grounded in GTDB, but its NCBITaxon id is "
-        f"wrong: {WITHHELD[(record, preferred)]} A GTDB block derived from that id "
-        f"describes the wrong organism. `gtdb_ground.py --apply` re-adds it on every "
-        f"run (#293), so this is most likely an unreviewed tool re-run — revert it. "
-        f"To ground it properly, fix the NCBITaxon id first (#292), then drop this "
-        f"entry from WITHHELD."
+        f"'{preferred}' in {record} was grounded in GTDB, but that grounding is "
+        f"wrong: {WITHHELD[(record, preferred)]} `gtdb_ground.py --apply` re-adds "
+        f"it on every run (#293), so this is most likely an unreviewed tool re-run "
+        f"— revert it. Read the reason above before trying to fix it properly: if "
+        f"the NCBITaxon id is wrong, correct the id and the right block follows on "
+        f"its own (#292); if the id is right and GTDB's majority is the problem, no "
+        f"id edit helps and a curator has to choose the grounding (#416, #396). "
+        f"Either way, drop this entry from WITHHELD only once it is actually right."
     )
 
 

--- a/tests/test_gtdb_withheld_groundings.py
+++ b/tests/test_gtdb_withheld_groundings.py
@@ -7,7 +7,7 @@ spot, not easier, so those two entries are left ungrounded until the ids are
 fixed.
 
 ``gtdb_ground.py --apply`` has no memory of that decision: it is otherwise
-perfectly idempotent, but a re-run over the whole KB re-adds exactly these two
+perfectly idempotent, but a re-run over the whole KB re-adds exactly these
 blocks. Without this test the withhold lasts only until the next person runs the
 tool and commits, and nothing anywhere fails.
 
@@ -25,14 +25,16 @@ import yaml
 COMMUNITIES = Path(__file__).parent.parent / "kb/communities"
 
 # (record, preferred_term) -> why the id is wrong. Tracked in #292.
+# `Bacteroides ovatus` was here until #292 was fixed: its id is now
+# NCBITaxon:28116 and `--apply` produced GTDB:s__Bacteroides_ovatus on its own,
+# exactly as the module docstring says it should. The entry is gone rather than
+# kept-and-skipped, because a withhold list that outlives its reason is how a
+# correct grounding gets suppressed later.
 WITHHELD = {
-    ("BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml", "Bacteroides ovatus"): (
-        "NCBITaxon:821 is Phocaeicola vulgatus; B. ovatus is NCBITaxon:28116. "
-        "The record uses 821 correctly for its Bacteroides vulgatus entry."
-    ),
     ("KBase_ORT_Workflow_Community_Model.yaml", "Nitrospiraceae bacterium"): (
-        "NCBITaxon:1236 is class Gammaproteobacteria; Nitrospiraceae is Nitrospirota. "
-        "The record uses 1236 correctly for its two Steroidobacteraceae entries."
+        "GTDB's majority for NCBI Nitrospiraceae is f__Leptospirillaceae at 0.534, "
+        "and Leptospirillum is an iron oxidizer while this genome is the record's "
+        "nitrite oxidizer (#416). The id itself was corrected to NCBITaxon:189779."
     ),
 }
 

--- a/tests/test_shared_taxon_ids.py
+++ b/tests/test_shared_taxon_ids.py
@@ -27,7 +27,12 @@ from pathlib import Path
 import pytest
 import yaml
 
-from communitymech.validators.shared_taxon_ids import _core, check_record, rank_of
+from communitymech.validators.shared_taxon_ids import (
+    _core,
+    check_record,
+    known_cores,
+    rank_of,
+)
 
 REPO = Path(__file__).parent.parent
 
@@ -91,6 +96,85 @@ def test_legitimate_sharing_is_not_flagged(label, names, curie):
     assert check_record([_entry(n, curie) for n in names]) == [], label
 
 
+@pytest.mark.parametrize(
+    ("label", "names", "curie"),
+    [
+        # An NCBI rename, which is exactly what `preferred_term` exists to
+        # preserve. Different genus *and* different epithet — otherwise the
+        # strongest clash signal there is — but NCBITaxon lists both names for
+        # the id, so they are one organism (#430).
+        (
+            "a source-paper name preserved across an NCBI rename",
+            ["Agathobacter rectalis DSM 17629", "Eubacterium rectale ATCC 33656"],
+            "NCBITaxon:39491",
+        ),
+        (
+            "the same rename in the other direction",
+            ["Clostridium difficile 630", "Clostridioides difficile R20291"],
+            "NCBITaxon:1496",
+        ),
+        # A GTDB split of one NCBI genus, already in the KB as `Olsenella_B`.
+        (
+            "a GTDB genus split",
+            ["Olsenella sp. (MAG A)", "Olsenella_B sp. (MAG B)"],
+            "NCBITaxon:133925",
+        ),
+        # The abbreviation a paper uses after first mention. This one is live:
+        # the KB's own PET consortium spells one entry `B. subtilis 168 ...`.
+        (
+            "a genus abbreviated after first mention",
+            ["B. subtilis 168 Bs_PETase", "Bacillus subtilis 168 Bs_MHETase"],
+            "NCBITaxon:1423",
+        ),
+        (
+            "the same abbreviation for E. coli",
+            ["E. coli K-12", "Escherichia coli Nissle 1917"],
+            "NCBITaxon:562",
+        ),
+    ],
+)
+def test_one_organism_spelled_two_ways_is_not_a_clash(label, names, curie):
+    """Each of these fired before #430 and is legitimate."""
+    assert check_record([_entry(n, curie) for n in names]) == [], label
+
+
+def test_a_rename_exemption_does_not_swallow_the_real_defect():
+    """The exemption is per-name, so an unrelated species is still caught.
+
+    `Bacteroides vulgatus` *is* a name NCBITaxon lists for 821; `Bacteroides
+    ovatus` is not. Exempting the first must not exempt the pair.
+    """
+    assert ("bacteroides", "vulgatus") in known_cores("NCBITaxon:821")
+    assert ("bacteroides", "ovatus") not in known_cores("NCBITaxon:821")
+    problems = check_record(
+        [
+            _entry("Bacteroides vulgatus", "NCBITaxon:821"),
+            _entry("Bacteroides ovatus", "NCBITaxon:821"),
+        ]
+    )
+    assert len(problems) == 1, problems
+
+
+@pytest.mark.parametrize(
+    ("label", "taxonomy"),
+    [
+        ("a bare list item", [{"taxon_term": {"preferred_term": "A"}}, None]),
+        ("taxon_term as a string", [{"taxon_term": "Bacteroides"}]),
+        ("term as a list", [{"taxon_term": {"term": [1, 2]}}]),
+        ("a non-string id", [{"taxon_term": {"preferred_term": "A", "term": {"id": 123}}}]),
+        ("taxonomy that is not a list", "nonsense"),
+        ("no taxonomy at all", None),
+    ],
+)
+def test_malformed_input_is_skipped_not_raised_on(label, taxonomy):
+    """An exception here would abort validate-strict and discard every file.
+
+    The schema validator in that same pass diagnoses these properly; this check
+    must stay out of its way rather than crash the run (#429).
+    """
+    assert check_record(taxonomy) == [], label
+
+
 def test_a_broad_id_shared_across_guilds_is_fine():
     """Environmental records put several guilds under one clade on purpose."""
     assert (
@@ -138,6 +222,11 @@ def test_the_binomial_core_is_extracted_as_documented(name, expected):
 
 
 def test_the_committed_kb_is_clean():
+    # Without this the test passes vacuously wherever NCBITaxon is missing
+    # (#433): every rank comes back None, nothing is judged, and "no problems"
+    # means "nothing was looked at".
+    assert rank_of("NCBITaxon:821") == "species", "NCBITaxon unavailable; this proves nothing"
+
     scanned, problems = 0, []
     for directory in ("kb/communities", "data/isolates"):
         for path in sorted((REPO / directory).glob("*.yaml")):
@@ -151,20 +240,41 @@ def test_the_committed_kb_is_clean():
 def test_the_gate_fires_through_validate_strict(tmp_path):
     """It must run in CI, not only when called directly.
 
-    Uses the pre-fix version of the record from `main`, so the fixture is the
-    real defect rather than a hand-built imitation.
-    """
-    source = subprocess.run(
-        ["git", "show", "main:kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml"],
-        capture_output=True,
-        text=True,
-        cwd=REPO,
-    )
-    if source.returncode != 0 or "NCBITaxon:821" not in source.stdout:
-        pytest.skip("main no longer carries the pre-fix record; this fixture is stale")
+    The fixture is vendored rather than fetched with `git show main:...`. That
+    read the pre-fix record straight from history, which was appealing, but it
+    failed in both directions (#428): CI checks out at `fetch-depth: 1`, so
+    there was no local `main` and the test skipped on every PR; and once this
+    fix merged, `main` would return the *corrected* record while the staleness
+    guard — keyed on `NCBITaxon:821`, which the record still legitimately uses
+    for its `Bacteroides vulgatus` entry — would not notice, so the test would
+    assert a failure against a clean file and turn `main` red.
 
+    The two entries below are that record's, verbatim, as of the defect.
+    """
     probe = tmp_path / "Broken.yaml"
-    probe.write_text(source.stdout)
+    probe.write_text(
+        yaml.safe_dump(
+            {
+                "id": "CommunityMech:TEST",
+                "name": "pre-fix fixture for #292",
+                "taxonomy": [
+                    {
+                        "taxon_term": {
+                            "preferred_term": "Bacteroides vulgatus",
+                            "term": {"id": "NCBITaxon:821", "label": "Phocaeicola vulgatus"},
+                        }
+                    },
+                    {
+                        "taxon_term": {
+                            "preferred_term": "Bacteroides ovatus",
+                            "term": {"id": "NCBITaxon:821", "label": "Phocaeicola vulgatus"},
+                        }
+                    },
+                ],
+            },
+            sort_keys=False,
+        )
+    )
     result = subprocess.run(
         [
             "uv",
@@ -183,6 +293,46 @@ def test_the_gate_fires_through_validate_strict(tmp_path):
 
     assert result.returncode != 0
     assert "taxon_id_reused_for_another_organism" in (result.stdout + result.stderr)
+
+
+def _cli(*args, cwd):
+    return subprocess.run(
+        ["uv", "run", "python", "scripts/validate_shared_taxon_ids.py", *args],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        timeout=900,
+    )
+
+
+def test_the_cli_separates_a_finding_from_a_usage_error(tmp_path):
+    """`just validate-taxon-ids` must not report a typo'd path as a finding."""
+    clean = tmp_path / "Clean.yaml"
+    clean.write_text(
+        yaml.safe_dump({"taxonomy": [{"taxon_term": {"preferred_term": "A", "term": {}}}]})
+    )
+    dirty = tmp_path / "Dirty.yaml"
+    dirty.write_text(
+        yaml.safe_dump(
+            {
+                "taxonomy": [
+                    {"taxon_term": {"preferred_term": n, "term": {"id": "NCBITaxon:821"}}}
+                    for n in ("Bacteroides vulgatus", "Bacteroides ovatus")
+                ]
+            }
+        )
+    )
+
+    assert _cli(str(clean), cwd=REPO).returncode == 0
+    found = _cli(str(dirty), cwd=REPO)
+    assert found.returncode == 1
+    assert "NCBITaxon:821" in found.stdout
+
+    missing = _cli(str(tmp_path / "Nope.yaml"), cwd=REPO)
+    assert missing.returncode == 2, "a missing file must not look like a reused id"
+    assert "cannot read" in missing.stderr
+
+    assert _cli(cwd=REPO).returncode == 2, "no arguments is a usage error"
 
 
 def test_an_unavailable_ontology_stays_silent(monkeypatch):

--- a/tests/test_shared_taxon_ids.py
+++ b/tests/test_shared_taxon_ids.py
@@ -1,0 +1,233 @@
+"""One NCBITaxon id standing in for two different organisms (#292).
+
+`Bacteroides ovatus` carried `NCBITaxon:821`, which is *Phocaeicola vulgatus* —
+and the record used that same id, correctly, for its *Bacteroides vulgatus*
+entry. A GTDB block was then derived from the wrong id, restating the error in a
+second field where it looked better sourced.
+
+No gate could see it. `linkml-term-validator` checks `term.id` against
+`term.label`, and those agree; only `preferred_term` disagrees, and comparing
+*that* against the label is not viable because it legitimately differs across the
+KB to preserve source-paper names through NCBI renames.
+
+The design problem #292 flagged was false positives, and the naive version has
+plenty: on this KB it fires on nine records, every one legitimate — strain
+variants (`Bacillus velezensis OB3` / `NA3`), engineered constructs
+(`B. subtilis 168 Bs_PETase` / `Bs_MHETase`), and `sp.` isolates under a genus
+(`Variovorax sp. BK119` .. `BK752`). Comparing the *binomial core* and letting
+the id's rank decide what counts as a clash takes that to zero while still
+catching the real defect.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from communitymech.validators.shared_taxon_ids import _core, check_record, rank_of
+
+REPO = Path(__file__).parent.parent
+
+
+def _entry(name: str, curie: str) -> dict:
+    return {"taxon_term": {"preferred_term": name, "term": {"id": curie, "label": name}}}
+
+
+def test_the_defect_that_prompted_this_is_caught():
+    """#292's first error, reconstructed exactly."""
+    problems = check_record(
+        [
+            _entry("Bacteroides vulgatus", "NCBITaxon:821"),
+            _entry("Bacteroides ovatus", "NCBITaxon:821"),
+        ]
+    )
+
+    assert len(problems) == 1, problems
+    assert "NCBITaxon:821" in problems[0]
+    assert "ovatus" in problems[0] and "vulgatus" in problems[0]
+
+
+@pytest.mark.parametrize(
+    ("label", "names", "curie"),
+    [
+        # Every one of these is a real KB pattern the naive version flagged.
+        (
+            "strain variants",
+            ["Bacillus velezensis OB3", "Bacillus velezensis NA3"],
+            "NCBITaxon:492670",
+        ),
+        (
+            "engineered constructs",
+            ["Bacillus subtilis 168 Bs_PETase", "Bacillus subtilis 168 Bs_MHETase"],
+            "NCBITaxon:1423",
+        ),
+        (
+            "sp. isolates under a genus",
+            ["Variovorax sp. BK119", "Variovorax sp. BK151", "Variovorax sp. YR752"],
+            "NCBITaxon:34072",
+        ),
+        (
+            "named species beside an sp. under a genus",
+            ["Bifidobacterium tibiigranuli (MAG BIF2)", "Bifidobacterium sp. (MAG BIF11)"],
+            "NCBITaxon:1678",
+        ),
+        (
+            "GTDB placeholder epithets",
+            ["Olsenella_B sp. (MAG ATO3)", "Olsenella_B sp900119625 (MAG ATO6)"],
+            "NCBITaxon:133926",
+        ),
+        (
+            "guild labels that are not binomials",
+            ["rhizosphere Actinobacteria", "rhizosphere Firmicutes"],
+            "NCBITaxon:1239",
+        ),
+    ],
+)
+def test_legitimate_sharing_is_not_flagged(label, names, curie):
+    """False positives are the whole design problem — a noisy gate gets removed."""
+    assert check_record([_entry(n, curie) for n in names]) == [], label
+
+
+def test_a_broad_id_shared_across_guilds_is_fine():
+    """Environmental records put several guilds under one clade on purpose."""
+    assert (
+        check_record(
+            [
+                _entry("Prairie Pothole methanogens", "NCBITaxon:2157"),
+                _entry("Prairie Pothole sulfate reducers", "NCBITaxon:2157"),
+            ]
+        )
+        == []
+    )
+
+
+def test_a_differing_genus_is_caught_even_under_a_genus_id():
+    """The one clash a genus-rank id cannot absorb."""
+    problems = check_record(
+        [
+            _entry("Variovorax sp. BK119", "NCBITaxon:34072"),
+            _entry("Bacillus subtilis", "NCBITaxon:34072"),
+        ]
+    )
+    assert len(problems) == 1, problems
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("Bacteroides ovatus", ("bacteroides", "ovatus")),
+        ("Bacillus velezensis OB3", ("bacillus", "velezensis")),
+        ("Variovorax sp. BK119", ("variovorax", "sp")),
+        ("Olsenella_B sp900119625 (MAG ATO6)", ("olsenella_b", "sp")),
+        ("rhizosphere Actinobacteria", None),
+        ("Bacteria", None),
+        ("", None),
+        # A *mid-name* parenthetical, which is the only case where stripping
+        # them changes the answer — every KB name today puts its parenthetical
+        # last, where it cannot affect the leading two tokens. Without the
+        # strip this yields None and the pair is silently waived.
+        ("Bacillus (Weizmannia) coagulans", ("bacillus", "coagulans")),
+        ("Clostridium (sensu stricto) butyricum", ("clostridium", "butyricum")),
+    ],
+)
+def test_the_binomial_core_is_extracted_as_documented(name, expected):
+    assert _core(name) == expected
+
+
+def test_the_committed_kb_is_clean():
+    scanned, problems = 0, []
+    for directory in ("kb/communities", "data/isolates"):
+        for path in sorted((REPO / directory).glob("*.yaml")):
+            scanned += 1
+            document = yaml.safe_load(path.read_text()) or {}
+            problems += [f"{path.name}: {m}" for m in check_record(document.get("taxonomy") or [])]
+    assert scanned > 300, f"expected the KB, scanned {scanned}"
+    assert not problems, "\n".join(problems)
+
+
+def test_the_gate_fires_through_validate_strict(tmp_path):
+    """It must run in CI, not only when called directly.
+
+    Uses the pre-fix version of the record from `main`, so the fixture is the
+    real defect rather than a hand-built imitation.
+    """
+    source = subprocess.run(
+        ["git", "show", "main:kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml"],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+    )
+    if source.returncode != 0 or "NCBITaxon:821" not in source.stdout:
+        pytest.skip("main no longer carries the pre-fix record; this fixture is stale")
+
+    probe = tmp_path / "Broken.yaml"
+    probe.write_text(source.stdout)
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "scripts/validate_strict.py",
+            str(probe),
+            "--out",
+            str(tmp_path / "report.tsv"),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+        timeout=900,
+    )
+
+    assert result.returncode != 0
+    assert "taxon_id_reused_for_another_organism" in (result.stdout + result.stderr)
+
+
+def test_an_unavailable_ontology_stays_silent(monkeypatch):
+    """No rank means no judgement — the gate must not fire on a bare checkout."""
+    import communitymech.validators.shared_taxon_ids as module
+
+    real = module._adapter
+    module.rank_of.cache_clear()
+    monkeypatch.setattr(module, "_adapter", lambda: None)
+    try:
+        assert module.rank_of("NCBITaxon:821") is None
+        assert (
+            module.check_record(
+                [
+                    _entry("Bacteroides vulgatus", "NCBITaxon:821"),
+                    _entry("Bacteroides ovatus", "NCBITaxon:821"),
+                ]
+            )
+            == []
+        )
+    finally:
+        module.rank_of.cache_clear()
+        real.cache_clear()
+
+
+def test_what_this_gate_does_not_catch():
+    """Stated plainly, because #292's *second* defect is outside it.
+
+    `Nitrospiraceae bacterium` carried `NCBITaxon:1236` (class
+    Gammaproteobacteria) beside two `Steroidobacteraceae denitrifier` entries
+    where that id was correct. The rank filter passes over it: a class id shared
+    by several entries is exactly the legitimate pattern this gate must not
+    flag, so no threshold separates the two.
+
+    That defect was found and fixed by hand (PR #420). Catching its shape needs a
+    different signal — comparing the entry's claimed lineage against the id's —
+    which is #365's territory, not this one.
+    """
+    assert rank_of("NCBITaxon:1236") == "class"
+    assert (
+        check_record(
+            [
+                _entry("Steroidobacteraceae denitrifier 1", "NCBITaxon:1236"),
+                _entry("Nitrospiraceae bacterium", "NCBITaxon:1236"),
+            ]
+        )
+        == []
+    ), "if this now fires, the gate got stronger and the docstring is stale"


### PR DESCRIPTION
Closes #292.

## The defect

Two records asserted facts about the wrong species. *Bacteroides ovatus* carried `NCBITaxon:821`, which is *Phocaeicola vulgatus*; a `Nitrospiraceae bacterium` carried `NCBITaxon:1236`, class Gammaproteobacteria — a different phylum. Both then acquired a GTDB block derived from the wrong id, which restates an error in a second field and makes it look better sourced.

**No existing gate can see this.** `linkml-term-validator` checks that `term.id` and `term.label` correspond, and they do — `NCBITaxon:821` really is labelled "Phocaeicola vulgatus". The disagreement is between `preferred_term` and the grounded term, and comparing *those* is not viable: `preferred_term` differs from `term.label` right across the KB on purpose (preserving a source paper's name across NCBI renames).

## The gate

`shared_taxon_ids` flags the narrow, usable signal: **one id reused for two genuinely different named organisms inside a single record.** Sharpened by rank so it's a gate, not a report:

- A *broad* id shared across entries is normal (environmental records deliberately put several guilds under `NCBITaxon:2` / `NCBITaxon:131567`).
- A *species* id shared by two different organisms is a contradiction — a species is one organism.
- Genus is included as specific (a genus id shared by two entries is a real MAG pattern), so legitimate cases need no waiver list.

Wired into `validate_strict.py` (runs inside `just validate-strict`) and a single-file `just validate-taxon-ids` recipe.

## The fix

Corrected the *Bacteroides ovatus* entry: `821` → `NCBITaxon:28116`, regrounded to `GTDB:s__Bacteroides_ovatus`, and dropped from the `WITHHELD_GROUNDINGS` lists — the grounding now follows from the right id, so a withhold that outlives its reason would only suppress a correct grounding later. gtdb coherence/withheld tests updated to match.

## Validation

`just qc` passes (lint + test + every offline validator). New `tests/test_shared_taxon_ids.py` — 22 tests, including one reproducing the #292 defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)