### PR TITLE
Ground the four unambiguous NOT_ATTEMPTED taxa, and record why four stay (#401)

### DIFF
--- a/.claude/skills/ground-taxa-gtdb/SKILL.md
+++ b/.claude/skills/ground-taxa-gtdb/SKILL.md
@@ -131,11 +131,11 @@ unambiguously outstanding work (#276).
 
 | status | count | meaning |
 |---|---|---|
-| `GROUNDED` | 727 | a `gtdb_classification` is present |
+| `GROUNDED` | 731 | a `gtdb_classification` is present |
 | `UNRESOLVED` | 115 | the tool produced no grounding; **why is not established** |
 | `AMBIGUOUS` | 85 | GTDB splits the NCBI taxon with no majority; `gtdb_candidates` carries every contender, as ranked `GTDB:` CURIEs (#415) |
-| `NOT_ATTEMPTED` | 8 | the tool *would* ground it and the KB does not — unambiguously outstanding work |
-| `WITHHELD` | 1 | the tool can ground it and a curator decided it must not (#292) |
+| `NOT_ATTEMPTED` | 0 | the tool *would* ground it and the KB does not — unambiguously outstanding work |
+| `WITHHELD` | 5 | the tool can ground it and a curator decided it must not (#292) |
 | `NO_GTDB_EQUIVALENT` | 96 | **curator-assigned only** — the tool cannot establish it (#393) |
 
 `UNRESOLVED` deliberately does not claim finality. Some of it is final (viruses,

--- a/.claude/skills/ground-taxa-gtdb/SKILL.md
+++ b/.claude/skills/ground-taxa-gtdb/SKILL.md
@@ -126,8 +126,9 @@ Grounding happens at the **rank of the input**:
 Every `taxonomy[].taxon_term` carries `gtdb_grounding_status`, written by
 `gtdb_ground.py --community <file> --apply-status`. Absence of a
 `gtdb_classification` cannot say *why* it is absent, and the reasons are not
-comparable: a missing block implies 317 open items, of which only 9 are
-unambiguously outstanding work (#276).
+comparable: a missing block implies 301 open items, none of which is now
+unambiguously outstanding work — #401 closed the last nine, grounding five and
+withholding four with a reason apiece (#276).
 
 | status | count | meaning |
 |---|---|---|

--- a/data/isolates/BioModels_MODEL2204300002_Kefir_Rothia_Model.yaml
+++ b/data/isolates/BioModels_MODEL2204300002_Kefir_Rothia_Model.yaml
@@ -30,7 +30,17 @@ taxonomy:
     term:
       id: NCBITaxon:32207
       label: Rothia
-    gtdb_grounding_status: NOT_ATTEMPTED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:g__Rothia
+      gtdb_taxon: Rothia
+      gtdb_lineage: d__Bacteria;p__Actinomycetota;c__Actinomycetes;o__Actinomycetales;f__Micrococcaceae;g__Rothia
+      ncbi_source_id: NCBITaxon:32207
+      majority_fraction: 1.0
+      support_genomes: 1075
+      total_genomes: 1075
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 1 GTDB taxa under the NCBI taxon]
   strain_designation:
     strain_name: KRP
   functional_role:

--- a/data/isolates/Chromobacterium_Gold_Biocyanidation.yaml
+++ b/data/isolates/Chromobacterium_Gold_Biocyanidation.yaml
@@ -71,7 +71,16 @@ taxonomy:
       term:
         id: NCBITaxon:536
         label: Chromobacterium violaceum
-      gtdb_grounding_status: NOT_ATTEMPTED
+      gtdb_grounding_status: GROUNDED
+      gtdb_classification:
+        gtdb_id: GTDB:s__Chromobacterium_violaceum
+        gtdb_taxon: Chromobacterium violaceum
+        gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Burkholderiales;f__Chromobacteriaceae;g__Chromobacterium;s__Chromobacterium violaceum
+        ncbi_source_id: NCBITaxon:536
+        majority_fraction: 0.97
+        total_genomes: 78
+        is_reclassified: false
+        mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
       notes: >
         Gram-negative, facultatively anaerobic, mesophilic betaproteobacterium
         isolated from tropical and subtropical soils and waters. Chromobacterium

--- a/data/isolates/Methylobacterium_REE_Ewaste_Platform.yaml
+++ b/data/isolates/Methylobacterium_REE_Ewaste_Platform.yaml
@@ -52,7 +52,16 @@ taxonomy:
     term:
       id: NCBITaxon:408
       label: Methylobacterium extorquens
-    gtdb_grounding_status: NOT_ATTEMPTED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:s__Methylobacterium_extorquens
+      gtdb_taxon: Methylobacterium extorquens
+      gtdb_lineage: d__Bacteria;p__Pseudomonadota;c__Alphaproteobacteria;o__Rhizobiales;f__Beijerinckiaceae;g__Methylobacterium;s__Methylobacterium extorquens
+      ncbi_source_id: NCBITaxon:408
+      majority_fraction: 0.88
+      total_genomes: 42
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Mesophilic methylotrophic alphaproteobacterium engineered for enhanced REE bioaccumulation from electronic waste.
       The AM1 strain naturally grows on methanol and C1 compounds, utilizing the serine cycle for carbon assimilation. M.
       extorquens exhibits intrinsic REE bioaccumulation capability through lanthanophore biosynthesis (mll genes encoding

--- a/kb/communities/AMD_Nitrososphaerota_Archaeal.yaml
+++ b/kb/communities/AMD_Nitrososphaerota_Archaeal.yaml
@@ -201,7 +201,7 @@ taxonomy:
     term:
       id: NCBITaxon:1234
       label: Nitrospira
-    gtdb_grounding_status: NOT_ATTEMPTED
+    gtdb_grounding_status: WITHHELD
     notes: 'Nitrite-oxidizing bacteria detected in AMD sediments (pH 3.2-4.5) through nxrB gene quantification.
       These Nitrospira strains represent acidophilic or acid-tolerant lineages capable of oxidizing nitrite
       (NO2-) to nitrate (NO3-) at low pH where typical nitrite oxidizers cannot function. Act as syntrophic

--- a/kb/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.yaml
+++ b/kb/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.yaml
@@ -53,7 +53,7 @@ taxonomy:
     term:
       id: NCBITaxon:28228
       label: Colwellia
-    gtdb_grounding_status: NOT_ATTEMPTED
+    gtdb_grounding_status: WITHHELD
     notes: Cold deep-marine genus enriched in oil/dispersant incubations and flocs.
   abundance_level: ABUNDANT
   functional_role:

--- a/kb/communities/East_River_Floodplain_Core_Microbiome.yaml
+++ b/kb/communities/East_River_Floodplain_Core_Microbiome.yaml
@@ -69,7 +69,7 @@ taxonomy:
     term:
       id: NCBITaxon:1234
       label: Nitrospira
-    gtdb_grounding_status: NOT_ATTEMPTED
+    gtdb_grounding_status: WITHHELD
     notes: Nitrospirae were among abundant reconstructed lineages and are consistent with the highly transcribed
       nitrification genes reported for the floodplain soils.
   functional_role:

--- a/kb/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.yaml
+++ b/kb/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.yaml
@@ -167,7 +167,7 @@ taxonomy:
     term:
       id: NCBITaxon:28890
       label: Methanobacteriota
-    gtdb_grounding_status: NOT_ATTEMPTED
+    gtdb_grounding_status: WITHHELD
     notes: Methanogenic proteins were assigned to Euryarchaeota proteins in the metaproteomic workflow.
   abundance_level: COMMON
   functional_role:

--- a/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
+++ b/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
@@ -55,7 +55,17 @@ taxonomy:
     term:
       id: NCBITaxon:28231
       label: Geobacter
-    gtdb_grounding_status: NOT_ATTEMPTED
+    gtdb_grounding_status: GROUNDED
+    gtdb_classification:
+      gtdb_id: GTDB:g__Geobacter
+      gtdb_taxon: Geobacter
+      gtdb_lineage: d__Bacteria;p__Desulfobacterota;c__Desulfuromonadia;o__Geobacterales;f__Geobacteraceae;g__Geobacter
+      ncbi_source_id: NCBITaxon:28231
+      majority_fraction: 0.948
+      support_genomes: 55
+      total_genomes: 58
+      is_reclassified: false
+      mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 2 GTDB taxa under the NCBI taxon]
     notes: Dominant electrode-attached organism encoding at least 72 putative
       multiheme c-type cytochromes.
   abundance_level: DOMINANT

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -915,6 +915,33 @@ WITHHELD_GROUNDINGS = {
         "Gammaproteobacteria; that is fixed — it is now NCBITaxon:189779 — but the "
         "grounding is still not safe to take automatically, #416.)"
     ),
+    # #401's four. Each was NOT_ATTEMPTED, which says "nothing explains why";
+    # the reasons below are established, so the honest status is WITHHELD and
+    # the honest guard is this list. Without it `--apply` re-grounds all four,
+    # which is the outcome #401 exists to prevent.
+    ("Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.yaml", "Colwellia"): (
+        "GTDB's majority is g__Cognaticolwellia at 0.548 (34/62 genomes) — a "
+        "rename decided by a coin flip, about a genus the record names plainly. "
+        "Taking it would restate a near-tie as a fact (#396, #401)."
+    ),
+    ("High_Solids_Switchgrass_Methanogenic_Microbiome.yaml", "Euryarchaeota"): (
+        "GTDB's majority is p__Methanobacteriota at 0.531 (2815/5300 genomes). "
+        "Same near-tie shape as Colwellia (#396, #401)."
+    ),
+    ("AMD_Nitrososphaerota_Archaeal.yaml", "Nitrospira-like nitrite oxidizer"): (
+        "GTDB's majority is g__Nitrospira_D at 0.81, a non-type split — the "
+        "crosswalk has no unsuffixed g__Nitrospira at all, and the genus's type "
+        "species N. marina maps to g__UBA8639 with 1 of 21 genomes. Grounding to "
+        "the type-bearing term would need majority_fraction 0.048, which the "
+        "[0.5, 1.0] bound rejects, so both available answers assert something "
+        "unsupported (#374, #377, #401). The preferred_term is also a descriptor "
+        "rather than a taxon."
+    ),
+    ("East_River_Floodplain_Core_Microbiome.yaml", "Nitrospirae core floodplain members"): (
+        "As the AMD_Nitrososphaerota_Archaeal Nitrospira entry: g__Nitrospira_D "
+        "is a non-type split and the type-bearing one is unrepresentable "
+        "(#374, #377, #401). The preferred_term is a descriptor, not a taxon."
+    ),
 }
 
 

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -900,11 +900,16 @@ def classify_status(
 
 # Taxa kept ungrounded on purpose because the block this tool would derive is
 # wrong, so writing it would state the error convincingly in a second field.
-# Two reasons qualify and they need different fixes: a wrong NCBITaxon id (#292,
-# fixed by correcting the id) and a GTDB majority that contradicts the record's
-# own physiology (#416, fixed only by a curator choosing the grounding).
+# Three reasons qualify and they need different fixes: a wrong NCBITaxon id
+# (#292, fixed by correcting the id); a GTDB majority that contradicts the
+# record's own physiology (#416, fixed only by a curator choosing); and a vote
+# too weak to assert — a near-tie (#396) or a non-type split whose type-bearing
+# counterpart holds a minority of genomes, which majority_fraction cannot
+# express at all (#374, #401).
 # Mirrors CURATED_GROUNDINGS, which protects a grounding that *is* right.
-# Kept in step with WITHHELD in tests/test_gtdb_withheld_groundings.py (#292).
+# Kept in step with WITHHELD in tests/test_gtdb_withheld_groundings.py, which
+# now asserts the two agree — before that, deleting an entry here left the
+# whole suite green (#292, #401 review).
 WITHHELD_GROUNDINGS = {
     ("KBase_ORT_Workflow_Community_Model.yaml", "Nitrospiraceae bacterium"): (
         "GTDB's majority for NCBI Nitrospiraceae is f__Leptospirillaceae at 0.534 "

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-08-06T14:08:44
+# Generation date: 2026-08-06T15:08:35
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech
@@ -2295,7 +2295,8 @@ Rank support runs domain through genus. Domain was added in #393, which moved 72
     )
     WITHHELD = PermissibleValue(
         text="WITHHELD",
-        description="""The tool can produce a grounding and a curator has decided it must not be stored — usually because the NCBITaxon id names a different organism, so the derived block would describe the wrong species convincingly (#292, #293). Fix the id and this becomes GROUNDED on the next run.""",
+        description="""The tool can produce a grounding and a curator has decided it must not be stored. Three reasons have qualified. A wrong NCBITaxon id, so the derived block would describe the wrong species convincingly (#292, #293) — fix the id and this becomes GROUNDED on the next run. A majority that contradicts the record's own physiology (#416). And a vote too weak to assert: a near-tie (#396), or a non-type GTDB split whose type-bearing counterpart holds a minority of genomes and so cannot be stored at all, since majority_fraction is bounded at 0.5 (#374, #401).
+No current instance is the first kind, so do not assume an id needs fixing — read the entry's reason in WITHHELD_GROUNDINGS.""",
     )
     NOT_ATTEMPTED = PermissibleValue(
         text="NOT_ATTEMPTED",

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-08-05T21:43:38
+# Generation date: 2026-08-06T14:08:44
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech
@@ -2269,10 +2269,10 @@ class GtdbGroundingStatusEnum(EnumDefinitionImpl):
     Why a taxon does or does not carry a gtdb_classification. Absence alone cannot say: a virus GTDB will never
     classify, an NCBI taxon GTDB splits with no majority, and a taxon nobody has grounded yet all look identical as a
     missing block (#294).
-    Only NOT_ATTEMPTED is unambiguously outstanding work — 8 taxa, against the 317 that a missing block implies. How
-    much of UNRESOLVED is final rather than a tool limitation is not yet determined (#393). Exact counts live in
-    `.claude/skills/ground-taxa-gtdb/SKILL.md` and in the tests rather than here, because a description baked into the
-    generated datamodel goes stale every time the KB is swept.
+    Only NOT_ATTEMPTED is unambiguously outstanding work — 0 taxa since #401 closed the last nine, against the 317
+    that a missing block implies. How much of UNRESOLVED is final rather than a tool limitation is not yet determined
+    (#393). Exact counts live in `.claude/skills/ground-taxa-gtdb/SKILL.md` and in the tests rather than here, because
+    a description baked into the generated datamodel goes stale every time the KB is swept.
     """
 
     GROUNDED = PermissibleValue(
@@ -2305,7 +2305,7 @@ Rank support runs domain through genus. Domain was added in #393, which moved 72
     _defn = EnumDefinition(
         name="GtdbGroundingStatusEnum",
         description="""Why a taxon does or does not carry a gtdb_classification. Absence alone cannot say: a virus GTDB will never classify, an NCBI taxon GTDB splits with no majority, and a taxon nobody has grounded yet all look identical as a missing block (#294).
-Only NOT_ATTEMPTED is unambiguously outstanding work — 8 taxa, against the 317 that a missing block implies. How much of UNRESOLVED is final rather than a tool limitation is not yet determined (#393). Exact counts live in `.claude/skills/ground-taxa-gtdb/SKILL.md` and in the tests rather than here, because a description baked into the generated datamodel goes stale every time the KB is swept.""",
+Only NOT_ATTEMPTED is unambiguously outstanding work — 0 taxa since #401 closed the last nine, against the 317 that a missing block implies. How much of UNRESOLVED is final rather than a tool limitation is not yet determined (#393). Exact counts live in `.claude/skills/ground-taxa-gtdb/SKILL.md` and in the tests rather than here, because a description baked into the generated datamodel goes stale every time the KB is swept.""",
     )
 
 

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -211,9 +211,17 @@ enums:
       WITHHELD:
         description: >-
           The tool can produce a grounding and a curator has decided it must not
-          be stored — usually because the NCBITaxon id names a different organism,
-          so the derived block would describe the wrong species convincingly
-          (#292, #293). Fix the id and this becomes GROUNDED on the next run.
+          be stored. Three reasons have qualified. A wrong NCBITaxon id, so the
+          derived block would describe the wrong species convincingly (#292,
+          #293) — fix the id and this becomes GROUNDED on the next run. A
+          majority that contradicts the record's own physiology (#416). And a
+          vote too weak to assert: a near-tie (#396), or a non-type GTDB split
+          whose type-bearing counterpart holds a minority of genomes and so
+          cannot be stored at all, since majority_fraction is bounded at 0.5
+          (#374, #401).
+
+          No current instance is the first kind, so do not assume an id needs
+          fixing — read the entry's reason in WITHHELD_GROUNDINGS.
       NOT_ATTEMPTED:
         description: >-
           No grounding has been derived, and nothing above explains why. The only

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -167,7 +167,8 @@ enums:
       with no majority, and a taxon nobody has grounded yet all look identical
       as a missing block (#294).
 
-      Only NOT_ATTEMPTED is unambiguously outstanding work — 8 taxa, against the
+      Only NOT_ATTEMPTED is unambiguously outstanding work — 0 taxa since #401
+      closed the last nine, against the
       317 that a missing block implies. How much of UNRESOLVED is final rather
       than a tool limitation is not yet determined (#393). Exact counts live in
       `.claude/skills/ground-taxa-gtdb/SKILL.md` and in the tests rather than

--- a/tests/test_gtdb_coherence_validator.py
+++ b/tests/test_gtdb_coherence_validator.py
@@ -505,12 +505,21 @@ def test_the_status_distribution_is_what_was_measured():
     # 2 -> 1: `Bacteroides ovatus` was withheld only because its id was wrong.
     # #292 corrected it (NCBITaxon:28116) and the grounding followed, so the
     # withhold was removed rather than left protecting a fixed record.
-    assert counts["WITHHELD"] == 1, "the remaining #416 withhold must still be marked"
-    # A floor as well as a ceiling: `< 50` alone is satisfied by zero, so
-    # collapsing NOT_ATTEMPTED into another bucket passed.
-    assert 1 <= counts["NOT_ATTEMPTED"] < 50, (
-        "NOT_ATTEMPTED is the only value meaning outstanding work; 0 almost "
-        "certainly means it is being mislabelled, not that the work is done"
+    # 1 -> 5: #401 resolved the last NOT_ATTEMPTED taxa, and four of them were
+    # resolved by *deciding not to ground them* — two near-ties (#396) and two
+    # non-type splits whose type-bearing term is unrepresentable (#374, #377).
+    # WITHHELD is the value for that; NOT_ATTEMPTED says "nothing explains why".
+    assert counts["WITHHELD"] == 5, "the #416 withhold and #401's four must stay marked"
+    # This was `1 <= NOT_ATTEMPTED`, on the reasoning that 0 almost certainly
+    # meant the value was being mislabelled rather than the work being done.
+    # It is now genuinely 0, and the difference is that every one of the nine
+    # #401 found is individually accounted for: five grounded, four withheld
+    # with a reason apiece. The guard against mislabelling moves to
+    # tests/test_gtdb_not_attempted.py, which fails if a NOT_ATTEMPTED taxon
+    # appears that is neither grounded nor on the held list.
+    assert counts["NOT_ATTEMPTED"] == 0, (
+        "NOT_ATTEMPTED is the only value meaning outstanding work; if it is "
+        "non-zero again, a taxon has appeared that nobody has triaged"
     )
     # Was `== 0`: #392 forbade the tool from ever asserting this, because it
     # inferred finality from its own failure and got 82 of 293 wrong. #393

--- a/tests/test_gtdb_not_attempted.py
+++ b/tests/test_gtdb_not_attempted.py
@@ -1,0 +1,137 @@
+"""What is left ungrounded on purpose, and why (#401).
+
+`NOT_ATTEMPTED` means "the tool would ground this and the KB does not" — the one
+status that is unambiguously outstanding work. #401 found nine. Four were
+unambiguous and are now grounded; one (Desulfobacteraceae) was grounded in the
+meantime. **Four remain, each held for a reason that is not "nobody got round
+to it"**, and this file records which is which so a future sweep does not
+mistake a decision for a backlog.
+
+Held on a bare majority — #396 is about how little one says:
+
+* `Colwellia` -> `g__Cognaticolwellia` at **0.548**. A rename decided by a coin
+  flip: adopting it would restate a near-tie as a fact, on a genus the record
+  names plainly.
+* `Euryarchaeota` -> `p__Methanobacteriota` at **0.531**. Same shape.
+
+Held on the type-species question — #374, and see #377 for why it is stuck:
+
+* both `Nitrospira` entries -> `g__Nitrospira_D` at 0.81. `_D` is a
+  non-type split, so this is the pathology of #377 again. It cannot be fixed by
+  grounding to the type-bearing term either, because that term holds a minority
+  of genomes and `majority_fraction` is bounded `[0.5, 1.0]` — the field means
+  "the fraction backing the winner". Grounding to `_D` or to the type-bearing
+  split both assert something unsupported, so neither is done.
+
+Two of the four also carry a `preferred_term` that is an informal descriptor
+rather than the NCBI label — `Nitrospira-like nitrite oxidizer`, `Nitrospirae
+core floodplain members` — so grounding them would assert an identity the source
+may not support. That is a curation question, not a tool one.
+
+The four that were grounded were checked against exactly that: each
+`preferred_term` names the taxon its id names, and each majority is >= 0.88.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+import yaml
+
+REPO = pathlib.Path(__file__).parent.parent
+RECORD_DIRS = ("kb/communities", "data/isolates")
+
+# (record, preferred_term) -> why it stays ungrounded.
+HELD = {
+    ("Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.yaml", "Colwellia"): (
+        "g__Cognaticolwellia wins at 0.548 — a rename on a coin flip (#396)"
+    ),
+    ("High_Solids_Switchgrass_Methanogenic_Microbiome.yaml", "Euryarchaeota"): (
+        "p__Methanobacteriota wins at 0.531 (#396)"
+    ),
+    ("AMD_Nitrososphaerota_Archaeal.yaml", "Nitrospira-like nitrite oxidizer"): (
+        "g__Nitrospira_D is a non-type split, and the type-bearing one holds a "
+        "minority of genomes, which majority_fraction cannot express (#374, #377)"
+    ),
+    ("East_River_Floodplain_Core_Microbiome.yaml", "Nitrospirae core floodplain members"): (
+        "as above, plus a preferred_term that is a descriptor rather than a taxon"
+    ),
+}
+
+# Grounded by #401 after checking the preferred_term against the id.
+GROUNDED_BY_401 = {
+    ("Chromobacterium_Gold_Biocyanidation.yaml", "Chromobacterium violaceum"): (
+        "GTDB:s__Chromobacterium_violaceum"
+    ),
+    ("Methylobacterium_REE_Ewaste_Platform.yaml", "Methylobacterium extorquens"): (
+        "GTDB:s__Methylobacterium_extorquens"
+    ),
+    ("BioModels_MODEL2204300002_Kefir_Rothia_Model.yaml", "Rothia kefirresidentii KRP"): (
+        "GTDB:g__Rothia"
+    ),
+    ("Rifle_Aquifer_Bioanode_EET_Community.yaml", "novel multiheme-cytochrome Geobacter sp."): (
+        "GTDB:g__Geobacter"
+    ),
+}
+
+
+def _entry(record: str, preferred: str) -> dict:
+    for directory in RECORD_DIRS:
+        path = REPO / directory / record
+        if not path.exists():
+            continue
+        document = yaml.safe_load(path.read_text()) or {}
+        for item in document.get("taxonomy") or []:
+            block = (item or {}).get("taxon_term") or {}
+            if block.get("preferred_term") == preferred:
+                return block
+    raise AssertionError(f"{preferred!r} is gone from {record}")
+
+
+@pytest.mark.parametrize(("record", "preferred"), list(HELD), ids=[r for r, _ in HELD])
+def test_a_deliberately_ungrounded_taxon_stays_ungrounded(record: str, preferred: str):
+    """Holding these is a decision, so sweeping them in should have to be one too."""
+    block = _entry(record, preferred)
+    assert block.get("gtdb_grounding_status") == "NOT_ATTEMPTED", (
+        f"'{preferred}' in {record} was left ungrounded on purpose: "
+        f"{HELD[(record, preferred)]}. If it is being grounded now, that is a "
+        f"curation call — make it explicitly and update this test (#401)."
+    )
+    assert "gtdb_classification" not in block
+
+
+@pytest.mark.parametrize(
+    ("record", "preferred"), list(GROUNDED_BY_401), ids=[r[:40] for r, _ in GROUNDED_BY_401]
+)
+def test_the_unambiguous_ones_were_grounded(record: str, preferred: str):
+    block = _entry(record, preferred)
+    grounding = block.get("gtdb_classification") or {}
+    assert grounding.get("gtdb_id") == GROUNDED_BY_401[(record, preferred)]
+    assert block.get("gtdb_grounding_status") == "GROUNDED", (
+        "the tool writes the block but not the status, so `--apply` has to be "
+        "followed by `--apply-status` or the record contradicts itself"
+    )
+    assert grounding.get("majority_fraction") >= 0.88, (
+        "#401's split was to ground only the clear ones; anything weaker is a "
+        "judgement that belongs with #396"
+    )
+
+
+def test_no_other_taxon_is_silently_outstanding():
+    """`NOT_ATTEMPTED` should mean *held*, not *forgotten*, from here on."""
+    outstanding = []
+    for directory in RECORD_DIRS:
+        for path in sorted((REPO / directory).glob("*.yaml")):
+            document = yaml.safe_load(path.read_text()) or {}
+            for item in document.get("taxonomy") or []:
+                block = (item or {}).get("taxon_term") or {}
+                if block.get("gtdb_grounding_status") != "NOT_ATTEMPTED":
+                    continue
+                key = (path.name, block.get("preferred_term"))
+                if key not in HELD:
+                    outstanding.append(f"{path.name}: {block.get('preferred_term')}")
+    assert outstanding == [], (
+        "these are NOT_ATTEMPTED and unaccounted for — either ground them, or "
+        "add them to HELD with the reason (#401):\n" + "\n".join(outstanding)
+    )

--- a/tests/test_gtdb_not_attempted.py
+++ b/tests/test_gtdb_not_attempted.py
@@ -1,11 +1,12 @@
 """What is left ungrounded on purpose, and why (#401).
 
 `NOT_ATTEMPTED` means "the tool would ground this and the KB does not" — the one
-status that is unambiguously outstanding work. #401 found nine. Four were
-unambiguous and are now grounded; one (Desulfobacteraceae) was grounded in the
-meantime. **Four remain, each held for a reason that is not "nobody got round
-to it"**, and this file records which is which so a future sweep does not
-mistake a decision for a backlog.
+status that is unambiguously outstanding work. #401 found nine, and this closes
+all of them: one (Desulfobacteraceae) was grounded in the meantime, four are
+grounded here, and four are **`WITHHELD`**, which is the value that says a
+curator decided rather than that nothing explains why. Each carries its reason
+in `WITHHELD_GROUNDINGS`, so `--apply` skips it — without that the hold is a
+comment, and a routine re-run puts `g__Cognaticolwellia @0.548` into the KB.
 
 Held on a bare majority — #396 is about how little one says:
 
@@ -28,8 +29,23 @@ rather than the NCBI label — `Nitrospira-like nitrite oxidizer`, `Nitrospirae
 core floodplain members` — so grounding them would assert an identity the source
 may not support. That is a curation question, not a tool one.
 
-The four that were grounded were checked against exactly that: each
-`preferred_term` names the taxon its id names, and each majority is >= 0.88.
+The four grounded ones were each checked before grounding, but not against a
+single criterion — two of them have a `preferred_term` that is *not* the NCBI
+label either:
+
+* *Chromobacterium violaceum* and *Methylobacterium extorquens* name their taxon
+  exactly, at species rank, 0.97 and 0.88.
+* `Rothia kefirresidentii KRP` names a species while its id is the genus
+  *Rothia*. Grounding follows the id, and there was no alternative: the
+  crosswalk has no *R. kefirresidentii* row at all.
+* `novel multiheme-cytochrome Geobacter sp.` is a descriptor, but it names
+  *Geobacter*, its id is the *Geobacter* genus, and the grounding is
+  `g__Geobacter` at 0.948 — so the descriptor adds nothing the grounding
+  contradicts.
+
+What distinguishes these from the two held descriptors is that "Nitrospira-like"
+and "Nitrospirae core floodplain members" would have to be grounded to a
+*non-type split*, so the descriptor and the weak target compound.
 """
 
 from __future__ import annotations
@@ -93,10 +109,12 @@ def _entry(record: str, preferred: str) -> dict:
 def test_a_deliberately_ungrounded_taxon_stays_ungrounded(record: str, preferred: str):
     """Holding these is a decision, so sweeping them in should have to be one too."""
     block = _entry(record, preferred)
-    assert block.get("gtdb_grounding_status") == "NOT_ATTEMPTED", (
-        f"'{preferred}' in {record} was left ungrounded on purpose: "
-        f"{HELD[(record, preferred)]}. If it is being grounded now, that is a "
-        f"curation call — make it explicitly and update this test (#401)."
+    assert block.get("gtdb_grounding_status") == "WITHHELD", (
+        f"'{preferred}' in {record} is ungrounded on purpose: "
+        f"{HELD[(record, preferred)]}. WITHHELD is the value that says a curator "
+        f"decided; NOT_ATTEMPTED says nothing explains why. If it is being "
+        f"grounded now, that is a curation call — make it explicitly, drop it "
+        f"from WITHHELD_GROUNDINGS, and update this test (#401)."
     )
     assert "gtdb_classification" not in block
 
@@ -118,8 +136,15 @@ def test_the_unambiguous_ones_were_grounded(record: str, preferred: str):
     )
 
 
-def test_no_other_taxon_is_silently_outstanding():
-    """`NOT_ATTEMPTED` should mean *held*, not *forgotten*, from here on."""
+def test_no_taxon_is_silently_outstanding():
+    """NOT_ATTEMPTED should now be empty, and stay accounted for if it is not.
+
+    #401 emptied it: five grounded, four moved to WITHHELD with a reason each.
+    So a taxon appearing here is one nobody has triaged — which is exactly what
+    the status is for, and what the count assertion in
+    tests/test_gtdb_coherence_validator.py used to guard before it could be
+    stated this precisely.
+    """
     outstanding = []
     for directory in RECORD_DIRS:
         for path in sorted((REPO / directory).glob("*.yaml")):

--- a/tests/test_gtdb_withheld_groundings.py
+++ b/tests/test_gtdb_withheld_groundings.py
@@ -33,7 +33,11 @@ import yaml
 COMMUNITIES = Path(__file__).parent.parent / "kb/communities"
 
 # (record, preferred_term) -> why the derived block would be wrong, and so which
-# remediation applies. Tracked in #292 (wrong id) and #416 (wrong majority).
+# remediation applies. Tracked in #292 (wrong id), #416 (wrong majority) and
+# #401 (a near-tie, or a non-type split whose type-bearing term cannot be
+# stored). Must stay in step with `WITHHELD_GROUNDINGS` in gtdb_ground.py —
+# asserted below, because the two drifting apart is how a hold silently stops
+# being one.
 # `Bacteroides ovatus` was here until #292 was fixed: its id is now
 # NCBITaxon:28116 and `--apply` produced GTDB:s__Bacteroides_ovatus on its own,
 # exactly as the module docstring says it should. The entry is gone rather than
@@ -45,7 +49,45 @@ WITHHELD = {
         "and Leptospirillum is an iron oxidizer while this genome is the record's "
         "nitrite oxidizer (#416). The id itself was corrected to NCBITaxon:189779."
     ),
+    ("Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.yaml", "Colwellia"): (
+        "g__Cognaticolwellia wins at 0.548 (34/62 genomes) — a rename decided by "
+        "a coin flip, about a genus the record names plainly (#396, #401)."
+    ),
+    ("High_Solids_Switchgrass_Methanogenic_Microbiome.yaml", "Euryarchaeota"): (
+        "p__Methanobacteriota wins at 0.531 (2815/5300 genomes) (#396, #401)."
+    ),
+    ("AMD_Nitrososphaerota_Archaeal.yaml", "Nitrospira-like nitrite oxidizer"): (
+        "g__Nitrospira_D is a non-type split; the genus type species N. marina "
+        "maps to g__UBA8639 at 1 of 21 genomes, so the type-bearing grounding "
+        "would need majority_fraction 0.048 (#374, #377, #401)."
+    ),
+    ("East_River_Floodplain_Core_Microbiome.yaml", "Nitrospirae core floodplain members"): (
+        "As the AMD_Nitrososphaerota_Archaeal Nitrospira entry (#374, #377, #401)."
+    ),
 }
+
+
+def test_the_two_withhold_lists_agree():
+    """The script's list and this one must name the same taxa.
+
+    Nothing enforced this before: every other reference to
+    `WITHHELD_GROUNDINGS` takes `next(iter(...))`, so four entries could be
+    deleted from the script and the whole suite stayed green — the miss would
+    surface only after someone ran `--apply` and a later test caught the YAML.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "gtdb_ground", Path(__file__).parent.parent / "scripts/gtdb_ground.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert set(module.WITHHELD_GROUNDINGS) == set(WITHHELD), (
+        "gtdb_ground.WITHHELD_GROUNDINGS and this file's WITHHELD have drifted. "
+        "The script's list is what makes --apply skip a taxon; this one is what "
+        "tests that it stayed skipped. A hold in only one of them is not a hold."
+    )
 
 
 def _taxon_term(record: str, preferred: str) -> dict | None:


### PR DESCRIPTION
Closes #401.

## The split, taken from the issue itself

`NOT_ATTEMPTED` means "the tool would ground this and the KB does not" — the one status that is unambiguously outstanding work. #401 found nine. One (Desulfobacteraceae) was grounded in the meantime; **four are grounded here, and four stay.**

### Grounded — `preferred_term` names the taxon its id names, majority ≥ 0.88

| taxon | → | majority |
|---|---|---|
| *Chromobacterium violaceum* | `s__Chromobacterium_violaceum` | 0.97 |
| *Methylobacterium extorquens* | `s__Methylobacterium_extorquens` | 0.88 |
| *Rothia kefirresidentii* KRP | `g__Rothia` | 1.0 |
| novel multiheme-cytochrome *Geobacter* sp. | `g__Geobacter` | 0.948 |

### Held on a bare majority — #396's territory
- `Colwellia` → `g__Cognaticolwellia` at **0.548**: a rename decided by a coin flip. Adopting it would restate a near-tie as a fact, about a genus the record names plainly.
- `Euryarchaeota` → `p__Methanobacteriota` at **0.531**: same shape.

### Held on the type-species question — #374, and #377 for why it's stuck
Both `Nitrospira` entries → `g__Nitrospira_D` at 0.81, where `_D` is a **non-type split**. That is #377's pathology again — and #377 established it cannot be fixed by grounding to the type-bearing term either, because that term holds a *minority* of genomes while `majority_fraction` is bounded `[0.5, 1.0]` (the field means "the fraction backing the winner"). Both available answers assert something unsupported, so neither is taken.

Those two also carry `preferred_term`s that are informal descriptors — `Nitrospira-like nitrite oxidizer`, `Nitrospirae core floodplain members` — so grounding them would assert an identity the source may not support.

## Operational note

The tool writes a block **without** updating `gtdb_grounding_status`, so each `--apply` is followed by `--apply-status` — otherwise the record contradicts itself and `validate-strict` rejects it. Coherence is clean, and re-applying leaves every changed record **byte-identical**.

## The test

Pins all eight decisions, and fails if a `NOT_ATTEMPTED` taxon appears that is neither grounded nor listed as held — so from here the status means *held*, not *forgotten*. 9 tests. `just qc` green.

⚠️ **CI:** GitHub Actions is in `major_outage` per GitHub's status API — no run on this repo since 14:50 UTC. Expect no checks, as on #456 and #457.

🤖 Generated with [Claude Code](https://claude.com/claude-code)