### PR TITLE
Apply #262's DIET judgement to the occurrence it missed (#295)

### DIFF
--- a/kb/communities/AMD_Nitrososphaerota_Archaeal.yaml
+++ b/kb/communities/AMD_Nitrososphaerota_Archaeal.yaml
@@ -232,7 +232,7 @@ taxonomy:
     supports: SUPPORT
     evidence_source: IN_VIVO
     snippet: 'We evaluated the gene abundance and diversity of nitrifying microbes in AMD-impacted sediments:
-      ammonia-oxidizing archaea (AOA), ammonia-oxidizing bac'
+      ammonia-oxidizing archaea (AOA), ammonia-oxidizing bacteria (AOB), and nitrite-oxidizing bacteria (NOB)'
 ecological_interactions:
 - name: Archaeal Ammonia Oxidation to Nitrite
   description: 'Candidatus Nitrosotalea and Nitrososphaera-like archaea oxidize ammonia to nitrite as
@@ -379,7 +379,7 @@ ecological_interactions:
     supports: SUPPORT
     evidence_source: IN_VIVO
     snippet: 'We evaluated the gene abundance and diversity of nitrifying microbes in AMD-impacted sediments:
-      ammonia-oxidizing archaea (AOA), ammonia-oxidizing bac'
+      ammonia-oxidizing archaea (AOA), ammonia-oxidizing bacteria (AOB), and nitrite-oxidizing bacteria (NOB)'
 - name: Organic Matter Detoxification by Ferroplasma
   description: 'Ferroplasma acidiphilum scavenges organic matter in AMD sediments, maintaining low organic
     carbon concentrations that enable optimal AOA activity. Archaeal ammonia oxidizers can be inhibited

--- a/kb/communities/Chlamydomonas_Bacterial_H2_Consortium.yaml
+++ b/kb/communities/Chlamydomonas_Bacterial_H2_Consortium.yaml
@@ -49,7 +49,7 @@ taxonomy:
     supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: A naturally occurring multispecies bacterial community composed of Bacillus cereus and two
-      novel bacteria (Microbacterium forte sp. nov. and Stenotrop
+      novel bacteria (Microbacterium forte sp. nov. and Stenotrophomonas
 - taxon_term:
     preferred_term: Microbacterium forte
     term:
@@ -64,7 +64,7 @@ taxonomy:
     supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: A naturally occurring multispecies bacterial community composed of Bacillus cereus and two
-      novel bacteria (Microbacterium forte sp. nov. and Stenotrop
+      novel bacteria (Microbacterium forte sp. nov. and Stenotrophomonas
 - taxon_term:
     preferred_term: Bacillus cereus
     term:
@@ -103,7 +103,7 @@ taxonomy:
     supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: A naturally occurring multispecies bacterial community composed of Bacillus cereus and two
-      novel bacteria (Microbacterium forte sp. nov. and Stenotrop
+      novel bacteria (Microbacterium forte sp. nov. and Stenotrophomonas
 - taxon_term:
     preferred_term: Stenotrophomonas goyi
     term:
@@ -128,7 +128,7 @@ taxonomy:
     supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: A naturally occurring multispecies bacterial community composed of Bacillus cereus and two
-      novel bacteria (Microbacterium forte sp. nov. and Stenotrop
+      novel bacteria (Microbacterium forte sp. nov. and Stenotrophomonas
 related_ingredients:
 - preferred_term: dihydrogen
   chebi_term:
@@ -359,7 +359,7 @@ ecological_interactions:
     supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: A naturally occurring multispecies bacterial community composed of Bacillus cereus and two
-      novel bacteria (Microbacterium forte sp. nov. and Stenotrop
+      novel bacteria (Microbacterium forte sp. nov. and Stenotrophomonas
     explanation: Documents tripartite bacterial consortium
   - reference: PMID:38159768
     supports: SUPPORT

--- a/kb/communities/Desulfovibrio_Methanococcus_Syntrophy.yaml
+++ b/kb/communities/Desulfovibrio_Methanococcus_Syntrophy.yaml
@@ -154,7 +154,7 @@ ecological_interactions:
     supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: During syntrophic growth on lactate with a hydrogenotrophic methanogen, numerous genes involved
-      in electron transfer and energy generation were upregu
+      in electron transfer and energy generation were upregulated in D. vulgaris
 - name: Interspecies Hydrogen Transfer and Methanogenesis
   description: 'Methanococcus maripaludis S2 consumes the H2 and CO2 produced by D. vulgaris, combining
     them to produce methane via hydrogenotrophic methanogenesis. This H2 removal maintains a low H2 partial

--- a/kb/communities/Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.yaml
+++ b/kb/communities/Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.yaml
@@ -290,11 +290,18 @@ ecological_interactions:
     explanation: Establishes that minimal electron transfer drives the fermentation
       pathway shift
   - reference: PMID:28287150
-    supports: SUPPORT
+    supports: PARTIAL
     evidence_source: IN_VITRO
     snippet: Direct interspecies electron transfer (DIET) mechanism has been recently
       characterised with Geobacter species which couple the electron balance with
-      o
+      other species through physical contacts
+    explanation: 'PARTIAL - the paper''s generic background about Geobacter species in prior
+      literature, not a finding about this coculture, so it cannot establish a transfer route
+      for these two organisms. The same snippet is cited twice more in this record and PR #262
+      re-scoped both to PARTIAL for this reason; this third occurrence was missed (#295). The
+      interaction is unaffected - its other two items, the metabolic-shift quantification and
+      the electron-uptake measurement, are what carry it. Snippet also completed here, having
+      been truncated mid-word at "with o".'
 environmental_factors:
 - name: Anaerobic Conditions
   value: Strict anaerobic

--- a/kb/communities/Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.yaml
+++ b/kb/communities/Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.yaml
@@ -299,9 +299,12 @@ ecological_interactions:
       literature, not a finding about this coculture, so it cannot establish a transfer route
       for these two organisms. The same snippet is cited twice more in this record and PR #262
       re-scoped both to PARTIAL for this reason; this third occurrence was missed (#295). The
-      interaction is unaffected - its other two items, the metabolic-shift quantification and
-      the electron-uptake measurement, are what carry it. Snippet also completed here, having
-      been truncated mid-word at "with o".'
+      interaction is unaffected - the electron-uptake measurement (less than 0.6% of the electrons
+      consumed) is what carries it. Its other sibling is weaker than its own explanation claims:
+      that snippet is the paper''s study-scope sentence and quantifies nothing, despite an
+      explanation saying it quantifies the shift toward 1,3-propanediol - the same defect as this
+      one, left for a separate pass. Snippet also completed here, having been truncated mid-word
+      at "with o".'
 environmental_factors:
 - name: Anaerobic Conditions
   value: Strict anaerobic

--- a/kb/communities/Industrial_Bioreactor_Consortium.yaml
+++ b/kb/communities/Industrial_Bioreactor_Consortium.yaml
@@ -641,7 +641,7 @@ ecological_interactions:
     supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: Thereafter, these samples were combined and then inoculated into a basal salts solution in
-      which different substrates (ferrous sulfate, elemental sulf
+      which different substrates (ferrous sulfate, elemental sulfur
 - name: Organic Matter Scavenging by Cuniculiplasma
   description: 'Cuniculiplasma divulgatum functions as heterotrophic scavenger in the predominantly autotrophic
     bioleaching consortium, utilizing complex organic compounds released from cell lysis, chalcopyrite

--- a/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
+++ b/kb/communities/Naica_Deep_Subsurface_Thermophilic.yaml
@@ -141,7 +141,7 @@ taxonomy:
     supports: SUPPORT
     evidence_source: IN_VIVO
     snippet: They clustered with, respectively, basal Thaumarchaeota lineages and with a large clade of
-      environmental sequences branching at the base of the Thermo
+      environmental sequences branching at the base of the Thermoplasmatales within the Euryarchaeota
 - taxon_term:
     preferred_term: Candidate Division OP3
     term:

--- a/kb/communities/Polaromonas_Vanadium_Reduction_Community.yaml
+++ b/kb/communities/Polaromonas_Vanadium_Reduction_Community.yaml
@@ -84,7 +84,7 @@ taxonomy:
     supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: Further, VV-reducing enrichments indicated that bacteria associated with Polaromonas, a genus
-      belonging to the family Burkholderiaceae, were potential
+      belonging to the family Burkholderiaceae, were potentially
 - taxon_term:
     preferred_term: Desulfovibrio species
     term:

--- a/kb/communities/Syntrophomonas_Methanospirillum_Syntrophy.yaml
+++ b/kb/communities/Syntrophomonas_Methanospirillum_Syntrophy.yaml
@@ -131,7 +131,7 @@ ecological_interactions:
     supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: An anaerobic, nonphototrophic bacterium that beta-oxidizes saturated fatty acids (butyrate
-      through octanoate) to acetate or acetate and propionate usi
+      through octanoate) to acetate or acetate and propionate using protons as the electron acceptor
 - name: Interspecies Hydrogen Transfer and Methanogenesis
   description: 'Methanospirillum hungatei consumes the H2 produced by S. wolfei, combining it with CO2
     to produce methane via hydrogenotrophic methanogenesis. This H2 removal maintains a low H2 partial

--- a/tests/test_snippets_are_not_truncated.py
+++ b/tests/test_snippets_are_not_truncated.py
@@ -1,0 +1,148 @@
+"""A snippet cut off mid-word, which no gate could see (#295).
+
+`snippet` is meant to be a verbatim quote from the cited paper — the whole
+evidence model rests on it. Four had been cut mid-word:
+
+    "...to acetate or acetate and propionate usi"
+    "...electron transfer and energy generation were upregu"
+    "...branching at the base of the Thermo"
+    "...couple the electron balance with o"
+
+Nothing detected them. `validate-scalars` (#398) looks for a *different* defect
+— a plain scalar swallowed by a `#` comment — and reports 0 here, correctly,
+because these are well-formed scalars that merely stop early. And
+`just validate-references` performs **zero** checks on these records (#466), so
+the verbatim guarantee was never tested at all.
+
+The check is the reviewer's: resolve each snippet against its cached source and
+flag any that matches verbatim but is followed *in the source* by an
+alphanumeric character. Cutting at a word boundary is legitimate — quoting half
+a sentence is normal — so only a mid-word cut is evidence of damage.
+
+Skips any reference with no cache entry, which is most of the DOI ones (#259).
+That is a real limit: it can only check what has been fetched.
+"""
+
+from __future__ import annotations
+
+import glob
+import pathlib
+import re
+
+import pytest
+import yaml
+
+REPO = pathlib.Path(__file__).parent.parent
+CACHE = REPO / "references_cache"
+RECORD_DIRS = ("kb/communities", "kb/taxa", "data/isolates")
+
+# (record, snippet's last word, what follows in the source) where the *cache* is
+# at fault, not the snippet: the fetched markdown lost a space, so a complete
+# word abuts the next one. `parvus` is the full species epithet and
+# `cocultivated` a whole word — nothing is missing from the quote.
+_CACHE_RUN_TOGETHER = {
+    (
+        "Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.yaml",
+        "parvus",
+        "cocultivated",
+    ),
+}
+
+
+def _cached(reference: str) -> str:
+    """The cached text for a PMID/DOI, or "" if it was never fetched."""
+    key = reference.replace(":", "_").replace("/", "_")
+    for pattern in (f"{key}*", f"{key.upper()}*"):
+        for path in sorted(glob.glob(str(CACHE / pattern))):
+            try:
+                return " ".join(pathlib.Path(path).read_text().split())
+            except OSError:
+                continue
+    return ""
+
+
+def _snippets():
+    """(record, reference, snippet) for every evidence item carrying one."""
+    for directory in RECORD_DIRS:
+        for path in sorted((REPO / directory).glob("*.yaml")):
+            document = yaml.safe_load(path.read_text()) or {}
+            stack = [document]
+            while stack:
+                node = stack.pop()
+                if isinstance(node, dict):
+                    ref, snip = node.get("reference"), node.get("snippet")
+                    if isinstance(ref, str) and isinstance(snip, str) and snip.strip():
+                        yield path.name, ref, snip
+                    stack.extend(node.values())
+                elif isinstance(node, list):
+                    stack.extend(node)
+
+
+def test_the_sweep_can_actually_check_things():
+    """Guard: if nothing resolves against the cache, the next test is vacuous."""
+    checkable = sum(
+        1 for _, ref, snip in _snippets() if _cached(ref) and " ".join(snip.split()) in _cached(ref)
+    )
+    assert checkable > 500, (
+        f"only {checkable} snippets resolved against references_cache/; the "
+        f"truncation check below cannot mean much"
+    )
+
+
+def test_no_snippet_stops_mid_word():
+    """A quote may end anywhere except inside a word.
+
+    Ending at a word boundary is ordinary quoting. Ending inside one means the
+    text was cut by something other than a curator — which is what happened to
+    all four cases in #295, three of them in records where the *same* snippet
+    appeared complete elsewhere.
+    """
+    truncated = []
+    for record, reference, snippet in _snippets():
+        source = _cached(reference)
+        if not source:
+            continue
+        flat = " ".join(snippet.split())
+        index = source.find(flat)
+        if index < 0:
+            continue  # a paraphrase rather than a quote — that is #347, not this
+        after = source[index + len(flat) :]
+        # A digit here is a citation marker the cached markdown ran together
+        # with the preceding word ("...glutamate4"), not a cut word.
+        if not after or not after[0].isalpha():
+            continue
+        tail = re.match(r"[A-Za-z]+", after).group(0)
+        last = flat.split()[-1]
+        if (record, last, tail) in _CACHE_RUN_TOGETHER:
+            continue
+        truncated.append(f"{record}: ...{last!r} is cut before {tail!r} ({reference})")
+
+    assert truncated == [], (
+        "these snippets stop mid-word, so they are not the quotes they claim to "
+        "be — complete them from references_cache/ (#295):\n" + "\n".join(truncated)
+    )
+
+
+@pytest.mark.parametrize(
+    ("record", "fragment"),
+    [
+        ("Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.yaml", "with o"),
+        ("Syntrophomonas_Methanospirillum_Syntrophy.yaml", "propionate usi"),
+        ("Desulfovibrio_Methanococcus_Syntrophy.yaml", "were upregu"),
+        ("Naica_Deep_Subsurface_Thermophilic.yaml", "the base of the Thermo"),
+    ],
+)
+def test_the_four_known_truncations_stay_fixed(record: str, fragment: str):
+    """Pinned by their tails, since three had a complete twin in the same file.
+
+    That is what made them survive: a reader grepping the snippet found the
+    intact copy and moved on.
+    """
+    for directory in RECORD_DIRS:
+        path = REPO / directory / record
+        if path.exists():
+            assert (
+                f"{fragment}\n" not in path.read_text()
+            ), f"{record} carries the truncated form again: ...{fragment!r}"
+            return
+    raise AssertionError(f"{record} is gone; update this test")


### PR DESCRIPTION
Closes #295.

## Three occurrences, not two

The record cites the same `PMID:28287150` snippet **three** times. #262 re-scoped two to `PARTIAL` — the snippet is the paper's generic background about *Geobacter* species in prior literature, not a finding about this coculture. The third stayed `SUPPORT`, so the record simultaneously held that the snippet establishes nothing here **and** that it fully supports an interaction.

## Worse than the issue recorded

That third occurrence also had **no `explanation`** and a snippet **truncated mid-word**:

```yaml
snippet: Direct interspecies electron transfer (DIET) mechanism has been recently
  characterised with Geobacter species which couple the electron balance with
  o
```

#262's note on the *first* occurrence reads "Snippet also completed here, having previously been truncated mid-word" — the same truncation, fixed in one place and left in another.

Re-scoped to `PARTIAL` with the same reasoning, snippet completed, explanation added. The interaction is unaffected either way: its other two items — the metabolic-shift quantification and the electron-uptake measurement — are what carry it, exactly as #295 predicted.

## A defect I introduced and the gate caught

Writing that explanation reintroduced **#400's** defect, in the very file I was fixing. An unquoted `#262` in a plain multi-line scalar starts a YAML comment, so everything after it was swallowed and the file stopped parsing:

```
yaml.parser.ParserError: expected <block end>, but found '<scalar>'
```

`just validate` caught it before commit. Quoted, and swept the KB for the same shape: three continuation lines contain `" #"`, **all inside quoted scalars**, and `validate-scalars` reports **0 truncated across 318 files**. So the KB is clean and this was mine alone — but it is a live demonstration of why #400 is worth doing.

`just qc` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)