### PR TITLE
Sharpen the one genuine GTDB demotion, and record why no rule can find them (#445)

### DIFF
--- a/.claude/skills/ground-taxa-gtdb/SKILL.md
+++ b/.claude/skills/ground-taxa-gtdb/SKILL.md
@@ -271,8 +271,19 @@ taxonomy entries and their id anchors do not line up.
   and `validate-gtdb` rejects the flag without a note — or a note without the
   flag, which reads as a decision while protecting nothing. (`--apply` only ever
   touches *ungrounded* taxa, so it could not have overwritten a pin anyway.)
-  Two blocks carry it: `NCBITaxon:18` (*Pelobacter* SFB93 → `g__Syntrophotalea`,
-  where the vote picks a selenate reducer) and `NCBITaxon:340177` (*Chlorobium*).
+  Eight blocks carry it, in two families. Three are votes a curator overrode:
+  `NCBITaxon:18` (*Pelobacter* SFB93 → `g__Syntrophotalea`, where the vote picks
+  a selenate reducer), `NCBITaxon:340177` (*Chlorobium*), and `NCBITaxon:85413`
+  (*Allobosea*, where the crosswalk predates an NCBI rename, #365). Four are
+  **demotions** — an NCBI clade GTDB kept but placed a rank lower, so the
+  rank-for-rank vote names a broader taxon than the record means (#445, #451):
+  *Ca. Parvarchaeota* → `o__Parvarchaeales`, *Ca. Dormiibacterota* →
+  `c__Dormibacteria`, *Chlorobiota* → `c__Chlorobiia`, *Ignavibacteriota* →
+  `c__Ignavibacteria`. The eighth is `NCBITaxon:28116` (*Bacteroides ovatus*).
+
+  Do not treat that list as authoritative — nothing enforces it, and it has gone
+  stale before. `grep -rl 'curated: true' kb/` is the current answer;
+  `tests/test_gtdb_demoted_clades.py` pins the demotion decisions specifically.
 
   The script also keeps a `CURATED_GROUNDINGS` list as a fallback, but prefer the
   flag: a list protects only what someone remembered to add, which is how

--- a/.claude/skills/ground-taxa-gtdb/SKILL.md
+++ b/.claude/skills/ground-taxa-gtdb/SKILL.md
@@ -271,16 +271,17 @@ taxonomy entries and their id anchors do not line up.
   and `validate-gtdb` rejects the flag without a note — or a note without the
   flag, which reads as a decision while protecting nothing. (`--apply` only ever
   touches *ungrounded* taxa, so it could not have overwritten a pin anyway.)
-  Nine blocks carry it, in two families. Four are votes a curator overrode:
+  Eleven blocks carry it, in two families. Four are votes a curator overrode:
   `NCBITaxon:18` (*Pelobacter* SFB93 → `g__Syntrophotalea`, where the vote picks
   a selenate reducer), `NCBITaxon:340177` (*Chlorobium*), and `NCBITaxon:85413`
-  (*Allobosea*, where the crosswalk predates an NCBI rename, #365). Five are
+  (*Allobosea*, where the crosswalk predates an NCBI rename, #365). Seven are
   **demotions** — an NCBI clade GTDB kept but placed a rank lower, so the
   rank-for-rank vote names a broader taxon than the record means (#445, #451):
   *Ca. Parvarchaeota* → `o__Parvarchaeales`, *Ca. Dormiibacterota* →
   `c__Dormibacteria`, *Chlorobiota* → `c__Chlorobiia`, *Ignavibacteriota* →
-  `c__Ignavibacteria`, and *Nitrososphaerota* -> `c__Nitrososphaeria`. The count
-  is blocks, not ids: `NCBITaxon:85413` is pinned in two records.
+  `c__Ignavibacteria`, *Nitrososphaerota* -> `c__Nitrososphaeria`, and
+  *Betaproteobacteria* -> `o__Burkholderiales`. The count is blocks, not ids:
+  `NCBITaxon:85413` and `NCBITaxon:28216` are each pinned in two records.
 
   Do not treat that list as authoritative — nothing enforces it, and it has gone
   stale before. `grep -rl 'curated: true' kb/` is the current answer;

--- a/.claude/skills/ground-taxa-gtdb/SKILL.md
+++ b/.claude/skills/ground-taxa-gtdb/SKILL.md
@@ -271,15 +271,16 @@ taxonomy entries and their id anchors do not line up.
   and `validate-gtdb` rejects the flag without a note — or a note without the
   flag, which reads as a decision while protecting nothing. (`--apply` only ever
   touches *ungrounded* taxa, so it could not have overwritten a pin anyway.)
-  Eight blocks carry it, in two families. Three are votes a curator overrode:
+  Nine blocks carry it, in two families. Four are votes a curator overrode:
   `NCBITaxon:18` (*Pelobacter* SFB93 → `g__Syntrophotalea`, where the vote picks
   a selenate reducer), `NCBITaxon:340177` (*Chlorobium*), and `NCBITaxon:85413`
-  (*Allobosea*, where the crosswalk predates an NCBI rename, #365). Four are
+  (*Allobosea*, where the crosswalk predates an NCBI rename, #365). Five are
   **demotions** — an NCBI clade GTDB kept but placed a rank lower, so the
   rank-for-rank vote names a broader taxon than the record means (#445, #451):
   *Ca. Parvarchaeota* → `o__Parvarchaeales`, *Ca. Dormiibacterota* →
   `c__Dormibacteria`, *Chlorobiota* → `c__Chlorobiia`, *Ignavibacteriota* →
-  `c__Ignavibacteria`. The eighth is `NCBITaxon:28116` (*Bacteroides ovatus*).
+  `c__Ignavibacteria`, and *Nitrososphaerota* -> `c__Nitrososphaeria`. The count
+  is blocks, not ids: `NCBITaxon:85413` is pinned in two records.
 
   Do not treat that list as authoritative — nothing enforces it, and it has gone
   stale before. `grep -rl 'curated: true' kb/` is the current answer;

--- a/kb/communities/Anammox_Granule_Metabolic_Interaction_Community.yaml
+++ b/kb/communities/Anammox_Granule_Metabolic_Interaction_Community.yaml
@@ -73,15 +73,24 @@ taxonomy:
       label: Chlorobiota
     gtdb_grounding_status: GROUNDED
     gtdb_classification:
-      gtdb_id: GTDB:p__Bacteroidota
-      gtdb_taxon: Bacteroidota
-      gtdb_lineage: d__Bacteria;p__Bacteroidota
+      curated: true
+      curation_note: 'Sharpened from p__Bacteroidota, which the rank-for-rank vote returns because NCBI
+        calls Chlorobiota a phylum (#451). GTDB demoted it rather than dissolving it - the clade survives
+        as c__Chlorobiia inside Bacteroidota - and all 24 named-species rows behind this grounding are
+        Chlorobiia, so the sharper term carries the same 132/132 confidence. The phylum term was not
+        wrong, only silent: GTDB:p__Bacteroidota is the most-shared higher-rank term in this KB, on seven
+        groundings, so it distinguished this entry from none of them. Class rather than order:
+        o__Chlorobiales also bears the name but is narrower than the NCBI phylum, and c__Chlorobiia is
+        the most senior GTDB term that still means Chlorobiota.'
+      gtdb_id: GTDB:c__Chlorobiia
+      gtdb_taxon: Chlorobiia
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Chlorobiia
       ncbi_source_id: NCBITaxon:1090
       majority_fraction: 1.0
       support_genomes: 132
       total_genomes: 132
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 1 GTDB taxa under the NCBI taxon]
     notes: Chlorobi-affiliated MAGs, especially CHB1 and CHB2, were inferred as active protein and peptide
       degraders in the EPS matrix.
   functional_role:

--- a/kb/communities/Anammox_Granule_Metabolic_Interaction_Community.yaml
+++ b/kb/communities/Anammox_Granule_Metabolic_Interaction_Community.yaml
@@ -78,10 +78,11 @@ taxonomy:
         calls Chlorobiota a phylum (#451). GTDB demoted it rather than dissolving it - the clade survives
         as c__Chlorobiia inside Bacteroidota - and all 24 named-species rows behind this grounding are
         Chlorobiia, so the sharper term carries the same 132/132 confidence. The phylum term was not
-        wrong, only silent: GTDB:p__Bacteroidota is the most-shared higher-rank term in this KB, on seven
-        groundings, so it distinguished this entry from none of them. Class rather than order:
-        o__Chlorobiales also bears the name but is narrower than the NCBI phylum, and c__Chlorobiia is
-        the most senior GTDB term that still means Chlorobiota.'
+        wrong, only silent: GTDB:p__Bacteroidota carries five other groundings in this KB, so it
+        distinguished this entry from none of them. Class because c__Chlorobiia is the most senior GTDB
+        term that bears the clade name; o__Chlorobiales bears it too and is coextensive with the class
+        here - every row under one is under the other - so the choice between them is about which rank
+        the NCBI phylum corresponds to, not about evidence.'
       gtdb_id: GTDB:c__Chlorobiia
       gtdb_taxon: Chlorobiia
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Chlorobiia

--- a/kb/communities/East_River_Floodplain_Core_Microbiome.yaml
+++ b/kb/communities/East_River_Floodplain_Core_Microbiome.yaml
@@ -43,7 +43,7 @@ taxonomy:
       support_genomes: 41903
       total_genomes: 41937
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: Betaproteobacteria had the highest number of representative genomes and dominated the operationally
       defined core floodplain microbiome.
   functional_role:

--- a/kb/communities/East_River_Floodplain_Core_Microbiome.yaml
+++ b/kb/communities/East_River_Floodplain_Core_Microbiome.yaml
@@ -24,15 +24,26 @@ taxonomy:
       label: Betaproteobacteria
     gtdb_grounding_status: GROUNDED
     gtdb_classification:
-      gtdb_id: GTDB:c__Gammaproteobacteria
-      gtdb_taxon: Gammaproteobacteria
-      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria
+      curated: true
+      curation_note: 'Sharpened from c__Gammaproteobacteria, which the rank-for-rank vote returns because
+        NCBI calls Betaproteobacteria a class (#451). GTDB demoted it - the clade is the order
+        Burkholderiales inside Gammaproteobacteria - and 41903 of the 41937 named-species genomes behind
+        this grounding are Burkholderiales, the remainder being 31 in Enterobacterales and 3 in
+        Pseudomonadales. The class term was not wrong, only silent: c__Gammaproteobacteria is where GTDB
+        also puts NCBI Gammaproteobacteria itself, so the vote said only "Proteobacteria of some kind"
+        about an entry whose whole content is that it is Betaproteobacteria. This case is why the
+        module docstring no longer claims to enumerate demotions: it defeats both screens used to find
+        the others, being neither unanimous (0.999) nor name-preserving (GTDB renamed while demoting, so
+        Betaproteobacteria and Burkholderiales share one letter).'
+      gtdb_id: GTDB:o__Burkholderiales
+      gtdb_taxon: Burkholderiales
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales
       ncbi_source_id: NCBITaxon:28216
-      majority_fraction: 1.0
-      support_genomes: 41937
+      majority_fraction: 0.999
+      support_genomes: 41903
       total_genomes: 41937
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: Betaproteobacteria had the highest number of representative genomes and dominated the operationally
       defined core floodplain microbiome.
   functional_role:

--- a/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
+++ b/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
@@ -44,15 +44,26 @@ taxonomy:
       label: Nitrososphaerota
     gtdb_grounding_status: GROUNDED
     gtdb_classification:
-      gtdb_id: GTDB:p__Thermoproteota
-      gtdb_taxon: Thermoproteota
-      gtdb_lineage: d__Archaea;p__Thermoproteota
+      curated: true
+      curation_note: 'Sharpened from p__Thermoproteota, which the rank-for-rank vote returns because NCBI
+        calls Nitrososphaerota (Thaumarchaeota) a phylum (#451). GTDB demoted it - the clade survives as
+        c__Nitrososphaeria inside Thermoproteota - and every one of the 65 named-species rows behind this
+        grounding is Nitrososphaeria, once GTDB''s polyphyly suffix is set aside: 57 rows read
+        Nitrososphaeria and 8 read Nitrososphaeria_A, which is the same clade split for monophyly, not a
+        different one. The stored fraction counts only the unsuffixed name, so 552 of 631 genomes, where
+        the phylum vote claimed 631 of 631 - less confident and more informative. p__Thermoproteota also
+        absorbs NCBI Crenarchaeota and Korarchaeota, so it did not distinguish this entry; the record
+        names Thaumarchaeota specifically and ties it to archaeal amoA ammonia oxidation, which is a
+        Nitrososphaeria trait.'
+      gtdb_id: GTDB:c__Nitrososphaeria
+      gtdb_taxon: Nitrososphaeria
+      gtdb_lineage: d__Archaea;p__Thermoproteota;c__Nitrososphaeria
       ncbi_source_id: NCBITaxon:651137
-      majority_fraction: 1.0
-      support_genomes: 631
+      majority_fraction: 0.875
+      support_genomes: 552
       total_genomes: 631
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: 'Dominant archaeal lineage representing basal Thaumarchaeota clades adapted to deep subsurface
       thermophilic conditions. Naica Thaumarchaeota possess archaeal ammonia monooxygenase (amoA) genes,
       demonstrating their role in autotrophic ammonia oxidation coupled to CO₂ fixation. High GC content

--- a/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
+++ b/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
@@ -280,7 +280,7 @@ taxonomy:
       support_genomes: 41903
       total_genomes: 41937
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 4 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 3 GTDB taxa under the NCBI taxon]
     notes: 'Beta-proteobacteria present in Naica subsurface waters, potentially representing autotrophic
       sulfur oxidizers or denitrifiers. In oligotrophic subsurface aquifers, Betaproteobacteria include
       chemolithoautotrophs such as Thiobacillus (sulfur oxidation coupled to denitrification) and heterotrophic

--- a/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
+++ b/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
@@ -48,11 +48,14 @@ taxonomy:
       curation_note: 'Sharpened from p__Thermoproteota, which the rank-for-rank vote returns because NCBI
         calls Nitrososphaerota (Thaumarchaeota) a phylum (#451). GTDB demoted it - the clade survives as
         c__Nitrososphaeria inside Thermoproteota - and every one of the 65 named-species rows behind this
-        grounding is Nitrososphaeria, once GTDB''s polyphyly suffix is set aside: 57 rows read
-        Nitrososphaeria and 8 read Nitrososphaeria_A, which is the same clade split for monophyly, not a
-        different one. The stored fraction counts only the unsuffixed name, so 552 of 631 genomes, where
-        the phylum vote claimed 631 of 631 - less confident and more informative. p__Thermoproteota also
-        absorbs NCBI Crenarchaeota and Korarchaeota, so it did not distinguish this entry; the record
+        grounding carries a Nitrososphaeria name: 57 rows read Nitrososphaeria and 8 read
+        Nitrososphaeria_A. The suffix is what made this demotion invisible to a sweep demanding exact
+        agreement (#453), but the two are not interchangeable - GTDB adds it to lineages that are not
+        monophyletic with the type, and these eight are o__Caldarchaeales thermophiles rather than
+        ammonia-oxidising Thaumarchaeota. So the grounding takes the unsuffixed name only: 552 of 631
+        genomes, where the phylum vote claimed 631 of 631 - less confident and more informative.
+        p__Thermoproteota also holds ten other NCBI phyla, among them Ca. Bathyarchaeota and
+        Ca. Marsarchaeota, so it did not distinguish this entry; the record
         names Thaumarchaeota specifically and ties it to archaeal amoA ammonia oxidation, which is a
         Nitrososphaeria trait.'
       gtdb_id: GTDB:c__Nitrososphaeria
@@ -258,15 +261,26 @@ taxonomy:
       label: Betaproteobacteria
     gtdb_grounding_status: GROUNDED
     gtdb_classification:
-      gtdb_id: GTDB:c__Gammaproteobacteria
-      gtdb_taxon: Gammaproteobacteria
-      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria
+      curated: true
+      curation_note: 'Sharpened from c__Gammaproteobacteria, which the rank-for-rank vote returns because
+        NCBI calls Betaproteobacteria a class (#451). GTDB demoted it - the clade is the order
+        Burkholderiales inside Gammaproteobacteria - and 41903 of the 41937 named-species genomes behind
+        this grounding are Burkholderiales, the remainder being 31 in Enterobacterales and 3 in
+        Pseudomonadales. The class term was not wrong, only silent: c__Gammaproteobacteria is where GTDB
+        also puts NCBI Gammaproteobacteria itself, so the vote said only "Proteobacteria of some kind"
+        about an entry whose whole content is that it is Betaproteobacteria. This case is why the
+        module docstring no longer claims to enumerate demotions: it defeats both screens used to find
+        the others, being neither unanimous (0.999) nor name-preserving (GTDB renamed while demoting, so
+        Betaproteobacteria and Burkholderiales share one letter).'
+      gtdb_id: GTDB:o__Burkholderiales
+      gtdb_taxon: Burkholderiales
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales
       ncbi_source_id: NCBITaxon:28216
-      majority_fraction: 1.0
-      support_genomes: 41937
+      majority_fraction: 0.999
+      support_genomes: 41903
       total_genomes: 41937
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 4 GTDB taxa under the NCBI taxon]
     notes: 'Beta-proteobacteria present in Naica subsurface waters, potentially representing autotrophic
       sulfur oxidizers or denitrifiers. In oligotrophic subsurface aquifers, Betaproteobacteria include
       chemolithoautotrophs such as Thiobacillus (sulfur oxidation coupled to denitrification) and heterotrophic

--- a/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
+++ b/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
@@ -233,8 +233,7 @@ taxonomy:
         grounding is Parvarchaeales, so the sharper term carries the same 20/20 confidence. The phylum
         term was not wrong, only uninformative - p__Nanoarchaeota also absorbs five other NCBI phyla
         (Ca. Woesearchaeota, Nanobdellota, Methanobacteriota, Ca. Iainarchaeota, Ca. Aenigmatarchaeota),
-        so it said nothing that distinguishes this entry, in a record whose Micrarchaeota (ARMAN-1/2)
-        entry is a near neighbour. Order rank because c__Nanoarchaeia does not bear the clade name and
+        so it said nothing that distinguishes this entry from those six. Order rank because c__Nanoarchaeia does not bear the clade name and
         o__Parvarchaeales is the most senior GTDB term that does. It is coextensive with
         f__Parvarchaeaceae in this crosswalk - every row under one is under the other - so the choice
         between them is about which rank the NCBI phylum corresponds to, not about evidence.'

--- a/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
+++ b/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
@@ -226,15 +226,26 @@ taxonomy:
       id: NCBITaxon:1462422
       label: Candidatus Parvarchaeota
     gtdb_classification:
-      gtdb_id: GTDB:p__Nanoarchaeota
-      gtdb_taxon: Nanoarchaeota
-      gtdb_lineage: d__Archaea;p__Nanoarchaeota
+      curated: true
+      curation_note: 'Sharpened from p__Nanoarchaeota, which the rank-for-rank vote returns because NCBI
+        calls Parvarchaeota a phylum (#445). GTDB demoted it rather than dissolving it: the clade survives
+        as o__Parvarchaeales inside p__Nanoarchaeota, and every one of the named-species rows behind this
+        grounding is Parvarchaeales, so the sharper term carries the same 20/20 confidence. The phylum
+        term was not wrong, only uninformative - p__Nanoarchaeota also absorbs NCBI Ca. Woesearchaeota,
+        Nanobdellota and Ca. Iainarchaeota, so it would have said nothing that distinguishes this entry
+        from three other phyla, in a record whose Micrarchaeota (ARMAN-1/2) entry is a near neighbour.
+        Order rank, not family: c__Nanoarchaeia does not bear the clade name and f__Parvarchaeaceae is
+        narrower than the NCBI phylum, so o__Parvarchaeales is the most senior GTDB term that still
+        means Parvarchaeota.'
+      gtdb_id: GTDB:o__Parvarchaeales
+      gtdb_taxon: Parvarchaeales
+      gtdb_lineage: d__Archaea;p__Nanoarchaeota;c__Nanoarchaeia;o__Parvarchaeales
       ncbi_source_id: NCBITaxon:1462422
       majority_fraction: 1.0
       support_genomes: 20
       total_genomes: 20
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at o__ rank; 1 GTDB taxa under the NCBI taxon]
     gtdb_grounding_status: GROUNDED
     notes: 'Ultra-small archaea (ARMAN-4 and ARMAN-5) belonging to Parvarchaeota phylum,
       limited to AMD and hot spring habitats. These nanoorganisms have genomes ~1

--- a/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
+++ b/kb/communities/Richmond_Mine_AMD_Biofilm.yaml
@@ -231,12 +231,13 @@ taxonomy:
         calls Parvarchaeota a phylum (#445). GTDB demoted it rather than dissolving it: the clade survives
         as o__Parvarchaeales inside p__Nanoarchaeota, and every one of the named-species rows behind this
         grounding is Parvarchaeales, so the sharper term carries the same 20/20 confidence. The phylum
-        term was not wrong, only uninformative - p__Nanoarchaeota also absorbs NCBI Ca. Woesearchaeota,
-        Nanobdellota and Ca. Iainarchaeota, so it would have said nothing that distinguishes this entry
-        from three other phyla, in a record whose Micrarchaeota (ARMAN-1/2) entry is a near neighbour.
-        Order rank, not family: c__Nanoarchaeia does not bear the clade name and f__Parvarchaeaceae is
-        narrower than the NCBI phylum, so o__Parvarchaeales is the most senior GTDB term that still
-        means Parvarchaeota.'
+        term was not wrong, only uninformative - p__Nanoarchaeota also absorbs five other NCBI phyla
+        (Ca. Woesearchaeota, Nanobdellota, Methanobacteriota, Ca. Iainarchaeota, Ca. Aenigmatarchaeota),
+        so it said nothing that distinguishes this entry, in a record whose Micrarchaeota (ARMAN-1/2)
+        entry is a near neighbour. Order rank because c__Nanoarchaeia does not bear the clade name and
+        o__Parvarchaeales is the most senior GTDB term that does. It is coextensive with
+        f__Parvarchaeaceae in this crosswalk - every row under one is under the other - so the choice
+        between them is about which rank the NCBI phylum corresponds to, not about evidence.'
       gtdb_id: GTDB:o__Parvarchaeales
       gtdb_taxon: Parvarchaeales
       gtdb_lineage: d__Archaea;p__Nanoarchaeota;c__Nanoarchaeia;o__Parvarchaeales

--- a/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
+++ b/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
@@ -107,8 +107,8 @@ taxonomy:
         calls Ignavibacteriota a phylum (#451). GTDB demoted it rather than dissolving it - the clade
         survives as c__Ignavibacteria inside Bacteroidota - and all 3 named-species rows behind this
         grounding are Ignavibacteria, so the sharper term carries the same 7/7 confidence. The phylum
-        term was not wrong, only silent: GTDB:p__Bacteroidota is the most-shared higher-rank term in this
-        KB, on seven groundings, and this record''s own preferred_term names Ignavibacteria specifically.
+        term was not wrong, only silent: GTDB:p__Bacteroidota carries five other groundings in this KB,
+        while this record''s own preferred_term names Ignavibacteria specifically.
         Class rather than order: o__Ignavibacteriales also bears the name but is narrower than the NCBI
         phylum, and c__Ignavibacteria is the most senior GTDB term that still means Ignavibacteriota.'
       gtdb_id: GTDB:c__Ignavibacteria

--- a/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
+++ b/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
@@ -109,8 +109,10 @@ taxonomy:
         grounding are Ignavibacteria, so the sharper term carries the same 7/7 confidence. The phylum
         term was not wrong, only silent: GTDB:p__Bacteroidota carries five other groundings in this KB,
         while this record''s own preferred_term names Ignavibacteria specifically.
-        Class rather than order: o__Ignavibacteriales also bears the name but is narrower than the NCBI
-        phylum, and c__Ignavibacteria is the most senior GTDB term that still means Ignavibacteriota.'
+        Class because c__Ignavibacteria is the most senior GTDB term that bears the clade name;
+        o__Ignavibacteriales bears it too and is coextensive with the class under the named-species rows
+        this block counts, so the choice between them is about which rank the NCBI phylum corresponds
+        to, not about evidence.'
       gtdb_id: GTDB:c__Ignavibacteria
       gtdb_taxon: Ignavibacteria
       gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Ignavibacteria

--- a/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
+++ b/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
@@ -102,15 +102,24 @@ taxonomy:
       label: Ignavibacteriota
     gtdb_grounding_status: GROUNDED
     gtdb_classification:
-      gtdb_id: GTDB:p__Bacteroidota
-      gtdb_taxon: Bacteroidota
-      gtdb_lineage: d__Bacteria;p__Bacteroidota
+      curated: true
+      curation_note: 'Sharpened from p__Bacteroidota, which the rank-for-rank vote returns because NCBI
+        calls Ignavibacteriota a phylum (#451). GTDB demoted it rather than dissolving it - the clade
+        survives as c__Ignavibacteria inside Bacteroidota - and all 3 named-species rows behind this
+        grounding are Ignavibacteria, so the sharper term carries the same 7/7 confidence. The phylum
+        term was not wrong, only silent: GTDB:p__Bacteroidota is the most-shared higher-rank term in this
+        KB, on seven groundings, and this record''s own preferred_term names Ignavibacteria specifically.
+        Class rather than order: o__Ignavibacteriales also bears the name but is narrower than the NCBI
+        phylum, and c__Ignavibacteria is the most senior GTDB term that still means Ignavibacteriota.'
+      gtdb_id: GTDB:c__Ignavibacteria
+      gtdb_taxon: Ignavibacteria
+      gtdb_lineage: d__Bacteria;p__Bacteroidota;c__Ignavibacteria
       ncbi_source_id: NCBITaxon:1134404
       majority_fraction: 1.0
       support_genomes: 7
       total_genomes: 7
       is_reclassified: true
-      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at p__ rank; 1 GTDB taxa under the NCBI taxon]
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at c__ rank; 1 GTDB taxa under the NCBI taxon]
   functional_role:
   - SYNTROPHIC_PARTNER
   evidence:

--- a/tests/test_gtdb_demoted_clades.py
+++ b/tests/test_gtdb_demoted_clades.py
@@ -1,0 +1,142 @@
+"""GTDB demotions, where the rank-for-rank vote is true but uninformative (#445).
+
+`gtdb_ground.py` votes at the rank the NCBI taxon sits at. When GTDB has
+**demoted** an NCBI clade — kept the organism concept but placed it lower — that
+answer names a broader taxon than the record meant. *Candidatus Dormiibacterota*
+is an NCBI candidate phylum that GTDB keeps as `c__Dormibacteria` inside
+Chloroflexota, so the phylum vote returned `p__Chloroflexota` — which the same
+record already used for its *Chloroflexi* entry, collapsing two of the three
+phyla its cited snippet contrasts into one GTDB concept.
+
+**No automatic rule is safe here, which is the finding rather than the
+workaround.** Measured over all 159 higher-rank groundings in the KB, six look
+sharpenable — every one of the winning rows agrees at a finer rank — but only
+two are demotions:
+
+* `Gemmatimonadota` (×2) and `Thermotogota` keep their own names in GTDB
+  (`is_reclassified: false`). The NCBI taxon *is* the GTDB phylum; sharpening to
+  a class would assert something the data does not say. A rule keyed on
+  "the winning rows agree at a finer rank" would have mis-sharpened all three.
+* `Rhodospirillales` -> `o__RF32` looks weak by *rows* (7 of 328) but is a
+  0.704 majority by *genomes*, which is the denominator the tool uses.
+* `Candidatus Methanophagales` -> `o__Alkanophagales` is a genuine
+  reclassification, but **no** GTDB taxon bears the NCBI clade's name, so there
+  is nothing to sharpen *to*. It stays where it is.
+
+What separates a demotion is that a finer GTDB rank still carries the clade's
+name — and testing *that* mechanically is where it breaks down: the shared stem
+of `Parvarchaeota`/`Parvarchaeales` is 10 characters, of
+`Dormiibacterota`/`Dormibacteria` only 5 (NCBI doubles the `i`), and of
+`Methanophagales`/`Methanospirareceae` 7. No threshold separates the two real
+cases from the false one.
+
+So this is a curator's call, and these tests pin the calls that were made rather
+than trying to re-derive them. Each decision travels with the data as
+`curated: true`, so `--apply` will not overwrite it; what these tests add is
+that removing the pin, or quietly re-broadening the term, fails.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).parent.parent
+COMMUNITIES = REPO / "kb/communities"
+
+# (record, preferred_term) -> the term a curator chose, and what the tool's
+# rank-for-rank vote would have returned instead.
+SHARPENED = {
+    ("Richmond_Mine_AMD_Biofilm.yaml", "Parvarchaeota (ARMAN-4/5)"): (
+        "GTDB:o__Parvarchaeales",
+        "GTDB:p__Nanoarchaeota",
+    ),
+    (
+        "Soil_BGC_Phylum_Depth_Vegetation_Community.yaml",
+        "Candidatus Dormibacteraeota (prolific BGC producers)",
+    ): (
+        "GTDB:c__Dormibacteria",
+        "GTDB:p__Chloroflexota",
+    ),
+}
+
+# The mirror case: reclassified, and deliberately *not* sharpened, because no
+# GTDB taxon carries the NCBI clade's name.
+LEFT_BROAD = {
+    (
+        "ANME_SRB_Anaerobic_Methanotrophic_Syntrophic_Consortia.yaml",
+        "ANME-1 (anaerobic methanotrophic archaea, clade 1)",
+    ): "GTDB:o__Alkanophagales",
+}
+
+
+def _entry(record: str, preferred: str) -> dict:
+    doc = yaml.safe_load((COMMUNITIES / record).read_text())
+    for item in doc.get("taxonomy") or []:
+        block = (item or {}).get("taxon_term") or {}
+        if block.get("preferred_term") == preferred:
+            return block
+    raise AssertionError(f"{preferred!r} is gone from {record}")
+
+
+@pytest.mark.parametrize(
+    ("record", "preferred"), list(SHARPENED), ids=[f"{r}::{p}"[:60] for r, p in SHARPENED]
+)
+def test_a_sharpened_grounding_keeps_its_curated_term(record: str, preferred: str):
+    chosen, would_be = SHARPENED[(record, preferred)]
+    block = _entry(record, preferred)
+    grounding = block.get("gtdb_classification") or {}
+
+    assert grounding.get("gtdb_id") == chosen, (
+        f"'{preferred}' in {record} should be grounded at {chosen}. If it now reads "
+        f"{would_be}, the rank-for-rank vote has been reapplied over a curator's "
+        f"decision — GTDB demoted this clade, so the vote names a broader taxon "
+        f"than the record means (#445)."
+    )
+    assert grounding.get("curated") is True, (
+        f"the pin on '{preferred}' is what stops `gtdb_ground.py --apply` "
+        f"rewriting it; without it the decision survives only in git."
+    )
+    assert grounding.get("curation_note"), "a pin without its reason is unreviewable"
+
+
+@pytest.mark.parametrize(
+    ("record", "preferred"), list(LEFT_BROAD), ids=[f"{r}::{p}"[:60] for r, p in LEFT_BROAD]
+)
+def test_a_reclassification_with_no_named_equivalent_is_left_alone(record: str, preferred: str):
+    """Not every reclassification is a demotion, and this is the counterexample.
+
+    Its winning rows do agree at a finer rank (`f__Methanospirareceae`), so a
+    rule keyed on agreement alone would sharpen it. Nothing in GTDB carries the
+    name *Methanophagales*, so there is no exact equivalent to sharpen to, and
+    the order term is the honest answer.
+    """
+    block = _entry(record, preferred)
+    grounding = block.get("gtdb_classification") or {}
+    assert grounding.get("gtdb_id") == LEFT_BROAD[(record, preferred)]
+
+
+def test_the_sharpened_terms_are_not_broader_than_what_they_replaced():
+    """A sharpening must move *down* the lineage, never sideways.
+
+    The chosen term has to appear in its own stored lineage below the rank the
+    vote would have picked — which is what makes it the same clade rather than
+    a different one.
+    """
+    ranks = ["d__", "p__", "c__", "o__", "f__", "g__"]
+    for (record, preferred), (chosen, would_be) in SHARPENED.items():
+        grounding = _entry(record, preferred).get("gtdb_classification") or {}
+        lineage = grounding.get("gtdb_lineage") or ""
+        chosen_name = chosen.split(":", 1)[1]
+        broad_name = would_be.split(":", 1)[1]
+
+        assert chosen_name in lineage.split(";"), f"{chosen} missing from its own lineage"
+        assert broad_name in lineage.split(";"), (
+            f"{would_be} should still appear in {record}'s lineage — a sharpening "
+            f"stays inside the broader taxon, it does not move to another one"
+        )
+        assert ranks.index(chosen_name[:3]) > ranks.index(
+            broad_name[:3]
+        ), f"{chosen} is not finer than {would_be}"

--- a/tests/test_gtdb_demoted_clades.py
+++ b/tests/test_gtdb_demoted_clades.py
@@ -8,43 +8,44 @@ Chloroflexota, so the phylum vote returned `p__Chloroflexota` — which the same
 record already used for its *Chloroflexi* entry, collapsing two of the three
 phyla its cited snippet contrasts into one GTDB concept.
 
-**No automatic rule is safe here, and the measurement is what shows it.** Of the
-KB's 159 groundings above genus rank, **21 look sharpenable** under the tool's
-own default policy (`exclude_unnamed=True`, which produced every stored block):
-every row behind the winning taxon agrees at some finer rank, once GTDB's `_A`
-polyphyly suffix is set aside. Only **five** are demotions.
+**No automatic rule is safe here, and three rounds of review are the evidence.**
+Every attempt to *enumerate* the KB's demotions has been falsified by the next
+one, each time through a different structural blind spot:
 
-* **15 keep their own NCBI name in GTDB** (`is_reclassified: false`) —
-  `Gemmatimonadota`, `Thermotogota`, `Verrucomicrobiota`, `Thermoplasmatales`
-  and others. The NCBI taxon *is* the GTDB taxon; sharpening to a child would
-  assert something the data does not say. A rule keyed on agreement alone
-  mis-sharpens all fifteen.
-* Of the 6 reclassified, `Rhodospirillales` -> `o__RF32`,
-  `Ca. Methanophagales` -> `o__Alkanophagales` and `Ca. Eiseniibacteriota` ->
-  `p__Eisenbacteria` have **nothing to sharpen to**: the finer terms are
-  `f__CAG-239` and `c__RBG-16-71-46`, alphanumeric placeholders, and
-  `f__Methanospirareceae`, which does not bear the NCBI clade's name.
+* demanding strict string unanimity at the finer rank missed `Nitrososphaerota`,
+  whose rows read `Nitrososphaeria` 57 and `Nitrososphaeria_A` 8 — GTDB splits a
+  clade it finds polyphyletic, so a suffix is not disagreement (#453);
+* demanding *any* unanimity missed `Betaproteobacteria`, which is 0.999 —
+  41903 of 41937 genomes in `o__Burkholderiales`, with 34 strays elsewhere;
+* keying on the clade's surviving *name* missed it too, because GTDB **renamed
+  while demoting**: `Betaproteobacteria` and `Burkholderiales` share one letter.
 
-The suffix point is not incidental. An earlier version of this sweep demanded
-*strict* string unanimity and so was blind to any demotion GTDB had split for
-monophyly — which is exactly how it missed `Nitrososphaerota`, whose rows read
-`Nitrososphaeria` 57 and `Nitrososphaeria_A` 8.
+So this module does not claim to list every demotion, and a screen is not what
+makes one findable. What it does is record the calls a curator made, with the
+evidence for each, so that a tool re-run cannot quietly undo them and the next
+person can see what the reasoning was.
 
-What marks a demotion is that a finer rank still carries the clade's *name*, and
-testing that mechanically is where it fails. Longest common prefix of the NCBI
-name and its GTDB counterpart, across the reclassified cases:
+The counter-examples are as load-bearing as the cases. Sharpening is wrong
+whenever GTDB kept the NCBI name — `Gemmatimonadota`, `Thermotogota`,
+`Verrucomicrobiota`, `Thermoplasmatales` and eleven more are `is_reclassified:
+false`, the NCBI taxon *is* the GTDB taxon, and a rule keyed on rank agreement
+alone mis-sharpens all fifteen. It is wrong again where a reclassification has
+nothing to sharpen *to*: `Rhodospirillales` -> `f__CAG-239` and
+`Ca. Eiseniibacteriota` -> `c__RBG-16-71-46` are alphanumeric placeholders, and
+`Ca. Methanophagales` -> `f__Methanospirareceae` does not bear the clade's name.
 
-    Nitrososphaerota / Nitrososphaeria     13   demotion
-    Ignavibacteriota / Ignavibacteria      13   demotion
-    Parvarchaeota    / Parvarchaeales      10   demotion
-    Chlorobiota      / Chlorobiia           8   demotion
-    Methanophagales  / Methanospirareceae   7   NOT a demotion
-    Dormiibacterota  / Dormibacteria        5   demotion (NCBI doubles the i)
-    Eiseniibacteriota/ RBG-16-71-46         0   NOT a demotion
+Longest common prefix of each reclassified NCBI name and its GTDB counterpart,
+which is why no threshold works:
 
-No threshold separates them — a cut anywhere above 5 loses Dormibacteria, and
-anywhere below 8 admits Methanospirareceae. So this stays a curator's call, and
-these tests pin the calls that were made rather than trying to re-derive them.
+    Nitrososphaerota   / Nitrososphaeria      13   demotion
+    Ignavibacteriota   / Ignavibacteria       13   demotion
+    Parvarchaeota      / Parvarchaeales       10   demotion
+    Chlorobiota        / Chlorobiia            8   demotion
+    Methanophagales    / Methanospirareceae    7   NOT a demotion
+    Dormiibacterota    / Dormibacteria         5   demotion
+    Betaproteobacteria / Burkholderiales       1   demotion
+    Rhodospirillales   / CAG-239               0   NOT a demotion
+    Eiseniibacteriota  / RBG-16-71-46          0   NOT a demotion
 
 A note on what the pin does. `--apply` only ever creates blocks on *ungrounded*
 taxa, so it could not overwrite one of these anyway; `curated: true` is what
@@ -55,7 +56,6 @@ that deleting the pin, or quietly re-broadening the term, fails.
 from __future__ import annotations
 
 import importlib.util
-import re
 from pathlib import Path
 
 import pytest
@@ -86,6 +86,26 @@ SHARPENED = {
     ("Naica_Deep_Subsurface_Thermophilic.yaml", "Thaumarchaeota"): (
         "GTDB:c__Nitrososphaeria",
         "GTDB:p__Thermoproteota",
+    ),
+    ("Naica_Deep_Subsurface_Thermophilic.yaml", "Betaproteobacteria"): (
+        "GTDB:o__Burkholderiales",
+        "GTDB:c__Gammaproteobacteria",
+    ),
+    (
+        "East_River_Floodplain_Core_Microbiome.yaml",
+        "Betaproteobacteria-dominated core floodplain microbiome",
+    ): ("GTDB:o__Burkholderiales", "GTDB:c__Gammaproteobacteria"),
+}
+
+# Demotions where GTDB *renamed* the clade on the way down, so the surviving
+# term shares almost none of the NCBI name. The name test below cannot see
+# these — it is the blind spot that hid Betaproteobacteria through two rounds of
+# review — so they are listed rather than inferred.
+RENAMED_WHILE_DEMOTED = {
+    ("Naica_Deep_Subsurface_Thermophilic.yaml", "Betaproteobacteria"),
+    (
+        "East_River_Floodplain_Core_Microbiome.yaml",
+        "Betaproteobacteria-dominated core floodplain microbiome",
     ),
 }
 
@@ -177,17 +197,19 @@ def _shared_stem(first: str, second: str) -> int:
 def test_the_curated_term_bears_the_clade_name_and_the_broad_one_does_not(
     record: str, preferred: str
 ):
-    """The property that makes a sharpening a *demotion* rather than a guess.
+    """One property that marks a demotion — for the cases where it holds.
 
-    This is what stops the pin being re-broadened. Checking the crosswalk alone
-    cannot: "every named row carries X at rank Y" is true of every **ancestor**
-    too, so `p__Bacteroidota` and `p__Nanoarchaeota` both satisfy it and the
-    earlier version of this test passed with the pins reverted.
+    GTDB usually keeps the clade's name when it moves it, so the chosen term
+    still reads like the NCBI one and the term the vote returned does not. That
+    is a real check, and it fails if a pin is re-broadened.
 
-    What separates them is the name. GTDB kept the clade and moved it, so the
-    chosen term still reads like the NCBI one, and the term the vote returned
-    does not.
+    It is *not* a definition. `Betaproteobacteria` -> `o__Burkholderiales` is a
+    genuine demotion that shares one letter, because GTDB renamed on the way
+    down; it is listed in `RENAMED_WHILE_DEMOTED` and skipped here rather than
+    weakening the threshold to admit it, which would admit everything.
     """
+    if (record, preferred) in RENAMED_WHILE_DEMOTED:
+        pytest.skip("GTDB renamed this clade while demoting it; see the module docstring")
     chosen, would_be = SHARPENED[(record, preferred)]
     label = (_entry(record, preferred).get("term") or {}).get("label") or ""
     clade = label.replace("Candidatus ", "")
@@ -207,18 +229,23 @@ def test_the_curated_term_bears_the_clade_name_and_the_broad_one_does_not(
 def test_the_curated_term_is_what_the_mapping_actually_supports(
     gtdb, mapping, record: str, preferred: str
 ):
-    """Check the pin against GTDB, not against the rest of the same YAML block.
+    """Check the pin's own numbers against GTDB, not against the same YAML block.
 
     An earlier version compared `gtdb_id` with `gtdb_lineage` — both written by
     the same curator in the same block — so any descendant of the vote's taxon
-    passed, including a wrong clade with a matching hand-written lineage. This
-    goes back to the crosswalk: every named-species row behind the grounding
-    must carry the chosen term at its own rank, which is exactly the claim each
-    `curation_note` makes.
+    passed. A later one demanded that *every* named-species row carry the chosen
+    term, which `Betaproteobacteria` fails at 0.999: unanimity was never the
+    property, it was an artefact of the small cases looked at first.
+
+    What actually has to hold is that the block's stored counts are the ones the
+    crosswalk gives for the chosen term at its own rank, which is the claim each
+    `curation_note` makes in prose.
     """
     chosen, _ = SHARPENED[(record, preferred)]
     prefix, name = chosen.split(":", 1)[1].split("__", 1)
-    label = (_entry(record, preferred).get("term") or {}).get("label") or ""
+    block = _entry(record, preferred)
+    grounding = block.get("gtdb_classification") or {}
+    label = (block.get("term") or {}).get("label") or ""
 
     _, _, by_higher = gtdb.collect_rows(mapping, set(), set(), set(gtdb.lookup_keys(label)))
     cells = next((by_higher[k] for k in gtdb.lookup_keys(label) if k in by_higher), [])
@@ -226,11 +253,15 @@ def test_the_curated_term_is_what_the_mapping_actually_supports(
     assert named, f"no named-species rows for {label!r}; the pin cannot be checked"
 
     column = {pr: col for col, pr in gtdb.GTDB_RANK_COLS}[prefix]
-    # GTDB splits a clade it finds polyphyletic into `X`, `X_A`, `X_B`. Those
-    # are the same clade for this purpose — demanding strict string unanimity
-    # is precisely what hid the Nitrososphaerota demotion until review.
-    values = {re.sub(r"_[A-Z]$", "", row[column].strip()) for row in named}
-    assert values == {re.sub(r"_[A-Z]$", "", name)}, (
-        f"{chosen} claims every named-species row for {label!r} is {name!r} at "
-        f"{prefix}__ rank, but the crosswalk says {sorted(values)}"
+    support = sum(gtdb._genomes(r) for r in named if r[column].strip() == name)
+    total = sum(gtdb._genomes(r) for r in named if r[column].strip())
+
+    assert support == grounding.get("support_genomes"), (
+        f"{chosen} stores support_genomes={grounding.get('support_genomes')}, "
+        f"but the crosswalk gives {support} genomes for {name!r} at {prefix}__"
     )
+    assert total == grounding.get("total_genomes"), (
+        f"{chosen} stores total_genomes={grounding.get('total_genomes')}, "
+        f"but the crosswalk gives {total}"
+    )
+    assert round(support / total, 3) == grounding.get("majority_fraction")

--- a/tests/test_gtdb_demoted_clades.py
+++ b/tests/test_gtdb_demoted_clades.py
@@ -9,30 +9,38 @@ record already used for its *Chloroflexi* entry, collapsing two of the three
 phyla its cited snippet contrasts into one GTDB concept.
 
 **No automatic rule is safe here, and the measurement is what shows it.** Of the
-KB's 159 groundings above genus rank, **20 look sharpenable** under the tool's
+KB's 159 groundings above genus rank, **21 look sharpenable** under the tool's
 own default policy (`exclude_unnamed=True`, which produced every stored block):
-every row behind the winning taxon agrees at some finer rank. Only **three** are
-demotions.
+every row behind the winning taxon agrees at some finer rank, once GTDB's `_A`
+polyphyly suffix is set aside. Only **five** are demotions.
 
 * **15 keep their own NCBI name in GTDB** (`is_reclassified: false`) —
   `Gemmatimonadota`, `Thermotogota`, `Verrucomicrobiota`, `Thermoplasmatales`
   and others. The NCBI taxon *is* the GTDB taxon; sharpening to a child would
   assert something the data does not say. A rule keyed on agreement alone
   mis-sharpens all fifteen.
-* `Rhodospirillales` -> `o__RF32` and `Ca. Methanophagales` ->
-  `o__Alkanophagales` are real reclassifications with **nothing to sharpen to**:
-  the finer terms are `f__CAG-239`, an alphanumeric placeholder, and
+* Of the 6 reclassified, `Rhodospirillales` -> `o__RF32`,
+  `Ca. Methanophagales` -> `o__Alkanophagales` and `Ca. Eiseniibacteriota` ->
+  `p__Eisenbacteria` have **nothing to sharpen to**: the finer terms are
+  `f__CAG-239` and `c__RBG-16-71-46`, alphanumeric placeholders, and
   `f__Methanospirareceae`, which does not bear the NCBI clade's name.
+
+The suffix point is not incidental. An earlier version of this sweep demanded
+*strict* string unanimity and so was blind to any demotion GTDB had split for
+monophyly — which is exactly how it missed `Nitrososphaerota`, whose rows read
+`Nitrososphaeria` 57 and `Nitrososphaeria_A` 8.
 
 What marks a demotion is that a finer rank still carries the clade's *name*, and
 testing that mechanically is where it fails. Longest common prefix of the NCBI
-name and its GTDB counterpart, for the four reclassified cases:
+name and its GTDB counterpart, across the reclassified cases:
 
-    Ignavibacteriota / Ignavibacteria      14   demotion
+    Nitrososphaerota / Nitrososphaeria     13   demotion
+    Ignavibacteriota / Ignavibacteria      13   demotion
     Parvarchaeota    / Parvarchaeales      10   demotion
     Chlorobiota      / Chlorobiia           8   demotion
     Methanophagales  / Methanospirareceae   7   NOT a demotion
     Dormiibacterota  / Dormibacteria        5   demotion (NCBI doubles the i)
+    Eiseniibacteriota/ RBG-16-71-46         0   NOT a demotion
 
 No threshold separates them — a cut anywhere above 5 loses Dormibacteria, and
 anywhere below 8 admits Methanospirareceae. So this stays a curator's call, and
@@ -47,6 +55,7 @@ that deleting the pin, or quietly re-broadening the term, fails.
 from __future__ import annotations
 
 import importlib.util
+import re
 from pathlib import Path
 
 import pytest
@@ -74,6 +83,10 @@ SHARPENED = {
         "Rifle_Aquifer_Bioanode_EET_Community.yaml",
         "EET-capable Rifle aquifer Ignavibacteria",
     ): ("GTDB:c__Ignavibacteria", "GTDB:p__Bacteroidota"),
+    ("Naica_Deep_Subsurface_Thermophilic.yaml", "Thaumarchaeota"): (
+        "GTDB:c__Nitrososphaeria",
+        "GTDB:p__Thermoproteota",
+    ),
 }
 
 # The mirror case: reclassified, and deliberately *not* sharpened, because no
@@ -149,6 +162,45 @@ def test_a_reclassification_with_no_named_equivalent_is_left_alone(record: str, 
     assert grounding.get("gtdb_id") == LEFT_BROAD[(record, preferred)]
 
 
+def _shared_stem(first: str, second: str) -> int:
+    """Length of the longest common prefix, case-insensitively."""
+    first, second = first.lower(), second.lower()
+    n = 0
+    while n < min(len(first), len(second)) and first[n] == second[n]:
+        n += 1
+    return n
+
+
+@pytest.mark.parametrize(
+    ("record", "preferred"), list(SHARPENED), ids=[f"{r}::{p}"[:60] for r, p in SHARPENED]
+)
+def test_the_curated_term_bears_the_clade_name_and_the_broad_one_does_not(
+    record: str, preferred: str
+):
+    """The property that makes a sharpening a *demotion* rather than a guess.
+
+    This is what stops the pin being re-broadened. Checking the crosswalk alone
+    cannot: "every named row carries X at rank Y" is true of every **ancestor**
+    too, so `p__Bacteroidota` and `p__Nanoarchaeota` both satisfy it and the
+    earlier version of this test passed with the pins reverted.
+
+    What separates them is the name. GTDB kept the clade and moved it, so the
+    chosen term still reads like the NCBI one, and the term the vote returned
+    does not.
+    """
+    chosen, would_be = SHARPENED[(record, preferred)]
+    label = (_entry(record, preferred).get("term") or {}).get("label") or ""
+    clade = label.replace("Candidatus ", "")
+
+    kept = _shared_stem(clade, chosen.split("__", 1)[1])
+    broad = _shared_stem(clade, would_be.split("__", 1)[1])
+    assert kept >= 5, f"{chosen} does not bear {clade!r}'s name (shared stem {kept})"
+    assert broad < kept, (
+        f"{would_be} shares as much of {clade!r}'s name as {chosen} does, so this "
+        f"is not a demotion — re-check whether the sharpening is justified"
+    )
+
+
 @pytest.mark.parametrize(
     ("record", "preferred"), list(SHARPENED), ids=[f"{r}::{p}"[:60] for r, p in SHARPENED]
 )
@@ -174,8 +226,11 @@ def test_the_curated_term_is_what_the_mapping_actually_supports(
     assert named, f"no named-species rows for {label!r}; the pin cannot be checked"
 
     column = {pr: col for col, pr in gtdb.GTDB_RANK_COLS}[prefix]
-    values = {row[column].strip() for row in named}
-    assert values == {name}, (
+    # GTDB splits a clade it finds polyphyletic into `X`, `X_A`, `X_B`. Those
+    # are the same clade for this purpose — demanding strict string unanimity
+    # is precisely what hid the Nitrososphaerota demotion until review.
+    values = {re.sub(r"_[A-Z]$", "", row[column].strip()) for row in named}
+    assert values == {re.sub(r"_[A-Z]$", "", name)}, (
         f"{chosen} claims every named-species row for {label!r} is {name!r} at "
         f"{prefix}__ rank, but the crosswalk says {sorted(values)}"
     )

--- a/tests/test_gtdb_demoted_clades.py
+++ b/tests/test_gtdb_demoted_clades.py
@@ -8,36 +8,45 @@ Chloroflexota, so the phylum vote returned `p__Chloroflexota` — which the same
 record already used for its *Chloroflexi* entry, collapsing two of the three
 phyla its cited snippet contrasts into one GTDB concept.
 
-**No automatic rule is safe here, which is the finding rather than the
-workaround.** Measured over all 159 higher-rank groundings in the KB, six look
-sharpenable — every one of the winning rows agrees at a finer rank — but only
-two are demotions:
+**No automatic rule is safe here, and the measurement is what shows it.** Of the
+KB's 159 groundings above genus rank, **20 look sharpenable** under the tool's
+own default policy (`exclude_unnamed=True`, which produced every stored block):
+every row behind the winning taxon agrees at some finer rank. Only **three** are
+demotions.
 
-* `Gemmatimonadota` (×2) and `Thermotogota` keep their own names in GTDB
-  (`is_reclassified: false`). The NCBI taxon *is* the GTDB phylum; sharpening to
-  a class would assert something the data does not say. A rule keyed on
-  "the winning rows agree at a finer rank" would have mis-sharpened all three.
-* `Rhodospirillales` -> `o__RF32` looks weak by *rows* (7 of 328) but is a
-  0.704 majority by *genomes*, which is the denominator the tool uses.
-* `Candidatus Methanophagales` -> `o__Alkanophagales` is a genuine
-  reclassification, but **no** GTDB taxon bears the NCBI clade's name, so there
-  is nothing to sharpen *to*. It stays where it is.
+* **15 keep their own NCBI name in GTDB** (`is_reclassified: false`) —
+  `Gemmatimonadota`, `Thermotogota`, `Verrucomicrobiota`, `Thermoplasmatales`
+  and others. The NCBI taxon *is* the GTDB taxon; sharpening to a child would
+  assert something the data does not say. A rule keyed on agreement alone
+  mis-sharpens all fifteen.
+* `Rhodospirillales` -> `o__RF32` and `Ca. Methanophagales` ->
+  `o__Alkanophagales` are real reclassifications with **nothing to sharpen to**:
+  the finer terms are `f__CAG-239`, an alphanumeric placeholder, and
+  `f__Methanospirareceae`, which does not bear the NCBI clade's name.
 
-What separates a demotion is that a finer GTDB rank still carries the clade's
-name — and testing *that* mechanically is where it breaks down: the shared stem
-of `Parvarchaeota`/`Parvarchaeales` is 10 characters, of
-`Dormiibacterota`/`Dormibacteria` only 5 (NCBI doubles the `i`), and of
-`Methanophagales`/`Methanospirareceae` 7. No threshold separates the two real
-cases from the false one.
+What marks a demotion is that a finer rank still carries the clade's *name*, and
+testing that mechanically is where it fails. Longest common prefix of the NCBI
+name and its GTDB counterpart, for the four reclassified cases:
 
-So this is a curator's call, and these tests pin the calls that were made rather
-than trying to re-derive them. Each decision travels with the data as
-`curated: true`, so `--apply` will not overwrite it; what these tests add is
-that removing the pin, or quietly re-broadening the term, fails.
+    Ignavibacteriota / Ignavibacteria      14   demotion
+    Parvarchaeota    / Parvarchaeales      10   demotion
+    Chlorobiota      / Chlorobiia           8   demotion
+    Methanophagales  / Methanospirareceae   7   NOT a demotion
+    Dormiibacterota  / Dormibacteria        5   demotion (NCBI doubles the i)
+
+No threshold separates them — a cut anywhere above 5 loses Dormibacteria, and
+anywhere below 8 admits Methanospirareceae. So this stays a curator's call, and
+these tests pin the calls that were made rather than trying to re-derive them.
+
+A note on what the pin does. `--apply` only ever creates blocks on *ungrounded*
+taxa, so it could not overwrite one of these anyway; `curated: true` is what
+stops `--refresh` and `--withdraw-ambiguous`. What these tests add on top is
+that deleting the pin, or quietly re-broadening the term, fails.
 """
 
 from __future__ import annotations
 
+import importlib.util
 from pathlib import Path
 
 import pytest
@@ -56,10 +65,15 @@ SHARPENED = {
     (
         "Soil_BGC_Phylum_Depth_Vegetation_Community.yaml",
         "Candidatus Dormibacteraeota (prolific BGC producers)",
-    ): (
-        "GTDB:c__Dormibacteria",
-        "GTDB:p__Chloroflexota",
-    ),
+    ): ("GTDB:c__Dormibacteria", "GTDB:p__Chloroflexota"),
+    (
+        "Anammox_Granule_Metabolic_Interaction_Community.yaml",
+        "Chlorobi-affiliated heterotrophic bacteria",
+    ): ("GTDB:c__Chlorobiia", "GTDB:p__Bacteroidota"),
+    (
+        "Rifle_Aquifer_Bioanode_EET_Community.yaml",
+        "EET-capable Rifle aquifer Ignavibacteria",
+    ): ("GTDB:c__Ignavibacteria", "GTDB:p__Bacteroidota"),
 }
 
 # The mirror case: reclassified, and deliberately *not* sharpened, because no
@@ -70,6 +84,25 @@ LEFT_BROAD = {
         "ANME-1 (anaerobic methanotrophic archaea, clade 1)",
     ): "GTDB:o__Alkanophagales",
 }
+
+
+@pytest.fixture(scope="module")
+def gtdb():
+    spec = importlib.util.spec_from_file_location("gtdb_ground", REPO / "scripts/gtdb_ground.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def mapping(gtdb):
+    try:
+        path = gtdb.resolve_kg_microbe_dir(None) / "data/raw/NCBI2GTDB.tsv.gz"
+    except SystemExit as exc:
+        pytest.skip(f"kg-microbe mapping unavailable: {str(exc).splitlines()[0]}")
+    if not path.exists():
+        pytest.skip(f"kg-microbe NCBI2GTDB mapping not available at {path}")
+    return path
 
 
 def _entry(record: str, preferred: str) -> dict:
@@ -86,18 +119,17 @@ def _entry(record: str, preferred: str) -> dict:
 )
 def test_a_sharpened_grounding_keeps_its_curated_term(record: str, preferred: str):
     chosen, would_be = SHARPENED[(record, preferred)]
-    block = _entry(record, preferred)
-    grounding = block.get("gtdb_classification") or {}
+    grounding = _entry(record, preferred).get("gtdb_classification") or {}
 
     assert grounding.get("gtdb_id") == chosen, (
         f"'{preferred}' in {record} should be grounded at {chosen}. If it now reads "
         f"{would_be}, the rank-for-rank vote has been reapplied over a curator's "
         f"decision — GTDB demoted this clade, so the vote names a broader taxon "
-        f"than the record means (#445)."
+        f"than the record means (#445, #451)."
     )
     assert grounding.get("curated") is True, (
-        f"the pin on '{preferred}' is what stops `gtdb_ground.py --apply` "
-        f"rewriting it; without it the decision survives only in git."
+        f"the pin on '{preferred}' is what stops `--refresh` and "
+        f"`--withdraw-ambiguous`; without it the decision survives only in git."
     )
     assert grounding.get("curation_note"), "a pin without its reason is unreviewable"
 
@@ -113,30 +145,37 @@ def test_a_reclassification_with_no_named_equivalent_is_left_alone(record: str, 
     name *Methanophagales*, so there is no exact equivalent to sharpen to, and
     the order term is the honest answer.
     """
-    block = _entry(record, preferred)
-    grounding = block.get("gtdb_classification") or {}
+    grounding = _entry(record, preferred).get("gtdb_classification") or {}
     assert grounding.get("gtdb_id") == LEFT_BROAD[(record, preferred)]
 
 
-def test_the_sharpened_terms_are_not_broader_than_what_they_replaced():
-    """A sharpening must move *down* the lineage, never sideways.
+@pytest.mark.parametrize(
+    ("record", "preferred"), list(SHARPENED), ids=[f"{r}::{p}"[:60] for r, p in SHARPENED]
+)
+def test_the_curated_term_is_what_the_mapping_actually_supports(
+    gtdb, mapping, record: str, preferred: str
+):
+    """Check the pin against GTDB, not against the rest of the same YAML block.
 
-    The chosen term has to appear in its own stored lineage below the rank the
-    vote would have picked — which is what makes it the same clade rather than
-    a different one.
+    An earlier version compared `gtdb_id` with `gtdb_lineage` — both written by
+    the same curator in the same block — so any descendant of the vote's taxon
+    passed, including a wrong clade with a matching hand-written lineage. This
+    goes back to the crosswalk: every named-species row behind the grounding
+    must carry the chosen term at its own rank, which is exactly the claim each
+    `curation_note` makes.
     """
-    ranks = ["d__", "p__", "c__", "o__", "f__", "g__"]
-    for (record, preferred), (chosen, would_be) in SHARPENED.items():
-        grounding = _entry(record, preferred).get("gtdb_classification") or {}
-        lineage = grounding.get("gtdb_lineage") or ""
-        chosen_name = chosen.split(":", 1)[1]
-        broad_name = would_be.split(":", 1)[1]
+    chosen, _ = SHARPENED[(record, preferred)]
+    prefix, name = chosen.split(":", 1)[1].split("__", 1)
+    label = (_entry(record, preferred).get("term") or {}).get("label") or ""
 
-        assert chosen_name in lineage.split(";"), f"{chosen} missing from its own lineage"
-        assert broad_name in lineage.split(";"), (
-            f"{would_be} should still appear in {record}'s lineage — a sharpening "
-            f"stays inside the broader taxon, it does not move to another one"
-        )
-        assert ranks.index(chosen_name[:3]) > ranks.index(
-            broad_name[:3]
-        ), f"{chosen} is not finer than {would_be}"
+    _, _, by_higher = gtdb.collect_rows(mapping, set(), set(), set(gtdb.lookup_keys(label)))
+    cells = next((by_higher[k] for k in gtdb.lookup_keys(label) if k in by_higher), [])
+    named = gtdb.named_species_only(cells)
+    assert named, f"no named-species rows for {label!r}; the pin cannot be checked"
+
+    column = {pr: col for col, pr in gtdb.GTDB_RANK_COLS}[prefix]
+    values = {row[column].strip() for row in named}
+    assert values == {name}, (
+        f"{chosen} claims every named-species row for {label!r} is {name!r} at "
+        f"{prefix}__ rank, but the crosswalk says {sorted(values)}"
+    )

--- a/tests/test_gtdb_demoted_clades.py
+++ b/tests/test_gtdb_demoted_clades.py
@@ -27,15 +27,16 @@ person can see what the reasoning was.
 
 The counter-examples are as load-bearing as the cases. Sharpening is wrong
 whenever GTDB kept the NCBI name — `Gemmatimonadota`, `Thermotogota`,
-`Verrucomicrobiota`, `Thermoplasmatales` and eleven more are `is_reclassified:
-false`, the NCBI taxon *is* the GTDB taxon, and a rule keyed on rank agreement
-alone mis-sharpens all fifteen. It is wrong again where a reclassification has
+`Verrucomicrobiota` and `Thermoplasmatales` among them are `is_reclassified:
+false` — the NCBI taxon *is* the GTDB taxon — and a rule keyed on rank agreement
+alone mis-sharpens every one of them. It is wrong again where a reclassification has
 nothing to sharpen *to*: `Rhodospirillales` -> `f__CAG-239` and
 `Ca. Eiseniibacteriota` -> `c__RBG-16-71-46` are alphanumeric placeholders, and
 `Ca. Methanophagales` -> `f__Methanospirareceae` does not bear the clade's name.
 
-Longest common prefix of each reclassified NCBI name and its GTDB counterpart,
-which is why no threshold works:
+Longest common prefix of the NCBI name and its GTDB counterpart, for the
+reclassified cases that came up while working through this — not an exhaustive
+list, for the reason above. It is why no threshold works:
 
     Nitrososphaerota   / Nitrososphaeria      13   demotion
     Ignavibacteriota   / Ignavibacteria       13   demotion
@@ -265,3 +266,15 @@ def test_the_curated_term_is_what_the_mapping_actually_supports(
         f"but the crosswalk gives {total}"
     )
     assert round(support / total, 3) == grounding.get("majority_fraction")
+
+    # The provenance string too. Nothing checked it until review, which is how a
+    # block shipped claiming "4 GTDB taxa" beside a note naming three.
+    alternatives = len({r[column].strip() for r in named if r[column].strip()})
+    source = grounding.get("mapping_source") or ""
+    assert (
+        f"grounded at {prefix}__ rank" in source
+    ), f"{chosen} is a {prefix}__ term, but its mapping_source says {source!r}"
+    assert f"{alternatives} GTDB taxa" in source, (
+        f"the crosswalk gives {alternatives} distinct {prefix}__ taxa under "
+        f"{label!r}, which mapping_source does not say: {source!r}"
+    )

--- a/tests/test_gtdb_demoted_clades.py
+++ b/tests/test_gtdb_demoted_clades.py
@@ -57,6 +57,7 @@ that deleting the pin, or quietly re-broadening the term, fails.
 from __future__ import annotations
 
 import importlib.util
+import re
 from pathlib import Path
 
 import pytest
@@ -274,7 +275,7 @@ def test_the_curated_term_is_what_the_mapping_actually_supports(
     assert (
         f"grounded at {prefix}__ rank" in source
     ), f"{chosen} is a {prefix}__ term, but its mapping_source says {source!r}"
-    assert f"{alternatives} GTDB taxa" in source, (
+    assert re.search(rf"\b{alternatives} GTDB taxa\b", source), (
         f"the crosswalk gives {alternatives} distinct {prefix}__ taxa under "
         f"{label!r}, which mapping_source does not say: {source!r}"
     )


### PR DESCRIPTION
Closes #445.

## The question, and the answer

#445 asked whether `gtdb_ground.py` should detect a **demotion** — an NCBI clade GTDB keeps but places a rank lower — and prefer the exact equivalent, rather than leaving it to a curator to notice.

**Measured over all 159 higher-rank groundings: it should not.** Six look sharpenable (every row behind the winning taxon agrees at a finer rank), but only **one** is a demotion:

| grounding | why it is not a demotion |
|---|---|
| `Gemmatimonadota` ×2, `Thermotogota` | keep their own names in GTDB (`is_reclassified: false`) — the NCBI taxon **is** the GTDB phylum. A rule keyed on agreement alone mis-sharpens all three. |
| `Rhodospirillales` → `o__RF32` | looks weak at 7 of 328 **rows**, but is a 0.704 majority by **genomes** — the denominator the tool uses. |
| `Ca. Methanophagales` → `o__Alkanophagales` | a real reclassification, but **no** GTDB taxon bears the NCBI clade's name, so there is nothing to sharpen *to*. |
| **`Ca. Parvarchaeota` → `p__Nanoarchaeota`** | **the one genuine demotion.** |

What marks a demotion is that a finer rank still carries the clade's **name** — and testing that mechanically is exactly where it breaks. Shared stems: `Parvarchaeota`/`Parvarchaeales` = 10 chars, `Dormiibacterota`/`Dormibacteria` = 5 (NCBI doubles the `i`), `Methanophagales`/`Methanospirareceae` = 7. **No threshold separates the two real cases from the false one.** So it stays a curator's call, and the durable artifact is the recorded decision, not a heuristic.

## The fix

`Candidatus Parvarchaeota` sharpened from `p__Nanoarchaeota` to **`o__Parvarchaeales`**. Every one of the named-species rows behind the grounding is Parvarchaeales, so the sharper term carries the **same 20/20 confidence** — sharpening costs nothing here. The phylum term was not wrong, only uninformative: `p__Nanoarchaeota` also absorbs NCBI Ca. Woesearchaeota, Nanobdellota and Ca. Iainarchaeota, so it said nothing distinguishing this entry, in a record whose `Micrarchaeota (ARMAN-1/2)` entry is a near neighbour.

Order rather than family: `c__Nanoarchaeia` does not bear the clade name, and `f__Parvarchaeaceae` is narrower than the NCBI phylum — `o__Parvarchaeales` is the most senior GTDB term that still means Parvarchaeota.

## Tests

Pin both sharpenings (Parvarchaeales, and #444's Dormibacteria) **and** the deliberate non-sharpening (Alkanophagales), so a tool re-run cannot quietly undo a decision no rule can re-derive. A fourth test checks that a sharpened term is genuinely *inside* the taxon it replaced — a sharpening moves down the lineage, never sideways.

## Method note

Three measurements were needed to get this right. The first keyed on the genome-level taxid column instead of the name columns the tool uses for higher ranks (yielding meaningless "1 row" agreement); the second read the 1-based header positions as 0-based indices (so "domain" was really phylum). Both are recorded in the test docstring, because the wrong answers were plausible-looking.

**Canaried:** `--apply` logs `skipping curated NCBITaxon:1462422`, applies 0 blocks, leaves the file byte-identical. `just qc` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)