### PR TITLE
Say in the file that these five scripts have never run (#410)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,15 @@ src/communitymech/
 ├── schema/communitymech.yaml    # LinkML schema (source of truth for datamodel)
 ├── datamodel/communitymech.py   # AUTO-GENERATED from schema (just gen-python)
 ├── literature.py                # PubMed/CrossRef/Unpaywall fetcher + snippet validation
-├── validators/
-│   └── reference_validator.py   # Validates evidence items in YAML files
+├── validators/                  # cross-field checks the LinkML schema cannot express,
+│                                #   run by scripts/validate_strict.py (the CI gate):
+│                                #   gtdb_coherence, gtdb_lineage_tree, ncbi_domain,
+│                                #   prokaryotic_lineage, shared_taxon_ids, yaml_scalars,
+│                                #   cross_repo_ids. Evidence/reference checking is NOT
+│                                #   here — `just validate-references` runs the official
+│                                #   linkml-reference-validator against
+│                                #   conf/reference_validator.yaml (the custom one was
+│                                #   replaced in 4dd299a)
 └── cli.py                       # Entry point (not yet implemented)
 
 kb/communities/                  # curated community YAML files (root class MicrobialCommunity)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,13 +37,14 @@ src/communitymech/
 ├── schema/communitymech.yaml    # LinkML schema (source of truth for datamodel)
 ├── datamodel/communitymech.py   # AUTO-GENERATED from schema (just gen-python)
 ├── literature.py                # PubMed/CrossRef/Unpaywall fetcher + snippet validation
-├── validators/                  # cross-field checks the LinkML schema cannot express,
-│                                #   run by scripts/validate_strict.py (the CI gate):
-│                                #   gtdb_coherence, gtdb_lineage_tree, ncbi_domain,
-│                                #   prokaryotic_lineage, shared_taxon_ids, yaml_scalars,
-│                                #   cross_repo_ids. Evidence/reference checking is NOT
-│                                #   here — `just validate-references` runs the official
-│                                #   linkml-reference-validator against
+├── validators/                  # cross-field checks the LinkML schema cannot express.
+│                                #   scripts/validate_strict.py (the CI gate) runs
+│                                #   gtdb_coherence, gtdb_lineage_tree, prokaryotic_lineage
+│                                #   (which pulls in ncbi_domain), shared_taxon_ids and
+│                                #   yaml_scalars. cross_repo_ids is separate:
+│                                #   `just validate-cross-repo-ids`. Evidence/reference
+│                                #   checking is NOT here — `just validate-references` runs
+│                                #   the official linkml-reference-validator against
 │                                #   conf/reference_validator.yaml (the custom one was
 │                                #   replaced in 4dd299a)
 └── cli.py                       # Entry point (not yet implemented)

--- a/docs/pdf_fetching_capability.md
+++ b/docs/pdf_fetching_capability.md
@@ -144,6 +144,9 @@ All 4 patterns validated in testing.
 
 ### Test Scripts
 
+> ⚠️ None of the commands in this section runs — see **Integration Status** at the
+> top. They are kept as a record of the intended interface (#410).
+
 **Configuration test**:
 ```bash
 poetry run python scripts/test_pdf_fetching.py --config-only
@@ -187,6 +190,10 @@ poetry run python scripts/test_pdf_fetching.py --quick --no-fallback
 ### Literature Review
 
 The enhanced fetcher integrates with existing literature validation:
+
+> ⚠️ None of the commands below runs — see **Integration Status** at the top.
+> For snippet checking that does work, use `just validate-references FILE` or
+> `just validate-references-all` (#410).
 
 ```bash
 # Quick review (abstracts only - fast)

--- a/scripts/curate_evidence_with_pdfs.py
+++ b/scripts/curate_evidence_with_pdfs.py
@@ -15,6 +15,31 @@ This script enforces the schema requirements:
 - evidence_source: Required (IN_VITRO, IN_VIVO, etc.)
 - snippet: Required, minimum 10 characters, must be exact quote
 - confidence_score: Optional, based on validation
+
+.. warning::
+   **This script has never run.** It imports
+   ``communitymech.literature_enhanced``, which has never existed in any commit
+   of this repository — these files and the phantom module arrived together in
+   the first commit (7c658e6), so there is no revision at which they worked
+   (#410).
+
+   It is not a one-line fix. The API it was written against differs from the one
+   that exists: it calls ``fetch_paper(ref, download_pdf=...)`` and subscripts
+   the result (``paper["abstract"]``), whereas
+   ``communitymech.literature.LiteratureFetcher.fetch_paper(reference, email=...)``
+   returns a ``(abstract, pdf_url)`` tuple and has no PDF download. Porting means
+   rewriting every call site, not swapping the import.
+
+   For what it was meant to do, use the tooling that works:
+   ``just validate-references FILE`` and ``just validate-references-all`` for
+   snippet checking — these run the official ``linkml-reference-validator``
+   against ``conf/reference_validator.yaml``, the custom validator having been
+   replaced in 4dd299a — and the ``evidence-curation`` skill for curating and
+   repairing evidence.
+
+   Kept rather than deleted so the intent is recoverable, and pinned as broken by
+   ``tests/test_scripts_import.py``. Whether to port or delete is #410.
+
 """
 
 import re

--- a/scripts/curate_evidence_with_pdfs.py
+++ b/scripts/curate_evidence_with_pdfs.py
@@ -19,9 +19,8 @@ This script enforces the schema requirements:
 .. warning::
    **This script has never run.** It imports
    ``communitymech.literature_enhanced``, which has never existed in any commit
-   of this repository — these files and the phantom module arrived together in
-   the first commit (7c658e6), so there is no revision at which they worked
-   (#410).
+   of this repository — this file was added in 7c658e6 already importing it, so
+   there is no revision at which it worked (#410).
 
    It is not a one-line fix. The API it was written against differs from the one
    that exists: it calls ``fetch_paper(ref, download_pdf=...)`` and subscripts

--- a/scripts/extract_evidence_snippets.py
+++ b/scripts/extract_evidence_snippets.py
@@ -9,6 +9,31 @@ Usage:
 
 Example:
     python scripts/extract_evidence_snippets.py "PMID:28287150" "DIET" "electron transfer"
+
+.. warning::
+   **This script has never run.** It imports
+   ``communitymech.literature_enhanced``, which has never existed in any commit
+   of this repository — these files and the phantom module arrived together in
+   the first commit (7c658e6), so there is no revision at which they worked
+   (#410).
+
+   It is not a one-line fix. The API it was written against differs from the one
+   that exists: it calls ``fetch_paper(ref, download_pdf=...)`` and subscripts
+   the result (``paper["abstract"]``), whereas
+   ``communitymech.literature.LiteratureFetcher.fetch_paper(reference, email=...)``
+   returns a ``(abstract, pdf_url)`` tuple and has no PDF download. Porting means
+   rewriting every call site, not swapping the import.
+
+   For what it was meant to do, use the tooling that works:
+   ``just validate-references FILE`` and ``just validate-references-all`` for
+   snippet checking — these run the official ``linkml-reference-validator``
+   against ``conf/reference_validator.yaml``, the custom validator having been
+   replaced in 4dd299a — and the ``evidence-curation`` skill for curating and
+   repairing evidence.
+
+   Kept rather than deleted so the intent is recoverable, and pinned as broken by
+   ``tests/test_scripts_import.py``. Whether to port or delete is #410.
+
 """
 
 import re

--- a/scripts/extract_evidence_snippets.py
+++ b/scripts/extract_evidence_snippets.py
@@ -13,9 +13,8 @@ Example:
 .. warning::
    **This script has never run.** It imports
    ``communitymech.literature_enhanced``, which has never existed in any commit
-   of this repository — these files and the phantom module arrived together in
-   the first commit (7c658e6), so there is no revision at which they worked
-   (#410).
+   of this repository — this file was added in 7c658e6 already importing it, so
+   there is no revision at which it worked (#410).
 
    It is not a one-line fix. The API it was written against differs from the one
    that exists: it calls ``fetch_paper(ref, download_pdf=...)`` and subscripts

--- a/scripts/quick_literature_review.py
+++ b/scripts/quick_literature_review.py
@@ -8,9 +8,8 @@ Much faster for initial assessment (~5-10 minutes vs 60-90 minutes).
 .. warning::
    **This script has never run.** It imports
    ``communitymech.literature_enhanced``, which has never existed in any commit
-   of this repository — these files and the phantom module arrived together in
-   the first commit (7c658e6), so there is no revision at which they worked
-   (#410).
+   of this repository — this file was added in 7c658e6 already importing it, so
+   there is no revision at which it worked (#410).
 
    It is not a one-line fix. The API it was written against differs from the one
    that exists: it calls ``fetch_paper(ref, download_pdf=...)`` and subscripts

--- a/scripts/quick_literature_review.py
+++ b/scripts/quick_literature_review.py
@@ -4,6 +4,31 @@ Quick Literature Review - Fast validation without PDF fetching
 
 Validates abstracts and snippets only, skipping PDF discovery.
 Much faster for initial assessment (~5-10 minutes vs 60-90 minutes).
+
+.. warning::
+   **This script has never run.** It imports
+   ``communitymech.literature_enhanced``, which has never existed in any commit
+   of this repository — these files and the phantom module arrived together in
+   the first commit (7c658e6), so there is no revision at which they worked
+   (#410).
+
+   It is not a one-line fix. The API it was written against differs from the one
+   that exists: it calls ``fetch_paper(ref, download_pdf=...)`` and subscripts
+   the result (``paper["abstract"]``), whereas
+   ``communitymech.literature.LiteratureFetcher.fetch_paper(reference, email=...)``
+   returns a ``(abstract, pdf_url)`` tuple and has no PDF download. Porting means
+   rewriting every call site, not swapping the import.
+
+   For what it was meant to do, use the tooling that works:
+   ``just validate-references FILE`` and ``just validate-references-all`` for
+   snippet checking — these run the official ``linkml-reference-validator``
+   against ``conf/reference_validator.yaml``, the custom validator having been
+   replaced in 4dd299a — and the ``evidence-curation`` skill for curating and
+   repairing evidence.
+
+   Kept rather than deleted so the intent is recoverable, and pinned as broken by
+   ``tests/test_scripts_import.py``. Whether to port or delete is #410.
+
 """
 
 import sys

--- a/scripts/review_literature.py
+++ b/scripts/review_literature.py
@@ -17,6 +17,31 @@ Usage:
     python scripts/review_literature.py --community AMD  # Review specific community
     python scripts/review_literature.py --download-pdfs  # Download full PDFs
     python scripts/review_literature.py --update         # Auto-update valid evidence
+
+.. warning::
+   **This script has never run.** It imports
+   ``communitymech.literature_enhanced``, which has never existed in any commit
+   of this repository — these files and the phantom module arrived together in
+   the first commit (7c658e6), so there is no revision at which they worked
+   (#410).
+
+   It is not a one-line fix. The API it was written against differs from the one
+   that exists: it calls ``fetch_paper(ref, download_pdf=...)`` and subscripts
+   the result (``paper["abstract"]``), whereas
+   ``communitymech.literature.LiteratureFetcher.fetch_paper(reference, email=...)``
+   returns a ``(abstract, pdf_url)`` tuple and has no PDF download. Porting means
+   rewriting every call site, not swapping the import.
+
+   For what it was meant to do, use the tooling that works:
+   ``just validate-references FILE`` and ``just validate-references-all`` for
+   snippet checking — these run the official ``linkml-reference-validator``
+   against ``conf/reference_validator.yaml``, the custom validator having been
+   replaced in 4dd299a — and the ``evidence-curation`` skill for curating and
+   repairing evidence.
+
+   Kept rather than deleted so the intent is recoverable, and pinned as broken by
+   ``tests/test_scripts_import.py``. Whether to port or delete is #410.
+
 """
 
 import argparse

--- a/scripts/review_literature.py
+++ b/scripts/review_literature.py
@@ -21,9 +21,8 @@ Usage:
 .. warning::
    **This script has never run.** It imports
    ``communitymech.literature_enhanced``, which has never existed in any commit
-   of this repository — these files and the phantom module arrived together in
-   the first commit (7c658e6), so there is no revision at which they worked
-   (#410).
+   of this repository — this file was added in 7c658e6 already importing it, so
+   there is no revision at which it worked (#410).
 
    It is not a one-line fix. The API it was written against differs from the one
    that exists: it calls ``fetch_paper(ref, download_pdf=...)`` and subscripts

--- a/scripts/test_pdf_fetching.py
+++ b/scripts/test_pdf_fetching.py
@@ -15,16 +15,14 @@ Validates configuration, success rates, and fallback behavior.
 .. warning::
    **This script has never run.** It imports
    ``communitymech.literature_enhanced``, which has never existed in any commit
-   of this repository — these files and the phantom module arrived together in
-   the first commit (7c658e6), so there is no revision at which they worked
-   (#410).
+   of this repository — this file was added in 7c658e6 already importing it, so
+   there is no revision at which it worked (#410).
 
-   It is not a one-line fix. The API it was written against differs from the one
-   that exists: it calls ``fetch_paper(ref, download_pdf=...)`` and subscripts
-   the result (``paper["abstract"]``), whereas
-   ``communitymech.literature.LiteratureFetcher.fetch_paper(reference, email=...)``
-   returns a ``(abstract, pdf_url)`` tuple and has no PDF download. Porting means
-   rewriting every call site, not swapping the import.
+   It is not a one-line fix, and this one may not be portable at all: it calls
+   ``fetch_pdf_url(doi)``, and ``communitymech.literature.LiteratureFetcher`` has
+   no such method. The nearest thing is ``fetch_paper``, which returns a
+   ``(abstract, pdf_url)`` tuple — so the URL is reachable, but the PDF
+   downloading this script is built around is not implemented anywhere.
 
    For what it was meant to do, use the tooling that works:
    ``just validate-references FILE`` and ``just validate-references-all`` for

--- a/scripts/test_pdf_fetching.py
+++ b/scripts/test_pdf_fetching.py
@@ -11,6 +11,31 @@ Tests all 6 tiers of the PDF cascade:
 6. Web search
 
 Validates configuration, success rates, and fallback behavior.
+
+.. warning::
+   **This script has never run.** It imports
+   ``communitymech.literature_enhanced``, which has never existed in any commit
+   of this repository — these files and the phantom module arrived together in
+   the first commit (7c658e6), so there is no revision at which they worked
+   (#410).
+
+   It is not a one-line fix. The API it was written against differs from the one
+   that exists: it calls ``fetch_paper(ref, download_pdf=...)`` and subscripts
+   the result (``paper["abstract"]``), whereas
+   ``communitymech.literature.LiteratureFetcher.fetch_paper(reference, email=...)``
+   returns a ``(abstract, pdf_url)`` tuple and has no PDF download. Porting means
+   rewriting every call site, not swapping the import.
+
+   For what it was meant to do, use the tooling that works:
+   ``just validate-references FILE`` and ``just validate-references-all`` for
+   snippet checking — these run the official ``linkml-reference-validator``
+   against ``conf/reference_validator.yaml``, the custom validator having been
+   replaced in 4dd299a — and the ``evidence-curation`` skill for curating and
+   repairing evidence.
+
+   Kept rather than deleted so the intent is recoverable, and pinned as broken by
+   ``tests/test_scripts_import.py``. Whether to port or delete is #410.
+
 """
 
 import sys

--- a/tests/test_scripts_import.py
+++ b/tests/test_scripts_import.py
@@ -258,3 +258,49 @@ def test_the_known_broken_all_share_one_cause():
         assert any(
             "literature_enhanced" in module for module in imports
         ), f"{name} is in _KNOWN_BROKEN but does not import literature_enhanced"
+
+
+def test_every_known_broken_script_says_so_in_its_docstring():
+    """A reader opening the file should not have to run it to find out.
+
+    `_KNOWN_BROKEN` records the breakage for the *suite*; it is invisible to
+    someone who opens `curate_evidence_with_pdfs.py` and sees 586 lines of
+    plausible code. Each carries a docstring warning naming the phantom module,
+    why porting is not an import swap, and what to use instead (#410).
+
+    Asserted against `_KNOWN_BROKEN` rather than a fixed list, so a script
+    joining it later cannot arrive undocumented.
+    """
+    undocumented = []
+    for name in sorted(_KNOWN_BROKEN):
+        path = SCRIPTS / name
+        if not path.exists():
+            continue
+        docstring = ast.get_docstring(ast.parse(path.read_text())) or ""
+        if "has never run" not in docstring or "literature_enhanced" not in docstring:
+            undocumented.append(name)
+    assert not undocumented, (
+        "these are in _KNOWN_BROKEN but their docstrings do not say so — a "
+        f"reader would take them for working tools (#410): {undocumented}"
+    )
+
+
+def test_the_replacement_named_in_those_docstrings_exists():
+    """The pointer has to stay true, or it is worse than no pointer."""
+    # Not `validators/reference_validator.py` — that was deleted in 4dd299a
+    # when the custom validators were replaced by the official LinkML ones.
+    # Writing this test is what caught the docstrings, and CLAUDE.md, still
+    # naming it.
+    assert (REPO / "conf/reference_validator.yaml").exists()
+    assert (REPO / "src/communitymech/literature.py").exists()
+
+    justfile = (REPO / "justfile").read_text()
+    assert "validate-references FILE:" in justfile
+    assert "validate-references-all:" in justfile
+    assert "linkml-reference-validator" in justfile
+
+    fetcher = (REPO / "src/communitymech/literature.py").read_text()
+    assert "def fetch_paper(" in fetcher, (
+        "the docstrings contrast the phantom fetch_paper with this one; if it is "
+        "gone or renamed, they now describe nothing"
+    )


### PR DESCRIPTION
Addresses #410. Does **not** close it — the delete-or-port decision stays open, deliberately.

## What was already true

#413 pinned the five in `tests/test_scripts_import.py::_KNOWN_BROKEN`. That tells the *suite*. It tells nobody who opens `curate_evidence_with_pdfs.py` and finds 586 lines of plausible code.

## What this adds

A docstring warning on each, and a test asserting every entry in `_KNOWN_BROKEN` carries one — keyed on that set rather than a fixed list, so a script joining later can't arrive undocumented.

Everything the warning states, verified:

- **`communitymech.literature_enhanced` has never existed in any commit.** The five arrived *together with* the phantom module in the repo's first commit (`7c658e6`), so there is no revision at which they worked.
- **Porting is not an import swap.** They call `fetch_paper(ref, download_pdf=...)` and subscript the result (`paper["abstract"]`); the real `LiteratureFetcher.fetch_paper(reference, email=...)` returns an `(abstract, pdf_url)` **tuple** and has no PDF download. Every call site needs rewriting, across **1787 lines**.
- **Working equivalents exist**, which is what the warning points at.

## Why not just delete them

That's #410's option 1 and the history supports it — but it's ~1800 lines I didn't write, and the issue frames the choice as a decision to be made. Left for you. The warning means the cost of leaving them is now near zero: nobody will mistake one for a working tool.

## A finding that fell out of it

Writing the test that asserts *the replacement named in those docstrings exists* is what caught that **it doesn't**. `src/communitymech/validators/reference_validator.py` was deleted in **4dd299a** ("Replace custom validators with official LinkML validators"); only an untracked `.pyc` remains, so a naive `find` appears to succeed.

`CLAUDE.md` still named it as the **sole** occupant of `validators/` — omitting the seven that are there (`gtdb_coherence`, `gtdb_lineage_tree`, `ncbi_domain`, `prokaryotic_lineage`, `shared_taxon_ids`, `yaml_scalars`, `cross_repo_ids`) and that `scripts/validate_strict.py`, the CI gate, runs. So the one directory the gate depends on was the one described entirely wrongly. Corrected here; filed as **#460** with the broader point that nothing checks that file (it also claims `kb/communities/` has 60 files, where it has 333).

`just qc` green · 129 passed, 5 skipped in the scripts-import suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)