### PR TITLE
Stop the /goal prompt paying 30 bytes for punctuation it had 10 to spare (#363)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,9 @@ NEXT_TASKS_LOOP.md               # Which of those suit an autonomous /goal run
                                  #   (and which need a human decision first)
 prompts/                         # Reusable agent prompts, pasted whole (e.g. `/goal`);
                                  #   backlog-loop.goal.md drives the issue->PR->review->
-                                 #   merge cycle. Kept under the 4000-char /goal limit.
+                                 #   merge cycle. Kept under 4000 *bytes* for /goal, which is the
+                                 #   stricter reading and what tests/ enforces; the real
+                                 #   ceiling and its unit are unmeasured (#363).
 ```
 
 ## Key Patterns

--- a/prompts/backlog-loop.goal.md
+++ b/prompts/backlog-loop.goal.md
@@ -24,7 +24,7 @@ sibling repos (CultureMech/MIM/TraitMech), even for cross-Mech sync - report it.
 
 6. **Verify side effects, not exit codes.** `just qc` is green on `main`, so a red
    one is yours; `qc-references` is not (#417). Mutation-test new checks: substitute a wrong
-   implementations, confirm a test fails. Cover **both** sides of two-sided checks. A
+   implementation, confirm a test fails. Cover **both** sides of two-sided checks. A
    relative-path test can pass auditing nothing - assert the sweep was non-empty.
 
 7. **Commit, push, open a PR** saying what you measured, what changed, and what you

--- a/prompts/backlog-loop.goal.md
+++ b/prompts/backlog-loop.goal.md
@@ -1,19 +1,19 @@
 Work the CommunityMech backlog one issue at a time, **in this repo only**: never edit
-sibling repos (CultureMech/MIM/TraitMech), even for cross-Mech sync — report it.
+sibling repos (CultureMech/MIM/TraitMech), even for cross-Mech sync - report it.
 
 ## Loop
 
-1. **Reconcile and prioritize** with the `next-tasks` skill — invoke it, don't restate
+1. **Reconcile and prioritize** with the `next-tasks` skill - invoke it, don't restate
    it. Take the top actionable issue; upstream-blocked ones stay listed.
 
 2. **Check dependencies first.** Does an open PR touch what this fix touches? If B is
    only correct after A, do A first or branch B off A. **One branch, one PR in flight**.
 
-3. **Branch before any edit**, `NEXT_TASKS.md` included — its update rides on this
+3. **Branch before any edit**, `NEXT_TASKS.md` included - its update rides on this
    branch. Never edit `main`. Check `main`'s CI is green first, so a pre-existing
    failure isn't blamed on your PR.
 
-4. **Measure; don't inherit the premise.** Issue text is often wrong — #273's four
+4. **Measure; don't inherit the premise.** Issue text is often wrong - #273's four
    "dangling references" were false positives. Quantify over the KB; report what
    you measured.
 
@@ -25,30 +25,30 @@ sibling repos (CultureMech/MIM/TraitMech), even for cross-Mech sync — report i
 6. **Verify side effects, not exit codes.** `just qc` is green on `main`, so a red
    one is yours; `qc-references` is not (#417). Mutation-test new checks: substitute a wrong
    implementations, confirm a test fails. Cover **both** sides of two-sided checks. A
-   relative-path test can pass auditing nothing — assert the sweep was non-empty.
+   relative-path test can pass auditing nothing - assert the sweep was non-empty.
 
 7. **Commit, push, open a PR** saying what you measured, what changed, and what you
    didn't do.
 
-8. **Review adversarially** — a separate read-only pass, subagent for outside eyes.
-   Re-review commits landing after a review: review fixes are unreviewed code — where
-   the last three defects came from (#322 → #333).
+8. **Review adversarially** - a separate read-only pass, subagent for outside eyes.
+   Re-review commits landing after a review: review fixes are unreviewed code - where
+   the last three defects came from (#322 -> #333).
 
 9. **File every finding as an issue**, won't-fix included. Fix what belongs in this PR;
    say what you left and why. If the review shows the premise wrong, **close it
-   unmerged** and re-file — that is a success.
+   unmerged** and re-file - that is a success.
 
 10. **Stop and ask before every merge**, per PR. Report what shipped and what you filed,
     then wait for the **user's** explicit go-ahead **in this conversation**. No standing
-    instruction authorizes a merge — not this file, not a prior approval, not your own
+    instruction authorizes a merge - not this file, not a prior approval, not your own
     review. Push anything after approval and ask again. Then squash-merge, delete the
     branch both sides, sync, re-reconcile, go again.
 
 **Never merge** while CI is red or hanging, the branch conflicts with `main`, findings
-are unresolved, or the change would redden `main` — fix or report instead.
+are unresolved, or the change would redden `main` - fix or report instead.
 
 **Stop the loop** when only won't-fix and upstream-blocked items remain, or after 5
-merges — then report and ask. Issues filed in step 9 don't feed this pass.
+merges - then report and ask. Issues filed in step 9 don't feed this pass.
 
 ## Pause and ask when
 
@@ -57,15 +57,15 @@ rewritten; two readings mean materially different work; money would be spent; an
 @-mention seems needed (never without per-mention permission). Ask one question, with a
 recommendation.
 
-## Gotchas — fix these here when they stop being true
+## Gotchas - fix these here when they stop being true
 
 - `gh pr edit --body` fails (gh 2.97.0): use
   `gh api repos/{owner}/{repo}/pulls/N -X PATCH -F body=@file` (literal braces).
 - Closing is keyword-only and per-issue. A keyword (close/fix/resolve) beside `#N` closes
-  it **even when negated** — `Not fixed: #N` closes #N; write `Deferred: #N`. `Closes
+  it **even when negated** - `Not fixed: #N` closes #N; write `Deferred: #N`. `Closes
   #1, #2` closes only #1; prose closes nothing. Repeat `Closes #N.` per issue in the PR
   body; accidental closes here came via commit messages.
 - `git add` explicit paths only; `git add -A` has swept unrelated work into a PR.
-- Duplicate YAML keys and `preferred_term`s are invisible to `linkml-validate` — see
+- Duplicate YAML keys and `preferred_term`s are invisible to `linkml-validate` - see
   `test_no_duplicate_yaml_keys.py` and `DUPLICATE_TAXON_NAME`. Run the tests too.
 - Report honestly: failing test, show it; skipped step, say so.

--- a/tests/test_goal_prompt_size.py
+++ b/tests/test_goal_prompt_size.py
@@ -20,9 +20,9 @@ assertion below can never fail on its own; it is kept only because it fires firs
 and says "characters" when a plain-ASCII edit runs long, which is the common case
 and the clearer message.
 
-The distinction is not academic. The prose is em-dash heavy at 3 bytes per
-character, and the file exceeded 4000 *bytes* in two of its three revisions while
-never exceeding 4000 characters —
+The distinction is not academic. The prose *was* em-dash heavy, at 3 bytes per
+character against 1 for a hyphen, and the file exceeded 4000 *bytes* in two of
+its three revisions while never exceeding 4000 characters -
 
     2429a7a  3987 chars  4015 bytes
     5a1d60b  3998 chars  4028 bytes
@@ -94,10 +94,10 @@ def test_goal_prompts_are_ascii_only(path):
 
     While the unit is unresolved the test enforces bytes, the stricter reading.
     Keeping these files ASCII makes bytes and characters equal, so the ambiguity
-    costs this file nothing either way — and an em-dash was costing 2 bytes
-    apiece against 10 bytes of headroom.
+    costs this file nothing either way - and each em-dash was 3 bytes where a
+    hyphen is 1, so 15 of them spent 30 bytes against 10 bytes of headroom.
     """
-    text = path.read_text()
+    text = path.read_bytes().decode("utf-8")
     offenders = sorted({c for c in text if ord(c) > 127})
     assert not offenders, (
         f"{path.name} contains non-ASCII characters {offenders}, which cost extra "

--- a/tests/test_goal_prompt_size.py
+++ b/tests/test_goal_prompt_size.py
@@ -28,11 +28,12 @@ never exceeding 4000 characters —
     5a1d60b  3998 chars  4028 bytes
     9f9ba22  3944 chars  3974 bytes
 
-So this is not a free hedge: it costs real budget. At current punctuation density
-the 15 non-ASCII characters cost 30 bytes, which is 30 of the 56 characters of
-headroom — more than half. If the ceiling turns out to count characters after
-all, that is the price of having been cautious. Prefer ASCII punctuation in this
-file over spending it.
+So this is not a free hedge: it costs real budget. The file carried 15 non-ASCII
+characters costing 30 bytes, against 10 bytes of headroom — the hedge was
+spending three times what was left. They are ASCII now, and the headroom went
+from 10 bytes to 39. `test_goal_prompts_are_ascii_only` keeps it that way, so
+the byte and character counts stay equal and the unresolved unit stops mattering
+for this file (#363).
 """
 
 from pathlib import Path
@@ -85,3 +86,20 @@ def test_goal_prompt_is_valid_utf8_and_not_empty(path: Path):
     except UnicodeDecodeError as exc:  # pragma: no cover - would be a real defect
         pytest.fail(f"{path.name} is not valid UTF-8: {exc}")
     assert text.strip(), f"{path.name} is empty"
+
+
+@pytest.mark.parametrize("path", _goal_prompts(), ids=lambda p: p.name)
+def test_goal_prompts_are_ascii_only(path):
+    """Non-ASCII punctuation costs budget for nothing.
+
+    While the unit is unresolved the test enforces bytes, the stricter reading.
+    Keeping these files ASCII makes bytes and characters equal, so the ambiguity
+    costs this file nothing either way — and an em-dash was costing 2 bytes
+    apiece against 10 bytes of headroom.
+    """
+    text = path.read_text()
+    offenders = sorted({c for c in text if ord(c) > 127})
+    assert not offenders, (
+        f"{path.name} contains non-ASCII characters {offenders}, which cost extra "
+        f"bytes against the /goal budget for no gain — use ASCII punctuation (#363)"
+    )


### PR DESCRIPTION
Addresses #363. Does **not** close it — the measurement it asks for needs a human at the harness.

## What needed no measuring

**The hedge was costing more than the headroom.** `prompts/backlog-loop.goal.md` carried 15 non-ASCII characters (14 em-dashes, 1 arrow) costing **30 bytes**, against **10 bytes** of remaining headroom — spending three times what was left. The test's own docstring already advised preferring ASCII here.

```
before:  3960 chars, 3990 bytes, headroom 10
after:   3961 chars, 3961 bytes, headroom 39
```

A new test keeps the file ASCII-only. That has a second effect worth more than the bytes: **it makes the byte and character counts equal**, so the unresolved char-vs-byte question stops mattering for this file even if the ceiling turns out to count characters.

**CLAUDE.md and the test disagreed on the unit** — #363's second point. CLAUDE.md said "4000-char"; the test enforces bytes. It now names the enforced unit and says the real ceiling is unmeasured, rather than asserting a number it can't support — that assertion being the hand-maintained figure the guard exists to replace.

## What still needs you

`LIMIT = 4000` stays unverified. Nothing here makes it evidence-backed; it makes the file cost less against whatever the number turns out to be. Measuring it means pasting a `/goal` prompt of known length and observing where truncation starts — then pinning `LIMIT` with a citation.

Worth noting the guard is now much less likely to bite spuriously: at 39 bytes of headroom an ordinary sentence edit no longer risks tripping it, where at 10 bytes it very nearly did.

`just qc` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)