### PR TITLE
Execute CLAUDE.md's architecture tree instead of trusting it (#460)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,5 +81,5 @@ NCBITaxon (taxonomy), ENVO (environments), CHEBI (chemicals/metabolites), GO (bi
 ## Style
 
 - Line length: 100 (black + ruff)
-- Python 3.9+ target
+- Python 3.10+ target
 - Uses `uv` for package management (never requirements.txt)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-CommunityMech is a LinkML-based knowledge base for modeling microbial community structure, function, and ecological interactions. Community data lives as curated YAML files in `kb/communities/` (60 files), each validated against a LinkML schema. Every claim is evidence-backed with PMID/DOI references and snippet validation against abstracts.
+CommunityMech is a LinkML-based knowledge base for modeling microbial community structure, function, and ecological interactions. Community data lives as curated YAML files in `kb/communities/` (312 files), each validated against a LinkML schema. Every claim is evidence-backed with PMID/DOI references and snippet validation against abstracts.
 
 Adapted from Monarch Initiative's dismech: YAML is the source of truth, with lossy Koza transforms planned for KG export.
 

--- a/tests/test_claude_md_is_accurate.py
+++ b/tests/test_claude_md_is_accurate.py
@@ -1,0 +1,96 @@
+"""CLAUDE.md is loaded as authoritative context, and nothing checked it (#460).
+
+Every session starts with this file in context, described as instructions that
+override default behaviour. It had drifted in two ways at once, both found by
+accident while working #410:
+
+* its architecture tree named `validators/reference_validator.py` as the sole
+  occupant of that directory. That file was deleted in **4dd299a**, "Replace
+  custom validators with official LinkML validators" — only an untracked
+  `.pyc` survives, so a naive `find` appears to succeed. Meanwhile the seven
+  validators that *are* there, and that the CI gate runs, went undocumented.
+* it said `kb/communities/` holds **60** files. It holds 312.
+
+Neither is exotic: a doc nobody executes drifts from a tree that changes weekly.
+The fix is to execute it. This parses the tree — tracking parents, since it is
+nested and a bare `cli.py` means `src/communitymech/cli.py` — and asserts every
+path is real, then checks the counts the prose quotes.
+
+Kept deliberately narrow. It checks facts that are mechanically checkable and
+says nothing about whether the prose is *good*, which no test can.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).parent.parent
+CLAUDE_MD = REPO / "CLAUDE.md"
+
+# `├── name` / `└── name`, and the bare `parent/` lines they hang from.
+_CHILD = re.compile(r"^[│\s]*[├└]──\s+(\S+)")
+_ROOT = re.compile(r"^([A-Za-z][A-Za-z0-9_./-]*/)\s*(?:#.*)?$")
+
+
+def _tree_block() -> str:
+    text = CLAUDE_MD.read_text()
+    start = text.index("## Architecture")
+    fence = text.index("```", start)
+    return text[fence + 3 : text.index("```", fence + 3)]
+
+
+def _declared_paths() -> list[str]:
+    """Reconstruct full paths from the nested tree."""
+    paths, parent = [], ""
+    for line in _tree_block().split("\n"):
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        root = _ROOT.match(line.strip())
+        if root:
+            parent = root.group(1)
+            paths.append(parent)
+            continue
+        child = _CHILD.match(line)
+        if not child:
+            continue
+        name = child.group(1)
+        # A parenthetical or prose aside, not a path.
+        if name.startswith("(") or name.endswith(","):
+            continue
+        paths.append(parent + name if not name.startswith(("kb/", "src/")) else name)
+    return paths
+
+
+def test_the_tree_is_parseable():
+    """Guard the parser, so a reformat cannot silently empty the next test."""
+    declared = _declared_paths()
+    assert len(declared) >= 10, f"parsed only {len(declared)} paths; has the tree been reformatted?"
+    assert any(p.endswith(".py") for p in declared)
+    assert any(p.endswith("/") for p in declared)
+
+
+@pytest.mark.parametrize("declared", _declared_paths())
+def test_every_path_named_in_the_architecture_tree_exists(declared: str):
+    assert (REPO / declared).exists(), (
+        f"CLAUDE.md's architecture tree names {declared!r}, which is not in the "
+        f"repo. This file is loaded as authoritative context every session, so a "
+        f"stale entry misdirects every reader — `validators/reference_validator.py` "
+        f"outlived its deletion in 4dd299a by many months this way (#460)."
+    )
+
+
+def test_the_community_record_count_is_current():
+    """The prose quotes a count, and counts rot faster than paths."""
+    text = CLAUDE_MD.read_text()
+    match = re.search(r"kb/communities/[^.]*?\((\d+) files\)", text)
+    assert match, "the 'kb/communities/ (N files)' claim has moved; update this test"
+
+    claimed = int(match.group(1))
+    actual = len(list((REPO / "kb/communities").glob("*.yaml")))
+    assert claimed == actual, (
+        f"CLAUDE.md says kb/communities/ holds {claimed} files; it holds {actual}. "
+        f"It said 60 for long enough to be off by a factor of five (#460)."
+    )

--- a/tests/test_claude_md_is_accurate.py
+++ b/tests/test_claude_md_is_accurate.py
@@ -30,9 +30,18 @@ import pytest
 REPO = Path(__file__).parent.parent
 CLAUDE_MD = REPO / "CLAUDE.md"
 
-# `├── name` / `└── name`, and the bare `parent/` lines they hang from.
+# Three line shapes carry a path. A nested child (`├── name`) hangs off the
+# most recent bare directory; a bare directory (`src/communitymech/`) is both a
+# path and a parent; and a top-level entry (`NEXT_TASKS.md`, `conf/oak_config.yaml`)
+# is neither. Missing that third shape is how the first version of this test
+# checked 12 of 15 paths and stayed green while CLAUDE.md named two files that
+# did not exist — including NEXT_TASKS.md, which the same doc calls the backlog
+# source of truth.
 _CHILD = re.compile(r"^[│\s]*[├└]──\s+(\S+)")
 _ROOT = re.compile(r"^([A-Za-z][A-Za-z0-9_./-]*/)\s*(?:#.*)?$")
+_TOP_FILE = re.compile(r"^([A-Za-z][A-Za-z0-9_./-]*\.[A-Za-z0-9]+)\s*(?:#.*)?$")
+# A continuation of the previous entry's comment, carrying no path of its own.
+_COMMENT_ONLY = re.compile(r"^[│\s]*#")
 
 
 def _tree_block() -> str:
@@ -42,34 +51,65 @@ def _tree_block() -> str:
     return text[fence + 3 : text.index("```", fence + 3)]
 
 
-def _declared_paths() -> list[str]:
-    """Reconstruct full paths from the nested tree."""
-    paths, parent = [], ""
+def _parse_tree() -> tuple[list[str], list[str]]:
+    """(paths declared, lines the parser could not account for).
+
+    Returning the leftovers is the point: a lower bound on the path count
+    cannot tell "the tree shrank" from "the parser went blind", but a line it
+    failed to classify can.
+    """
+    paths: list[str] = []
+    unconsumed: list[str] = []
+    parent = ""
     for line in _tree_block().split("\n"):
-        if not line.strip() or line.lstrip().startswith("#"):
+        if not line.strip() or _COMMENT_ONLY.match(line):
             continue
         root = _ROOT.match(line.strip())
         if root:
             parent = root.group(1)
             paths.append(parent)
             continue
+        top = _TOP_FILE.match(line.strip())
+        if top:
+            paths.append(top.group(1))
+            continue
         child = _CHILD.match(line)
-        if not child:
+        if child:
+            name = child.group(1)
+            # A parenthetical aside rather than a filename.
+            if name.startswith("("):
+                continue
+            # A child is relative to its parent — that is what the tree means.
+            # An earlier version had a ternary trying to special-case rooted
+            # names; it hardcoded two directory prefixes, was unreachable for
+            # the current tree, and got these wrong when it did fire.
+            paths.append(parent + name)
             continue
-        name = child.group(1)
-        # A parenthetical or prose aside, not a path.
-        if name.startswith("(") or name.endswith(","):
-            continue
-        paths.append(parent + name if not name.startswith(("kb/", "src/")) else name)
-    return paths
+        unconsumed.append(line)
+    return paths, unconsumed
 
 
-def test_the_tree_is_parseable():
-    """Guard the parser, so a reformat cannot silently empty the next test."""
-    declared = _declared_paths()
-    assert len(declared) >= 10, f"parsed only {len(declared)} paths; has the tree been reformatted?"
+def _declared_paths() -> list[str]:
+    return _parse_tree()[0]
+
+
+def test_the_parser_reads_every_line_of_the_tree():
+    """The guard that matters: no line goes unclassified.
+
+    A floor on the path count cannot distinguish a tree that shrank from a
+    parser that went blind — the first version asserted `>= 10` and reported
+    healthy at 12 while three entries were never checked at all.
+    """
+    declared, unconsumed = _parse_tree()
+    assert unconsumed == [], (
+        "these lines of the architecture tree were not recognised as a path, a "
+        "directory, or a comment, so nothing checked them:\n" + "\n".join(unconsumed)
+    )
     assert any(p.endswith(".py") for p in declared)
     assert any(p.endswith("/") for p in declared)
+    assert any(
+        p.endswith(".md") for p in declared
+    ), "the top-level file entries are the shape the first parser missed"
 
 
 @pytest.mark.parametrize("declared", _declared_paths())
@@ -93,4 +133,24 @@ def test_the_community_record_count_is_current():
     assert claimed == actual, (
         f"CLAUDE.md says kb/communities/ holds {claimed} files; it holds {actual}. "
         f"It said 60 for long enough to be off by a factor of five (#460)."
+    )
+
+
+def test_the_python_target_matches_pyproject():
+    """Another checkable number that had drifted.
+
+    CLAUDE.md said "Python 3.9+ target" while pyproject requires >=3.10, and
+    black/ruff/mypy are all configured for 3.10. A PR premised on executing this
+    file's checkable facts should not leave one wrong.
+    """
+    claimed = re.search(r"Python (\d+\.\d+)\+ target", CLAUDE_MD.read_text())
+    assert claimed, "the 'Python N.N+ target' line has moved; update this test"
+
+    pyproject = (REPO / "pyproject.toml").read_text()
+    required = re.search(r'requires-python\s*=\s*">=(\d+\.\d+)"', pyproject)
+    assert required, "could not read requires-python from pyproject.toml"
+
+    assert claimed.group(1) == required.group(1), (
+        f"CLAUDE.md targets Python {claimed.group(1)}+, pyproject requires "
+        f">={required.group(1)}"
     )


### PR DESCRIPTION
Closes #460.

## Why this file specifically

`CLAUDE.md` is loaded as authoritative context at the start of every session and described as instructions that **override default behaviour**. Nothing checked it. It had drifted two ways at once, and both were found by accident while working #410 — not by anyone reading it:

- It named `validators/reference_validator.py` as the **sole** occupant of that directory. That file was deleted in **4dd299a** ("Replace custom validators with official LinkML validators"); only an untracked `.pyc` survives, so a naive `find` appears to succeed. Meanwhile the seven validators that *are* there — the ones the CI gate runs — went undocumented. Fixed in #461.
- It said `kb/communities/` holds **60** files. It holds **312**. Off by a factor of five, fixed here.

## The test

Parses the tree rather than grepping it — tracking parents, since the tree is nested and a bare `cli.py` means `src/communitymech/cli.py` — and asserts every path resolves. A separate check pins the record count the prose quotes.

There's a guard on the parser itself, so reformatting the tree can't silently empty the check that depends on it. (My first attempt at this was a regex over path-like tokens; it reported 8 false positives because it ignored nesting. Worth mentioning because that version would have *passed* while checking nothing meaningful.)

**Verified by injecting a fake path:**
```
FAILED test_every_path_named_in_the_architecture_tree_exists[src/communitymech/nonexistent_module.py]
```

## Scope

Deliberately narrow: it checks what is mechanically checkable and says nothing about whether the prose is any *good*, which no test can. 14 tests. `just qc` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)