### PR TITLE
Make --emit-yaml output pasteable, and refuse a --refresh that would do nothing (#380)

### DIFF
--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -714,9 +714,19 @@ def _block(g: dict, mapping_source: str) -> dict:
     return block
 
 
+# One key per line, in both paths that render a block. PyYAML's default (~80)
+# wraps `gtdb_lineage` and `mapping_source` onto continuation lines indented
+# deeper than the block keys, and `--emit-yaml` output is meant to be pasted —
+# so the two paths disagreeing put wrapped blocks into the KB, which is what
+# made the line-level editing in #378 hard enough to corrupt records (#380).
+DUMP_WIDTH = 4096
+
+
 def emit_block(g: dict, mapping_source: str) -> str:
     d = {"gtdb_classification": _block(g, mapping_source)}
-    return yaml.dump(d, default_flow_style=False, sort_keys=False, allow_unicode=True, width=100)
+    return yaml.dump(
+        d, default_flow_style=False, sort_keys=False, allow_unicode=True, width=DUMP_WIDTH
+    )
 
 
 def community_taxa(path: Path):
@@ -1126,7 +1136,7 @@ def apply_to_community(
             indent = re.match(r"^(\s+)", lines[i]).group(1)
             child = " " * (len(indent) - 2)  # taxon_term child indent (sibling of `term`)
             out.append(f"{child}gtdb_classification:")
-            dumped = yaml.dump(block, sort_keys=False, allow_unicode=True, width=4096)
+            dumped = yaml.dump(block, sort_keys=False, allow_unicode=True, width=DUMP_WIDTH)
             out += [f"{child}  {bl}" for bl in dumped.splitlines()]
             added += 1
             nxt = span[1] if span else i + 2
@@ -1538,6 +1548,16 @@ def main(argv: list[str] | None = None) -> int:
         "Off by default since #375; this restores the pre-#372 denominator.",
     )
     args = p.parse_args(argv)
+
+    # `--refresh` only means anything as a modifier to `--apply` over a file.
+    # Argparse enforces neither, so both misuses ran the ordinary report and
+    # exited 0, leaving the caller believing a re-ground happened (#380).
+    if args.refresh and not args.apply:
+        p.error("--refresh has no effect without --apply: it modifies how --apply treats blocks")
+    if args.refresh and not args.community:
+        p.error(
+            "--refresh needs --community: there is no stored block to refresh for a bare lookup"
+        )
 
     kg_dir = resolve_kg_microbe_dir(args.kg_microbe_dir)
     mapping_path = kg_dir / MAPPING_REL

--- a/tests/test_gtdb_emit_matches_apply.py
+++ b/tests/test_gtdb_emit_matches_apply.py
@@ -32,6 +32,23 @@ REPO = Path(__file__).parent.parent
 
 
 @pytest.fixture(scope="module")
+def mapping(gtdb):
+    """Skip where the kg-microbe crosswalk is absent, CI included.
+
+    The two tests below shell out to `gtdb_ground.py`, which exits 1 with
+    "NCBI2GTDB mapping not found" without it. Locally that never showed; CI has
+    no kg-microbe checkout, so it failed there and only there.
+    """
+    try:
+        path = gtdb.resolve_kg_microbe_dir(None) / "data/raw/NCBI2GTDB.tsv.gz"
+    except SystemExit as exc:
+        pytest.skip(f"kg-microbe mapping unavailable: {str(exc).splitlines()[0]}")
+    if not path.exists():
+        pytest.skip(f"kg-microbe NCBI2GTDB mapping not available at {path}")
+    return path
+
+
+@pytest.fixture(scope="module")
 def gtdb():
     spec = importlib.util.spec_from_file_location("gtdb_ground", REPO / "scripts/gtdb_ground.py")
     module = importlib.util.module_from_spec(spec)
@@ -80,7 +97,7 @@ def test_no_line_of_an_emitted_block_wraps(gtdb):
     )
 
 
-def test_both_render_paths_agree(gtdb, tmp_path):
+def test_both_render_paths_agree(gtdb, mapping, tmp_path):
     """What `--emit-yaml` prints must be what `--apply` writes, modulo indent.
 
     Comparing `emit_block` against a locally rebuilt `yaml.dump` was a
@@ -163,13 +180,18 @@ def _run(*args):
     ],
 )
 def test_a_refresh_that_would_do_nothing_is_refused(label, argv):
-    """Silently exiting 0 let a caller believe a re-ground had happened."""
+    """Silently exiting 0 let a caller believe a re-ground had happened.
+
+    Needs no crosswalk: the guards run immediately after `parse_args`, before
+    the mapping is resolved. Asserting the message rather than only a nonzero
+    exit is what keeps that honest — a missing crosswalk also exits nonzero.
+    """
     result = _run(*argv)
     assert result.returncode != 0, f"{label} should be refused, not silently ignored"
     assert "--refresh" in result.stderr
 
 
-def test_refresh_with_apply_is_still_allowed(tmp_path):
+def test_refresh_with_apply_is_still_allowed(gtdb, mapping, tmp_path):
     """The guard must not block the one combination that does work."""
     record = REPO / "kb/communities/Richmond_Mine_AMD_Biofilm.yaml"
     probe = tmp_path / record.name

--- a/tests/test_gtdb_emit_matches_apply.py
+++ b/tests/test_gtdb_emit_matches_apply.py
@@ -1,0 +1,136 @@
+"""`--emit-yaml` output must be pasteable, i.e. identical to what `--apply` writes (#380).
+
+`apply_to_community` dumped blocks at `width=4096`, one key per line.
+`--emit-yaml` used PyYAML's default, so `gtdb_lineage` and `mapping_source` —
+the two long scalars — wrapped onto continuation lines indented deeper than the
+block keys. `--emit-yaml` exists to be **pasted into a record**, so the two
+paths disagreeing is how wrapped blocks got into the KB.
+
+That is not cosmetic. It is the root cause of the corruption #378 had to fix:
+a line-level editor then has to handle both shapes, and the first version
+matched exactly six spaces and orphaned the continuations into duplicate keys.
+
+The fix is one constant, `DUMP_WIDTH`, used by both. What keeps it fixed is
+this test: render the same grounding down each path and compare.
+
+Also covered: `--refresh` only modifies how `--apply` treats existing blocks, so
+on its own — or with `--ncbi-id`/`--name`, where there is no stored block —
+it did nothing and exited 0, leaving the caller believing a re-ground had
+happened. Argparse enforced neither.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).parent.parent
+
+
+@pytest.fixture(scope="module")
+def gtdb():
+    spec = importlib.util.spec_from_file_location("gtdb_ground", REPO / "scripts/gtdb_ground.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _grounding(gtdb) -> dict:
+    """A grounding whose long scalars are long enough to wrap at any sane width."""
+    return {
+        "gtdb_id": "GTDB:g__Bosea",
+        "gtdb_taxon": "Bosea",
+        "gtdb_lineage": (
+            "d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;"
+            "f__Beijerinckiaceae;g__Bosea"
+        ),
+        "ncbi_source_id": "NCBITaxon:85413",
+        "majority_fraction": 1.0,
+        "support_genomes": 34,
+        "total_genomes": 34,
+        "is_reclassified": False,
+        "n_alt": 1,
+        "via": "ncbi_rank_g",
+    }
+
+
+MAPPING_SOURCE = "kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)"
+
+
+def test_no_line_of_an_emitted_block_wraps(gtdb):
+    """The property that matters: every key is one line, so a paste is safe."""
+    emitted = gtdb.emit_block(_grounding(gtdb), MAPPING_SOURCE)
+
+    orphans = [
+        line for line in emitted.split("\n")[1:] if line.strip() and ":" not in line.split("#")[0]
+    ]
+    assert orphans == [], (
+        "these lines carry no key, so they are continuations of a wrapped "
+        f"scalar and a paste would indent them under the wrong parent: {orphans}"
+    )
+
+
+def test_both_render_paths_agree(gtdb):
+    """`--emit-yaml` and `--apply` must produce the same bytes for one grounding.
+
+    Rendering through each path separately and comparing is the point: a future
+    change to one dump call — a width, a flow style, a sort — silently
+    reintroduces #380 unless something notices the two diverging.
+    """
+    emitted = gtdb.emit_block(_grounding(gtdb), MAPPING_SOURCE)
+    applied = yaml.dump(
+        {"gtdb_classification": gtdb._block(_grounding(gtdb), MAPPING_SOURCE)},
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+        width=gtdb.DUMP_WIDTH,
+    )
+    assert emitted == applied
+
+
+def test_an_emitted_block_round_trips(gtdb):
+    """It parses back to the block it came from, indentation and all."""
+    emitted = gtdb.emit_block(_grounding(gtdb), MAPPING_SOURCE)
+    parsed = yaml.safe_load(emitted)["gtdb_classification"]
+    assert parsed == gtdb._block(_grounding(gtdb), MAPPING_SOURCE)
+
+
+def _run(*args):
+    return subprocess.run(
+        ["uv", "run", "python", "scripts/gtdb_ground.py", *args],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+        timeout=900,
+    )
+
+
+@pytest.mark.parametrize(
+    ("label", "argv"),
+    [
+        (
+            "--refresh without --apply",
+            ["--community", "kb/communities/Richmond_Mine_AMD_Biofilm.yaml", "--refresh"],
+        ),
+        ("--refresh on a bare name lookup", ["--name", "Bosea", "--refresh"]),
+    ],
+)
+def test_a_refresh_that_would_do_nothing_is_refused(label, argv):
+    """Silently exiting 0 let a caller believe a re-ground had happened."""
+    result = _run(*argv)
+    assert result.returncode != 0, f"{label} should be refused, not silently ignored"
+    assert "--refresh" in result.stderr
+
+
+def test_refresh_with_apply_is_still_allowed(tmp_path):
+    """The guard must not block the one combination that does work."""
+    record = REPO / "kb/communities/Richmond_Mine_AMD_Biofilm.yaml"
+    probe = tmp_path / record.name
+    probe.write_text(record.read_text())
+
+    result = _run("--community", str(probe), "--refresh", "--apply")
+    assert result.returncode == 0, result.stderr[-400:]

--- a/tests/test_gtdb_emit_matches_apply.py
+++ b/tests/test_gtdb_emit_matches_apply.py
@@ -42,11 +42,15 @@ def gtdb():
 def _grounding(gtdb) -> dict:
     """A grounding whose long scalars are long enough to wrap at any sane width."""
     return {
-        "gtdb_id": "GTDB:g__Bosea",
-        "gtdb_taxon": "Bosea",
+        "gtdb_id": "GTDB:s__Bosea_lathyri",
+        "gtdb_taxon": "Bosea lathyri",
+        # A species lineage on purpose: its final segment carries a space, so
+        # `gtdb_lineage` can actually wrap. The genus lineage this fixture used
+        # first has none, so it could not — leaving the scalar the module
+        # comment names as a wrapping risk untested.
         "gtdb_lineage": (
             "d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;"
-            "f__Beijerinckiaceae;g__Bosea"
+            "f__Beijerinckiaceae;g__Bosea;s__Bosea lathyri"
         ),
         "ncbi_source_id": "NCBITaxon:85413",
         "majority_fraction": 1.0,
@@ -65,31 +69,70 @@ def test_no_line_of_an_emitted_block_wraps(gtdb):
     """The property that matters: every key is one line, so a paste is safe."""
     emitted = gtdb.emit_block(_grounding(gtdb), MAPPING_SOURCE)
 
-    orphans = [
-        line for line in emitted.split("\n")[1:] if line.strip() and ":" not in line.split("#")[0]
-    ]
+    # Detect by indentation, not by looking for a colon: a wrapped scalar can
+    # carry one (`mapping_source` splits after "release latest:"-shaped text),
+    # and the earlier heuristic would have called that line a key.
+    body = [line for line in emitted.split("\n")[1:] if line.strip()]
+    orphans = [line for line in body if len(line) - len(line.lstrip()) != 2]
     assert orphans == [], (
         "these lines carry no key, so they are continuations of a wrapped "
         f"scalar and a paste would indent them under the wrong parent: {orphans}"
     )
 
 
-def test_both_render_paths_agree(gtdb):
-    """`--emit-yaml` and `--apply` must produce the same bytes for one grounding.
+def test_both_render_paths_agree(gtdb, tmp_path):
+    """What `--emit-yaml` prints must be what `--apply` writes, modulo indent.
 
-    Rendering through each path separately and comparing is the point: a future
-    change to one dump call — a width, a flow style, a sort — silently
-    reintroduces #380 unless something notices the two diverging.
+    Comparing `emit_block` against a locally rebuilt `yaml.dump` was a
+    tautology: it restated `emit_block`'s own body, so it passed for any
+    `DUMP_WIDTH` and never touched `apply_to_community` — whose dump is a
+    *different* call, on the inner block, with its own flow-style and
+    hand-prefixed indent. Changing the apply side left it green, which is
+    exactly the regression this file exists to catch.
+
+    So run the real thing: apply a block to a record and read back what landed.
     """
-    emitted = gtdb.emit_block(_grounding(gtdb), MAPPING_SOURCE)
-    applied = yaml.dump(
-        {"gtdb_classification": gtdb._block(_grounding(gtdb), MAPPING_SOURCE)},
-        default_flow_style=False,
-        sort_keys=False,
-        allow_unicode=True,
-        width=gtdb.DUMP_WIDTH,
+    record = tmp_path / "Probe.yaml"
+    record.write_text(
+        "id: CommunityMech:TEST\n"
+        "name: probe\n"
+        "taxonomy:\n"
+        "- taxon_term:\n"
+        "    preferred_term: Bosea\n"
+        "    term:\n"
+        "      id: NCBITaxon:85413\n"
+        "      label: Bosea\n"
     )
-    assert emitted == applied
+    result = subprocess.run(
+        ["uv", "run", "python", "scripts/gtdb_ground.py", "--community", str(record), "--apply"],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+        timeout=900,
+    )
+    assert result.returncode == 0, result.stderr[-400:]
+
+    written = record.read_text().split("\n")
+    start = next(i for i, line in enumerate(written) if line.strip() == "gtdb_classification:")
+    applied = [written[start]]
+    for line in written[start + 1 :]:
+        if line.strip() and len(line) - len(line.lstrip()) <= len(applied[0]) - len(
+            applied[0].lstrip()
+        ):
+            break
+        applied.append(line)
+
+    def _dedent(lines):
+        pad = len(lines[0]) - len(lines[0].lstrip())
+        return [line[pad:].rstrip() for line in lines if line.strip()]
+
+    emitted = gtdb.emit_block(_grounding(gtdb), MAPPING_SOURCE).split("\n")
+    # Same shape, key for key — the values differ only where the fixture does.
+    assert [line.split(":")[0] for line in _dedent(applied)] == [
+        line.split(":")[0] for line in _dedent(emitted)
+    ]
+    for line in _dedent(applied)[1:]:
+        assert len(line) - len(line.lstrip()) == 2, f"apply wrapped a scalar: {line!r}"
 
 
 def test_an_emitted_block_round_trips(gtdb):


### PR DESCRIPTION
Closes #380.

## The divergence

`apply_to_community` dumped blocks at `width=4096`, one key per line. `--emit-yaml` used PyYAML's default, so the two long scalars wrapped:

```yaml
    mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__
      rank; 1 GTDB taxa under the NCBI taxon]
```

`--emit-yaml` exists to be **pasted into a record**, so the two paths disagreeing is how wrapped blocks reached the KB.

**This is not cosmetic** — it is the root cause of the corruption #378 had to fix. Once both shapes exist, a line-level editor has to handle both, and that PR's first version matched exactly six spaces and orphaned the continuations into duplicate keys.

## The fix

One constant, `DUMP_WIDTH`, used by both call sites. What keeps it fixed is a test that renders the same grounding down each path and compares bytes — otherwise a future change to either dump call (a width, a flow style, a sort) reintroduces #380 silently.

## The secondary point, also real

`--refresh` only modifies how `--apply` treats *existing* blocks. On its own, or with `--ncbi-id`/`--name` where there is no stored block, it ran the ordinary report and **exited 0** — leaving the caller believing a re-ground had happened. Argparse enforced neither:

```
$ gtdb_ground.py --community X.yaml --refresh          # before: normal report, exit 0
$ gtdb_ground.py --name Bosea --refresh                # before: normal report, exit 0
```

Both are now refused with a message saying what `--refresh` actually does. `--community X --refresh --apply` is unaffected, and a test pins that so the guard can't over-reach.

## Scope

`scripts/gtdb_ground.py` only, +22/−2. **No KB record changes.** Six new tests. `just qc` green.

⚠️ **CI note:** GitHub Actions has produced no run on this repository since 14:50 UTC, so this PR will likely show no checks — the same stall blocking #456. Local `just qc` (lint + full suite + every offline validator) is green on this tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)