### PR TITLE
Bring data/isolates under the only gate that reports ID_NOT_FOUND (#471)

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -169,7 +169,7 @@ groundings**, almost all in the rare-earth block:
 | SAMARIUM | CHEBI:33376 → *terbium atom* | CHEBI:49890 samarium(3+) |
 | EUROPIUM | CHEBI:30688 → *(not in build)* | CHEBI:49591 europium(3+) |
 | TERBIUM | CHEBI:33374 → *samarium atom* | CHEBI:49902 terbium(3+) |
-| DYSPROSIUM | CHEBI:49782 → *(not in build)* | CHEBI:33377 dysprosium atom |
+| DYSPROSIUM | CHEBI:49782 → *(in no CHEBI release)* | CHEBI:33377 dysprosium atom — **applied 2026-08-07, #471** |
 | HOLMIUM | CHEBI:49649 → *(not in build)* | CHEBI:49650 holmium(3+) |
 | ERBIUM | CHEBI:49650 → *holmium(3+)* | CHEBI:33379 erbium |
 | THULIUM | CHEBI:33377 → *dysprosium atom* | CHEBI:33380 thulium atom |

--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -169,7 +169,7 @@ groundings**, almost all in the rare-earth block:
 | SAMARIUM | CHEBI:33376 → *terbium atom* | CHEBI:49890 samarium(3+) |
 | EUROPIUM | CHEBI:30688 → *(not in build)* | CHEBI:49591 europium(3+) |
 | TERBIUM | CHEBI:33374 → *samarium atom* | CHEBI:49902 terbium(3+) |
-| DYSPROSIUM | CHEBI:49782 → *(in no CHEBI release)* | CHEBI:33377 dysprosium atom — **applied 2026-08-07, #471** |
+| DYSPROSIUM | CHEBI:49782 → *(in no CHEBI release)* | CHEBI:33377 dysprosium atom |
 | HOLMIUM | CHEBI:49649 → *(not in build)* | CHEBI:49650 holmium(3+) |
 | ERBIUM | CHEBI:49650 → *holmium(3+)* | CHEBI:33379 erbium |
 | THULIUM | CHEBI:33377 → *dysprosium atom* | CHEBI:33380 thulium atom |
@@ -257,6 +257,18 @@ Read the rest of this section as history, with one correction that matters: the
 cannot resolve*, not because they were fixed — so option 2 below is still
 genuinely upstream-blocked, and the gate is green partly by blindness. It also
 does not catch a nonexistent CURIE at all (#471).
+
+**Partly closed 2026-08-07 (PR #473).** Engine B — which *does* report
+`ID_NOT_FOUND` — now has a `data/isolates/*.yaml` target, so that defect class
+is covered for the isolate records as well as the communities. It found one
+immediately: `CHEBI:49782 "dysprosium(3+)"`, an id in no CHEBI release, in
+`Methylobacterium_REE_Ewaste_Platform.yaml`. Note this was a *record-level*
+`term.{id,label}` pair, not the enum `meaning:` in the table above — that
+repoint landed 2026-07-18 in PR #207. The correction had been sitting in
+`chebi_fix_apply.py`'s REPOINT map the whole time, unapplied, because the
+script globbed `kb/communities` alone; it now sweeps the isolates and taxa too.
+What stays open on #471: Engine A still cannot fail on an unresolvable id
+(upstream in `linkml-term-validator`), and nothing pins the ontology release.
 
 The original framing, kept because it is still the right analysis of what
 enabling *would* have required:

--- a/conf/id_label_targets.yaml
+++ b/conf/id_label_targets.yaml
@@ -104,6 +104,18 @@ targets:
     pairs:
       - [id, label]
 
+  # data inputs (single-organism isolate records) — same term.{id,label} shape
+  # as the community records. Added because nothing covered them: Engine A
+  # (linkml-term-validator) does not fail on an id it cannot resolve, so a
+  # typo'd CURIE here passed every gate in the repo while the CI step name
+  # claimed to check data/isolates (#471).
+  - name: isolates_yaml
+    kind: yaml
+    glob: "data/isolates/*.yaml"
+    policy: canonical
+    pairs:
+      - [id, label]
+
   # data product: KGX node export carries (id, name) — canonical OR synonym
   - name: kgx_nodes
     kind: tabular

--- a/conf/id_label_targets.yaml
+++ b/conf/id_label_targets.yaml
@@ -113,6 +113,10 @@ targets:
     kind: yaml
     glob: "data/isolates/*.yaml"
     policy: canonical
+    # The failure this target exists to end was a silent absence, so it must
+    # not be able to go silently absent itself: without `required`, renaming or
+    # moving the directory prints "no files match" and exits 0 (#471).
+    required: true
     pairs:
       - [id, label]
 

--- a/data/isolates/Methylobacterium_REE_Ewaste_Platform.yaml
+++ b/data/isolates/Methylobacterium_REE_Ewaste_Platform.yaml
@@ -180,16 +180,22 @@ ecological_interactions:
       label: dysprosium atom
     concentration: Up to 8 mg/g DCW from magnet swarf
     notes: >-
-      Grounded to the atom, not the trivalent cation, because CHEBI has no
-      dysprosium(3+) term - upstream carries only dysprosium atom and
-      dysprosium molecular entity. Its neighbours here are exact cations
-      (CHEBI:229785 neodymium(3+), CHEBI:229784 praseodymium(3+)), so the
-      coarser grounding is a gap in CHEBI rather than a curation choice;
-      preferred_term keeps the species the paper reports. The id this
-      replaced, CHEBI:49782, exists in no CHEBI release - it was part of the
-      rare-earth mis-grounding block in NEXT_TASKS.md and the correction was
-      already recorded in scripts/chebi_fix_apply.py, which only ever swept
-      kb/communities (#471).
+      Grounded to the atom, not the trivalent cation: CHEBI has no
+      dysprosium(3+) term, carrying only dysprosium atom and dysprosium
+      molecular entity. Its neighbours here are exact cations (CHEBI:229785
+      neodymium(3+), CHEBI:229784 praseodymium(3+)), so this one is coarser
+      than the block around it, and preferred_term keeps the species the paper
+      reports. Two CHEBI terms could have taken it - CHEBI:37295 dysprosium
+      molecular entity does subsume the cation by is_a, which dysprosium atom
+      does not - and CHEBI:33377 is chosen because it is what the rest of the
+      repo means by DYSPROSIUM: the schema enum, kgx_export, the reverse map in
+      metal_extraction.py, and the identical triple in
+      Ion_Adsorption_REE_Indigenous_Community.yaml. Grounding this record to
+      37295 alone would drop its dysprosium out of every enum-driven analysis.
+      The id this replaced, CHEBI:49782, exists in no CHEBI release - it was
+      part of the rare-earth mis-grounding block in NEXT_TASKS.md and the
+      correction was already recorded in scripts/chebi_fix_apply.py, which only
+      ever swept kb/communities (#471).
   biological_processes:
   - preferred_term: metal ion transport
     term:

--- a/data/isolates/Methylobacterium_REE_Ewaste_Platform.yaml
+++ b/data/isolates/Methylobacterium_REE_Ewaste_Platform.yaml
@@ -176,9 +176,20 @@ ecological_interactions:
     concentration: Up to 15 mg/g DCW from magnet swarf
   - preferred_term: dysprosium(3+)
     term:
-      id: CHEBI:49782
-      label: dysprosium(3+)
+      id: CHEBI:33377
+      label: dysprosium atom
     concentration: Up to 8 mg/g DCW from magnet swarf
+    notes: >-
+      Grounded to the atom, not the trivalent cation, because CHEBI has no
+      dysprosium(3+) term - upstream carries only dysprosium atom and
+      dysprosium molecular entity. Its neighbours here are exact cations
+      (CHEBI:229785 neodymium(3+), CHEBI:229784 praseodymium(3+)), so the
+      coarser grounding is a gap in CHEBI rather than a curation choice;
+      preferred_term keeps the species the paper reports. The id this
+      replaced, CHEBI:49782, exists in no CHEBI release - it was part of the
+      rare-earth mis-grounding block in NEXT_TASKS.md and the correction was
+      already recorded in scripts/chebi_fix_apply.py, which only ever swept
+      kb/communities (#471).
   biological_processes:
   - preferred_term: metal ion transport
     term:

--- a/justfile
+++ b/justfile
@@ -232,8 +232,14 @@ validate-terms-all:
     done
     exit $rc
 
-# id↔label gate (Engine B): verify (id,label) pairs in DATA PRODUCTS
-# (KGX node export) correspond to the ontology. Exits 2 on any mismatch.
+# id↔label gate (Engine B): verify (id,label) pairs correspond to the ontology,
+# across every target in conf/id_label_targets.yaml - kb/communities, kb/taxa,
+# data/isolates, and the KGX node export. Exits 2 on any mismatch.
+#
+# This is the only gate that reports ID_NOT_FOUND. Engine A
+# (linkml-term-validator, `validate-terms-all`) checks a wrong label but
+# silently skips an id it cannot resolve even under --no-lenient, so a
+# nonexistent CURIE is caught here or nowhere (#471).
 validate-products:
     uv run python scripts/validate_id_label_correspondence.py -c conf/id_label_targets.yaml
 

--- a/scripts/chebi_fix_apply.py
+++ b/scripts/chebi_fix_apply.py
@@ -17,7 +17,13 @@ import sys
 from pathlib import Path
 
 DRY = "--dry-run" in sys.argv
-COMM = Path("kb/communities")
+# Every directory carrying term.{id,label} pairs, not just the communities. The
+# dysprosium repoint below sat in this table, correct and unapplied, because
+# this was `Path("kb/communities")` alone while the same wrong id was in
+# data/isolates - and no gate covered isolates either, so nothing said so
+# (#471). A correction table that does not reach every record is a record of a
+# decision rather than the decision itself.
+RECORD_DIRS = (Path("kb/communities"), Path("data/isolates"), Path("kb/taxa"))
 ID_RE = re.compile(r"^(\s*)id:\s*(CHEBI:\d+)\s*$")
 LBL_RE = re.compile(r"^(\s*)label:\s*(.+?)\s*$")
 
@@ -175,7 +181,7 @@ if bad:
 changes = 0
 files_touched = set()
 per_pair = {}
-for f in sorted(COMM.glob("*.yaml")):
+for f in sorted(p for d in RECORD_DIRS for p in d.glob("*.yaml")):
     L = f.read_text().splitlines(keepends=True)
     out = list(L)
     i = 0

--- a/tests/test_isolates_are_covered_by_id_checks.py
+++ b/tests/test_isolates_are_covered_by_id_checks.py
@@ -21,8 +21,8 @@ does too.
 
 from __future__ import annotations
 
+import ast
 import pathlib
-import re
 
 import pytest
 import yaml
@@ -66,27 +66,71 @@ def test_the_isolate_records_are_actually_matched_by_that_glob():
     )
 
 
-def test_the_chebi_sweep_reaches_every_record_directory():
-    """The repoint table was right and unapplied because this globbed one dir.
+def _sweep_ast() -> tuple[set[str], ast.For]:
+    """(directories in RECORD_DIRS, the loop that walks the records).
 
-    Asserting on the source text rather than importing: the script executes its
-    OAK lookups at module scope, so importing it shells out to `runoak` for
-    ~100 ids.
+    Parsed rather than imported: the script does its OAK lookups at module
+    scope, so importing it shells out to `runoak` for ~100 ids. Parsed rather
+    than regexed because both regexes tried here were wrong in opposite
+    directions — `([^)]*)` stopped inside the first `Path("...")`, and the
+    `.*` that replaced it stops at the newline, so `black` splitting the tuple
+    across lines (which a 4th directory would trigger — it is at 76 of 100
+    columns now) would report an empty sweep set. An AST has neither failure
+    mode.
     """
-    source = (REPO / "scripts/chebi_fix_apply.py").read_text()
-    # To the end of the line, not to the first ")": every entry is `Path("...")`,
-    # so a non-greedy `[^)]*` capture stops inside the first one and reports an
-    # empty set no matter what the script actually sweeps.
-    dirs = re.search(r"RECORD_DIRS\s*=\s*\(.*", source)
-    assert dirs, "RECORD_DIRS is gone from chebi_fix_apply.py; update this test"
+    tree = ast.parse((REPO / "scripts/chebi_fix_apply.py").read_text())
 
-    named = set(re.findall(r'Path\("([^"]+)"\)', dirs.group(0)))
-    assert "data/isolates" in named, (
+    dirs: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "RECORD_DIRS" for t in node.targets
+        ):
+            for call in ast.walk(node.value):
+                if (
+                    isinstance(call, ast.Call)
+                    and isinstance(call.func, ast.Name)
+                    and call.func.id == "Path"
+                    and call.args
+                    and isinstance(call.args[0], ast.Constant)
+                ):
+                    dirs.add(call.args[0].value)
+
+    loops = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.For) and "glob" in ast.dump(node.iter)
+    ]
+    assert len(loops) == 1, f"expected one record-globbing loop, found {len(loops)}"
+    return dirs, loops[0]
+
+
+def test_the_chebi_sweep_reaches_every_record_directory():
+    """The repoint table was right and unapplied because this globbed one dir."""
+    dirs, _ = _sweep_ast()
+    assert "data/isolates" in dirs, (
         "chebi_fix_apply.py does not sweep data/isolates, which is how the "
         "dysprosium repoint stayed unapplied while sitting in its own REPOINT "
-        f"table (#471). It sweeps: {sorted(named)}"
+        f"table (#471). It sweeps: {sorted(dirs)}"
     )
-    assert "kb/communities" in named
+    assert "kb/communities" in dirs
+
+
+def test_the_sweep_loop_actually_reads_that_constant():
+    """Naming the directories is not sweeping them.
+
+    The first version of this file asserted only on the value of RECORD_DIRS,
+    which the review broke in one line: leave the constant exactly as written
+    and revert the loop to `Path("kb/communities").glob("*.yaml")`. The whole
+    suite stayed green while the precise regression this PR exists to prevent —
+    a correction sitting in REPOINT that never reaches data/isolates — was
+    fully reintroduced. A constant nothing reads is a comment.
+    """
+    _, loop = _sweep_ast()
+    assert "RECORD_DIRS" in ast.dump(loop.iter), (
+        "the record loop in chebi_fix_apply.py does not iterate RECORD_DIRS, so "
+        "the directories declared there are decorative and the sweep can still "
+        "miss data/isolates (#471)"
+    )
 
 
 def test_no_isolate_carries_the_nonexistent_dysprosium_id():

--- a/tests/test_isolates_are_covered_by_id_checks.py
+++ b/tests/test_isolates_are_covered_by_id_checks.py
@@ -1,0 +1,139 @@
+"""A typo'd CURIE in data/isolates passed every gate in the repo (#471).
+
+Two engines check (id, label) pairs. Engine A, `linkml-term-validator --labels`,
+runs on isolates but **does not fail on an id it cannot resolve** — its
+`--no-lenient` default catches a wrong label and silently skips a nonexistent
+id. Engine B, `scripts/validate_id_label_correspondence.py`, does report
+`ID_NOT_FOUND`, but its targets in `conf/id_label_targets.yaml` were
+`kb/communities`, `kb/taxa`, and `output/kgx/nodes.tsv` — isolates were in
+none. The CI step name said it gated `data/isolates`; for this defect class it
+did not.
+
+What was hiding there: `CHEBI:49782 "dysprosium(3+)"`, an id in no CHEBI
+release. Its correction was *already decided* — recorded in NEXT_TASKS.md's
+rare-earth table and in `chebi_fix_apply.py`'s REPOINT map — but that script
+globbed `kb/communities` alone, so the fix never reached the record. A decision
+that cannot reach every record is not yet applied.
+
+These tests pin both halves: the config covers isolates, and the sweep script
+does too.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+import yaml
+
+REPO = pathlib.Path(__file__).parent.parent
+CONFIG = REPO / "conf/id_label_targets.yaml"
+ISOLATES = REPO / "data/isolates"
+
+
+def _targets() -> list[dict]:
+    return yaml.safe_load(CONFIG.read_text())["targets"]
+
+
+def test_engine_b_has_a_target_covering_the_isolates():
+    """Without this, ID_NOT_FOUND is unreachable for every isolate record."""
+    globs = [t.get("glob", "") for t in _targets()]
+    assert any(g.startswith("data/isolates/") for g in globs), (
+        "conf/id_label_targets.yaml has no data/isolates target, so Engine B "
+        f"never reads those records and nothing else reports ID_NOT_FOUND for "
+        f"them (#471). Current globs: {globs}"
+    )
+
+
+def test_that_target_checks_the_id_label_pair_canonically():
+    """A target that checked some other pair, or leniently, would not close this."""
+    target = next(t for t in _targets() if t.get("glob", "").startswith("data/isolates/"))
+    assert target["policy"] == "canonical"
+    assert ["id", "label"] in [list(p) for p in target["pairs"]]
+
+
+def test_the_isolate_records_are_actually_matched_by_that_glob():
+    """A target whose glob matches nothing passes vacuously."""
+    target = next(t for t in _targets() if t.get("glob", "").startswith("data/isolates/"))
+    # Glob from the repo root, which is what the validator does — resolving it
+    # against data/isolates/ instead silently looked for data/isolates/isolates/
+    # and matched nothing, so this test failed while the config was correct.
+    matched = list(REPO.glob(target["glob"]))
+    assert len(matched) >= 4, (
+        f"{target['glob']!r} matches {len(matched)} files; the isolate records "
+        f"are {sorted(p.name for p in ISOLATES.glob('*.yaml'))}"
+    )
+
+
+def test_the_chebi_sweep_reaches_every_record_directory():
+    """The repoint table was right and unapplied because this globbed one dir.
+
+    Asserting on the source text rather than importing: the script executes its
+    OAK lookups at module scope, so importing it shells out to `runoak` for
+    ~100 ids.
+    """
+    source = (REPO / "scripts/chebi_fix_apply.py").read_text()
+    # To the end of the line, not to the first ")": every entry is `Path("...")`,
+    # so a non-greedy `[^)]*` capture stops inside the first one and reports an
+    # empty set no matter what the script actually sweeps.
+    dirs = re.search(r"RECORD_DIRS\s*=\s*\(.*", source)
+    assert dirs, "RECORD_DIRS is gone from chebi_fix_apply.py; update this test"
+
+    named = set(re.findall(r'Path\("([^"]+)"\)', dirs.group(0)))
+    assert "data/isolates" in named, (
+        "chebi_fix_apply.py does not sweep data/isolates, which is how the "
+        "dysprosium repoint stayed unapplied while sitting in its own REPOINT "
+        f"table (#471). It sweeps: {sorted(named)}"
+    )
+    assert "kb/communities" in named
+
+
+def test_no_isolate_carries_the_nonexistent_dysprosium_id():
+    """CHEBI:49782 is in no CHEBI release — not obsolete, absent.
+
+    Pinned by id rather than by validator run so it fails in the fast test
+    suite, with no ontology download.
+
+    Checks parsed `id` values, not raw text: the record's curation note names
+    the retired id in prose to explain the change, and a substring scan cannot
+    tell that apart from the grounding itself — it flagged the very note that
+    documents the fix.
+    """
+    offenders = []
+    for path in sorted(ISOLATES.glob("*.yaml")):
+        stack = [yaml.safe_load(path.read_text()) or {}]
+        while stack:
+            node = stack.pop()
+            if isinstance(node, dict):
+                if node.get("id") == "CHEBI:49782":
+                    offenders.append(path.name)
+                    break
+                stack.extend(node.values())
+            elif isinstance(node, list):
+                stack.extend(node)
+    assert offenders == [], (
+        "CHEBI:49782 does not resolve in the OAK snapshot or at EBI; the "
+        f"decided replacement is CHEBI:33377 'dysprosium atom' (#471): {offenders}"
+    )
+
+
+@pytest.mark.parametrize("record", sorted(p.name for p in ISOLATES.glob("*.yaml")))
+def test_every_isolate_ontology_label_is_a_string_pair(record: str):
+    """Guard for the sweep above: the pairs it checks must actually be there.
+
+    If `term` blocks were restructured, the glob could keep matching while the
+    (id, label) pairs it looks for no longer exist — passing for the wrong
+    reason.
+    """
+    document = yaml.safe_load((ISOLATES / record).read_text()) or {}
+    pairs, stack = 0, [document]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, dict):
+            if isinstance(node.get("id"), str) and isinstance(node.get("label"), str):
+                pairs += 1
+            stack.extend(node.values())
+        elif isinstance(node, list):
+            stack.extend(node)
+    assert pairs > 0, f"{record} carries no (id, label) pair for the gate to check"


### PR DESCRIPTION
Closes #471 in part — see *What this does not fix* below.

## The gap

Two engines check `(id, label)` pairs, and neither covered this case for isolates:

| | isolates in scope? | fails on a wrong label? | fails on a nonexistent id? |
|---|---|---|---|
| Engine A — `linkml-term-validator --labels` | yes | yes | **no** — skips ids it cannot resolve, even at its `--no-lenient` default |
| Engine B — `validate_id_label_correspondence.py` | **no** | yes | yes (`ID_NOT_FOUND`) |

Engine B's targets were `kb/communities/*.yaml`, `kb/taxa/*.yaml`, and `output/kgx/nodes.tsv`. So a typo'd CURIE in `data/isolates` passed every gate in the repo, while the CI step is named *"Enforce id-label correspondence (kb/communities, data/isolates)"*.

## What it found

Adding the target surfaced a real defect on the first run:

```
ID_NOT_FOUND: data/isolates/Methylobacterium_REE_Ewaste_Platform.yaml
  ...metabolites[2].term.id CHEBI:49782 label='dysprosium(3+)' canonical=''
```

`CHEBI:49782` is in **no** CHEBI release — not obsolete, absent. EBI's OLS returns nothing for it either, so this is not a stale-snapshot case.

**The correction already existed and had never been applied.** `NEXT_TASKS.md`'s rare-earth table lists it, and `scripts/chebi_fix_apply.py` carries `("CHEBI:49782", "dysprosium(3+)") -> "CHEBI:33377"` in its `REPOINT` map. That script globbed `kb/communities` alone, so it never reached the record — and no gate covered isolates to notice. A correction table that cannot reach every record is a record of a decision, not the decision applied.

## Changes

- `conf/id_label_targets.yaml` — new `isolates_yaml` target, `policy: canonical`, `[id, label]`.
- `data/isolates/Methylobacterium_REE_Ewaste_Platform.yaml` — grounded to `CHEBI:33377 "dysprosium atom"`, the already-decided target, with a note.
- `scripts/chebi_fix_apply.py` — sweeps `kb/communities`, `data/isolates`, `kb/taxa` instead of communities alone.
- `justfile` — the `validate-products` comment claimed it covered "DATA PRODUCTS (KGX node export)"; it has covered the community and taxa YAMLs for some time and now the isolates too. It also now records that this is the *only* gate reporting `ID_NOT_FOUND`.
- `NEXT_TASKS.md` — dysprosium row marked applied.
- `tests/test_isolates_are_covered_by_id_checks.py` — new.

### On the grounding choice

`CHEBI:33377 "dysprosium atom"` is the element, not the Dy³⁺ ion the record means. Its two neighbours in the same block *are* exact cations (`CHEBI:229785` neodymium(3+), `CHEBI:229784` praseodymium(3+)), so the record is internally inconsistent — unavoidably. Upstream CHEBI has exactly two dysprosium terms, `dysprosium atom` and `dysprosium molecular entity`, and no trivalent cation. The imprecision is a gap in CHEBI, not a curation preference; `preferred_term: dysprosium(3+)` keeps what the paper reports and the note says why.

## Verification

End to end, not by exit code. Planting `CHEBI:99999999` in an isolate:

```
ID_NOT_FOUND: data/isolates/Chromobacterium_Gold_Biocyanidation.yaml ... CHEBI:99999999
GATE_EXIT=2
```

An earlier attempt at this proved nothing — the `sed` that was meant to plant the id silently matched nothing and the gate "passed". The run above confirms the planted id was on disk first.

Repo clean afterwards: **6094 OK_CANONICAL / 17 OK_EXCEPTION / 0 errors**. Full suite **1631 passed, 16 skipped**. `ruff`, `black`, and `linkml-validate` on the edited record all clean.

### The tests were mutation-checked, and three could not fail

Each of the three fixes is pinned by reverting it and confirming its own test goes red. That check earned its keep — on the first pass three tests failed *at baseline* for reasons unrelated to what they claimed to test:

- one globbed `data/isolates/isolates/*.yaml` (split the target glob against the wrong root) and matched nothing;
- one used `RECORD_DIRS\s*=\s*\(([^)]*)\)`, whose capture stops inside the first `Path("...")`, so it reported an empty sweep set regardless of the script;
- one grepped raw file text for `CHEBI:49782` and so flagged the curation note that documents the fix.

All three now check parsed values or the correct root. The final matrix: baseline 9 passed; conf reverted → 3 fail; script scope reverted → 1 fail; bad id restored → 1 fail; restored → 9 passed.

## What this does not fix

Both stay open on #471:

1. **Engine A still cannot fail on an unresolvable id.** That is upstream in `linkml-term-validator`. Three curator-accepted residuals (`CHEBI:75315`, `GO:0070812`, `NCBITaxon:1807132`) still pass it by being invisible to it rather than by being right — though Engine B does see them, via the `exceptions:` list.
2. **Nothing pins the ontology release.** The OAK cache is the only thing freezing the snapshot, GitHub evicts caches after 7 days unused, and Engine A has no waiver mechanism — an upstream label change can turn CI red on a PR that changed nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)