### PR TITLE
Check the middle of gtdb_lineage, not just its head and tail (#454)

### DIFF
--- a/justfile
+++ b/justfile
@@ -184,6 +184,8 @@ validate-taxon-ids *files:
 validate-gtdb-domain *files:
     PYTHONPATH=src uv run python scripts/validate_prokaryotic_lineage.py {{files}}
 
+# Also reports one GTDB taxon placed under two parent lineages (#454), which
+# only the whole corpus can show - a single record cannot disagree with itself.
 validate-gtdb-all:
     PYTHONPATH=src uv run python scripts/validate_gtdb_coherence.py kb/communities/*.yaml data/isolates/*.yaml
 

--- a/scripts/validate_gtdb_coherence.py
+++ b/scripts/validate_gtdb_coherence.py
@@ -31,7 +31,10 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
 from communitymech.validators.gtdb_coherence import validate_gtdb_coherence  # noqa: E402
-from communitymech.validators.gtdb_lineage_tree import check_corpus  # noqa: E402
+from communitymech.validators.gtdb_lineage_tree import (  # noqa: E402
+    check_corpus,
+    check_lineage_shape,
+)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -61,16 +64,23 @@ def main(argv: list[str] | None = None) -> int:
             corpus.append((path.name, yaml.safe_load(path.read_text())))
         except yaml.YAMLError:
             continue
+    # Shape first: a lineage skipping a rank would otherwise surface as a
+    # hierarchy conflict naming the record that is correct (#455 review).
+    malformed = [f"{name}: {m}" for name, doc in corpus for m in check_lineage_shape(doc)]
+    for message in malformed:
+        print(f"[gtdb-lineage-shape] {message}")
+
     conflicts = check_corpus(corpus)
     for message in conflicts:
         print(f"[gtdb-lineage-tree] {message}")
 
     print(f"\nfiles checked: {len(args.files)}", file=sys.stderr)
     print(f"incoherent blocks: {len(issues)}", file=sys.stderr)
+    print(f"malformed lineages: {len(malformed)}", file=sys.stderr)
     print(f"lineage conflicts: {len(conflicts)}", file=sys.stderr)
     for category, count in sorted(by_category.items(), key=lambda kv: -kv[1]):
         print(f"  {category:34s} {count:>6d}", file=sys.stderr)
-    return 1 if (issues or conflicts) else 0
+    return 1 if (issues or conflicts or malformed) else 0
 
 
 if __name__ == "__main__":

--- a/scripts/validate_gtdb_coherence.py
+++ b/scripts/validate_gtdb_coherence.py
@@ -6,9 +6,14 @@ to each other — the JSON-Schema backend has no cross-field arithmetic — so
 `linkml-validate` accepts a block claiming 99 supporting genomes out of 3, and
 accepts `total_genomes: null` because a null satisfies `required` (#387).
 
-The same checks run inside `just validate-strict`, which is the CI gate. This
-script exists for the single-file case, where booting the full closed-schema
-validator to ask one question is slow and its output buries the answer.
+It also reports one taxon placed under two different parent lineages (#454).
+That half needs every record at once — a single record cannot disagree with
+itself about where a taxon sits — so passing one file checks its shape but can
+find no cross-record conflict. Use `just validate-gtdb-all` for that.
+
+The per-record checks also run inside `just validate-strict`, which is the CI
+gate. This script exists for the single-file case, where booting the full
+closed-schema validator to ask one question is slow and buries the answer.
 
     just validate-gtdb kb/communities/Foo.yaml
     just validate-gtdb-all

--- a/scripts/validate_gtdb_coherence.py
+++ b/scripts/validate_gtdb_coherence.py
@@ -26,6 +26,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
 from communitymech.validators.gtdb_coherence import validate_gtdb_coherence  # noqa: E402
+from communitymech.validators.gtdb_lineage_tree import check_corpus  # noqa: E402
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -45,11 +46,26 @@ def main(argv: list[str] | None = None) -> int:
         by_category[issue.category] = by_category.get(issue.category, 0) + 1
         print(f"{issue.file}: {issue.taxon}\n  [{issue.category}] {issue.message}")
 
+    # One taxon under two parent lineages, which only shows up across records
+    # (#454). Needs no crosswalk, so it runs wherever this script does.
+    import yaml
+
+    corpus = []
+    for path in args.files:
+        try:
+            corpus.append((path.name, yaml.safe_load(path.read_text())))
+        except yaml.YAMLError:
+            continue
+    conflicts = check_corpus(corpus)
+    for message in conflicts:
+        print(f"[gtdb-lineage-tree] {message}")
+
     print(f"\nfiles checked: {len(args.files)}", file=sys.stderr)
     print(f"incoherent blocks: {len(issues)}", file=sys.stderr)
+    print(f"lineage conflicts: {len(conflicts)}", file=sys.stderr)
     for category, count in sorted(by_category.items(), key=lambda kv: -kv[1]):
         print(f"  {category:34s} {count:>6d}", file=sys.stderr)
-    return 1 if issues else 0
+    return 1 if (issues or conflicts) else 0
 
 
 if __name__ == "__main__":

--- a/scripts/validate_strict.py
+++ b/scripts/validate_strict.py
@@ -201,13 +201,10 @@ def validate_one(path: Path) -> list[dict]:
             }
         )
 
-    # A GTDB block on a eukaryote or a virus (#365). GTDB classifies prokaryotes
-    # only, so this is a contradiction rather than a suspicion — and no other
-    # gate sees it, because id, label and ncbi_source_id all agree. Takes the
-    # whole document because interaction participants can carry a block too.
-    # A lineage whose ranks are out of order or unprefixed (#454). The corpus
-    # half of that check — one taxon, one parent — needs every record at once,
-    # so it lives in the CLI and the test suite rather than here.
+    # A lineage that is not a contiguous chain of ranks from d__ (#454).
+    # Contiguity is what makes the corpus half of that check sound, and the
+    # corpus half — one taxon, one parent — needs every record at once, so it
+    # runs in `just validate-gtdb-all` rather than here.
     for message in check_lineage_shape(instance):
         rows.append(
             {
@@ -219,6 +216,10 @@ def validate_one(path: Path) -> list[dict]:
             }
         )
 
+    # A GTDB block on a eukaryote or a virus (#365). GTDB classifies prokaryotes
+    # only, so this is a contradiction rather than a suspicion — and no other
+    # gate sees it, because id, label and ncbi_source_id all agree. Takes the
+    # whole document because interaction participants can carry a block too.
     for message in check_prokaryotic_lineage(instance):
         rows.append(
             {

--- a/scripts/validate_strict.py
+++ b/scripts/validate_strict.py
@@ -41,6 +41,7 @@ from linkml.validator.plugins import JsonschemaValidationPlugin
 from linkml.validator.report import Severity
 
 from communitymech.validators.gtdb_coherence import validate_gtdb_coherence
+from communitymech.validators.gtdb_lineage_tree import check_lineage_shape
 from communitymech.validators.prokaryotic_lineage import check_record as check_prokaryotic_lineage
 from communitymech.validators.shared_taxon_ids import check_record as check_shared_taxon_ids
 from communitymech.validators.yaml_scalars import find_truncated_scalars
@@ -204,6 +205,20 @@ def validate_one(path: Path) -> list[dict]:
     # only, so this is a contradiction rather than a suspicion — and no other
     # gate sees it, because id, label and ncbi_source_id all agree. Takes the
     # whole document because interaction participants can carry a block too.
+    # A lineage whose ranks are out of order or unprefixed (#454). The corpus
+    # half of that check — one taxon, one parent — needs every record at once,
+    # so it lives in the CLI and the test suite rather than here.
+    for message in check_lineage_shape(instance):
+        rows.append(
+            {
+                "file": str(path),
+                "category": "gtdb_lineage_malformed",
+                "detail": message.split(":", 1)[0],
+                "path": "",
+                "message": message[:300],
+            }
+        )
+
     for message in check_prokaryotic_lineage(instance):
         rows.append(
             {

--- a/src/communitymech/validators/gtdb_lineage_tree.py
+++ b/src/communitymech/validators/gtdb_lineage_tree.py
@@ -44,16 +44,29 @@ def _segments(lineage) -> list[str]:
     return [part.strip() for part in lineage.split(";") if part.strip()]
 
 
-def _blocks(document):
-    """Every `gtdb_classification` with the taxon it belongs to."""
+def _descriptors(document):
+    """Every taxon descriptor, in `taxonomy` and in the interactions.
+
+    `source_taxon`/`target_taxon` share `taxon_term`'s range, so the schema
+    permits a `gtdb_classification` there too, and the sibling #365 gate already
+    walks them (#439). None exist today; missing them would be a silent gap.
+    """
     if not isinstance(document, dict):
         return
     for entry in document.get("taxonomy") or []:
-        if not isinstance(entry, dict):
+        if isinstance(entry, dict) and isinstance(entry.get("taxon_term"), dict):
+            yield entry["taxon_term"]
+    for interaction in document.get("ecological_interactions") or []:
+        if not isinstance(interaction, dict):
             continue
-        term_block = entry.get("taxon_term")
-        if not isinstance(term_block, dict):
-            continue
+        for role in ("source_taxon", "target_taxon"):
+            if isinstance(interaction.get(role), dict):
+                yield interaction[role]
+
+
+def _blocks(document):
+    """Every `gtdb_classification` with the taxon it belongs to."""
+    for term_block in _descriptors(document):
         block = term_block.get("gtdb_classification")
         if not isinstance(block, dict):
             continue
@@ -67,7 +80,19 @@ def _blocks(document):
 
 
 def check_lineage_shape(document) -> list[str]:
-    """Per-record: rank prefixes present, in order, and ending at `gtdb_id`."""
+    """Per-record: a lineage is a contiguous chain of ranks starting at `d__`.
+
+    Contiguity is not pedantry — it is what makes `check_corpus` sound. That
+    check keys a taxon by the literal path above it, so a lineage skipping a
+    rank (`d__Bacteria;p__Bacteroidota;f__Chlorobiaceae`) would place
+    `f__Chlorobiaceae` under a different path than the full chain does, and be
+    reported as a hierarchy conflict against a record that is perfectly
+    correct. Rejecting the skip here turns that into a precise per-record error
+    against the record that actually has the problem.
+
+    No crosswalk lineage skips a rank, so this constrains hand-written pins
+    (#450) rather than tool output.
+    """
     problems: list[str] = []
     for name, block in _blocks(document):
         segments = _segments(block.get("gtdb_lineage"))
@@ -79,10 +104,16 @@ def check_lineage_shape(document) -> list[str]:
             if prefix not in RANK_ORDER:
                 problems.append(f"{name!r}: lineage segment {segment!r} has no rank prefix")
                 break
-            if seen and RANK_ORDER.index(prefix) <= RANK_ORDER.index(seen[-1]):
+            if not seen and prefix != "d__":
                 problems.append(
-                    f"{name!r}: lineage goes from {seen[-1]} to {prefix}, which is not "
-                    f"finer — {block.get('gtdb_lineage')!r}"
+                    f"{name!r}: lineage starts at {prefix} rather than d__ — "
+                    f"{block.get('gtdb_lineage')!r}"
+                )
+                break
+            if seen and RANK_ORDER.index(prefix) != RANK_ORDER.index(seen[-1]) + 1:
+                problems.append(
+                    f"{name!r}: lineage goes from {seen[-1]} to {prefix}, skipping a rank "
+                    f"or repeating one — {block.get('gtdb_lineage')!r}"
                 )
                 break
             seen.append(prefix)

--- a/src/communitymech/validators/gtdb_lineage_tree.py
+++ b/src/communitymech/validators/gtdb_lineage_tree.py
@@ -1,0 +1,118 @@
+"""One GTDB taxon under two different parent lineages (#454).
+
+`gtdb_lineage` is a denormalised path — `d__Bacteria;p__Bacteroidota;c__Chlorobiia`
+— and until #450 every one was written by `gtdb_ground.py` from the crosswalk,
+so nothing needed to check the middle of it. The freshness checks compare
+`gtdb_id`, `gtdb_taxon` and the lineage's *tail*; the prokaryote-only gate
+(#365) reads its *head*. Corrupting a segment in between passed everything:
+
+    d__Bacteria;p__Bacteroidota;c__Chlorobiia
+    d__Archaea;p__Nonsense;c__Chlorobiia        <- still passes both
+
+#450 made seven of those lineages **hand-written** curator pins, which is when
+that stopped being theoretical.
+
+The check needs no crosswalk, which is what makes it usable in CI — the
+kg-microbe checkout is not there, so anything asking the mapping a question
+would skip. GTDB is a strict hierarchy, so **a taxon has exactly one parent**.
+Read every block's lineage as a set of (taxon, path-above-it) pairs and a
+segment appearing under two different paths is a contradiction between two
+records, whichever of them is wrong.
+
+That is a weaker claim than "this lineage matches GTDB" and a much cheaper one.
+It cannot catch a corruption that is internally consistent — a taxon named in
+one record only, spelled wrongly throughout — but it catches the case that
+matters here, where a hand-edited pin drifts from the 720 blocks the tool wrote.
+
+Measured when added: 727 blocks, 740 distinct taxa, zero conflicts.
+"""
+
+from __future__ import annotations
+
+RANK_ORDER = ["d__", "p__", "c__", "o__", "f__", "g__", "s__"]
+
+
+def _segments(lineage) -> list[str]:
+    """The non-empty segments of a lineage, or [] for anything unusable.
+
+    Tolerates a non-string: `gtdb_lineage` carries no `range` in the schema, so
+    a YAML list is schema-valid, and raising here would abort `validate-strict`
+    and discard every other file's findings (#429, #438).
+    """
+    if not isinstance(lineage, str):
+        return []
+    return [part.strip() for part in lineage.split(";") if part.strip()]
+
+
+def _blocks(document):
+    """Every `gtdb_classification` with the taxon it belongs to."""
+    if not isinstance(document, dict):
+        return
+    for entry in document.get("taxonomy") or []:
+        if not isinstance(entry, dict):
+            continue
+        term_block = entry.get("taxon_term")
+        if not isinstance(term_block, dict):
+            continue
+        block = term_block.get("gtdb_classification")
+        if not isinstance(block, dict):
+            continue
+        term = term_block.get("term")
+        name = (
+            term_block.get("preferred_term")
+            or (term.get("label") if isinstance(term, dict) else None)
+            or "?"
+        )
+        yield name, block
+
+
+def check_lineage_shape(document) -> list[str]:
+    """Per-record: rank prefixes present, in order, and ending at `gtdb_id`."""
+    problems: list[str] = []
+    for name, block in _blocks(document):
+        segments = _segments(block.get("gtdb_lineage"))
+        if not segments:
+            continue
+        seen: list[str] = []
+        for segment in segments:
+            prefix = segment[:3]
+            if prefix not in RANK_ORDER:
+                problems.append(f"{name!r}: lineage segment {segment!r} has no rank prefix")
+                break
+            if seen and RANK_ORDER.index(prefix) <= RANK_ORDER.index(seen[-1]):
+                problems.append(
+                    f"{name!r}: lineage goes from {seen[-1]} to {prefix}, which is not "
+                    f"finer — {block.get('gtdb_lineage')!r}"
+                )
+                break
+            seen.append(prefix)
+    return problems
+
+
+def check_corpus(documents) -> list[str]:
+    """Across records: every GTDB taxon must sit under one parent lineage.
+
+    `documents` is an iterable of (label, parsed-document) pairs — a corpus
+    check, unlike its neighbours, because a single record cannot disagree with
+    itself about where a taxon sits.
+    """
+    parents: dict[str, dict[str, list[str]]] = {}
+    for label, document in documents:
+        for name, block in _blocks(document):
+            segments = _segments(block.get("gtdb_lineage"))
+            for index, segment in enumerate(segments):
+                path = ";".join(segments[:index])
+                parents.setdefault(segment, {}).setdefault(path, []).append(f"{label} ({name})")
+
+    problems = []
+    for segment, paths in sorted(parents.items()):
+        if len(paths) < 2:
+            continue
+        detail = "; ".join(
+            f"under {path or '(root)'!r} in {sources[0]}" for path, sources in sorted(paths.items())
+        )
+        problems.append(
+            f"{segment} is placed under {len(paths)} different lineages — GTDB is a "
+            f"hierarchy, so at most one can be right: {detail}"
+        )
+    return problems

--- a/tests/test_gtdb_lineage_tree.py
+++ b/tests/test_gtdb_lineage_tree.py
@@ -1,0 +1,122 @@
+"""The middle of `gtdb_lineage`, which nothing checked until #454.
+
+The freshness checks compare `gtdb_id`, `gtdb_taxon` and the lineage's *tail*;
+the prokaryote-only gate (#365) reads its *head*. A segment corrupted in
+between passed every gate and the whole suite:
+
+    d__Bacteria;p__Bacteroidota;c__Chlorobiia
+    d__Archaea;p__Nonsense;c__Chlorobiia        <- indistinguishable
+
+That was tolerable while `gtdb_ground.py` wrote every lineage from the
+crosswalk. #450 made seven of them hand-written curator pins, so it stopped
+being theoretical — and the review that found it could only find it by asking
+the crosswalk, which CI has no checkout of.
+
+Both checks here are corpus-internal and need no mapping, which is what lets
+them run in CI: ranks must be prefixed and get finer left to right, and — since
+GTDB is a hierarchy — a taxon must sit under exactly one parent path across
+every record that mentions it.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+import yaml
+
+from communitymech.validators.gtdb_lineage_tree import check_corpus, check_lineage_shape
+
+REPO = pathlib.Path(__file__).parent.parent
+RECORD_DIRS = ("kb/communities", "data/isolates")
+
+
+def _doc(lineage) -> dict:
+    return {
+        "taxonomy": [
+            {
+                "taxon_term": {
+                    "preferred_term": "X",
+                    "gtdb_classification": {"gtdb_lineage": lineage},
+                }
+            }
+        ]
+    }
+
+
+@pytest.mark.parametrize(
+    ("label", "lineage"),
+    [
+        ("ranks out of order", "d__Bacteria;c__Chlorobiia;p__Bacteroidota"),
+        ("a repeated rank", "d__Bacteria;p__Bacteroidota;p__Chlorobiota"),
+        ("a segment with no rank prefix", "Bacteria;p__Bacteroidota"),
+        ("an unknown rank prefix", "d__Bacteria;x__Bacteroidota"),
+    ],
+)
+def test_a_malformed_lineage_is_reported(label, lineage):
+    assert check_lineage_shape(_doc(lineage)), label
+
+
+@pytest.mark.parametrize(
+    ("label", "lineage"),
+    [
+        (
+            "a full species lineage",
+            "d__Bacteria;p__Bacteroidota;c__Chlorobiia;o__x;f__y;g__z;s__z a",
+        ),
+        ("a domain-only lineage", "d__Bacteria"),
+        ("a curated class pin", "d__Bacteria;p__Bacteroidota;c__Chlorobiia"),
+        # Not a lineage at all, and must not raise: `gtdb_lineage` has no
+        # `range` in the schema, so these are all schema-valid (#429, #438).
+        ("a list", ["d__Bacteria", "p__x"]),
+        ("nothing", None),
+        ("an empty string", ""),
+    ],
+)
+def test_a_well_formed_or_unusable_lineage_is_silent(label, lineage):
+    assert check_lineage_shape(_doc(lineage)) == [], label
+
+
+def test_malformed_records_do_not_raise():
+    """An exception here would abort validate-strict and lose every file."""
+    for document in ({"taxonomy": [None]}, {"taxonomy": "x"}, "nonsense", None, {}):
+        assert check_lineage_shape(document) == []
+        assert check_corpus([("a.yaml", document)]) == []
+
+
+def test_the_corruption_that_prompted_this_is_caught():
+    """The exact edit that passed every other gate."""
+    problems = check_corpus(
+        [
+            ("good.yaml", _doc("d__Bacteria;p__Bacteroidota;c__Chlorobiia")),
+            ("bad.yaml", _doc("d__Archaea;p__Nonsense;c__Chlorobiia")),
+        ]
+    )
+    assert len(problems) == 1, problems
+    assert "c__Chlorobiia" in problems[0]
+    assert "good.yaml" in problems[0] and "bad.yaml" in problems[0]
+
+
+def test_one_taxon_under_one_parent_is_silent():
+    """The same taxon in many records is the normal case, not a conflict."""
+    lineage = "d__Bacteria;p__Bacteroidota;c__Chlorobiia"
+    assert check_corpus([(f"r{n}.yaml", _doc(lineage)) for n in range(5)]) == []
+
+
+def _corpus():
+    for directory in RECORD_DIRS:
+        for path in sorted((REPO / directory).glob("*.yaml")):
+            yield path.name, yaml.safe_load(path.read_text())
+
+
+def test_the_committed_kb_is_a_consistent_hierarchy():
+    corpus = list(_corpus())
+    blocks = sum(1 for _, doc in corpus for _ in (doc.get("taxonomy") or []) if _)
+    assert len(corpus) > 300, f"expected the KB, read {len(corpus)} records"
+    assert blocks > 300, "expected the KB's taxonomy entries"
+
+    conflicts = check_corpus(corpus)
+    assert conflicts == [], "\n".join(conflicts)
+
+    shape = [f"{name}: {m}" for name, doc in corpus for m in check_lineage_shape(doc)]
+    assert shape == [], "\n".join(shape)

--- a/tests/test_gtdb_lineage_tree.py
+++ b/tests/test_gtdb_lineage_tree.py
@@ -25,7 +25,11 @@ import pathlib
 import pytest
 import yaml
 
-from communitymech.validators.gtdb_lineage_tree import check_corpus, check_lineage_shape
+from communitymech.validators.gtdb_lineage_tree import (
+    _blocks,
+    check_corpus,
+    check_lineage_shape,
+)
 
 REPO = pathlib.Path(__file__).parent.parent
 RECORD_DIRS = ("kb/communities", "data/isolates")
@@ -51,6 +55,11 @@ def _doc(lineage) -> dict:
         ("a repeated rank", "d__Bacteria;p__Bacteroidota;p__Chlorobiota"),
         ("a segment with no rank prefix", "Bacteria;p__Bacteroidota"),
         ("an unknown rank prefix", "d__Bacteria;x__Bacteroidota"),
+        # Contiguity is what makes the corpus check sound: a skipped rank would
+        # put the tail under a different path than the full chain does, and be
+        # reported as a hierarchy conflict against an innocent record.
+        ("a skipped rank", "d__Bacteria;p__Bacteroidota;f__Chlorobiaceae"),
+        ("not starting at d__", "p__Bacteroidota;c__Chlorobiia"),
     ],
 )
 def test_a_malformed_lineage_is_reported(label, lineage):
@@ -103,6 +112,24 @@ def test_one_taxon_under_one_parent_is_silent():
     assert check_corpus([(f"r{n}.yaml", _doc(lineage)) for n in range(5)]) == []
 
 
+def test_a_block_on_an_interaction_participant_is_checked_too():
+    """`source_taxon`/`target_taxon` can carry a block, and the #365 gate walks
+    them already (#439). None exist today; missing them would be silent.
+    """
+    document = {
+        "ecological_interactions": [
+            {
+                "name": "Cross-Feeding",
+                "target_taxon": {
+                    "preferred_term": "X",
+                    "gtdb_classification": {"gtdb_lineage": "d__Bacteria;c__Chlorobiia"},
+                },
+            }
+        ]
+    }
+    assert check_lineage_shape(document), "a malformed participant lineage must be reported"
+
+
 def _corpus():
     for directory in RECORD_DIRS:
         for path in sorted((REPO / directory).glob("*.yaml")):
@@ -111,9 +138,14 @@ def _corpus():
 
 def test_the_committed_kb_is_a_consistent_hierarchy():
     corpus = list(_corpus())
-    blocks = sum(1 for _, doc in corpus for _ in (doc.get("taxonomy") or []) if _)
     assert len(corpus) > 300, f"expected the KB, read {len(corpus)} records"
-    assert blocks > 300, "expected the KB's taxonomy entries"
+
+    # Count what the checks actually walk. An earlier version counted taxonomy
+    # entries, so if `_blocks` ever stopped matching — a slot rename, the block
+    # moved — both checks would return [] for every record and this test would
+    # stay green on an empty corpus.
+    blocks = sum(1 for _, doc in corpus for _ in _blocks(doc))
+    assert blocks > 700, f"expected the KB's ~727 gtdb_classification blocks, walked {blocks}"
 
     conflicts = check_corpus(corpus)
     assert conflicts == [], "\n".join(conflicts)


### PR DESCRIPTION
Closes #454.

## The gap

`gtdb_lineage` is a denormalised path, and the existing checks only look at its ends — freshness compares `gtdb_id`, `gtdb_taxon` and the **tail**; the prokaryote-only gate (#365) reads the **head**. A segment corrupted in between passed every gate and the entire test suite:

```
d__Bacteria;p__Bacteroidota;c__Chlorobiia
d__Archaea;p__Nonsense;c__Chlorobiia        <- indistinguishable
```

That was tolerable while `gtdb_ground.py` wrote every lineage from the crosswalk. **#450 made seven of them hand-written curator pins**, which is when it stopped being theoretical — and the review that found it could only do so by querying the crosswalk, which CI has no checkout of. A crosswalk-based check would skip precisely where it is needed.

## Two checks, both offline

**Shape, per record** — every segment carries a known rank prefix, and ranks get finer left to right. Runs inside `validate-strict` as `gtdb_lineage_malformed`. Catches `d__Bacteria;c__Chlorobiia;p__Bacteroidota`, a missing prefix, an unknown prefix, a repeated rank.

**Hierarchy, across records** — GTDB is a strict hierarchy, so **a taxon has exactly one parent**. Reading all 727 blocks as (taxon, path-above-it) pairs, a segment appearing under two different paths is a contradiction between two records, whichever is wrong. This needs the whole corpus at once, so it runs in `just validate-gtdb-all` and in the test suite rather than per file.

Neither needs the mapping, which is the point: they run wherever CI runs.

## What it does and does not catch

The corpus check is a weaker claim than "this lineage matches GTDB" and a far cheaper one. It **cannot** catch a corruption that is internally consistent — a taxon named in one record only, misspelled throughout. It **does** catch the case that motivated it: a hand-edited pin drifting from the 720 blocks the tool wrote. The docstring says so plainly rather than implying more.

## Measured

727 blocks · 740 distinct GTDB taxa · **0 conflicts, 0 malformed**.

14 new tests, including the exact corruption that prompted this, the malformed-input guards (`gtdb_lineage` has no `range` in the schema, so a YAML list is schema-valid), and a KB sweep. Verified end to end: `validate_strict.py` on a record with reversed ranks exits 1 with a `gtdb_lineage_malformed` row.

`just qc` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)