### PR TITLE
Stop publishing a plant's taxon id for a bacterium, and gate docs/ (#442)

### DIFF
--- a/.github/workflows/docs-current.yaml
+++ b/.github/workflows/docs-current.yaml
@@ -7,10 +7,13 @@ name: docs-current
 #
 # It had drifted both ways by the time this was added (#442):
 #
-#   * 7 pages rendered taxon ids the KB no longer holds. Two published
+#   * 8 pages rendered taxon ids the KB no longer holds there. Two published
 #     NCBITaxon:169215 — the *plant* genus Bosea — as a live NCBI link on a
-#     bacterium, and KBase_ORT_Workflow_Community_Model still showed the
-#     class/phylum ids its record replaced in 2a3b691.
+#     bacterium; one linked Bacteroides ovatus to NCBITaxon:821, the row above
+#     it; and KBase_ORT_Workflow_Community_Model still showed the class/phylum
+#     ids its record replaced in 2a3b691. The 8th was found only after the
+#     drift test was made positional — a set comparison cannot see two rows
+#     swap ids.
 #   * 7 records had no published page at all, having been added without a
 #     regeneration. That is the failure mode a diff of existing files cannot
 #     see, which is why the check counts untracked files too.
@@ -21,15 +24,24 @@ name: docs-current
 
 on:
   pull_request:
-    # These are files, not packages: `src/communitymech/render/**` matches
-    # nothing, and a filter that matches nothing is a gate that never fires
-    # (CultureBotAI/TraitMech#198 is the same mistake). Verified against the
-    # tree rather than assumed.
+    # Two ways to get this wrong, both hit while writing it:
+    #
+    #   * `src/communitymech/render/**` matches nothing — render is a module,
+    #     not a package — and a filter matching nothing is a gate that never
+    #     fires (CultureBotAI/TraitMech#198 is the same mistake).
+    #   * naming only the .py files still missed the templates, which are the
+    #     renderer's largest input: a one-line edit to community.html rewrites
+    #     all 312 pages, and matched no filter in any workflow, so it ran
+    #     neither this gate nor pytest.
+    #
+    # Verifying that the listed paths exist is not the same as verifying they
+    # cover what changes the output. Both were checked against the tree.
     paths: &trigger_paths
       - "kb/communities/**"
+      - "src/communitymech/templates/**"
       - "src/communitymech/render.py"
       - "src/communitymech/render_community_pages.py"
-      - "src/communitymech/export/browser_export.py"
+      - "src/communitymech/paths.py"
       - "docs/**"
       - ".github/workflows/docs-current.yaml"
   push:

--- a/.github/workflows/docs-current.yaml
+++ b/.github/workflows/docs-current.yaml
@@ -1,0 +1,61 @@
+name: docs-current
+
+# `generate-pages.yaml` publishes the committed `docs/` tree verbatim. Nothing
+# regenerated or checked it, so a data PR that changed a record and not its page
+# shipped a site contradicting the KB — silently, since neither the schema
+# validators nor the id↔label gates read HTML.
+#
+# It had drifted both ways by the time this was added (#442):
+#
+#   * 7 pages rendered taxon ids the KB no longer holds. Two published
+#     NCBITaxon:169215 — the *plant* genus Bosea — as a live NCBI link on a
+#     bacterium, and KBase_ORT_Workflow_Community_Model still showed the
+#     class/phylum ids its record replaced in 2a3b691.
+#   * 7 records had no published page at all, having been added without a
+#     regeneration. That is the failure mode a diff of existing files cannot
+#     see, which is why the check counts untracked files too.
+#
+# The render is ~7s and deterministic — a clean checkout that runs it gets a
+# byte-identical tree — so gating costs nothing and the alternative (remember to
+# run `just gen-html`) is what produced the drift.
+
+on:
+  pull_request:
+    # These are files, not packages: `src/communitymech/render/**` matches
+    # nothing, and a filter that matches nothing is a gate that never fires
+    # (CultureBotAI/TraitMech#198 is the same mistake). Verified against the
+    # tree rather than assumed.
+    paths: &trigger_paths
+      - "kb/communities/**"
+      - "src/communitymech/render.py"
+      - "src/communitymech/render_community_pages.py"
+      - "src/communitymech/export/browser_export.py"
+      - "docs/**"
+      - ".github/workflows/docs-current.yaml"
+  push:
+    branches: [main]
+    paths: *trigger_paths
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  docs-current:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v3
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+          enable-cache: true
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: uv sync --frozen
+      - name: docs/ matches the KB
+        run: just check-docs-current

--- a/docs/browser.html
+++ b/docs/browser.html
@@ -512,7 +512,7 @@
                     <button id="search-clear" class="clear-btn" title="Clear search">✕</button>
                 </div>
                 <div class="search-results-count">
-                    Showing <span id="results-count">305</span> of 305 communities
+                    Showing <span id="results-count">312</span> of 312 communities
                 </div>
 
                 <!-- Active filters summary -->
@@ -1508,6 +1508,37 @@
                         </div>
                     </a>
                     
+                    <a href="communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.html"
+                       class="community-card"
+                       data-id="Bifidobacterium_Trichomonas_Vaginal_Coculture"
+                       data-name="bifidobacterium breve-trichomonas vaginalis vaginal co-culture"
+                       data-description="a defined two-member co-culture of the vaginal commensal bifidobacterium breve with the sexually transmitted protozoan parasite trichomonas vaginalis, assayed against hela epithelial cells. the result runs counter to the expectation that a beneficial commensal antagonises the parasite: over 4 h the protozoan proliferated 1.2-fold more while bacterial abundance fell 27%, microscopy showed direct physical association between the two organisms, and transcriptomics of t. vaginalis showed upregulation of fatty acid metabolism and dna replication genes together with virulence-associated genes including adhesins, corroborated by metabolomic changes in long-chain fatty acids. b. breve conferred no protection on host epithelial cells, and the effects on the parasite were transient. the record captures a commensal-parasite association in which the commensal is depleted while the parasite is enhanced.
+"
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="3">
+                        <h2>Bifidobacterium breve-Trichomonas vaginalis Vaginal Co-culture</h2>
+                        <p class="description">A defined two-member co-culture of the vaginal commensal Bifidobacterium breve with the sexually transmitted protozoan parasite Trichomonas vaginalis, assayed against HeLa epithelial cells. The result runs counter to the expectation that a beneficial commensal antagonises the parasite: over 4 h the protozoan proliferated 1.2-fold more while bacterial abundance fell 27%, microscopy showed direct physical association between the two organisms, and transcriptomics of T. vaginalis showed upregulation of fatty acid metabolism and DNA replication genes together with virulence-associated genes including adhesins, corroborated by metabolomic changes in long-chain fatty acids. B. breve conferred no protection on host epithelial cells, and the effects on the parasite were transient. The record captures a commensal-parasite association in which the commensal is depleted while the parasite is enhanced.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    3
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
                     <a href="communities/BioAsteroid_ISS_Chondrite_Biomining_Consortium.html"
                        class="community-card"
                        data-id="BioAsteroid_ISS_Chondrite_Biomining_Consortium"
@@ -2320,6 +2351,37 @@
                                 <span class="badge badge-ENGINEERED">ENGINEERED</span>
                             </div>
                             <span class="badge badge-category">BIOTECHNOLOGY</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.html"
+                       class="community-card"
+                       data-id="Chlorella_Keystone_Taxa_Antifungal_SynCom"
+                       data-name="chlorella fusca chk0059 keystone-taxa antifungal syncom"
+                       data-description="a three-member bacterial synthetic community assembled from the keystone taxa of the chlorella fusca chk0059 phytomicrobiome — pseudomonas, duganella and brevibacterium — identified by microbiota structure and co-occurrence network analysis of plant hosts treated with the biofertilizer microalga. applying chlorella, a chlorella methanol extract, or d-mannitol to the plant system shifted microbial distribution and diversity, with 2% d-mannitol markedly enriching pseudomonas, implicating an algal-derived polyol as a recruitment signal in chlorella-microbiome-plant communication. recombined as a syncom, the three keystone taxa suppressed the soilborne pathogen fusarium oxysporum in both strawberry and tomato more strongly than any constituent strain alone — a community-level phenotype; the source reports &#34;compared to individual strains&#34; and does not report an additivity model, so no claim of synergy or superadditivity is made here. the record captures the syncom as the mechanistic unit through which c. fusca chk0059 exerts its disease-suppressive effect. a 2025 precursor study of the same strain (pmid:40064531) located the chk0059-correlated keystone bacteria in the strawberry rhizosphere and named pseudomonas, duganella and rhizomicrobium; the third genus differs from the brevibacterium of the syncom reported here, so the keystone set is not identical between the two studies.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="7">
+                        <h2>Chlorella fusca CHK0059 Keystone-Taxa Antifungal SynCom</h2>
+                        <p class="description">A three-member bacterial synthetic community assembled from the keystone taxa of the Chlorella fusca CHK0059 phytomicrobiome — Pseudomonas, Duganella and Brevibacterium — identified by microbiota structure and co-occurrence network analysis of plant hosts treated with the biofertilizer microalga. Applying Chlorella, a Chlorella methanol extract, or D-mannitol to the plant system shifted microbial distribution and diversity, with 2% D-mannitol markedly enriching Pseudomonas, implicating an algal-derived polyol as a recruitment signal in Chlorella-microbiome-plant communication. Recombined as a SynCom, the three keystone taxa suppressed the soilborne pathogen Fusarium oxysporum in both strawberry and tomato more strongly than any constituent strain alone — a community-level phenotype; the source reports &#34;compared to individual strains&#34; and does not report an additivity model, so no claim of synergy or superadditivity is made here. The record captures the SynCom as the mechanistic unit through which C. fusca CHK0059 exerts its disease-suppressive effect. A 2025 precursor study of the same strain (PMID:40064531) located the CHK0059-correlated keystone bacteria in the strawberry rhizosphere and named Pseudomonas, Duganella and Rhizomicrobium; the third genus differs from the Brevibacterium of the SynCom reported here, so the keystone set is not identical between the two studies.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    7
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
                         </div>
                     </a>
                     
@@ -3965,6 +4027,37 @@
                         </div>
                     </a>
                     
+                    <a href="communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.html"
+                       class="community-card"
+                       data-id="Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom"
+                       data-name="eucalyptus nursery five-strain bacterial inoculant consortium"
+                       data-description="a five-strain synthetic consortium of eucalyptus-derived bacteria — bacillus subtilis, paraburkholderia caribensis, methylobacterium tardum, and two strains representing putative novel species in paenibacillus and mesorhizobium — assembled from isolates of eucalyptus rhizosphere and roots and selected for complementary functional traits in nitrogen cycling and rhizosphere colonisation. applied to three eucalyptus clones in a large tree-nursery field experiment and assessed after 13 weeks, the inoculant did not change bacterial richness or diversity but did alter root microbial community structure; two genotypes showed improved seedling quality and one showed mortality fall from 21.8% to 6.7%. the record captures a case where a defined inoculant reshapes community composition and host outcome without shifting diversity metrics, and where the response is genotype-dependent rather than uniform.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="6">
+                        <h2>Eucalyptus Nursery Five-Strain Bacterial Inoculant Consortium</h2>
+                        <p class="description">A five-strain synthetic consortium of Eucalyptus-derived bacteria — Bacillus subtilis, Paraburkholderia caribensis, Methylobacterium tardum, and two strains representing putative novel species in Paenibacillus and Mesorhizobium — assembled from isolates of Eucalyptus rhizosphere and roots and selected for complementary functional traits in nitrogen cycling and rhizosphere colonisation. Applied to three Eucalyptus clones in a large tree-nursery field experiment and assessed after 13 weeks, the inoculant did not change bacterial richness or diversity but did alter root microbial community structure; two genotypes showed improved seedling quality and one showed mortality fall from 21.8% to 6.7%. The record captures a case where a defined inoculant reshapes community composition and host outcome without shifting diversity metrics, and where the response is genotype-dependent rather than uniform.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    6
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
+                        </div>
+                    </a>
+                    
                     <a href="communities/Ewaste_Bioleaching_Consortium.html"
                        class="community-card"
                        data-id="Ewaste_Bioleaching_Consortium"
@@ -4481,6 +4574,37 @@ MECHANISM CONTESTED - do not read this record as establishing contact-dependent 
                                 <span class="badge badge-STABLE">STABLE</span>
                             </div>
                             <span class="badge badge-category">EXTREME_ENVIRONMENT</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Human_Gut_FourMember_Proteome_Complementarity_Consortium.html"
+                       class="community-card"
+                       data-id="Human_Gut_FourMember_Proteome_Complementarity_Consortium"
+                       data-name="human gut four-member proteome-complementarity consortium"
+                       data-description="a defined four-member consortium of metabolically distinct human gut anaerobes — eubacterium hallii, roseburia intestinalis, marvinbryantia formatexigens and faecalibacterium prausnitzii — assembled in all pairwise combinations and as the full community, on distinct carbon sources, and profiled by species-resolved proteomics. the finding is regulatory rather than compositional: bacteria modulate protein abundance in response to specific partners, and those partner-specific shifts reduce functional overlap between members and are frequently associated with increased community productivity. biotic interactions, not the carbon source, dominated proteomic variation. the record captures a community whose members divide labour by changing what they express in each other&#39;s presence, so metabolic complementarity is an outcome of regulation rather than a fixed property of the members.
+"
+                       data-category="DIET"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Human Gut Four-Member Proteome-Complementarity Consortium</h2>
+                        <p class="description">A defined four-member consortium of metabolically distinct human gut anaerobes — Eubacterium hallii, Roseburia intestinalis, Marvinbryantia formatexigens and Faecalibacterium prausnitzii — assembled in all pairwise combinations and as the full community, on distinct carbon sources, and profiled by species-resolved proteomics. The finding is regulatory rather than compositional: bacteria modulate protein abundance in response to specific partners, and those partner-specific shifts reduce functional overlap between members and are frequently associated with increased community productivity. Biotic interactions, not the carbon source, dominated proteomic variation. The record captures a community whose members divide labour by changing what they express in each other&#39;s presence, so metabolic complementarity is an outcome of regulation rather than a fixed property of the members.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">DIET</span>
                         </div>
                     </a>
                     
@@ -5509,6 +5633,37 @@ MECHANISM CONTESTED - do not read this record as establishing contact-dependent 
                                 <span class="badge badge-PERTURBED">PERTURBED</span>
                             </div>
                             <span class="badge badge-category">BIOREMEDIATION</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.html"
+                       class="community-card"
+                       data-id="Mesorhizobium_Synechococcus_B12_Synthetic_Consortium"
+                       data-name="mesorhizobium taihu-synechococcus pcc 7002 vitamin b12 synthetic consortium"
+                       data-description="a synthetic consortium built by co-culturing the marine cyanobacterium synechococcus sp. pcc 7002 (syn7002) — a model strain that lacks the gene cluster for vitamin b12 biosynthesis and therefore depends on other microbes for it — with a bloom-forming microcystis community from lake taihu, then purifying the result. metagenomics showed the early community consisted mainly of syn7002, mesorhizobium sp. taihu (mesth) and pseudomonas sp. taihu (pseth); pseth declined once the community stabilised, leaving the cyanobacterium and mesth as the persistent pair. electron microscopy found rod-shaped bacteria clustered around syn7002 cells. metatranscriptomics showed vitamin b12 biosynthesis and transport genes significantly upregulated in mesth, and b12-positive control experiments supported complementarity between the two strains, so the community is a worked example of a vitamin auxotrophy being satisfied by a partner rather than by the medium.
+"
+                       data-category="OTHER"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>Mesorhizobium TaiHu-Synechococcus PCC 7002 Vitamin B12 Synthetic Consortium</h2>
+                        <p class="description">A synthetic consortium built by co-culturing the marine cyanobacterium Synechococcus sp. PCC 7002 (Syn7002) — a model strain that lacks the gene cluster for vitamin B12 biosynthesis and therefore depends on other microbes for it — with a bloom-forming Microcystis community from Lake Taihu, then purifying the result. Metagenomics showed the early community consisted mainly of Syn7002, Mesorhizobium sp. TaiHu (MesTH) and Pseudomonas sp. TaiHu (PseTH); PseTH declined once the community stabilised, leaving the cyanobacterium and MesTH as the persistent pair. Electron microscopy found rod-shaped bacteria clustered around Syn7002 cells. Metatranscriptomics showed vitamin B12 biosynthesis and transport genes significantly upregulated in MesTH, and B12-positive control experiments supported complementarity between the two strains, so the community is a worked example of a vitamin auxotrophy being satisfied by a partner rather than by the medium.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">OTHER</span>
                         </div>
                     </a>
                     
@@ -7593,6 +7748,37 @@ MECHANISM CONTESTED - do not read this record as establishing contact-dependent 
                         </div>
                     </a>
                     
+                    <a href="communities/SPRUCE_Peatland_Warming_Community.html"
+                       class="community-card"
+                       data-id="SPRUCE_Peatland_Warming_Community"
+                       data-name="spruce peatland warming microbial community"
+                       data-description="microbial community from the spruce (spruce and peatland responses under changing environments) whole-ecosystem warming experiment at marcell experimental forest, minnesota. this long-term doe-funded experiment (ornl) provides a unique whole-ecosystem warming gradient (+0°c to +9°c) with elevated co2 (eco2) treatments in a northern boreal peatland. the natural microbial community has been extensively characterized through amplicon sequencing (16s rrna for bacteria/archaea, its for fungi) and metatranscriptomics, revealing climate change-driven shifts in community composition and function. key findings include: (1) warming promotes saprophytic fungi and chemoorganoheterotrophic bacteria in root-associated environments, (2) eco2 enhances ectomycorrhizal fungal associations with vascular plants, particularly short-distance exploration strategies targeting labile soil nitrogen, (3) vascular plant fine root traits mediate climate effects on microbial communities, serving as a critical mechanism for peatland vegetation responses to global change. the community exhibits distinct niche partitioning between aquatic (waterlogged surface peat) and terrestrial (deeper peat) zones. viral communities (4,326 votus) show strong correlations with peat depth, water content, and carbon chemistry (ch4/co2) but not temperature during initial warming phases. this represents one of the most comprehensively studied natural microbial communities under realistic climate change scenarios, with implications for carbon cycling, methane emissions, and ecosystem feedbacks in boreal peatlands. northern peatlands store approximately one-third of global soil carbon despite covering only 3% of land area, making their responses to warming and eco2 critical for global carbon cycle feedbacks. the comprehensive multi-omics datasets (amplicon, metagenome, metatranscriptome, virome) make this community exceptionally well-characterized for mechanistic modeling of climate-microbe-plant-carbon interactions.
+"
+                       data-category="EXTREME_ENVIRONMENT"
+                       data-state="STABLE"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="4">
+                        <h2>SPRUCE Peatland Warming Microbial Community</h2>
+                        <p class="description">Microbial community from the SPRUCE (Spruce and Peatland Responses Under Changing Environments) whole-ecosystem warming experiment at Marcell Experimental Forest, Minnesota. This long-term DOE-funded experiment (ORNL) provides a unique whole-ecosystem warming gradient (+0°C to +9°C) with elevated CO2 (eCO2) treatments in a northern boreal peatland. The natural microbial community has been extensively characterized through amplicon sequencing (16S rRNA for bacteria/archaea, ITS for fungi) and metatranscriptomics, revealing climate change-driven shifts in community composition and function. Key findings include: (1) warming promotes saprophytic fungi and chemoorganoheterotrophic bacteria in root-associated environments, (2) eCO2 enhances ectomycorrhizal fungal associations with vascular plants, particularly short-distance exploration strategies targeting labile soil nitrogen, (3) vascular plant fine root traits mediate climate effects on microbial communities, serving as a critical mechanism for peatland vegetation responses to global change. The community exhibits distinct niche partitioning between aquatic (waterlogged surface peat) and terrestrial (deeper peat) zones. Viral communities (4,326 vOTUs) show strong correlations with peat depth, water content, and carbon chemistry (CH4/CO2) but not temperature during initial warming phases. This represents one of the most comprehensively studied natural microbial communities under realistic climate change scenarios, with implications for carbon cycling, methane emissions, and ecosystem feedbacks in boreal peatlands. Northern peatlands store approximately one-third of global soil carbon despite covering only 3% of land area, making their responses to warming and eCO2 critical for global carbon cycle feedbacks. The comprehensive multi-omics datasets (amplicon, metagenome, metatranscriptome, virome) make this community exceptionally well-characterized for mechanistic modeling of climate-microbe-plant-carbon interactions.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    4
+                                </span>
+                                <span class="badge badge-STABLE">STABLE</span>
+                            </div>
+                            <span class="badge badge-category">EXTREME_ENVIRONMENT</span>
+                        </div>
+                    </a>
+                    
                     <a href="communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.html"
                        class="community-card"
                        data-id="Saanich_Inlet_OMZ_Redox_Gradient_Community"
@@ -8289,6 +8475,37 @@ MECHANISM CONTESTED - do not read this record as establishing contact-dependent 
                                 <span class="badge badge-ENGINEERED">ENGINEERED</span>
                             </div>
                             <span class="badge badge-category">OTHER</span>
+                        </div>
+                    </a>
+                    
+                    <a href="communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.html"
+                       class="community-card"
+                       data-id="SynCom_ARC_Peanut_Aflatoxin_Nodulation"
+                       data-name="syncom arc peanut aflatoxin-control and nodulation-coupling community"
+                       data-description="a four-strain rhizosphere synthetic community — three bacillus isolates (bl13-2c11, ba13-20e05, bm14-5g09) and one enterobacter isolate (el17-4b09) — assembled to couple two functions that are normally pursued separately in peanut: suppression of the aflatoxin-producing fungus aspergillus flavus, and induction of rhizobia-legume nodulation. candidate genera were chosen from cross-regional rhizosphere surveys as taxa negatively correlated with aspergillus abundance but not with bradyrhizobium, so that antifungal activity would not come at the cost of the nitrogen- fixing symbiont; strains that inhibited bradyrhizobium in coculture were screened out on exactly that criterion. the resulting community, syncom arc, reduced peanut aflatoxin by 85.6% across four years of field trials and enhanced nodulation and nitrogenase activity while retaining active nodules at harvest. the record captures the community as a deliberately compatibility- constrained consortium: its design problem is not maximal antifungal potency but antagonism of the pathogen that spares a mutualist.
+"
+                       data-category="RHIZOSPHERE"
+                       data-state="ENGINEERED"
+                       data-metals=""
+                       data-ree=""
+                       data-relevance="NOT_APPLICABLE"
+                       data-member-count="5">
+                        <h2>SynCom ARC Peanut Aflatoxin-Control and Nodulation-Coupling Community</h2>
+                        <p class="description">A four-strain rhizosphere synthetic community — three Bacillus isolates (Bl13-2C11, Ba13-20E05, Bm14-5G09) and one Enterobacter isolate (El17-4B09) — assembled to couple two functions that are normally pursued separately in peanut: suppression of the aflatoxin-producing fungus Aspergillus flavus, and induction of rhizobia-legume nodulation. Candidate genera were chosen from cross-regional rhizosphere surveys as taxa negatively correlated with Aspergillus abundance but not with Bradyrhizobium, so that antifungal activity would not come at the cost of the nitrogen- fixing symbiont; strains that inhibited Bradyrhizobium in coculture were screened out on exactly that criterion. The resulting community, SynCom ARC, reduced peanut aflatoxin by 85.6% across four years of field trials and enhanced nodulation and nitrogenase activity while retaining active nodules at harvest. The record captures the community as a deliberately compatibility- constrained consortium: its design problem is not maximal antifungal potency but antagonism of the pathogen that spares a mutualist.
+</p>
+                        <div class="card-footer">
+                            <div class="card-footer-left">
+                                <span class="badge badge-member-count" title="Number of member taxa">
+                                    <svg width="12" height="12" viewBox="0 0 12 12" style="vertical-align: middle; margin-right: 3px;">
+                                        <circle cx="6" cy="3" r="2" fill="currentColor"/>
+                                        <circle cx="3" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                        <circle cx="9" cy="8" r="1.5" fill="currentColor" opacity="0.7"/>
+                                    </svg>
+                                    5
+                                </span>
+                                <span class="badge badge-ENGINEERED">ENGINEERED</span>
+                            </div>
+                            <span class="badge badge-category">RHIZOSPHERE</span>
                         </div>
                     </a>
                     

--- a/docs/communities/AMD_Nitrososphaerota_Archaeal.html
+++ b/docs/communities/AMD_Nitrososphaerota_Archaeal.html
@@ -658,7 +658,7 @@
                                     
                                     - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"We evaluated the gene abundance and diversity of nitrifying microbes in AMD-impacted sediments: ammonia-oxidizing archaea (AOA), ammonia-oxidizing bac"</div>
+                                    <div class="snippet">"We evaluated the gene abundance and diversity of nitrifying microbes in AMD-impacted sediments: ammonia-oxidizing archaea (AOA), ammonia-oxidizing bacteria (AOB), and nitrite-oxidizing bacteria (NOB)"</div>
                                     
                                 </li>
                                 
@@ -900,7 +900,7 @@
                             - SUPPORT (IN_VIVO)
                         </div>
                         
-                        <div class="snippet">"We evaluated the gene abundance and diversity of nitrifying microbes in AMD-impacted sediments: ammonia-oxidizing archaea (AOA), ammonia-oxidizing bac"</div>
+                        <div class="snippet">"We evaluated the gene abundance and diversity of nitrifying microbes in AMD-impacted sediments: ammonia-oxidizing archaea (AOA), ammonia-oxidizing bacteria (AOB), and nitrite-oxidizing bacteria (NOB)"</div>
                         
                     </li>
                     

--- a/docs/communities/Aalborg_East_Full_Scale_EBPR_Community.html
+++ b/docs/communities/Aalborg_East_Full_Scale_EBPR_Community.html
@@ -440,9 +440,9 @@
                             <strong>Candidatus Accumulibacter phosphatis and related PAOs</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=28216"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=327159"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:28216
+                                NCBITaxon:327159
                             </a>
                         </td>
                         <td>
@@ -1048,7 +1048,7 @@
         var taxonData = {};
         
         taxonData["Candidatus Accumulibacter phosphatis and related PAOs"] = {
-            id: "NCBITaxon:28216",
+            id: "NCBITaxon:327159",
             label: "Candidatus Accumulibacter phosphatis and related PAOs",
             abundance: "DOMINANT",
             roles: ["PRIMARY_DEGRADER", "CROSS_FEEDER"]

--- a/docs/communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.html
+++ b/docs/communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>BioModels MODEL1806250005 Cicada Sulcia-Hodgkinia Symbiosis - CommunityMech</title>
+    <title>Bifidobacterium breve-Trichomonas vaginalis Vaginal Co-culture - CommunityMech</title>
     <style>
         :root {
             --primary: #3D7DD6;
@@ -372,7 +372,7 @@
     <header>
         <div class="container">
             <a href="../browser.html" class="back-link">← Back to Communities</a>
-            <h1>BioModels MODEL1806250005 Cicada Sulcia-Hodgkinia Symbiosis</h1>
+            <h1>Bifidobacterium breve-Trichomonas vaginalis Vaginal Co-culture</h1>
         </div>
     </header>
 
@@ -383,19 +383,31 @@
                 <div class="metadata-item">
                     <span class="metadata-label">Community ID</span>
                     <span class="metadata-value">
-                        <code style="background: var(--border); color: var(--text); padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.9rem;">CommunityMech:000008</code>
+                        <code style="background: var(--border); color: var(--text); padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.9rem;">CommunityMech:000318</code>
                     </span>
                 </div>
 
                 <div class="metadata-item">
                     <span class="metadata-label">Ecological State</span>
                     <span class="metadata-value">
-                        <span class="badge badge-natural">
-                            STABLE
+                        <span class="badge badge-engineered">
+                            ENGINEERED
                         </span>
                     </span>
                 </div>
 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Environment</span>
+                    <span class="metadata-value">
+                        laboratory co-culture with HeLa epithelial cells
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01001405"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:01001405
+                        </a>
+                    </span>
+                </div>
                 
                 
             </div>
@@ -404,7 +416,8 @@
         <!-- Description -->
         
         <section class="description">
-            <p>BioModels record MODEL1806250005 is a multi-compartment metabolic model of the cicada Neotibicen canicularis and its bacterial endosymbionts Sulcia and Hodgkinia.</p>
+            <p>A defined two-member co-culture of the vaginal commensal Bifidobacterium breve with the sexually transmitted protozoan parasite Trichomonas vaginalis, assayed against HeLa epithelial cells. The result runs counter to the expectation that a beneficial commensal antagonises the parasite: over 4 h the protozoan proliferated 1.2-fold more while bacterial abundance fell 27%, microscopy showed direct physical association between the two organisms, and transcriptomics of T. vaginalis showed upregulation of fatty acid metabolism and DNA replication genes together with virulence-associated genes including adhesins, corroborated by metabolomic changes in long-chain fatty acids. B. breve conferred no protection on host epithelial cells, and the effects on the parasite were transient. The record captures a commensal-parasite association in which the commensal is depleted while the parasite is enhanced.
+</p>
         </section>
         
 
@@ -425,70 +438,109 @@
                     
                     <tr>
                         <td>
-                            <strong>Neotibicen canicularis</strong>
+                            <strong>Bifidobacterium breve</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1699721"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1685"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:1699721
+                                NCBITaxon:1685
                             </a>
                         </td>
                         <td>
-                            
-                            <div class="roles-list">
-                                
-                                <span class="role-badge">CROSS_FEEDER</span>
-                                
-                            </div>
                             
                         </td>
                         <td>N/A</td>
                     </tr>
                     
-                    
-                    <tr>
-                        <td>
-                            <strong>Sulcia</strong>
-                        </td>
-                        <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=336809"
-                               class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:336809
-                            </a>
-                        </td>
-                        <td>
-                            
-                            <div class="roles-list">
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
                                 
-                                <span class="role-badge">SYNTROPHIC_PARTNER</span>
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/41688526/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41688526</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"a reduction in the population of Bifidobacterium breve has been documented in women infected with T. vaginalis"</div>
+                                    
+                                </li>
                                 
-                            </div>
-                            
+                            </ul>
                         </td>
-                        <td>N/A</td>
                     </tr>
                     
                     
                     <tr>
                         <td>
-                            <strong>Hodgkinia</strong>
+                            <strong>Trichomonas vaginalis</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=573657"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=5722"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:573657
+                                NCBITaxon:5722
                             </a>
                         </td>
                         <td>
                             
-                            <div class="roles-list">
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
                                 
-                                <span class="role-badge">SYNTROPHIC_PARTNER</span>
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/41688526/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41688526</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"Co-culture of T. vaginalis with B. breve for 4 h significantly increased protozoan proliferation by 1.2-fold, while bacterial abundance was reduced by 27%"</div>
+                                    
+                                </li>
                                 
-                            </div>
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td>
+                            <strong>HeLa human epithelial cells</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=9606"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:9606
+                            </a>
+                        </td>
+                        <td>
                             
                         </td>
                         <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/41688526/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41688526</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"HeLa cells showed no cytopathic effects or changes after treatment with B. breve, whether given before or alongside T. vaginalis"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
                     </tr>
                     
                     
@@ -504,15 +556,18 @@
             <div class="network-container" id="network-container">
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
-                    <title id="network-svg-title">Ecological interaction network for BioModels MODEL1806250005 Cicada Sulcia-Hodgkinia Symbiosis</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <title id="network-svg-title">Ecological interaction network for Bifidobacterium breve-Trichomonas vaginalis Vaginal Co-culture</title>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (commensalism, predation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #913079;"></span> Predation
                     </div>
                 </div>
             </div>
@@ -520,32 +575,24 @@
             
             <div class="interaction-card">
                 <div class="interaction-header">
-                    <h3>Sulcia Essential Amino Acid Provisioning</h3>
-                    <span class="interaction-type">MUTUALISM</span>
+                    <h3>Trichomonas vaginalis Proliferation at the Expense of Bifidobacterium breve</h3>
+                    <span class="interaction-type">PREDATION</span>
                 </div>
 
                 
-                <p><strong>Source Taxon:</strong> Sulcia</p>
+                <p><strong>Source Taxon:</strong> Trichomonas vaginalis</p>
                 
 
                 
-                <p><strong>Target Taxon:</strong> Neotibicen canicularis</p>
+                <p><strong>Target Taxon:</strong> Bifidobacterium breve</p>
                 
 
                 
                 <p><strong>Metabolites:</strong>
                     
-                    L-leucine
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=15603"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:15603</a>), 
-                    
-                    L-isoleucine
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=17191"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:17191</a>), 
-                    
-                    nitrogen
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=25555"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:25555</a>)
+                    long-chain fatty acid
+                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=15904"
+                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:15904</a>)
                     
                 </p>
                 
@@ -561,26 +608,26 @@
                     <li class="evidence-item">
                         <div>
                             
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/41688526/"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41688526</a>
                             
-                            - SUPPORT (COMPUTATIONAL)
+                            - PARTIAL (IN_VITRO)
                         </div>
                         
-                        <div class="snippet">"Sulcia and Hodgkinia with genomes of ≤0.3 Mb are calculated to recycle ∼30 to 80% of host-derived nitrogen to essential amino acids returned to the host"</div>
+                        <div class="snippet">"Co-culture of T. vaginalis with B. breve for 4 h significantly increased protozoan proliferation by 1.2-fold, while bacterial abundance was reduced by 27%"</div>
                         
                     </li>
                     
                     <li class="evidence-item">
                         <div>
                             
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/41688526/"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41688526</a>
                             
-                            - SUPPORT (COMPUTATIONAL)
+                            - PARTIAL (IN_VITRO)
                         </div>
                         
-                        <div class="snippet">"Our simulations reveal extensive bidirectional flux of multiple metabolites between each symbiont and the host"</div>
+                        <div class="snippet">"Transcriptomic profiling of T. vaginalis co-cultured with B. breve revealed an upregulation of genes related to fatty acid metabolism and DNA replication"</div>
                         
                     </li>
                     
@@ -590,26 +637,14 @@
             
             <div class="interaction-card">
                 <div class="interaction-header">
-                    <h3>Hodgkinia Metabolic Complementarity</h3>
-                    <span class="interaction-type">MUTUALISM</span>
+                    <h3>Absence of Host Epithelial Protection</h3>
+                    <span class="interaction-type">COMMENSALISM</span>
                 </div>
 
                 
-                <p><strong>Source Taxon:</strong> Hodgkinia</p>
-                
 
                 
-                <p><strong>Target Taxon:</strong> Neotibicen canicularis</p>
-                
 
-                
-                <p><strong>Metabolites:</strong>
-                    
-                    nitrogen
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=25555"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:25555</a>)
-                    
-                </p>
                 
 
                 
@@ -623,26 +658,13 @@
                     <li class="evidence-item">
                         <div>
                             
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/41688526/"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41688526</a>
                             
-                            - SUPPORT (COMPUTATIONAL)
+                            - SUPPORT (IN_VITRO)
                         </div>
                         
-                        <div class="snippet">"Sulcia and Hodgkinia with genomes of ≤0.3 Mb are calculated to recycle ∼30 to 80% of host-derived nitrogen to essential amino acids returned to the host"</div>
-                        
-                    </li>
-                    
-                    <li class="evidence-item">
-                        <div>
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
-                            
-                            - SUPPORT (COMPUTATIONAL)
-                        </div>
-                        
-                        <div class="snippet">"near-complete metabolic segregation (i.e., near absence of metabolic cross-feeding) between the two symbionts, a likely mode of host control over symbiont metabolism"</div>
+                        <div class="snippet">"it does not confer protection on host epithelial cells during infection"</div>
                         
                     </li>
                     
@@ -655,83 +677,27 @@
 
         <!-- Associated Datasets -->
         
-        <section>
-            <h2>Associated Datasets</h2>
-            <table>
-                <thead>
-                    <tr>
-                        <th>Dataset</th>
-                        <th>Type</th>
-                        <th>Repository</th>
-                        <th>Accession</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    
-                    <tr>
-                        <td>
-                            <strong>BioModels model file</strong>
-                            
-                            <br><span class="dataset-description">Multi-compartment SBML model for cicada symbiosis.</span>
-                            
-                        </td>
-                        <td><span class="role-badge">OTHER</span></td>
-                        <td>OTHER</td>
-                        <td>
-                            
-                            <a href="https://www.ebi.ac.uk/biomodels/MODEL1806250005" class="term-link" target="_blank" rel="noopener noreferrer">Neotibicen_iNA533.xml</a>
-                            
-                        </td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                            <strong>Primary publication</strong>
-                            
-                            <br><span class="dataset-description">Study on the cost of metabolic interactions in insect-bacterial symbioses.</span>
-                            
-                        </td>
-                        <td><span class="role-badge">OTHER</span></td>
-                        <td>OTHER</td>
-                        <td>
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/" class="term-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
-                            
-                        </td>
-                    </tr>
-                    
-                </tbody>
-            </table>
-        </section>
-        
 
         <!-- Environmental Factors -->
         
+
+        
         <section>
-            <h2>External Resources</h2>
+            <h2>Environmental Factors</h2>
             <table>
                 <thead>
                     <tr>
-                        <th>Name</th>
-                        <th>Repository</th>
-                        <th>Resource ID</th>
+                        <th>Factor</th>
+                        <th>Value</th>
+                        <th>Unit</th>
                     </tr>
                 </thead>
                 <tbody>
                     
                     <tr>
-                        <td>
-                            <strong>BioModels entry</strong>
-                            
-                            <br><span class="dataset-description">Cicada symbiosis metabolic model.</span>
-                            
-                        </td>
-                        <td>BIOMODELS</td>
-                        <td>
-                            
-                            <a href="https://www.ebi.ac.uk/biomodels/MODEL1806250005" class="term-link" target="_blank" rel="noopener noreferrer">MODEL1806250005</a>
-                            
-                        </td>
+                        <td><strong>Co-culture duration</strong></td>
+                        <td>4 h</td>
+                        <td>N/A</td>
                     </tr>
                     
                     <tr class="evidence-row-container">
@@ -740,12 +706,12 @@
                                 
                                 <li class="evidence-item">
                                     
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/41688526/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41688526</a>
                                     
-                                    - SUPPORT (COMPUTATIONAL)
+                                    - SUPPORT (IN_VITRO)
                                     
-                                    <div class="snippet">"The Cost of Metabolic Interactions in Symbioses between Insects and Bacteria with Reduced Genomes."</div>
+                                    <div class="snippet">"modulates parasite gene expression and lipid metabolism transiently"</div>
                                     
                                 </li>
                                 
@@ -757,8 +723,6 @@
                 </tbody>
             </table>
         </section>
-        
-
         
 
         <!-- Growth Media -->
@@ -791,25 +755,25 @@
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
-        taxonData["Neotibicen canicularis"] = {
-            id: "NCBITaxon:1699721",
-            label: "Neotibicen canicularis",
+        taxonData["Bifidobacterium breve"] = {
+            id: "NCBITaxon:1685",
+            label: "Bifidobacterium breve",
             abundance: "UNKNOWN",
-            roles: ["CROSS_FEEDER"]
+            roles: []
         };
         
-        taxonData["Sulcia"] = {
-            id: "NCBITaxon:336809",
-            label: "Sulcia",
+        taxonData["Trichomonas vaginalis"] = {
+            id: "NCBITaxon:5722",
+            label: "Trichomonas vaginalis",
             abundance: "UNKNOWN",
-            roles: ["SYNTROPHIC_PARTNER"]
+            roles: []
         };
         
-        taxonData["Hodgkinia"] = {
-            id: "NCBITaxon:573657",
-            label: "Hodgkinia",
+        taxonData["HeLa human epithelial cells"] = {
+            id: "NCBITaxon:9606",
+            label: "HeLa human epithelial cells",
             abundance: "UNKNOWN",
-            roles: ["SYNTROPHIC_PARTNER"]
+            roles: []
         };
         
 
@@ -837,15 +801,11 @@
         
         (function() {
             var intId = "interaction:0";
-            var intType = "MUTUALISM";
+            var intType = "PREDATION";
             var metabolites = [];
             
             
-            metabolites.push("L-leucine");
-            
-            metabolites.push("L-isoleucine");
-            
-            metabolites.push("nitrogen");
+            metabolites.push("long-chain fatty acid");
             
             
             var processes = [];
@@ -854,7 +814,7 @@
 
             nodes.push({
                 id: intId,
-                label: "Sulcia Essential Amino Acid Provisioning",
+                label: "Trichomonas vaginalis Proliferation at the Expense of Bifidobacterium breve",
                 type: "interaction",
                 interactionType: intType,
                 metabolites: metabolites,
@@ -863,14 +823,14 @@
             });
 
             
-            var srcKey = "Sulcia";
+            var srcKey = "Trichomonas vaginalis";
             if (taxonNodeIds[srcKey]) {
                 links.push({ source: taxonNodeIds[srcKey], target: intId });
             }
             
 
             
-            var tgtKey = "Neotibicen canicularis";
+            var tgtKey = "Bifidobacterium breve";
             if (taxonNodeIds[tgtKey]) {
                 links.push({ source: intId, target: taxonNodeIds[tgtKey] });
             }
@@ -879,20 +839,16 @@
         
         (function() {
             var intId = "interaction:1";
-            var intType = "MUTUALISM";
+            var intType = "COMMENSALISM";
             var metabolites = [];
-            
-            
-            metabolites.push("nitrogen");
-            
             
             var processes = [];
             
-            var evidenceCount = 2;
+            var evidenceCount = 1;
 
             nodes.push({
                 id: intId,
-                label: "Hodgkinia Metabolic Complementarity",
+                label: "Absence of Host Epithelial Protection",
                 type: "interaction",
                 interactionType: intType,
                 metabolites: metabolites,
@@ -901,17 +857,7 @@
             });
 
             
-            var srcKey = "Hodgkinia";
-            if (taxonNodeIds[srcKey]) {
-                links.push({ source: taxonNodeIds[srcKey], target: intId });
-            }
-            
 
-            
-            var tgtKey = "Neotibicen canicularis";
-            if (taxonNodeIds[tgtKey]) {
-                links.push({ source: intId, target: taxonNodeIds[tgtKey] });
-            }
             
         })();
         

--- a/docs/communities/BioModels_MODEL1806250003_Spittlebug_Sulcia_Sodalis.html
+++ b/docs/communities/BioModels_MODEL1806250003_Spittlebug_Sulcia_Sodalis.html
@@ -451,9 +451,9 @@
                             <strong>Sulcia</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=2716471"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=336809"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:2716471
+                                NCBITaxon:336809
                             </a>
                         </td>
                         <td>
@@ -799,7 +799,7 @@
         };
         
         taxonData["Sulcia"] = {
-            id: "NCBITaxon:2716471",
+            id: "NCBITaxon:336809",
             label: "Sulcia",
             abundance: "UNKNOWN",
             roles: ["SYNTROPHIC_PARTNER"]

--- a/docs/communities/BioModels_MODEL1806250004_Sharpshooter_Sulcia_Baumannia.html
+++ b/docs/communities/BioModels_MODEL1806250004_Sharpshooter_Sulcia_Baumannia.html
@@ -451,9 +451,9 @@
                             <strong>Sulcia</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=2716471"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=336809"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:2716471
+                                NCBITaxon:336809
                             </a>
                         </td>
                         <td>
@@ -799,7 +799,7 @@
         };
         
         taxonData["Sulcia"] = {
-            id: "NCBITaxon:2716471",
+            id: "NCBITaxon:336809",
             label: "Sulcia",
             abundance: "UNKNOWN",
             roles: ["SYNTROPHIC_PARTNER"]

--- a/docs/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.html
+++ b/docs/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.html
@@ -608,9 +608,9 @@
                             <strong>Bacteroides ovatus</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=821"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=28116"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:821
+                                NCBITaxon:28116
                             </a>
                         </td>
                         <td>
@@ -1256,7 +1256,7 @@
         };
         
         taxonData["Bacteroides ovatus"] = {
-            id: "NCBITaxon:821",
+            id: "NCBITaxon:28116",
             label: "Bacteroides ovatus",
             abundance: "UNKNOWN",
             roles: ["PRIMARY_DEGRADER"]

--- a/docs/communities/Chlamydomonas_Bacterial_H2_Consortium.html
+++ b/docs/communities/Chlamydomonas_Bacterial_H2_Consortium.html
@@ -469,7 +469,7 @@
                                     
                                     - SUPPORT (IN_VITRO)
                                     
-                                    <div class="snippet">"A naturally occurring multispecies bacterial community composed of Bacillus cereus and two novel bacteria (Microbacterium forte sp. nov. and Stenotrop"</div>
+                                    <div class="snippet">"A naturally occurring multispecies bacterial community composed of Bacillus cereus and two novel bacteria (Microbacterium forte sp. nov. and Stenotrophomonas"</div>
                                     
                                 </li>
                                 
@@ -511,7 +511,7 @@
                                     
                                     - SUPPORT (IN_VITRO)
                                     
-                                    <div class="snippet">"A naturally occurring multispecies bacterial community composed of Bacillus cereus and two novel bacteria (Microbacterium forte sp. nov. and Stenotrop"</div>
+                                    <div class="snippet">"A naturally occurring multispecies bacterial community composed of Bacillus cereus and two novel bacteria (Microbacterium forte sp. nov. and Stenotrophomonas"</div>
                                     
                                 </li>
                                 
@@ -553,7 +553,7 @@
                                     
                                     - SUPPORT (IN_VITRO)
                                     
-                                    <div class="snippet">"A naturally occurring multispecies bacterial community composed of Bacillus cereus and two novel bacteria (Microbacterium forte sp. nov. and Stenotrop"</div>
+                                    <div class="snippet">"A naturally occurring multispecies bacterial community composed of Bacillus cereus and two novel bacteria (Microbacterium forte sp. nov. and Stenotrophomonas"</div>
                                     
                                 </li>
                                 
@@ -595,7 +595,7 @@
                                     
                                     - SUPPORT (IN_VITRO)
                                     
-                                    <div class="snippet">"A naturally occurring multispecies bacterial community composed of Bacillus cereus and two novel bacteria (Microbacterium forte sp. nov. and Stenotrop"</div>
+                                    <div class="snippet">"A naturally occurring multispecies bacterial community composed of Bacillus cereus and two novel bacteria (Microbacterium forte sp. nov. and Stenotrophomonas"</div>
                                     
                                 </li>
                                 
@@ -826,7 +826,7 @@
                             - SUPPORT (IN_VITRO)
                         </div>
                         
-                        <div class="snippet">"A naturally occurring multispecies bacterial community composed of Bacillus cereus and two novel bacteria (Microbacterium forte sp. nov. and Stenotrop"</div>
+                        <div class="snippet">"A naturally occurring multispecies bacterial community composed of Bacillus cereus and two novel bacteria (Microbacterium forte sp. nov. and Stenotrophomonas"</div>
                         
                     </li>
                     

--- a/docs/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.html
+++ b/docs/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Naica Deep Subsurface Thermophilic Community - CommunityMech</title>
+    <title>Chlorella fusca CHK0059 Keystone-Taxa Antifungal SynCom - CommunityMech</title>
     <style>
         :root {
             --primary: #3D7DD6;
@@ -372,7 +372,7 @@
     <header>
         <div class="container">
             <a href="../browser.html" class="back-link">← Back to Communities</a>
-            <h1>Naica Deep Subsurface Thermophilic Community</h1>
+            <h1>Chlorella fusca CHK0059 Keystone-Taxa Antifungal SynCom</h1>
         </div>
     </header>
 
@@ -383,15 +383,15 @@
                 <div class="metadata-item">
                     <span class="metadata-label">Community ID</span>
                     <span class="metadata-value">
-                        <code style="background: var(--border); color: var(--text); padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.9rem;">CommunityMech:000046</code>
+                        <code style="background: var(--border); color: var(--text); padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.9rem;">CommunityMech:000313</code>
                     </span>
                 </div>
 
                 <div class="metadata-item">
                     <span class="metadata-label">Ecological State</span>
                     <span class="metadata-value">
-                        <span class="badge badge-natural">
-                            STABLE
+                        <span class="badge badge-engineered">
+                            ENGINEERED
                         </span>
                     </span>
                 </div>
@@ -400,15 +400,30 @@
                 <div class="metadata-item">
                     <span class="metadata-label">Environment</span>
                     <span class="metadata-value">
-                        deep subsurface environment
+                        strawberry and tomato plant-associated environment
                         <br>
-                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01000942"
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01001001"
                            class="term-link" target="_blank" rel="noopener noreferrer">
-                            ENVO:01000942
+                            ENVO:01001001
                         </a>
                     </span>
                 </div>
                 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        strawberry rhizosphere
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_00005801"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:00005801
+                        </a>
+                        
+                        
+                    </span>
+                </div>
                 
             </div>
         </section>
@@ -416,7 +431,7 @@
         <!-- Description -->
         
         <section class="description">
-            <p>A deep subsurface thermophilic microbial community from the Naica Mine crystal cave system in Chihuahua, Mexico, representing one of Earth&#39;s most extreme oligotrophic deep biosphere habitats. This community thrives in hydrothermal waters at 700-760 m depth with temperatures of 54-60°C, extremely low nutrient availability, and isolation from surface inputs. The prokaryotic community is dominated by chemolithoautotrophic archaea, particularly basal Thaumarchaeota (performing ammonia oxidation) and environmental Thermoplasmatales lineages (Euryarchaeota), with bacterial diversity limited to Candidate Division OP3, Firmicutes, and Alpha/Beta-proteobacteria. High GC content of archaeal and OP3 16S rRNA genes confirms thermophilic adaptation to 50-70°C. Genes encoding archaeal ammonia monooxygenase (amoA) demonstrate that Naica Thaumarchaeota are thermophilic chemolithoautotrophic nitrifiers adapted to extreme energy limitation. The system exhibits astrobiology significance as an analog for subsurface life on Mars and icy moons, with fluid inclusions in giant gypsum crystals potentially harboring ancient microbes for up to 50,000-60,000 years. The absence of detectable eukaryotes reflects the extreme oligotrophy and thermal stress. This natural deep biosphere community provides insights into minimal energy requirements for life, thermophilic adaptation, and survival strategies in isolated subsurface aquifers with extremely limited carbon and nitrogen availability.
+            <p>A three-member bacterial synthetic community assembled from the keystone taxa of the Chlorella fusca CHK0059 phytomicrobiome — Pseudomonas, Duganella and Brevibacterium — identified by microbiota structure and co-occurrence network analysis of plant hosts treated with the biofertilizer microalga. Applying Chlorella, a Chlorella methanol extract, or D-mannitol to the plant system shifted microbial distribution and diversity, with 2% D-mannitol markedly enriching Pseudomonas, implicating an algal-derived polyol as a recruitment signal in Chlorella-microbiome-plant communication. Recombined as a SynCom, the three keystone taxa suppressed the soilborne pathogen Fusarium oxysporum in both strawberry and tomato more strongly than any constituent strain alone — a community-level phenotype; the source reports &#34;compared to individual strains&#34; and does not report an additivity model, so no claim of synergy or superadditivity is made here. The record captures the SynCom as the mechanistic unit through which C. fusca CHK0059 exerts its disease-suppressive effect. A 2025 precursor study of the same strain (PMID:40064531) located the CHK0059-correlated keystone bacteria in the strawberry rhizosphere and named Pseudomonas, Duganella and Rhizomicrobium; the third genus differs from the Brevibacterium of the SynCom reported here, so the keystone set is not identical between the two studies.
 </p>
         </section>
         
@@ -438,12 +453,12 @@
                     
                     <tr>
                         <td>
-                            <strong>Thaumarchaeota</strong>
+                            <strong>Chlorella fusca CHK0059</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=651137"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=3073"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:651137
+                                NCBITaxon:3073
                             </a>
                         </td>
                         <td>
@@ -455,7 +470,7 @@
                             </div>
                             
                         </td>
-                        <td>DOMINANT</td>
+                        <td>N/A</td>
                     </tr>
                     
                     <tr class="evidence-row-container">
@@ -464,34 +479,12 @@
                                 
                                 <li class="evidence-item">
                                     
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/41937467/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41937467</a>
                                     
                                     - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"These organisms are likely thermophilic chemolithoautotrophs adapted to thrive in an extremely energy-limited environment."</div>
-                                    
-                                </li>
-                                
-                                <li class="evidence-item">
-                                    
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                                    
-                                    - SUPPORT (IN_VIVO)
-                                    
-                                    <div class="snippet">"Genes encoding archaeal ammonium monooxygenase (AamoA) were amplified, suggesting that Naica Thaumarchaeota are involved in nitrification"</div>
-                                    
-                                </li>
-                                
-                                <li class="evidence-item">
-                                    
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                                    
-                                    - SUPPORT (IN_VIVO)
-                                    
-                                    <div class="snippet">"these organisms are likely thermophilic chemolithoautotrophs adapted to thrive in an extremely energy-limited environment"</div>
+                                    <div class="snippet">"keystone taxa (Psedomonas, Duganella, Brevibacterium) interaction with C. fusca CHK0059 within plant hosts were identified"</div>
                                     
                                 </li>
                                 
@@ -502,24 +495,18 @@
                     
                     <tr>
                         <td>
-                            <strong>Thermoplasmatales environmental lineage</strong>
+                            <strong>Pseudomonas</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=2301"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=286"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:2301
+                                NCBITaxon:286
                             </a>
                         </td>
                         <td>
                             
-                            <div class="roles-list">
-                                
-                                <span class="role-badge">CROSS_FEEDER</span>
-                                
-                            </div>
-                            
                         </td>
-                        <td>ABUNDANT</td>
+                        <td>N/A</td>
                     </tr>
                     
                     <tr class="evidence-row-container">
@@ -528,23 +515,23 @@
                                 
                                 <li class="evidence-item">
                                     
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/41937467/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41937467</a>
                                     
                                     - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"In addition, the high GC content of 16S rRNA gene sequences belonging to the archaea and to some OP3 OTUs suggests that at least these lineages are thermophilic"</div>
+                                    <div class="snippet">"a notable increase in Pseudomonas abundance following 2% D-mannitol treatment"</div>
                                     
                                 </li>
                                 
                                 <li class="evidence-item">
                                     
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/40064531/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:40064531</a>
                                     
                                     - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"They clustered with, respectively, basal Thaumarchaeota lineages and with a large clade of environmental sequences branching at the base of the Thermoplasmatales within the Euryarchaeota"</div>
+                                    <div class="snippet">"Pseudomonas, Duganella, and Rhizomicrobium species appear to be correlated with CHK0059 treatment in the rhizosphere"</div>
                                     
                                 </li>
                                 
@@ -555,24 +542,18 @@
                     
                     <tr>
                         <td>
-                            <strong>Candidate Division OP3</strong>
+                            <strong>Duganella</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=67812"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=75654"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:67812
+                                NCBITaxon:75654
                             </a>
                         </td>
                         <td>
                             
-                            <div class="roles-list">
-                                
-                                <span class="role-badge">CROSS_FEEDER</span>
-                                
-                            </div>
-                            
                         </td>
-                        <td>COMMON</td>
+                        <td>N/A</td>
                     </tr>
                     
                     <tr class="evidence-row-container">
@@ -581,23 +562,12 @@
                                 
                                 <li class="evidence-item">
                                     
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/41937467/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41937467</a>
                                     
                                     - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"Bacterial sequences belonged to the Candidate Division OP3, Firmicutes and the Alpha- and Beta-proteobacteria"</div>
-                                    
-                                </li>
-                                
-                                <li class="evidence-item">
-                                    
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                                    
-                                    - SUPPORT (IN_VIVO)
-                                    
-                                    <div class="snippet">"some OP3 OTUs suggests that at least these lineages are thermophilic"</div>
+                                    <div class="snippet">"keystone taxa (Psedomonas, Duganella, Brevibacterium) interaction with C. fusca CHK0059 within plant hosts were identified"</div>
                                     
                                 </li>
                                 
@@ -608,24 +578,18 @@
                     
                     <tr>
                         <td>
-                            <strong>Firmicutes</strong>
+                            <strong>Brevibacterium</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1239"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1696"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:1239
+                                NCBITaxon:1696
                             </a>
                         </td>
                         <td>
                             
-                            <div class="roles-list">
-                                
-                                <span class="role-badge">SECONDARY_FERMENTER</span>
-                                
-                            </div>
-                            
                         </td>
-                        <td>COMMON</td>
+                        <td>N/A</td>
                     </tr>
                     
                     <tr class="evidence-row-container">
@@ -634,12 +598,12 @@
                                 
                                 <li class="evidence-item">
                                     
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/41937467/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41937467</a>
                                     
                                     - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"Bacterial sequences belonged to the Candidate Division OP3, Firmicutes and the Alpha- and Beta-proteobacteria"</div>
+                                    <div class="snippet">"keystone taxa (Psedomonas, Duganella, Brevibacterium) interaction with C. fusca CHK0059 within plant hosts were identified"</div>
                                     
                                 </li>
                                 
@@ -650,24 +614,18 @@
                     
                     <tr>
                         <td>
-                            <strong>Alphaproteobacteria</strong>
+                            <strong>Fusarium oxysporum</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=28211"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=5507"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:28211
+                                NCBITaxon:5507
                             </a>
                         </td>
                         <td>
                             
-                            <div class="roles-list">
-                                
-                                <span class="role-badge">CROSS_FEEDER</span>
-                                
-                            </div>
-                            
                         </td>
-                        <td>RARE</td>
+                        <td>N/A</td>
                     </tr>
                     
                     <tr class="evidence-row-container">
@@ -676,12 +634,12 @@
                                 
                                 <li class="evidence-item">
                                     
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/41937467/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41937467</a>
                                     
                                     - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"Bacterial sequences belonged to the Candidate Division OP3, Firmicutes and the Alpha- and Beta-proteobacteria"</div>
+                                    <div class="snippet">"enhanced antifungal effects against Fusarium oxysporum in both strawberry and tomato"</div>
                                     
                                 </li>
                                 
@@ -692,24 +650,18 @@
                     
                     <tr>
                         <td>
-                            <strong>Betaproteobacteria</strong>
+                            <strong>strawberry</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=28216"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=3747"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:28216
+                                NCBITaxon:3747
                             </a>
                         </td>
                         <td>
                             
-                            <div class="roles-list">
-                                
-                                <span class="role-badge">CROSS_FEEDER</span>
-                                
-                            </div>
-                            
                         </td>
-                        <td>RARE</td>
+                        <td>N/A</td>
                     </tr>
                     
                     <tr class="evidence-row-container">
@@ -718,12 +670,48 @@
                                 
                                 <li class="evidence-item">
                                     
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/41937467/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41937467</a>
                                     
                                     - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"Bacterial sequences belonged to the Candidate Division OP3, Firmicutes and the Alpha- and Beta-proteobacteria"</div>
+                                    <div class="snippet">"enhanced antifungal effects against Fusarium oxysporum in both strawberry and tomato"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td>
+                            <strong>tomato</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=4081"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:4081
+                            </a>
+                        </td>
+                        <td>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/41937467/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41937467</a>
+                                    
+                                    - SUPPORT (IN_VIVO)
+                                    
+                                    <div class="snippet">"enhanced antifungal effects against Fusarium oxysporum in both strawberry and tomato"</div>
                                     
                                 </li>
                                 
@@ -744,18 +732,18 @@
             <div class="network-container" id="network-container">
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
-                    <title id="network-svg-title">Ecological interaction network for Naica Deep Subsurface Thermophilic Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy).</desc>
+                    <title id="network-svg-title">Ecological interaction network for Chlorella fusca CHK0059 Keystone-Taxa Antifungal SynCom</title>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (competition, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -763,58 +751,18 @@
             
             <div class="interaction-card">
                 <div class="interaction-header">
-                    <h3>Thermophilic Ammonia Oxidation</h3>
-                    <span class="interaction-type">CROSS_FEEDING</span>
+                    <h3>Keystone-Taxa SynCom Suppression of Fusarium oxysporum</h3>
+                    <span class="interaction-type">COMPETITION</span>
                 </div>
 
                 
-                <p><strong>Source Taxon:</strong> Thaumarchaeota</p>
-                
 
                 
 
                 
-                <p><strong>Metabolites:</strong>
-                    
-                    ammonia
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=16134"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:16134</a>), 
-                    
-                    nitrite
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=16301"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:16301</a>)
-                    
-                </p>
-                
 
                 
-                <p><strong>Biological Processes:</strong></p>
-                <ul>
-                    
-                    <li>
-                        nitrification
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0019676"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0019676</a>)
-                    </li>
-                    
-                    <li>
-                        carbon fixation
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0015977"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0015977</a>)
-                    </li>
-                    
-                </ul>
-                
 
-                
-                <div class="interaction-flow">
-                    <strong>Downstream Effects:</strong>
-                    
-                    <div class="flow-item">
-                        <span class="flow-arrow">→</span> Denitrification by Betaproteobacteria
-                    </div>
-                    
-                </div>
                 
 
                 
@@ -824,26 +772,13 @@
                     <li class="evidence-item">
                         <div>
                             
-                            <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/41937467/"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41937467</a>
                             
                             - SUPPORT (IN_VIVO)
                         </div>
                         
-                        <div class="snippet">"These organisms are likely thermophilic chemolithoautotrophs adapted to thrive in an extremely energy-limited environment."</div>
-                        
-                    </li>
-                    
-                    <li class="evidence-item">
-                        <div>
-                            
-                            <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                            
-                            - SUPPORT (IN_VIVO)
-                        </div>
-                        
-                        <div class="snippet">"these organisms are likely thermophilic chemolithoautotrophs adapted to thrive in an extremely energy-limited environment"</div>
+                        <div class="snippet">"a synthetic community (SynCom) of keystone taxa exhibited enhanced antifungal effects against Fusarium oxysporum in both strawberry and tomato, compared to individual strains"</div>
                         
                     </li>
                     
@@ -853,24 +788,24 @@
             
             <div class="interaction-card">
                 <div class="interaction-header">
-                    <h3>Heterotrophic Carbon Scavenging</h3>
-                    <span class="interaction-type">CROSS_FEEDING</span>
+                    <h3>D-mannitol Enrichment of Pseudomonas in the Chlorella Phytomicrobiome</h3>
+                    <span class="interaction-type">COLONIZATION_FACILITATION</span>
                 </div>
 
                 
-                <p><strong>Source Taxon:</strong> Thermoplasmatales environmental lineage</p>
+                <p><strong>Source Taxon:</strong> Chlorella fusca CHK0059</p>
                 
 
                 
-                <p><strong>Target Taxon:</strong> Candidate Division OP3</p>
+                <p><strong>Target Taxon:</strong> Pseudomonas</p>
                 
 
                 
                 <p><strong>Metabolites:</strong>
                     
-                    organic molecular entity
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=50860"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:50860</a>)
+                    D-mannitol
+                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=16899"
+                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:16899</a>)
                     
                 </p>
                 
@@ -886,192 +821,13 @@
                     <li class="evidence-item">
                         <div>
                             
-                            <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                            
-                            - SUPPORT (IN_VIVO)
-                        </div>
-                        
-                        <div class="snippet">"These organisms are likely thermophilic chemolithoautotrophs adapted to thrive in an extremely energy-limited environment."</div>
-                        
-                    </li>
-                    
-                </ul>
-                
-            </div>
-            
-            <div class="interaction-card">
-                <div class="interaction-header">
-                    <h3>Fermentation and Syntrophy</h3>
-                    <span class="interaction-type">SYNTROPHY</span>
-                </div>
-
-                
-                <p><strong>Source Taxon:</strong> Firmicutes</p>
-                
-
-                
-                <p><strong>Target Taxon:</strong> Thermoplasmatales environmental lineage</p>
-                
-
-                
-                <p><strong>Metabolites:</strong>
-                    
-                    hydrogen
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=18276"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:18276</a>), 
-                    
-                    acetate
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=30089"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:30089</a>)
-                    
-                </p>
-                
-
-                
-                <p><strong>Biological Processes:</strong></p>
-                <ul>
-                    
-                    <li>
-                        fermentation
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0006113"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0006113</a>)
-                    </li>
-                    
-                </ul>
-                
-
-                
-
-                
-                <h4>Evidence</h4>
-                <ul class="evidence-list">
-                    
-                    <li class="evidence-item">
-                        <div>
-                            
-                            <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/41937467/"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41937467</a>
                             
                             - PARTIAL (IN_VIVO)
                         </div>
                         
-                        <div class="snippet">"Bacterial sequences belonged to the Candidate Division OP3, Firmicutes and the Alpha- and Beta-proteobacteria"</div>
-                        
-                    </li>
-                    
-                </ul>
-                
-            </div>
-            
-            <div class="interaction-card">
-                <div class="interaction-header">
-                    <h3>Proteobacterial Oligotrophic Metabolism</h3>
-                    <span class="interaction-type">CROSS_FEEDING</span>
-                </div>
-
-                
-                <p><strong>Source Taxon:</strong> Alphaproteobacteria</p>
-                
-
-                
-                <p><strong>Target Taxon:</strong> Betaproteobacteria</p>
-                
-
-                
-                <p><strong>Metabolites:</strong>
-                    
-                    organic molecular entity
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=50860"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:50860</a>), 
-                    
-                    dihydrogen
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=18276"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:18276</a>)
-                    
-                </p>
-                
-
-                
-
-                
-
-                
-                <h4>Evidence</h4>
-                <ul class="evidence-list">
-                    
-                    <li class="evidence-item">
-                        <div>
-                            
-                            <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                            
-                            - SUPPORT (IN_VIVO)
-                        </div>
-                        
-                        <div class="snippet">"Bacterial sequences belonged to the Candidate Division OP3, Firmicutes and the Alpha- and Beta-proteobacteria"</div>
-                        
-                    </li>
-                    
-                </ul>
-                
-            </div>
-            
-            <div class="interaction-card">
-                <div class="interaction-header">
-                    <h3>Denitrification by Betaproteobacteria</h3>
-                    <span class="interaction-type">CROSS_FEEDING</span>
-                </div>
-
-                
-                <p><strong>Source Taxon:</strong> Betaproteobacteria</p>
-                
-
-                
-
-                
-                <p><strong>Metabolites:</strong>
-                    
-                    nitrite
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=16301"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:16301</a>), 
-                    
-                    dinitrogen
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=17997"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:17997</a>)
-                    
-                </p>
-                
-
-                
-                <p><strong>Biological Processes:</strong></p>
-                <ul>
-                    
-                    <li>
-                        denitrification
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0019333"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0019333</a>)
-                    </li>
-                    
-                </ul>
-                
-
-                
-
-                
-                <h4>Evidence</h4>
-                <ul class="evidence-list">
-                    
-                    <li class="evidence-item">
-                        <div>
-                            
-                            <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                            
-                            - PARTIAL (IN_VIVO)
-                        </div>
-                        
-                        <div class="snippet">"Bacterial sequences belonged to the Candidate Division OP3, Firmicutes and the Alpha- and Beta-proteobacteria"</div>
+                        <div class="snippet">"a notable increase in Pseudomonas abundance following 2% D-mannitol treatment"</div>
                         
                     </li>
                     
@@ -1102,9 +858,9 @@
                 <tbody>
                     
                     <tr>
-                        <td><strong>Temperature</strong></td>
-                        <td>54-60</td>
-                        <td>°C</td>
+                        <td><strong>D-mannitol amendment</strong></td>
+                        <td>2%</td>
+                        <td>N/A</td>
                     </tr>
                     
                     <tr class="evidence-row-container">
@@ -1113,138 +869,12 @@
                                 
                                 <li class="evidence-item">
                                     
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/41937467/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41937467</a>
                                     
                                     - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"In addition, the high GC content of 16S rRNA gene sequences belonging to the archaea and to some OP3 OTUs suggests that at least these lineages are thermophilic"</div>
-                                    
-                                </li>
-                                
-                                <li class="evidence-item">
-                                    
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                                    
-                                    - SUPPORT (IN_VIVO)
-                                    
-                                    <div class="snippet">"The high GC content of 16S rRNA gene sequences belonging to the archaea and to some OP3 OTUs suggests that at least these lineages are thermophilic"</div>
-                                    
-                                </li>
-                                
-                            </ul>
-                        </td>
-                    </tr>
-                    
-                    
-                    <tr>
-                        <td><strong>Depth</strong></td>
-                        <td>700-760</td>
-                        <td>m</td>
-                    </tr>
-                    
-                    <tr class="evidence-row-container">
-                        <td colspan="3">
-                            <ul class="evidence-list">
-                                
-                                <li class="evidence-item">
-                                    
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                                    
-                                    - SUPPORT (IN_VIVO)
-                                    
-                                    <div class="snippet">"We have explored the microbial diversity associated to these deep, saline hydrothermal waters collected in the deepest (ca"</div>
-                                    
-                                </li>
-                                
-                            </ul>
-                        </td>
-                    </tr>
-                    
-                    
-                    <tr>
-                        <td><strong>Oligotrophy</strong></td>
-                        <td>Extreme</td>
-                        <td>qualitative</td>
-                    </tr>
-                    
-                    <tr class="evidence-row-container">
-                        <td colspan="3">
-                            <ul class="evidence-list">
-                                
-                                <li class="evidence-item">
-                                    
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                                    
-                                    - SUPPORT (IN_VIVO)
-                                    
-                                    <div class="snippet">"These crystals formed under particularly stable geochemical conditions in cavities filled by low salinity hydrothermal water at 54-58°C"</div>
-                                    
-                                </li>
-                                
-                                <li class="evidence-item">
-                                    
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                                    
-                                    - SUPPORT (IN_VIVO)
-                                    
-                                    <div class="snippet">"thermophilic chemolithoautotrophs adapted to thrive in an extremely energy-limited environment"</div>
-                                    
-                                </li>
-                                
-                            </ul>
-                        </td>
-                    </tr>
-                    
-                    
-                    <tr>
-                        <td><strong>Isolation and Geological Stability</strong></td>
-                        <td>500,000+ years</td>
-                        <td>years</td>
-                    </tr>
-                    
-                    <tr class="evidence-row-container">
-                        <td colspan="3">
-                            <ul class="evidence-list">
-                                
-                                <li class="evidence-item">
-                                    
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                                    
-                                    - PARTIAL (IN_VIVO)
-                                    
-                                    <div class="snippet">"The Naica Mine in northern Mexico is famous for its giant gypsum crystals, which may reach up to 11 m long and contain fluid inclusions that might have captured microorganisms during their formation"</div>
-                                    
-                                </li>
-                                
-                            </ul>
-                        </td>
-                    </tr>
-                    
-                    
-                    <tr>
-                        <td><strong>Astrobiology Relevance</strong></td>
-                        <td>High</td>
-                        <td>qualitative</td>
-                    </tr>
-                    
-                    <tr class="evidence-row-container">
-                        <td colspan="3">
-                            <ul class="evidence-list">
-                                
-                                <li class="evidence-item">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23640690/"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:23640690</a>
-                                    
-                                    - SUPPORT (IN_VIVO)
-                                    
-                                    <div class="snippet">"The &#34;Cave of Crystals&#34; (aka &#39;Naica&#39;) in Chihuahua Mexico is a natural unique subterranean ecosystem which mainly consists of crystals made of calcium sulfate"</div>
+                                    <div class="snippet">"By applying various substances, including Chlorella, Chlorella methanol extract (methanol extract), and D-mannitol"</div>
                                     
                                 </li>
                                 
@@ -1288,46 +918,53 @@
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
-        taxonData["Thaumarchaeota"] = {
-            id: "NCBITaxon:651137",
-            label: "Thaumarchaeota",
-            abundance: "DOMINANT",
+        taxonData["Chlorella fusca CHK0059"] = {
+            id: "NCBITaxon:3073",
+            label: "Chlorella fusca CHK0059",
+            abundance: "UNKNOWN",
             roles: ["PRIMARY_PRODUCER"]
         };
         
-        taxonData["Thermoplasmatales environmental lineage"] = {
-            id: "NCBITaxon:2301",
-            label: "Thermoplasmatales environmental lineage",
-            abundance: "ABUNDANT",
-            roles: ["CROSS_FEEDER"]
+        taxonData["Pseudomonas"] = {
+            id: "NCBITaxon:286",
+            label: "Pseudomonas",
+            abundance: "UNKNOWN",
+            roles: []
         };
         
-        taxonData["Candidate Division OP3"] = {
-            id: "NCBITaxon:67812",
-            label: "Candidate Division OP3",
-            abundance: "COMMON",
-            roles: ["CROSS_FEEDER"]
+        taxonData["Duganella"] = {
+            id: "NCBITaxon:75654",
+            label: "Duganella",
+            abundance: "UNKNOWN",
+            roles: []
         };
         
-        taxonData["Firmicutes"] = {
-            id: "NCBITaxon:1239",
-            label: "Firmicutes",
-            abundance: "COMMON",
-            roles: ["SECONDARY_FERMENTER"]
+        taxonData["Brevibacterium"] = {
+            id: "NCBITaxon:1696",
+            label: "Brevibacterium",
+            abundance: "UNKNOWN",
+            roles: []
         };
         
-        taxonData["Alphaproteobacteria"] = {
-            id: "NCBITaxon:28211",
-            label: "Alphaproteobacteria",
-            abundance: "RARE",
-            roles: ["CROSS_FEEDER"]
+        taxonData["Fusarium oxysporum"] = {
+            id: "NCBITaxon:5507",
+            label: "Fusarium oxysporum",
+            abundance: "UNKNOWN",
+            roles: []
         };
         
-        taxonData["Betaproteobacteria"] = {
-            id: "NCBITaxon:28216",
-            label: "Betaproteobacteria",
-            abundance: "RARE",
-            roles: ["CROSS_FEEDER"]
+        taxonData["strawberry"] = {
+            id: "NCBITaxon:3747",
+            label: "strawberry",
+            abundance: "UNKNOWN",
+            roles: []
+        };
+        
+        taxonData["tomato"] = {
+            id: "NCBITaxon:4081",
+            label: "tomato",
+            abundance: "UNKNOWN",
+            roles: []
         };
         
 
@@ -1355,28 +992,16 @@
         
         (function() {
             var intId = "interaction:0";
-            var intType = "CROSS_FEEDING";
+            var intType = "COMPETITION";
             var metabolites = [];
-            
-            
-            metabolites.push("ammonia");
-            
-            metabolites.push("nitrite");
-            
             
             var processes = [];
             
-            
-            processes.push("nitrification");
-            
-            processes.push("carbon fixation");
-            
-            
-            var evidenceCount = 2;
+            var evidenceCount = 1;
 
             nodes.push({
                 id: intId,
-                label: "Thermophilic Ammonia Oxidation",
+                label: "Keystone-Taxa SynCom Suppression of Fusarium oxysporum",
                 type: "interaction",
                 interactionType: intType,
                 metabolites: metabolites,
@@ -1384,11 +1009,6 @@
                 evidenceCount: evidenceCount
             });
 
-            
-            var srcKey = "Thaumarchaeota";
-            if (taxonNodeIds[srcKey]) {
-                links.push({ source: taxonNodeIds[srcKey], target: intId });
-            }
             
 
             
@@ -1396,11 +1016,11 @@
         
         (function() {
             var intId = "interaction:1";
-            var intType = "CROSS_FEEDING";
+            var intType = "COLONIZATION_FACILITATION";
             var metabolites = [];
             
             
-            metabolites.push("organic molecular entity");
+            metabolites.push("D-mannitol");
             
             
             var processes = [];
@@ -1409,7 +1029,7 @@
 
             nodes.push({
                 id: intId,
-                label: "Heterotrophic Carbon Scavenging",
+                label: "D-mannitol Enrichment of Pseudomonas in the Chlorella Phytomicrobiome",
                 type: "interaction",
                 interactionType: intType,
                 metabolites: metabolites,
@@ -1418,140 +1038,17 @@
             });
 
             
-            var srcKey = "Thermoplasmatales environmental lineage";
+            var srcKey = "Chlorella fusca CHK0059";
             if (taxonNodeIds[srcKey]) {
                 links.push({ source: taxonNodeIds[srcKey], target: intId });
             }
             
 
             
-            var tgtKey = "Candidate Division OP3";
+            var tgtKey = "Pseudomonas";
             if (taxonNodeIds[tgtKey]) {
                 links.push({ source: intId, target: taxonNodeIds[tgtKey] });
             }
-            
-        })();
-        
-        (function() {
-            var intId = "interaction:2";
-            var intType = "SYNTROPHY";
-            var metabolites = [];
-            
-            
-            metabolites.push("hydrogen");
-            
-            metabolites.push("acetate");
-            
-            
-            var processes = [];
-            
-            
-            processes.push("fermentation");
-            
-            
-            var evidenceCount = 1;
-
-            nodes.push({
-                id: intId,
-                label: "Fermentation and Syntrophy",
-                type: "interaction",
-                interactionType: intType,
-                metabolites: metabolites,
-                processes: processes,
-                evidenceCount: evidenceCount
-            });
-
-            
-            var srcKey = "Firmicutes";
-            if (taxonNodeIds[srcKey]) {
-                links.push({ source: taxonNodeIds[srcKey], target: intId });
-            }
-            
-
-            
-            var tgtKey = "Thermoplasmatales environmental lineage";
-            if (taxonNodeIds[tgtKey]) {
-                links.push({ source: intId, target: taxonNodeIds[tgtKey] });
-            }
-            
-        })();
-        
-        (function() {
-            var intId = "interaction:3";
-            var intType = "CROSS_FEEDING";
-            var metabolites = [];
-            
-            
-            metabolites.push("organic molecular entity");
-            
-            metabolites.push("dihydrogen");
-            
-            
-            var processes = [];
-            
-            var evidenceCount = 1;
-
-            nodes.push({
-                id: intId,
-                label: "Proteobacterial Oligotrophic Metabolism",
-                type: "interaction",
-                interactionType: intType,
-                metabolites: metabolites,
-                processes: processes,
-                evidenceCount: evidenceCount
-            });
-
-            
-            var srcKey = "Alphaproteobacteria";
-            if (taxonNodeIds[srcKey]) {
-                links.push({ source: taxonNodeIds[srcKey], target: intId });
-            }
-            
-
-            
-            var tgtKey = "Betaproteobacteria";
-            if (taxonNodeIds[tgtKey]) {
-                links.push({ source: intId, target: taxonNodeIds[tgtKey] });
-            }
-            
-        })();
-        
-        (function() {
-            var intId = "interaction:4";
-            var intType = "CROSS_FEEDING";
-            var metabolites = [];
-            
-            
-            metabolites.push("nitrite");
-            
-            metabolites.push("dinitrogen");
-            
-            
-            var processes = [];
-            
-            
-            processes.push("denitrification");
-            
-            
-            var evidenceCount = 1;
-
-            nodes.push({
-                id: intId,
-                label: "Denitrification by Betaproteobacteria",
-                type: "interaction",
-                interactionType: intType,
-                metabolites: metabolites,
-                processes: processes,
-                evidenceCount: evidenceCount
-            });
-
-            
-            var srcKey = "Betaproteobacteria";
-            if (taxonNodeIds[srcKey]) {
-                links.push({ source: taxonNodeIds[srcKey], target: intId });
-            }
-            
-
             
         })();
         
@@ -1571,7 +1068,7 @@
         var svg = d3.select("#network-svg");
         var width = container.clientWidth - 32;
         // Dynamic height based on node count: minimum 500px, add 40px per node
-        var nodeCount = 11;
+        var nodeCount = 9;
         var height = Math.max(500, 400 + nodeCount * 20);
         svg.attr("width", width).attr("height", height);
 

--- a/docs/communities/Desulfovibrio_Methanococcus_Syntrophy.html
+++ b/docs/communities/Desulfovibrio_Methanococcus_Syntrophy.html
@@ -638,7 +638,7 @@
                             - SUPPORT (IN_VITRO)
                         </div>
                         
-                        <div class="snippet">"During syntrophic growth on lactate with a hydrogenotrophic methanogen, numerous genes involved in electron transfer and energy generation were upregu"</div>
+                        <div class="snippet">"During syntrophic growth on lactate with a hydrogenotrophic methanogen, numerous genes involved in electron transfer and energy generation were upregulated in D. vulgaris"</div>
                         
                     </li>
                     

--- a/docs/communities/EcoFAB_Ring_Trial_SynCom17.html
+++ b/docs/communities/EcoFAB_Ring_Trial_SynCom17.html
@@ -681,9 +681,9 @@
                             <strong>Bosea sp. OAE506</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=169215"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=85413"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:169215
+                                NCBITaxon:85413
                             </a>
                         </td>
                         <td>
@@ -2192,7 +2192,7 @@
         };
         
         taxonData["Bosea sp. OAE506"] = {
-            id: "NCBITaxon:169215",
+            id: "NCBITaxon:85413",
             label: "Bosea sp. OAE506",
             abundance: "UNKNOWN",
             roles: []

--- a/docs/communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.html
+++ b/docs/communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>BioModels MODEL1806250005 Cicada Sulcia-Hodgkinia Symbiosis - CommunityMech</title>
+    <title>Eucalyptus Nursery Five-Strain Bacterial Inoculant Consortium - CommunityMech</title>
     <style>
         :root {
             --primary: #3D7DD6;
@@ -372,7 +372,7 @@
     <header>
         <div class="container">
             <a href="../browser.html" class="back-link">← Back to Communities</a>
-            <h1>BioModels MODEL1806250005 Cicada Sulcia-Hodgkinia Symbiosis</h1>
+            <h1>Eucalyptus Nursery Five-Strain Bacterial Inoculant Consortium</h1>
         </div>
     </header>
 
@@ -383,19 +383,31 @@
                 <div class="metadata-item">
                     <span class="metadata-label">Community ID</span>
                     <span class="metadata-value">
-                        <code style="background: var(--border); color: var(--text); padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.9rem;">CommunityMech:000008</code>
+                        <code style="background: var(--border); color: var(--text); padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.9rem;">CommunityMech:000316</code>
                     </span>
                 </div>
 
                 <div class="metadata-item">
                     <span class="metadata-label">Ecological State</span>
                     <span class="metadata-value">
-                        <span class="badge badge-natural">
-                            STABLE
+                        <span class="badge badge-engineered">
+                            ENGINEERED
                         </span>
                     </span>
                 </div>
 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Environment</span>
+                    <span class="metadata-value">
+                        Eucalyptus nursery rhizosphere
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_00005801"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:00005801
+                        </a>
+                    </span>
+                </div>
                 
                 
             </div>
@@ -404,7 +416,8 @@
         <!-- Description -->
         
         <section class="description">
-            <p>BioModels record MODEL1806250005 is a multi-compartment metabolic model of the cicada Neotibicen canicularis and its bacterial endosymbionts Sulcia and Hodgkinia.</p>
+            <p>A five-strain synthetic consortium of Eucalyptus-derived bacteria — Bacillus subtilis, Paraburkholderia caribensis, Methylobacterium tardum, and two strains representing putative novel species in Paenibacillus and Mesorhizobium — assembled from isolates of Eucalyptus rhizosphere and roots and selected for complementary functional traits in nitrogen cycling and rhizosphere colonisation. Applied to three Eucalyptus clones in a large tree-nursery field experiment and assessed after 13 weeks, the inoculant did not change bacterial richness or diversity but did alter root microbial community structure; two genotypes showed improved seedling quality and one showed mortality fall from 21.8% to 6.7%. The record captures a case where a defined inoculant reshapes community composition and host outcome without shifting diversity metrics, and where the response is genotype-dependent rather than uniform.
+</p>
         </section>
         
 
@@ -425,70 +438,217 @@
                     
                     <tr>
                         <td>
-                            <strong>Neotibicen canicularis</strong>
+                            <strong>Bacillus subtilis</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1699721"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1423"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:1699721
+                                NCBITaxon:1423
                             </a>
                         </td>
                         <td>
-                            
-                            <div class="roles-list">
-                                
-                                <span class="role-badge">CROSS_FEEDER</span>
-                                
-                            </div>
                             
                         </td>
                         <td>N/A</td>
                     </tr>
                     
-                    
-                    <tr>
-                        <td>
-                            <strong>Sulcia</strong>
-                        </td>
-                        <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=336809"
-                               class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:336809
-                            </a>
-                        </td>
-                        <td>
-                            
-                            <div class="roles-list">
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
                                 
-                                <span class="role-badge">SYNTROPHIC_PARTNER</span>
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/42050290/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42050290</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"The consortium comprises five strains, including Bacillus subtilis, Paraburkholderia caribensis, and Methylobacterium tardum"</div>
+                                    
+                                </li>
                                 
-                            </div>
-                            
+                            </ul>
                         </td>
-                        <td>N/A</td>
                     </tr>
                     
                     
                     <tr>
                         <td>
-                            <strong>Hodgkinia</strong>
+                            <strong>Paraburkholderia caribensis</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=573657"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=75105"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:573657
+                                NCBITaxon:75105
                             </a>
                         </td>
                         <td>
                             
-                            <div class="roles-list">
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
                                 
-                                <span class="role-badge">SYNTROPHIC_PARTNER</span>
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/42050290/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42050290</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"The consortium comprises five strains, including Bacillus subtilis, Paraburkholderia caribensis, and Methylobacterium tardum"</div>
+                                    
+                                </li>
                                 
-                            </div>
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td>
+                            <strong>Methylobacterium tardum</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=374432"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:374432
+                            </a>
+                        </td>
+                        <td>
                             
                         </td>
                         <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/42050290/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42050290</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"The consortium comprises five strains, including Bacillus subtilis, Paraburkholderia caribensis, and Methylobacterium tardum"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td>
+                            <strong>Paenibacillus sp. (putative novel species)</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=44249"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:44249
+                            </a>
+                        </td>
+                        <td>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/42050290/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42050290</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"two strains representing putative novel species within the genera Paenibacillus and Mesorhizobium, based on metagenome-assembled genome (MAG) analyses"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td>
+                            <strong>Mesorhizobium sp. (putative novel species)</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=68287"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:68287
+                            </a>
+                        </td>
+                        <td>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/42050290/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42050290</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"two strains representing putative novel species within the genera Paenibacillus and Mesorhizobium, based on metagenome-assembled genome (MAG) analyses"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td>
+                            <strong>Eucalyptus (three clones)</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=3932"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:3932
+                            </a>
+                        </td>
+                        <td>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/42050290/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42050290</a>
+                                    
+                                    - SUPPORT (IN_VIVO)
+                                    
+                                    <div class="snippet">"was applied to three Eucalyptus clones, a large field experiment was conducted in a tree nursery"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
                     </tr>
                     
                     
@@ -504,7 +664,7 @@
             <div class="network-container" id="network-container">
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
-                    <title id="network-svg-title">Ecological interaction network for BioModels MODEL1806250005 Cicada Sulcia-Hodgkinia Symbiosis</title>
+                    <title id="network-svg-title">Ecological interaction network for Eucalyptus Nursery Five-Strain Bacterial Inoculant Consortium</title>
                     <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
@@ -520,34 +680,14 @@
             
             <div class="interaction-card">
                 <div class="interaction-header">
-                    <h3>Sulcia Essential Amino Acid Provisioning</h3>
+                    <h3>Genotype-Dependent Improvement of Seedling Quality and Survival</h3>
                     <span class="interaction-type">MUTUALISM</span>
                 </div>
 
                 
-                <p><strong>Source Taxon:</strong> Sulcia</p>
-                
 
                 
-                <p><strong>Target Taxon:</strong> Neotibicen canicularis</p>
-                
 
-                
-                <p><strong>Metabolites:</strong>
-                    
-                    L-leucine
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=15603"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:15603</a>), 
-                    
-                    L-isoleucine
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=17191"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:17191</a>), 
-                    
-                    nitrogen
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=25555"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:25555</a>)
-                    
-                </p>
                 
 
                 
@@ -561,88 +701,13 @@
                     <li class="evidence-item">
                         <div>
                             
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/42050290/"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42050290</a>
                             
-                            - SUPPORT (COMPUTATIONAL)
+                            - PARTIAL (IN_VIVO)
                         </div>
                         
-                        <div class="snippet">"Sulcia and Hodgkinia with genomes of ≤0.3 Mb are calculated to recycle ∼30 to 80% of host-derived nitrogen to essential amino acids returned to the host"</div>
-                        
-                    </li>
-                    
-                    <li class="evidence-item">
-                        <div>
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
-                            
-                            - SUPPORT (COMPUTATIONAL)
-                        </div>
-                        
-                        <div class="snippet">"Our simulations reveal extensive bidirectional flux of multiple metabolites between each symbiont and the host"</div>
-                        
-                    </li>
-                    
-                </ul>
-                
-            </div>
-            
-            <div class="interaction-card">
-                <div class="interaction-header">
-                    <h3>Hodgkinia Metabolic Complementarity</h3>
-                    <span class="interaction-type">MUTUALISM</span>
-                </div>
-
-                
-                <p><strong>Source Taxon:</strong> Hodgkinia</p>
-                
-
-                
-                <p><strong>Target Taxon:</strong> Neotibicen canicularis</p>
-                
-
-                
-                <p><strong>Metabolites:</strong>
-                    
-                    nitrogen
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=25555"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:25555</a>)
-                    
-                </p>
-                
-
-                
-
-                
-
-                
-                <h4>Evidence</h4>
-                <ul class="evidence-list">
-                    
-                    <li class="evidence-item">
-                        <div>
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
-                            
-                            - SUPPORT (COMPUTATIONAL)
-                        </div>
-                        
-                        <div class="snippet">"Sulcia and Hodgkinia with genomes of ≤0.3 Mb are calculated to recycle ∼30 to 80% of host-derived nitrogen to essential amino acids returned to the host"</div>
-                        
-                    </li>
-                    
-                    <li class="evidence-item">
-                        <div>
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
-                            
-                            - SUPPORT (COMPUTATIONAL)
-                        </div>
-                        
-                        <div class="snippet">"near-complete metabolic segregation (i.e., near absence of metabolic cross-feeding) between the two symbionts, a likely mode of host control over symbiont metabolism"</div>
+                        <div class="snippet">"Two genotypes exhibited improved seedling quality, with a higher proportion classified into superior categories, and one genotype showed a significant reduction in mortality (from 21.8% to 6.7%)"</div>
                         
                     </li>
                     
@@ -655,83 +720,27 @@
 
         <!-- Associated Datasets -->
         
-        <section>
-            <h2>Associated Datasets</h2>
-            <table>
-                <thead>
-                    <tr>
-                        <th>Dataset</th>
-                        <th>Type</th>
-                        <th>Repository</th>
-                        <th>Accession</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    
-                    <tr>
-                        <td>
-                            <strong>BioModels model file</strong>
-                            
-                            <br><span class="dataset-description">Multi-compartment SBML model for cicada symbiosis.</span>
-                            
-                        </td>
-                        <td><span class="role-badge">OTHER</span></td>
-                        <td>OTHER</td>
-                        <td>
-                            
-                            <a href="https://www.ebi.ac.uk/biomodels/MODEL1806250005" class="term-link" target="_blank" rel="noopener noreferrer">Neotibicen_iNA533.xml</a>
-                            
-                        </td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                            <strong>Primary publication</strong>
-                            
-                            <br><span class="dataset-description">Study on the cost of metabolic interactions in insect-bacterial symbioses.</span>
-                            
-                        </td>
-                        <td><span class="role-badge">OTHER</span></td>
-                        <td>OTHER</td>
-                        <td>
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/" class="term-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
-                            
-                        </td>
-                    </tr>
-                    
-                </tbody>
-            </table>
-        </section>
-        
 
         <!-- Environmental Factors -->
         
+
+        
         <section>
-            <h2>External Resources</h2>
+            <h2>Environmental Factors</h2>
             <table>
                 <thead>
                     <tr>
-                        <th>Name</th>
-                        <th>Repository</th>
-                        <th>Resource ID</th>
+                        <th>Factor</th>
+                        <th>Value</th>
+                        <th>Unit</th>
                     </tr>
                 </thead>
                 <tbody>
                     
                     <tr>
-                        <td>
-                            <strong>BioModels entry</strong>
-                            
-                            <br><span class="dataset-description">Cicada symbiosis metabolic model.</span>
-                            
-                        </td>
-                        <td>BIOMODELS</td>
-                        <td>
-                            
-                            <a href="https://www.ebi.ac.uk/biomodels/MODEL1806250005" class="term-link" target="_blank" rel="noopener noreferrer">MODEL1806250005</a>
-                            
-                        </td>
+                        <td><strong>Root community restructuring without diversity change</strong></td>
+                        <td></td>
+                        <td>N/A</td>
                     </tr>
                     
                     <tr class="evidence-row-container">
@@ -740,12 +749,38 @@
                                 
                                 <li class="evidence-item">
                                     
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/42050290/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42050290</a>
                                     
-                                    - SUPPORT (COMPUTATIONAL)
+                                    - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"The Cost of Metabolic Interactions in Symbioses between Insects and Bacteria with Reduced Genomes."</div>
+                                    <div class="snippet">"While inoculation did not significantly affect bacterial richness and diversity, it altered the root microbial community structure"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td><strong>Tree-nursery field trial</strong></td>
+                        <td>three Eucalyptus clones; 13 weeks</td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="3">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/42050290/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42050290</a>
+                                    
+                                    - SUPPORT (IN_VIVO)
+                                    
+                                    <div class="snippet">"After 13 weeks, we assessed microbial diversity, morphological seedling traits, and survival rates"</div>
                                     
                                 </li>
                                 
@@ -757,8 +792,6 @@
                 </tbody>
             </table>
         </section>
-        
-
         
 
         <!-- Growth Media -->
@@ -791,25 +824,46 @@
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
-        taxonData["Neotibicen canicularis"] = {
-            id: "NCBITaxon:1699721",
-            label: "Neotibicen canicularis",
+        taxonData["Bacillus subtilis"] = {
+            id: "NCBITaxon:1423",
+            label: "Bacillus subtilis",
             abundance: "UNKNOWN",
-            roles: ["CROSS_FEEDER"]
+            roles: []
         };
         
-        taxonData["Sulcia"] = {
-            id: "NCBITaxon:336809",
-            label: "Sulcia",
+        taxonData["Paraburkholderia caribensis"] = {
+            id: "NCBITaxon:75105",
+            label: "Paraburkholderia caribensis",
             abundance: "UNKNOWN",
-            roles: ["SYNTROPHIC_PARTNER"]
+            roles: []
         };
         
-        taxonData["Hodgkinia"] = {
-            id: "NCBITaxon:573657",
-            label: "Hodgkinia",
+        taxonData["Methylobacterium tardum"] = {
+            id: "NCBITaxon:374432",
+            label: "Methylobacterium tardum",
             abundance: "UNKNOWN",
-            roles: ["SYNTROPHIC_PARTNER"]
+            roles: []
+        };
+        
+        taxonData["Paenibacillus sp. (putative novel species)"] = {
+            id: "NCBITaxon:44249",
+            label: "Paenibacillus sp. (putative novel species)",
+            abundance: "UNKNOWN",
+            roles: []
+        };
+        
+        taxonData["Mesorhizobium sp. (putative novel species)"] = {
+            id: "NCBITaxon:68287",
+            label: "Mesorhizobium sp. (putative novel species)",
+            abundance: "UNKNOWN",
+            roles: []
+        };
+        
+        taxonData["Eucalyptus (three clones)"] = {
+            id: "NCBITaxon:3932",
+            label: "Eucalyptus (three clones)",
+            abundance: "UNKNOWN",
+            roles: []
         };
         
 
@@ -840,21 +894,13 @@
             var intType = "MUTUALISM";
             var metabolites = [];
             
-            
-            metabolites.push("L-leucine");
-            
-            metabolites.push("L-isoleucine");
-            
-            metabolites.push("nitrogen");
-            
-            
             var processes = [];
             
-            var evidenceCount = 2;
+            var evidenceCount = 1;
 
             nodes.push({
                 id: intId,
-                label: "Sulcia Essential Amino Acid Provisioning",
+                label: "Genotype-Dependent Improvement of Seedling Quality and Survival",
                 type: "interaction",
                 interactionType: intType,
                 metabolites: metabolites,
@@ -863,55 +909,7 @@
             });
 
             
-            var srcKey = "Sulcia";
-            if (taxonNodeIds[srcKey]) {
-                links.push({ source: taxonNodeIds[srcKey], target: intId });
-            }
-            
 
-            
-            var tgtKey = "Neotibicen canicularis";
-            if (taxonNodeIds[tgtKey]) {
-                links.push({ source: intId, target: taxonNodeIds[tgtKey] });
-            }
-            
-        })();
-        
-        (function() {
-            var intId = "interaction:1";
-            var intType = "MUTUALISM";
-            var metabolites = [];
-            
-            
-            metabolites.push("nitrogen");
-            
-            
-            var processes = [];
-            
-            var evidenceCount = 2;
-
-            nodes.push({
-                id: intId,
-                label: "Hodgkinia Metabolic Complementarity",
-                type: "interaction",
-                interactionType: intType,
-                metabolites: metabolites,
-                processes: processes,
-                evidenceCount: evidenceCount
-            });
-
-            
-            var srcKey = "Hodgkinia";
-            if (taxonNodeIds[srcKey]) {
-                links.push({ source: taxonNodeIds[srcKey], target: intId });
-            }
-            
-
-            
-            var tgtKey = "Neotibicen canicularis";
-            if (taxonNodeIds[tgtKey]) {
-                links.push({ source: intId, target: taxonNodeIds[tgtKey] });
-            }
             
         })();
         
@@ -931,7 +929,7 @@
         var svg = d3.select("#network-svg");
         var width = container.clientWidth - 32;
         // Dynamic height based on node count: minimum 500px, add 40px per node
-        var nodeCount = 5;
+        var nodeCount = 7;
         var height = Math.max(500, 400 + nodeCount * 20);
         svg.attr("width", width).attr("height", height);
 

--- a/docs/communities/Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.html
+++ b/docs/communities/Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.html
@@ -774,10 +774,10 @@ MECHANISM CONTESTED - do not read this record as establishing contact-dependent 
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28287150/"
                                class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:28287150</a>
                             
-                            - SUPPORT (IN_VITRO)
+                            - PARTIAL (IN_VITRO)
                         </div>
                         
-                        <div class="snippet">"Direct interspecies electron transfer (DIET) mechanism has been recently characterised with Geobacter species which couple the electron balance with o"</div>
+                        <div class="snippet">"Direct interspecies electron transfer (DIET) mechanism has been recently characterised with Geobacter species which couple the electron balance with other species through physical contacts"</div>
                         
                     </li>
                     

--- a/docs/communities/Human_Gut_FourMember_Proteome_Complementarity_Consortium.html
+++ b/docs/communities/Human_Gut_FourMember_Proteome_Complementarity_Consortium.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>BioModels MODEL1806250005 Cicada Sulcia-Hodgkinia Symbiosis - CommunityMech</title>
+    <title>Human Gut Four-Member Proteome-Complementarity Consortium - CommunityMech</title>
     <style>
         :root {
             --primary: #3D7DD6;
@@ -372,7 +372,7 @@
     <header>
         <div class="container">
             <a href="../browser.html" class="back-link">← Back to Communities</a>
-            <h1>BioModels MODEL1806250005 Cicada Sulcia-Hodgkinia Symbiosis</h1>
+            <h1>Human Gut Four-Member Proteome-Complementarity Consortium</h1>
         </div>
     </header>
 
@@ -383,20 +383,47 @@
                 <div class="metadata-item">
                     <span class="metadata-label">Community ID</span>
                     <span class="metadata-value">
-                        <code style="background: var(--border); color: var(--text); padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.9rem;">CommunityMech:000008</code>
+                        <code style="background: var(--border); color: var(--text); padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.9rem;">CommunityMech:000317</code>
                     </span>
                 </div>
 
                 <div class="metadata-item">
                     <span class="metadata-label">Ecological State</span>
                     <span class="metadata-value">
-                        <span class="badge badge-natural">
-                            STABLE
+                        <span class="badge badge-engineered">
+                            ENGINEERED
                         </span>
                     </span>
                 </div>
 
                 
+                <div class="metadata-item">
+                    <span class="metadata-label">Environment</span>
+                    <span class="metadata-value">
+                        laboratory anaerobic co-culture
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01001405"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:01001405
+                        </a>
+                    </span>
+                </div>
+                
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        human gut
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_2100002"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:2100002
+                        </a>
+                        
+                        
+                    </span>
+                </div>
                 
             </div>
         </section>
@@ -404,7 +431,8 @@
         <!-- Description -->
         
         <section class="description">
-            <p>BioModels record MODEL1806250005 is a multi-compartment metabolic model of the cicada Neotibicen canicularis and its bacterial endosymbionts Sulcia and Hodgkinia.</p>
+            <p>A defined four-member consortium of metabolically distinct human gut anaerobes — Eubacterium hallii, Roseburia intestinalis, Marvinbryantia formatexigens and Faecalibacterium prausnitzii — assembled in all pairwise combinations and as the full community, on distinct carbon sources, and profiled by species-resolved proteomics. The finding is regulatory rather than compositional: bacteria modulate protein abundance in response to specific partners, and those partner-specific shifts reduce functional overlap between members and are frequently associated with increased community productivity. Biotic interactions, not the carbon source, dominated proteomic variation. The record captures a community whose members divide labour by changing what they express in each other&#39;s presence, so metabolic complementarity is an outcome of regulation rather than a fixed property of the members.
+</p>
         </section>
         
 
@@ -425,70 +453,145 @@
                     
                     <tr>
                         <td>
-                            <strong>Neotibicen canicularis</strong>
+                            <strong>Eubacterium hallii</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1699721"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=39488"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:1699721
+                                NCBITaxon:39488
                             </a>
                         </td>
                         <td>
-                            
-                            <div class="roles-list">
-                                
-                                <span class="role-badge">CROSS_FEEDER</span>
-                                
-                            </div>
                             
                         </td>
                         <td>N/A</td>
                     </tr>
                     
-                    
-                    <tr>
-                        <td>
-                            <strong>Sulcia</strong>
-                        </td>
-                        <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=336809"
-                               class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:336809
-                            </a>
-                        </td>
-                        <td>
-                            
-                            <div class="roles-list">
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
                                 
-                                <span class="role-badge">SYNTROPHIC_PARTNER</span>
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/42032280/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42032280</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"Eubacterium hallii is a versatile anaerobe that ferments glucose and lactate into butyrate and hydrogen, and can utilize glycerol to produce 1,3-propanediol"</div>
+                                    
+                                </li>
                                 
-                            </div>
-                            
+                            </ul>
                         </td>
-                        <td>N/A</td>
                     </tr>
                     
                     
                     <tr>
                         <td>
-                            <strong>Hodgkinia</strong>
+                            <strong>Roseburia intestinalis</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=573657"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=166486"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:573657
+                                NCBITaxon:166486
                             </a>
                         </td>
                         <td>
                             
-                            <div class="roles-list">
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
                                 
-                                <span class="role-badge">SYNTROPHIC_PARTNER</span>
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/42032280/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42032280</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"Roseburia intestinalis degrades hemicellulose and starch, producing butyrate as a terminal metabolite, and is frequently associated with dietary fibre metabolism"</div>
+                                    
+                                </li>
                                 
-                            </div>
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td>
+                            <strong>Marvinbryantia formatexigens</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=168384"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:168384
+                            </a>
+                        </td>
+                        <td>
                             
                         </td>
                         <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/42032280/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42032280</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"Marvinbryantia formatexigens specializes in degrading amorphous cellulose and produces formate and acetate as fermentation end products"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td>
+                            <strong>Faecalibacterium prausnitzii</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=853"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:853
+                            </a>
+                        </td>
+                        <td>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/42032280/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42032280</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"Faecalibacterium prausnitzii is a prominent butyrate producer with proposed anti-inflammatory effects"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
                     </tr>
                     
                     
@@ -504,15 +607,15 @@
             <div class="network-container" id="network-container">
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
-                    <title id="network-svg-title">Ecological interaction network for BioModels MODEL1806250005 Cicada Sulcia-Hodgkinia Symbiosis</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <title id="network-svg-title">Ecological interaction network for Human Gut Four-Member Proteome-Complementarity Consortium</title>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -520,32 +623,28 @@
             
             <div class="interaction-card">
                 <div class="interaction-header">
-                    <h3>Sulcia Essential Amino Acid Provisioning</h3>
-                    <span class="interaction-type">MUTUALISM</span>
+                    <h3>Partner-Specific Proteome Remodelling Reduces Functional Overlap</h3>
+                    <span class="interaction-type">NICHE_PARTITIONING</span>
                 </div>
 
                 
-                <p><strong>Source Taxon:</strong> Sulcia</p>
-                
 
-                
-                <p><strong>Target Taxon:</strong> Neotibicen canicularis</p>
                 
 
                 
                 <p><strong>Metabolites:</strong>
                     
-                    L-leucine
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=15603"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:15603</a>), 
+                    butyrate
+                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=17968"
+                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:17968</a>), 
                     
-                    L-isoleucine
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=17191"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:17191</a>), 
+                    formate
+                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=15740"
+                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:15740</a>), 
                     
-                    nitrogen
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=25555"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:25555</a>)
+                    acetate
+                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=30089"
+                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:30089</a>)
                     
                 </p>
                 
@@ -561,88 +660,26 @@
                     <li class="evidence-item">
                         <div>
                             
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/42032280/"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42032280</a>
                             
-                            - SUPPORT (COMPUTATIONAL)
+                            - SUPPORT (IN_VITRO)
                         </div>
                         
-                        <div class="snippet">"Sulcia and Hodgkinia with genomes of ≤0.3 Mb are calculated to recycle ∼30 to 80% of host-derived nitrogen to essential amino acids returned to the host"</div>
+                        <div class="snippet">"These interactions led to reproducible, partner-specific expression shifts that significantly reduced functional overlap and were frequently associated with increased community productivity"</div>
                         
                     </li>
                     
                     <li class="evidence-item">
                         <div>
                             
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/42032280/"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42032280</a>
                             
-                            - SUPPORT (COMPUTATIONAL)
+                            - SUPPORT (IN_VITRO)
                         </div>
                         
-                        <div class="snippet">"Our simulations reveal extensive bidirectional flux of multiple metabolites between each symbiont and the host"</div>
-                        
-                    </li>
-                    
-                </ul>
-                
-            </div>
-            
-            <div class="interaction-card">
-                <div class="interaction-header">
-                    <h3>Hodgkinia Metabolic Complementarity</h3>
-                    <span class="interaction-type">MUTUALISM</span>
-                </div>
-
-                
-                <p><strong>Source Taxon:</strong> Hodgkinia</p>
-                
-
-                
-                <p><strong>Target Taxon:</strong> Neotibicen canicularis</p>
-                
-
-                
-                <p><strong>Metabolites:</strong>
-                    
-                    nitrogen
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=25555"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:25555</a>)
-                    
-                </p>
-                
-
-                
-
-                
-
-                
-                <h4>Evidence</h4>
-                <ul class="evidence-list">
-                    
-                    <li class="evidence-item">
-                        <div>
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
-                            
-                            - SUPPORT (COMPUTATIONAL)
-                        </div>
-                        
-                        <div class="snippet">"Sulcia and Hodgkinia with genomes of ≤0.3 Mb are calculated to recycle ∼30 to 80% of host-derived nitrogen to essential amino acids returned to the host"</div>
-                        
-                    </li>
-                    
-                    <li class="evidence-item">
-                        <div>
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
-                            
-                            - SUPPORT (COMPUTATIONAL)
-                        </div>
-                        
-                        <div class="snippet">"near-complete metabolic segregation (i.e., near absence of metabolic cross-feeding) between the two symbionts, a likely mode of host control over symbiont metabolism"</div>
+                        <div class="snippet">"We found that biotic interactions, rather than abiotic conditions, were the dominant drivers of proteomic variation"</div>
                         
                     </li>
                     
@@ -655,83 +692,27 @@
 
         <!-- Associated Datasets -->
         
-        <section>
-            <h2>Associated Datasets</h2>
-            <table>
-                <thead>
-                    <tr>
-                        <th>Dataset</th>
-                        <th>Type</th>
-                        <th>Repository</th>
-                        <th>Accession</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    
-                    <tr>
-                        <td>
-                            <strong>BioModels model file</strong>
-                            
-                            <br><span class="dataset-description">Multi-compartment SBML model for cicada symbiosis.</span>
-                            
-                        </td>
-                        <td><span class="role-badge">OTHER</span></td>
-                        <td>OTHER</td>
-                        <td>
-                            
-                            <a href="https://www.ebi.ac.uk/biomodels/MODEL1806250005" class="term-link" target="_blank" rel="noopener noreferrer">Neotibicen_iNA533.xml</a>
-                            
-                        </td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                            <strong>Primary publication</strong>
-                            
-                            <br><span class="dataset-description">Study on the cost of metabolic interactions in insect-bacterial symbioses.</span>
-                            
-                        </td>
-                        <td><span class="role-badge">OTHER</span></td>
-                        <td>OTHER</td>
-                        <td>
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/" class="term-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
-                            
-                        </td>
-                    </tr>
-                    
-                </tbody>
-            </table>
-        </section>
-        
 
         <!-- Environmental Factors -->
         
+
+        
         <section>
-            <h2>External Resources</h2>
+            <h2>Environmental Factors</h2>
             <table>
                 <thead>
                     <tr>
-                        <th>Name</th>
-                        <th>Repository</th>
-                        <th>Resource ID</th>
+                        <th>Factor</th>
+                        <th>Value</th>
+                        <th>Unit</th>
                     </tr>
                 </thead>
                 <tbody>
                     
                     <tr>
-                        <td>
-                            <strong>BioModels entry</strong>
-                            
-                            <br><span class="dataset-description">Cicada symbiosis metabolic model.</span>
-                            
-                        </td>
-                        <td>BIOMODELS</td>
-                        <td>
-                            
-                            <a href="https://www.ebi.ac.uk/biomodels/MODEL1806250005" class="term-link" target="_blank" rel="noopener noreferrer">MODEL1806250005</a>
-                            
-                        </td>
+                        <td><strong>Distinct carbon sources</strong></td>
+                        <td></td>
+                        <td>N/A</td>
                     </tr>
                     
                     <tr class="evidence-row-container">
@@ -740,12 +721,12 @@
                                 
                                 <li class="evidence-item">
                                     
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/42032280/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42032280</a>
                                     
-                                    - SUPPORT (COMPUTATIONAL)
+                                    - SUPPORT (IN_VITRO)
                                     
-                                    <div class="snippet">"The Cost of Metabolic Interactions in Symbioses between Insects and Bacteria with Reduced Genomes."</div>
+                                    <div class="snippet">"Using synthetic gut-derived consortia exposed to distinct carbon sources"</div>
                                     
                                 </li>
                                 
@@ -757,8 +738,6 @@
                 </tbody>
             </table>
         </section>
-        
-
         
 
         <!-- Growth Media -->
@@ -791,25 +770,32 @@
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
-        taxonData["Neotibicen canicularis"] = {
-            id: "NCBITaxon:1699721",
-            label: "Neotibicen canicularis",
+        taxonData["Eubacterium hallii"] = {
+            id: "NCBITaxon:39488",
+            label: "Eubacterium hallii",
             abundance: "UNKNOWN",
-            roles: ["CROSS_FEEDER"]
+            roles: []
         };
         
-        taxonData["Sulcia"] = {
-            id: "NCBITaxon:336809",
-            label: "Sulcia",
+        taxonData["Roseburia intestinalis"] = {
+            id: "NCBITaxon:166486",
+            label: "Roseburia intestinalis",
             abundance: "UNKNOWN",
-            roles: ["SYNTROPHIC_PARTNER"]
+            roles: []
         };
         
-        taxonData["Hodgkinia"] = {
-            id: "NCBITaxon:573657",
-            label: "Hodgkinia",
+        taxonData["Marvinbryantia formatexigens"] = {
+            id: "NCBITaxon:168384",
+            label: "Marvinbryantia formatexigens",
             abundance: "UNKNOWN",
-            roles: ["SYNTROPHIC_PARTNER"]
+            roles: []
+        };
+        
+        taxonData["Faecalibacterium prausnitzii"] = {
+            id: "NCBITaxon:853",
+            label: "Faecalibacterium prausnitzii",
+            abundance: "UNKNOWN",
+            roles: []
         };
         
 
@@ -837,15 +823,15 @@
         
         (function() {
             var intId = "interaction:0";
-            var intType = "MUTUALISM";
+            var intType = "NICHE_PARTITIONING";
             var metabolites = [];
             
             
-            metabolites.push("L-leucine");
+            metabolites.push("butyrate");
             
-            metabolites.push("L-isoleucine");
+            metabolites.push("formate");
             
-            metabolites.push("nitrogen");
+            metabolites.push("acetate");
             
             
             var processes = [];
@@ -854,7 +840,7 @@
 
             nodes.push({
                 id: intId,
-                label: "Sulcia Essential Amino Acid Provisioning",
+                label: "Partner-Specific Proteome Remodelling Reduces Functional Overlap",
                 type: "interaction",
                 interactionType: intType,
                 metabolites: metabolites,
@@ -863,55 +849,7 @@
             });
 
             
-            var srcKey = "Sulcia";
-            if (taxonNodeIds[srcKey]) {
-                links.push({ source: taxonNodeIds[srcKey], target: intId });
-            }
-            
 
-            
-            var tgtKey = "Neotibicen canicularis";
-            if (taxonNodeIds[tgtKey]) {
-                links.push({ source: intId, target: taxonNodeIds[tgtKey] });
-            }
-            
-        })();
-        
-        (function() {
-            var intId = "interaction:1";
-            var intType = "MUTUALISM";
-            var metabolites = [];
-            
-            
-            metabolites.push("nitrogen");
-            
-            
-            var processes = [];
-            
-            var evidenceCount = 2;
-
-            nodes.push({
-                id: intId,
-                label: "Hodgkinia Metabolic Complementarity",
-                type: "interaction",
-                interactionType: intType,
-                metabolites: metabolites,
-                processes: processes,
-                evidenceCount: evidenceCount
-            });
-
-            
-            var srcKey = "Hodgkinia";
-            if (taxonNodeIds[srcKey]) {
-                links.push({ source: taxonNodeIds[srcKey], target: intId });
-            }
-            
-
-            
-            var tgtKey = "Neotibicen canicularis";
-            if (taxonNodeIds[tgtKey]) {
-                links.push({ source: intId, target: taxonNodeIds[tgtKey] });
-            }
             
         })();
         

--- a/docs/communities/Industrial_Bioreactor_Consortium.html
+++ b/docs/communities/Industrial_Bioreactor_Consortium.html
@@ -1240,7 +1240,7 @@
                             - SUPPORT (IN_VITRO)
                         </div>
                         
-                        <div class="snippet">"Thereafter, these samples were combined and then inoculated into a basal salts solution in which different substrates (ferrous sulfate, elemental sulf"</div>
+                        <div class="snippet">"Thereafter, these samples were combined and then inoculated into a basal salts solution in which different substrates (ferrous sulfate, elemental sulfur"</div>
                         
                     </li>
                     

--- a/docs/communities/KBase_ORT_Workflow_Community_Model.html
+++ b/docs/communities/KBase_ORT_Workflow_Community_Model.html
@@ -440,9 +440,9 @@
                             <strong>Nitrososphaeraceae archaeon</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=2157"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1033997"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:2157
+                                NCBITaxon:1033997
                             </a>
                         </td>
                         <td>
@@ -482,9 +482,9 @@
                             <strong>Nitrospiraceae bacterium</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1236"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=189779"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:1236
+                                NCBITaxon:189779
                             </a>
                         </td>
                         <td>
@@ -524,9 +524,9 @@
                             <strong>Steroidobacteraceae denitrifier 1</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1236"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=2689614"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:1236
+                                NCBITaxon:2689614
                             </a>
                         </td>
                         <td>
@@ -566,9 +566,9 @@
                             <strong>Steroidobacteraceae denitrifier 2</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1236"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=2689614"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:1236
+                                NCBITaxon:2689614
                             </a>
                         </td>
                         <td>
@@ -915,28 +915,28 @@
         var taxonData = {};
         
         taxonData["Nitrososphaeraceae archaeon"] = {
-            id: "NCBITaxon:2157",
+            id: "NCBITaxon:1033997",
             label: "Nitrososphaeraceae archaeon",
             abundance: "UNKNOWN",
             roles: ["PRIMARY_PRODUCER"]
         };
         
         taxonData["Nitrospiraceae bacterium"] = {
-            id: "NCBITaxon:1236",
+            id: "NCBITaxon:189779",
             label: "Nitrospiraceae bacterium",
             abundance: "UNKNOWN",
             roles: ["PRIMARY_PRODUCER"]
         };
         
         taxonData["Steroidobacteraceae denitrifier 1"] = {
-            id: "NCBITaxon:1236",
+            id: "NCBITaxon:2689614",
             label: "Steroidobacteraceae denitrifier 1",
             abundance: "UNKNOWN",
             roles: ["SECONDARY_FERMENTER"]
         };
         
         taxonData["Steroidobacteraceae denitrifier 2"] = {
-            id: "NCBITaxon:1236",
+            id: "NCBITaxon:2689614",
             label: "Steroidobacteraceae denitrifier 2",
             abundance: "UNKNOWN",
             roles: ["SECONDARY_FERMENTER"]

--- a/docs/communities/MSC1_Dominant_Core.html
+++ b/docs/communities/MSC1_Dominant_Core.html
@@ -609,9 +609,9 @@
                             <strong>Bosea sp.</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=169215"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=85413"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:169215
+                                NCBITaxon:85413
                             </a>
                         </td>
                         <td>
@@ -1848,7 +1848,7 @@
         };
         
         taxonData["Bosea sp."] = {
-            id: "NCBITaxon:169215",
+            id: "NCBITaxon:85413",
             label: "Bosea sp.",
             abundance: "COMMON",
             roles: ["SYNTROPHIC_PARTNER"]

--- a/docs/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.html
+++ b/docs/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>BioModels MODEL1806250005 Cicada Sulcia-Hodgkinia Symbiosis - CommunityMech</title>
+    <title>Mesorhizobium TaiHu-Synechococcus PCC 7002 Vitamin B12 Synthetic Consortium - CommunityMech</title>
     <style>
         :root {
             --primary: #3D7DD6;
@@ -372,7 +372,7 @@
     <header>
         <div class="container">
             <a href="../browser.html" class="back-link">← Back to Communities</a>
-            <h1>BioModels MODEL1806250005 Cicada Sulcia-Hodgkinia Symbiosis</h1>
+            <h1>Mesorhizobium TaiHu-Synechococcus PCC 7002 Vitamin B12 Synthetic Consortium</h1>
         </div>
     </header>
 
@@ -383,20 +383,47 @@
                 <div class="metadata-item">
                     <span class="metadata-label">Community ID</span>
                     <span class="metadata-value">
-                        <code style="background: var(--border); color: var(--text); padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.9rem;">CommunityMech:000008</code>
+                        <code style="background: var(--border); color: var(--text); padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.9rem;">CommunityMech:000315</code>
                     </span>
                 </div>
 
                 <div class="metadata-item">
                     <span class="metadata-label">Ecological State</span>
                     <span class="metadata-value">
-                        <span class="badge badge-natural">
-                            STABLE
+                        <span class="badge badge-engineered">
+                            ENGINEERED
                         </span>
                     </span>
                 </div>
 
                 
+                <div class="metadata-item">
+                    <span class="metadata-label">Environment</span>
+                    <span class="metadata-value">
+                        laboratory co-culture
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01001405"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:01001405
+                        </a>
+                    </span>
+                </div>
+                
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Modeled Environment</span>
+                    <span class="metadata-value">
+                        
+                        Lake Taihu freshwater bloom
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_00000021"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:00000021
+                        </a>
+                        
+                        
+                    </span>
+                </div>
                 
             </div>
         </section>
@@ -404,7 +431,8 @@
         <!-- Description -->
         
         <section class="description">
-            <p>BioModels record MODEL1806250005 is a multi-compartment metabolic model of the cicada Neotibicen canicularis and its bacterial endosymbionts Sulcia and Hodgkinia.</p>
+            <p>A synthetic consortium built by co-culturing the marine cyanobacterium Synechococcus sp. PCC 7002 (Syn7002) — a model strain that lacks the gene cluster for vitamin B12 biosynthesis and therefore depends on other microbes for it — with a bloom-forming Microcystis community from Lake Taihu, then purifying the result. Metagenomics showed the early community consisted mainly of Syn7002, Mesorhizobium sp. TaiHu (MesTH) and Pseudomonas sp. TaiHu (PseTH); PseTH declined once the community stabilised, leaving the cyanobacterium and MesTH as the persistent pair. Electron microscopy found rod-shaped bacteria clustered around Syn7002 cells. Metatranscriptomics showed vitamin B12 biosynthesis and transport genes significantly upregulated in MesTH, and B12-positive control experiments supported complementarity between the two strains, so the community is a worked example of a vitamin auxotrophy being satisfied by a partner rather than by the medium.
+</p>
         </section>
         
 
@@ -425,19 +453,19 @@
                     
                     <tr>
                         <td>
-                            <strong>Neotibicen canicularis</strong>
+                            <strong>Synechococcus sp. PCC 7002 (Syn7002)</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1699721"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=32049"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:1699721
+                                NCBITaxon:32049
                             </a>
                         </td>
                         <td>
                             
                             <div class="roles-list">
                                 
-                                <span class="role-badge">CROSS_FEEDER</span>
+                                <span class="role-badge">PRIMARY_PRODUCER</span>
                                 
                             </div>
                             
@@ -445,50 +473,131 @@
                         <td>N/A</td>
                     </tr>
                     
-                    
-                    <tr>
-                        <td>
-                            <strong>Sulcia</strong>
-                        </td>
-                        <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=336809"
-                               class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:336809
-                            </a>
-                        </td>
-                        <td>
-                            
-                            <div class="roles-list">
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
                                 
-                                <span class="role-badge">SYNTROPHIC_PARTNER</span>
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/41790499/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41790499</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"The marine cyanobacterium Synechococcus sp. PCC 7002 (Syn7002) is a model organism that lacks the gene cluster required for vitamin B12 biosynthesis, necessitating cooperative interactions with other microbes"</div>
+                                    
+                                </li>
                                 
-                            </div>
-                            
+                            </ul>
                         </td>
-                        <td>N/A</td>
                     </tr>
                     
                     
                     <tr>
                         <td>
-                            <strong>Hodgkinia</strong>
+                            <strong>Mesorhizobium sp. TaiHu (MesTH)</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=573657"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=68287"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:573657
+                                NCBITaxon:68287
                             </a>
                         </td>
                         <td>
                             
-                            <div class="roles-list">
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
                                 
-                                <span class="role-badge">SYNTROPHIC_PARTNER</span>
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/41790499/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41790499</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"Transcriptomic data further indicated that vitamin B12 biosynthesis and transport genes were significantly upregulated in MesTH"</div>
+                                    
+                                </li>
                                 
-                            </div>
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td>
+                            <strong>Pseudomonas sp. TaiHu (PseTH)</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=286"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:286
+                            </a>
+                        </td>
+                        <td>
                             
                         </td>
                         <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/41790499/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41790499</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"the early-stage community consisted mainly of Syn7002, Mesorhizobium sp. TaiHu (MesTH) and Pseudomonas sp. TaiHu (PseTH), although the abundance of PseTH declined after community stabilization"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td>
+                            <strong>bloom-forming Microcystis community (source inoculum)</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1125"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:1125
+                            </a>
+                        </td>
+                        <td>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/41790499/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41790499</a>
+                                    
+                                    - PARTIAL (IN_VITRO)
+                                    
+                                    <div class="snippet">"co-culturing Syn7002 with a bloom-forming Microcystis community"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
                     </tr>
                     
                     
@@ -504,15 +613,18 @@
             <div class="network-container" id="network-container">
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
-                    <title id="network-svg-title">Ecological interaction network for BioModels MODEL1806250005 Cicada Sulcia-Hodgkinia Symbiosis</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <title id="network-svg-title">Ecological interaction network for Mesorhizobium TaiHu-Synechococcus PCC 7002 Vitamin B12 Synthetic Consortium</title>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -520,32 +632,24 @@
             
             <div class="interaction-card">
                 <div class="interaction-header">
-                    <h3>Sulcia Essential Amino Acid Provisioning</h3>
-                    <span class="interaction-type">MUTUALISM</span>
+                    <h3>Vitamin B12 Provision from Mesorhizobium TaiHu to Synechococcus PCC 7002</h3>
+                    <span class="interaction-type">CROSS_FEEDING</span>
                 </div>
 
                 
-                <p><strong>Source Taxon:</strong> Sulcia</p>
+                <p><strong>Source Taxon:</strong> Mesorhizobium sp. TaiHu (MesTH)</p>
                 
 
                 
-                <p><strong>Target Taxon:</strong> Neotibicen canicularis</p>
+                <p><strong>Target Taxon:</strong> Synechococcus sp. PCC 7002 (Syn7002)</p>
                 
 
                 
                 <p><strong>Metabolites:</strong>
                     
-                    L-leucine
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=15603"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:15603</a>), 
-                    
-                    L-isoleucine
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=17191"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:17191</a>), 
-                    
-                    nitrogen
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=25555"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:25555</a>)
+                    vitamin B12
+                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=176843"
+                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:176843</a>)
                     
                 </p>
                 
@@ -561,26 +665,13 @@
                     <li class="evidence-item">
                         <div>
                             
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/41790499/"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41790499</a>
                             
-                            - SUPPORT (COMPUTATIONAL)
+                            - PARTIAL (IN_VITRO)
                         </div>
                         
-                        <div class="snippet">"Sulcia and Hodgkinia with genomes of ≤0.3 Mb are calculated to recycle ∼30 to 80% of host-derived nitrogen to essential amino acids returned to the host"</div>
-                        
-                    </li>
-                    
-                    <li class="evidence-item">
-                        <div>
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
-                            
-                            - SUPPORT (COMPUTATIONAL)
-                        </div>
-                        
-                        <div class="snippet">"Our simulations reveal extensive bidirectional flux of multiple metabolites between each symbiont and the host"</div>
+                        <div class="snippet">"The results further suggest that MesTH promotes the growth of Syn7002 in the community by providing the small amount of vitamin B12 needed for its growth"</div>
                         
                     </li>
                     
@@ -590,26 +681,14 @@
             
             <div class="interaction-card">
                 <div class="interaction-header">
-                    <h3>Hodgkinia Metabolic Complementarity</h3>
-                    <span class="interaction-type">MUTUALISM</span>
+                    <h3>Close Spatial Association of Partner Bacteria with Syn7002 Cells</h3>
+                    <span class="interaction-type">COLONIZATION_FACILITATION</span>
                 </div>
 
                 
-                <p><strong>Source Taxon:</strong> Hodgkinia</p>
-                
 
                 
-                <p><strong>Target Taxon:</strong> Neotibicen canicularis</p>
-                
 
-                
-                <p><strong>Metabolites:</strong>
-                    
-                    nitrogen
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=25555"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:25555</a>)
-                    
-                </p>
                 
 
                 
@@ -623,26 +702,13 @@
                     <li class="evidence-item">
                         <div>
                             
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/41790499/"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41790499</a>
                             
-                            - SUPPORT (COMPUTATIONAL)
+                            - PARTIAL (IN_VITRO)
                         </div>
                         
-                        <div class="snippet">"Sulcia and Hodgkinia with genomes of ≤0.3 Mb are calculated to recycle ∼30 to 80% of host-derived nitrogen to essential amino acids returned to the host"</div>
-                        
-                    </li>
-                    
-                    <li class="evidence-item">
-                        <div>
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
-                            
-                            - SUPPORT (COMPUTATIONAL)
-                        </div>
-                        
-                        <div class="snippet">"near-complete metabolic segregation (i.e., near absence of metabolic cross-feeding) between the two symbionts, a likely mode of host control over symbiont metabolism"</div>
+                        <div class="snippet">"Electron microscopy revealed numerous rod-shaped bacteria clustered around Syn7002 cells, indicating close spatial associations between species"</div>
                         
                     </li>
                     
@@ -655,83 +721,27 @@
 
         <!-- Associated Datasets -->
         
-        <section>
-            <h2>Associated Datasets</h2>
-            <table>
-                <thead>
-                    <tr>
-                        <th>Dataset</th>
-                        <th>Type</th>
-                        <th>Repository</th>
-                        <th>Accession</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    
-                    <tr>
-                        <td>
-                            <strong>BioModels model file</strong>
-                            
-                            <br><span class="dataset-description">Multi-compartment SBML model for cicada symbiosis.</span>
-                            
-                        </td>
-                        <td><span class="role-badge">OTHER</span></td>
-                        <td>OTHER</td>
-                        <td>
-                            
-                            <a href="https://www.ebi.ac.uk/biomodels/MODEL1806250005" class="term-link" target="_blank" rel="noopener noreferrer">Neotibicen_iNA533.xml</a>
-                            
-                        </td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                            <strong>Primary publication</strong>
-                            
-                            <br><span class="dataset-description">Study on the cost of metabolic interactions in insect-bacterial symbioses.</span>
-                            
-                        </td>
-                        <td><span class="role-badge">OTHER</span></td>
-                        <td>OTHER</td>
-                        <td>
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/" class="term-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
-                            
-                        </td>
-                    </tr>
-                    
-                </tbody>
-            </table>
-        </section>
-        
 
         <!-- Environmental Factors -->
         
+
+        
         <section>
-            <h2>External Resources</h2>
+            <h2>Environmental Factors</h2>
             <table>
                 <thead>
                     <tr>
-                        <th>Name</th>
-                        <th>Repository</th>
-                        <th>Resource ID</th>
+                        <th>Factor</th>
+                        <th>Value</th>
+                        <th>Unit</th>
                     </tr>
                 </thead>
                 <tbody>
                     
                     <tr>
-                        <td>
-                            <strong>BioModels entry</strong>
-                            
-                            <br><span class="dataset-description">Cicada symbiosis metabolic model.</span>
-                            
-                        </td>
-                        <td>BIOMODELS</td>
-                        <td>
-                            
-                            <a href="https://www.ebi.ac.uk/biomodels/MODEL1806250005" class="term-link" target="_blank" rel="noopener noreferrer">MODEL1806250005</a>
-                            
-                        </td>
+                        <td><strong>Vitamin B12-positive control supplementation</strong></td>
+                        <td></td>
+                        <td>N/A</td>
                     </tr>
                     
                     <tr class="evidence-row-container">
@@ -740,12 +750,12 @@
                                 
                                 <li class="evidence-item">
                                     
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/41790499/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:41790499</a>
                                     
-                                    - SUPPORT (COMPUTATIONAL)
+                                    - SUPPORT (IN_VITRO)
                                     
-                                    <div class="snippet">"The Cost of Metabolic Interactions in Symbioses between Insects and Bacteria with Reduced Genomes."</div>
+                                    <div class="snippet">"Combined with vitamin B12-positive control experiments, these results confirm potential vitamin B12 complementarity between the two strains"</div>
                                     
                                 </li>
                                 
@@ -757,8 +767,6 @@
                 </tbody>
             </table>
         </section>
-        
-
         
 
         <!-- Growth Media -->
@@ -791,25 +799,32 @@
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
-        taxonData["Neotibicen canicularis"] = {
-            id: "NCBITaxon:1699721",
-            label: "Neotibicen canicularis",
+        taxonData["Synechococcus sp. PCC 7002 (Syn7002)"] = {
+            id: "NCBITaxon:32049",
+            label: "Synechococcus sp. PCC 7002 (Syn7002)",
             abundance: "UNKNOWN",
-            roles: ["CROSS_FEEDER"]
+            roles: ["PRIMARY_PRODUCER"]
         };
         
-        taxonData["Sulcia"] = {
-            id: "NCBITaxon:336809",
-            label: "Sulcia",
+        taxonData["Mesorhizobium sp. TaiHu (MesTH)"] = {
+            id: "NCBITaxon:68287",
+            label: "Mesorhizobium sp. TaiHu (MesTH)",
             abundance: "UNKNOWN",
-            roles: ["SYNTROPHIC_PARTNER"]
+            roles: []
         };
         
-        taxonData["Hodgkinia"] = {
-            id: "NCBITaxon:573657",
-            label: "Hodgkinia",
+        taxonData["Pseudomonas sp. TaiHu (PseTH)"] = {
+            id: "NCBITaxon:286",
+            label: "Pseudomonas sp. TaiHu (PseTH)",
             abundance: "UNKNOWN",
-            roles: ["SYNTROPHIC_PARTNER"]
+            roles: []
+        };
+        
+        taxonData["bloom-forming Microcystis community (source inoculum)"] = {
+            id: "NCBITaxon:1125",
+            label: "bloom-forming Microcystis community (source inoculum)",
+            abundance: "UNKNOWN",
+            roles: []
         };
         
 
@@ -837,24 +852,20 @@
         
         (function() {
             var intId = "interaction:0";
-            var intType = "MUTUALISM";
+            var intType = "CROSS_FEEDING";
             var metabolites = [];
             
             
-            metabolites.push("L-leucine");
-            
-            metabolites.push("L-isoleucine");
-            
-            metabolites.push("nitrogen");
+            metabolites.push("vitamin B12");
             
             
             var processes = [];
             
-            var evidenceCount = 2;
+            var evidenceCount = 1;
 
             nodes.push({
                 id: intId,
-                label: "Sulcia Essential Amino Acid Provisioning",
+                label: "Vitamin B12 Provision from Mesorhizobium TaiHu to Synechococcus PCC 7002",
                 type: "interaction",
                 interactionType: intType,
                 metabolites: metabolites,
@@ -863,14 +874,14 @@
             });
 
             
-            var srcKey = "Sulcia";
+            var srcKey = "Mesorhizobium sp. TaiHu (MesTH)";
             if (taxonNodeIds[srcKey]) {
                 links.push({ source: taxonNodeIds[srcKey], target: intId });
             }
             
 
             
-            var tgtKey = "Neotibicen canicularis";
+            var tgtKey = "Synechococcus sp. PCC 7002 (Syn7002)";
             if (taxonNodeIds[tgtKey]) {
                 links.push({ source: intId, target: taxonNodeIds[tgtKey] });
             }
@@ -879,20 +890,16 @@
         
         (function() {
             var intId = "interaction:1";
-            var intType = "MUTUALISM";
+            var intType = "COLONIZATION_FACILITATION";
             var metabolites = [];
-            
-            
-            metabolites.push("nitrogen");
-            
             
             var processes = [];
             
-            var evidenceCount = 2;
+            var evidenceCount = 1;
 
             nodes.push({
                 id: intId,
-                label: "Hodgkinia Metabolic Complementarity",
+                label: "Close Spatial Association of Partner Bacteria with Syn7002 Cells",
                 type: "interaction",
                 interactionType: intType,
                 metabolites: metabolites,
@@ -901,17 +908,7 @@
             });
 
             
-            var srcKey = "Hodgkinia";
-            if (taxonNodeIds[srcKey]) {
-                links.push({ source: taxonNodeIds[srcKey], target: intId });
-            }
-            
 
-            
-            var tgtKey = "Neotibicen canicularis";
-            if (taxonNodeIds[tgtKey]) {
-                links.push({ source: intId, target: taxonNodeIds[tgtKey] });
-            }
             
         })();
         
@@ -931,7 +928,7 @@
         var svg = d3.select("#network-svg");
         var width = container.clientWidth - 32;
         // Dynamic height based on node count: minimum 500px, add 40px per node
-        var nodeCount = 5;
+        var nodeCount = 6;
         var height = Math.max(500, 400 + nodeCount * 20);
         svg.attr("width", width).attr("height", height);
 

--- a/docs/communities/Polaromonas_Vanadium_Reduction_Community.html
+++ b/docs/communities/Polaromonas_Vanadium_Reduction_Community.html
@@ -482,7 +482,7 @@
                                     
                                     - SUPPORT (IN_VITRO)
                                     
-                                    <div class="snippet">"Further, VV-reducing enrichments indicated that bacteria associated with Polaromonas, a genus belonging to the family Burkholderiaceae, were potential"</div>
+                                    <div class="snippet">"Further, VV-reducing enrichments indicated that bacteria associated with Polaromonas, a genus belonging to the family Burkholderiaceae, were potentially"</div>
                                     
                                 </li>
                                 

--- a/docs/communities/SPRUCE_Peatland_Warming_Community.html
+++ b/docs/communities/SPRUCE_Peatland_Warming_Community.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Naica Deep Subsurface Thermophilic Community - CommunityMech</title>
+    <title>SPRUCE Peatland Warming Microbial Community - CommunityMech</title>
     <style>
         :root {
             --primary: #3D7DD6;
@@ -372,7 +372,7 @@
     <header>
         <div class="container">
             <a href="../browser.html" class="back-link">← Back to Communities</a>
-            <h1>Naica Deep Subsurface Thermophilic Community</h1>
+            <h1>SPRUCE Peatland Warming Microbial Community</h1>
         </div>
     </header>
 
@@ -383,7 +383,7 @@
                 <div class="metadata-item">
                     <span class="metadata-label">Community ID</span>
                     <span class="metadata-value">
-                        <code style="background: var(--border); color: var(--text); padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.9rem;">CommunityMech:000046</code>
+                        <code style="background: var(--border); color: var(--text); padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.9rem;">CommunityMech:000319</code>
                     </span>
                 </div>
 
@@ -400,11 +400,11 @@
                 <div class="metadata-item">
                     <span class="metadata-label">Environment</span>
                     <span class="metadata-value">
-                        deep subsurface environment
+                        peatland
                         <br>
-                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_01000942"
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_00000044"
                            class="term-link" target="_blank" rel="noopener noreferrer">
-                            ENVO:01000942
+                            ENVO:00000044
                         </a>
                     </span>
                 </div>
@@ -416,7 +416,7 @@
         <!-- Description -->
         
         <section class="description">
-            <p>A deep subsurface thermophilic microbial community from the Naica Mine crystal cave system in Chihuahua, Mexico, representing one of Earth&#39;s most extreme oligotrophic deep biosphere habitats. This community thrives in hydrothermal waters at 700-760 m depth with temperatures of 54-60°C, extremely low nutrient availability, and isolation from surface inputs. The prokaryotic community is dominated by chemolithoautotrophic archaea, particularly basal Thaumarchaeota (performing ammonia oxidation) and environmental Thermoplasmatales lineages (Euryarchaeota), with bacterial diversity limited to Candidate Division OP3, Firmicutes, and Alpha/Beta-proteobacteria. High GC content of archaeal and OP3 16S rRNA genes confirms thermophilic adaptation to 50-70°C. Genes encoding archaeal ammonia monooxygenase (amoA) demonstrate that Naica Thaumarchaeota are thermophilic chemolithoautotrophic nitrifiers adapted to extreme energy limitation. The system exhibits astrobiology significance as an analog for subsurface life on Mars and icy moons, with fluid inclusions in giant gypsum crystals potentially harboring ancient microbes for up to 50,000-60,000 years. The absence of detectable eukaryotes reflects the extreme oligotrophy and thermal stress. This natural deep biosphere community provides insights into minimal energy requirements for life, thermophilic adaptation, and survival strategies in isolated subsurface aquifers with extremely limited carbon and nitrogen availability.
+            <p>Microbial community from the SPRUCE (Spruce and Peatland Responses Under Changing Environments) whole-ecosystem warming experiment at Marcell Experimental Forest, Minnesota. This long-term DOE-funded experiment (ORNL) provides a unique whole-ecosystem warming gradient (+0°C to +9°C) with elevated CO2 (eCO2) treatments in a northern boreal peatland. The natural microbial community has been extensively characterized through amplicon sequencing (16S rRNA for bacteria/archaea, ITS for fungi) and metatranscriptomics, revealing climate change-driven shifts in community composition and function. Key findings include: (1) warming promotes saprophytic fungi and chemoorganoheterotrophic bacteria in root-associated environments, (2) eCO2 enhances ectomycorrhizal fungal associations with vascular plants, particularly short-distance exploration strategies targeting labile soil nitrogen, (3) vascular plant fine root traits mediate climate effects on microbial communities, serving as a critical mechanism for peatland vegetation responses to global change. The community exhibits distinct niche partitioning between aquatic (waterlogged surface peat) and terrestrial (deeper peat) zones. Viral communities (4,326 vOTUs) show strong correlations with peat depth, water content, and carbon chemistry (CH4/CO2) but not temperature during initial warming phases. This represents one of the most comprehensively studied natural microbial communities under realistic climate change scenarios, with implications for carbon cycling, methane emissions, and ecosystem feedbacks in boreal peatlands. Northern peatlands store approximately one-third of global soil carbon despite covering only 3% of land area, making their responses to warming and eCO2 critical for global carbon cycle feedbacks. The comprehensive multi-omics datasets (amplicon, metagenome, metatranscriptome, virome) make this community exceptionally well-characterized for mechanistic modeling of climate-microbe-plant-carbon interactions.
 </p>
         </section>
         
@@ -438,19 +438,21 @@
                     
                     <tr>
                         <td>
-                            <strong>Thaumarchaeota</strong>
+                            <strong>Bacteria</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=651137"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=2"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:651137
+                                NCBITaxon:2
                             </a>
                         </td>
                         <td>
                             
                             <div class="roles-list">
                                 
-                                <span class="role-badge">PRIMARY_PRODUCER</span>
+                                <span class="role-badge">PRIMARY_DEGRADER</span>
+                                
+                                <span class="role-badge">SECONDARY_FERMENTER</span>
                                 
                             </div>
                             
@@ -464,34 +466,12 @@
                                 
                                 <li class="evidence-item">
                                     
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38515239/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:38515239</a>
                                     
                                     - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"These organisms are likely thermophilic chemolithoautotrophs adapted to thrive in an extremely energy-limited environment."</div>
-                                    
-                                </li>
-                                
-                                <li class="evidence-item">
-                                    
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                                    
-                                    - SUPPORT (IN_VIVO)
-                                    
-                                    <div class="snippet">"Genes encoding archaeal ammonium monooxygenase (AamoA) were amplified, suggesting that Naica Thaumarchaeota are involved in nitrification"</div>
-                                    
-                                </li>
-                                
-                                <li class="evidence-item">
-                                    
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                                    
-                                    - SUPPORT (IN_VIVO)
-                                    
-                                    <div class="snippet">"these organisms are likely thermophilic chemolithoautotrophs adapted to thrive in an extremely energy-limited environment"</div>
+                                    <div class="snippet">"Warming promoted saprophytic fungi and chemoorganoheterotrophic bacteria in root-associated environments"</div>
                                     
                                 </li>
                                 
@@ -502,118 +482,12 @@
                     
                     <tr>
                         <td>
-                            <strong>Thermoplasmatales environmental lineage</strong>
+                            <strong>Archaea</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=2301"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=2157"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:2301
-                            </a>
-                        </td>
-                        <td>
-                            
-                            <div class="roles-list">
-                                
-                                <span class="role-badge">CROSS_FEEDER</span>
-                                
-                            </div>
-                            
-                        </td>
-                        <td>ABUNDANT</td>
-                    </tr>
-                    
-                    <tr class="evidence-row-container">
-                        <td colspan="4">
-                            <ul class="evidence-list">
-                                
-                                <li class="evidence-item">
-                                    
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                                    
-                                    - SUPPORT (IN_VIVO)
-                                    
-                                    <div class="snippet">"In addition, the high GC content of 16S rRNA gene sequences belonging to the archaea and to some OP3 OTUs suggests that at least these lineages are thermophilic"</div>
-                                    
-                                </li>
-                                
-                                <li class="evidence-item">
-                                    
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                                    
-                                    - SUPPORT (IN_VIVO)
-                                    
-                                    <div class="snippet">"They clustered with, respectively, basal Thaumarchaeota lineages and with a large clade of environmental sequences branching at the base of the Thermoplasmatales within the Euryarchaeota"</div>
-                                    
-                                </li>
-                                
-                            </ul>
-                        </td>
-                    </tr>
-                    
-                    
-                    <tr>
-                        <td>
-                            <strong>Candidate Division OP3</strong>
-                        </td>
-                        <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=67812"
-                               class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:67812
-                            </a>
-                        </td>
-                        <td>
-                            
-                            <div class="roles-list">
-                                
-                                <span class="role-badge">CROSS_FEEDER</span>
-                                
-                            </div>
-                            
-                        </td>
-                        <td>COMMON</td>
-                    </tr>
-                    
-                    <tr class="evidence-row-container">
-                        <td colspan="4">
-                            <ul class="evidence-list">
-                                
-                                <li class="evidence-item">
-                                    
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                                    
-                                    - SUPPORT (IN_VIVO)
-                                    
-                                    <div class="snippet">"Bacterial sequences belonged to the Candidate Division OP3, Firmicutes and the Alpha- and Beta-proteobacteria"</div>
-                                    
-                                </li>
-                                
-                                <li class="evidence-item">
-                                    
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                                    
-                                    - SUPPORT (IN_VIVO)
-                                    
-                                    <div class="snippet">"some OP3 OTUs suggests that at least these lineages are thermophilic"</div>
-                                    
-                                </li>
-                                
-                            </ul>
-                        </td>
-                    </tr>
-                    
-                    
-                    <tr>
-                        <td>
-                            <strong>Firmicutes</strong>
-                        </td>
-                        <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1239"
-                               class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:1239
+                                NCBITaxon:2157
                             </a>
                         </td>
                         <td>
@@ -634,12 +508,12 @@
                                 
                                 <li class="evidence-item">
                                     
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34836550/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:34836550</a>
                                     
                                     - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"Bacterial sequences belonged to the Candidate Division OP3, Firmicutes and the Alpha- and Beta-proteobacteria"</div>
+                                    <div class="snippet">"Analyzed 87 metagenomes examining viral-host linkages in peat"</div>
                                     
                                 </li>
                                 
@@ -650,24 +524,26 @@
                     
                     <tr>
                         <td>
-                            <strong>Alphaproteobacteria</strong>
+                            <strong>Fungi</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=28211"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=4751"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:28211
+                                NCBITaxon:4751
                             </a>
                         </td>
                         <td>
                             
                             <div class="roles-list">
                                 
-                                <span class="role-badge">CROSS_FEEDER</span>
+                                <span class="role-badge">PRIMARY_DEGRADER</span>
+                                
+                                <span class="role-badge">SYNTROPHIC_PARTNER</span>
                                 
                             </div>
                             
                         </td>
-                        <td>RARE</td>
+                        <td>DOMINANT</td>
                     </tr>
                     
                     <tr class="evidence-row-container">
@@ -676,12 +552,23 @@
                                 
                                 <li class="evidence-item">
                                     
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38515239/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:38515239</a>
                                     
                                     - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"Bacterial sequences belonged to the Candidate Division OP3, Firmicutes and the Alpha- and Beta-proteobacteria"</div>
+                                    <div class="snippet">"Warming promoted saprophytic fungi; eCO2 promoted ectomycorrhizal fungal associations"</div>
+                                    
+                                </li>
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38515239/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:38515239</a>
+                                    
+                                    - SUPPORT (IN_VIVO)
+                                    
+                                    <div class="snippet">"Under eCO2, trees preferentially associated with ectomycorrhizal fungi using short-distance exploration strategies that targeted labile nitrogen"</div>
                                     
                                 </li>
                                 
@@ -692,24 +579,24 @@
                     
                     <tr>
                         <td>
-                            <strong>Betaproteobacteria</strong>
+                            <strong>Viruses</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=28216"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=10239"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:28216
+                                NCBITaxon:10239
                             </a>
                         </td>
                         <td>
                             
                             <div class="roles-list">
                                 
-                                <span class="role-badge">CROSS_FEEDER</span>
+                                <span class="role-badge">PRIMARY_DEGRADER</span>
                                 
                             </div>
                             
                         </td>
-                        <td>RARE</td>
+                        <td>ABUNDANT</td>
                     </tr>
                     
                     <tr class="evidence-row-container">
@@ -718,12 +605,34 @@
                                 
                                 <li class="evidence-item">
                                     
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34836550/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:34836550</a>
                                     
                                     - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"Bacterial sequences belonged to the Candidate Division OP3, Firmicutes and the Alpha- and Beta-proteobacteria"</div>
+                                    <div class="snippet">"Recovered 4,326 viral operational taxonomic units (vOTUs) from peat samples"</div>
+                                    
+                                </li>
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34836550/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:34836550</a>
+                                    
+                                    - SUPPORT (IN_VIVO)
+                                    
+                                    <div class="snippet">"Viral community composition correlated significantly with peat depth, water content, and carbon chemistry, but not with temperature during the first 2 years"</div>
+                                    
+                                </li>
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34836550/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:34836550</a>
+                                    
+                                    - SUPPORT (IN_VIVO)
+                                    
+                                    <div class="snippet">"Viruses with aquatic characteristics were enriched in waterlogged surface peat"</div>
                                     
                                 </li>
                                 
@@ -744,18 +653,21 @@
             <div class="network-container" id="network-container">
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
-                    <title id="network-svg-title">Ecological interaction network for Naica Deep Subsurface Thermophilic Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy).</desc>
+                    <title id="network-svg-title">Ecological interaction network for SPRUCE Peatland Warming Microbial Community</title>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, niche partitioning, predation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #913079;"></span> Predation
                     </div>
                 </div>
             </div>
@@ -763,26 +675,28 @@
             
             <div class="interaction-card">
                 <div class="interaction-header">
-                    <h3>Thermophilic Ammonia Oxidation</h3>
-                    <span class="interaction-type">CROSS_FEEDING</span>
+                    <h3>Warming-Enhanced Saprophytic Decomposition</h3>
+                    <span class="interaction-type">MUTUALISM</span>
                 </div>
 
                 
-                <p><strong>Source Taxon:</strong> Thaumarchaeota</p>
+                <p><strong>Source Taxon:</strong> Fungi</p>
                 
 
+                
+                <p><strong>Target Taxon:</strong> Bacteria</p>
                 
 
                 
                 <p><strong>Metabolites:</strong>
                     
-                    ammonia
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=16134"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:16134</a>), 
+                    carbon dioxide
+                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=16526"
+                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:16526</a>), 
                     
-                    nitrite
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=16301"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:16301</a>)
+                    methane
+                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=16183"
+                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:16183</a>)
                     
                 </p>
                 
@@ -792,89 +706,18 @@
                 <ul>
                     
                     <li>
-                        nitrification
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0019676"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0019676</a>)
+                        cellulose catabolic process
+                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0030245"
+                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0030245</a>)
                     </li>
                     
                     <li>
-                        carbon fixation
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0015977"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0015977</a>)
+                        lignin catabolic process
+                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0046274"
+                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0046274</a>)
                     </li>
                     
                 </ul>
-                
-
-                
-                <div class="interaction-flow">
-                    <strong>Downstream Effects:</strong>
-                    
-                    <div class="flow-item">
-                        <span class="flow-arrow">→</span> Denitrification by Betaproteobacteria
-                    </div>
-                    
-                </div>
-                
-
-                
-                <h4>Evidence</h4>
-                <ul class="evidence-list">
-                    
-                    <li class="evidence-item">
-                        <div>
-                            
-                            <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                            
-                            - SUPPORT (IN_VIVO)
-                        </div>
-                        
-                        <div class="snippet">"These organisms are likely thermophilic chemolithoautotrophs adapted to thrive in an extremely energy-limited environment."</div>
-                        
-                    </li>
-                    
-                    <li class="evidence-item">
-                        <div>
-                            
-                            <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                            
-                            - SUPPORT (IN_VIVO)
-                        </div>
-                        
-                        <div class="snippet">"these organisms are likely thermophilic chemolithoautotrophs adapted to thrive in an extremely energy-limited environment"</div>
-                        
-                    </li>
-                    
-                </ul>
-                
-            </div>
-            
-            <div class="interaction-card">
-                <div class="interaction-header">
-                    <h3>Heterotrophic Carbon Scavenging</h3>
-                    <span class="interaction-type">CROSS_FEEDING</span>
-                </div>
-
-                
-                <p><strong>Source Taxon:</strong> Thermoplasmatales environmental lineage</p>
-                
-
-                
-                <p><strong>Target Taxon:</strong> Candidate Division OP3</p>
-                
-
-                
-                <p><strong>Metabolites:</strong>
-                    
-                    organic molecular entity
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=50860"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:50860</a>)
-                    
-                </p>
-                
-
                 
 
                 
@@ -886,13 +729,13 @@
                     <li class="evidence-item">
                         <div>
                             
-                            <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/38515239/"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:38515239</a>
                             
                             - SUPPORT (IN_VIVO)
                         </div>
                         
-                        <div class="snippet">"These organisms are likely thermophilic chemolithoautotrophs adapted to thrive in an extremely energy-limited environment."</div>
+                        <div class="snippet">"Warming promoted saprophytic fungi and chemoorganoheterotrophic bacteria in root-associated environments"</div>
                         
                     </li>
                     
@@ -902,28 +745,30 @@
             
             <div class="interaction-card">
                 <div class="interaction-header">
-                    <h3>Fermentation and Syntrophy</h3>
-                    <span class="interaction-type">SYNTROPHY</span>
+                    <h3>Elevated CO2-Enhanced Ectomycorrhizal Symbiosis</h3>
+                    <span class="interaction-type">MUTUALISM</span>
                 </div>
 
                 
-                <p><strong>Source Taxon:</strong> Firmicutes</p>
+                <p><strong>Source Taxon:</strong> Fungi</p>
                 
 
-                
-                <p><strong>Target Taxon:</strong> Thermoplasmatales environmental lineage</p>
                 
 
                 
                 <p><strong>Metabolites:</strong>
                     
-                    hydrogen
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=18276"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:18276</a>), 
+                    glucose
+                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=17234"
+                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:17234</a>), 
                     
-                    acetate
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=30089"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:30089</a>)
+                    L-glutamine
+                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=18050"
+                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:18050</a>), 
+                    
+                    ammonium
+                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=28938"
+                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:28938</a>)
                     
                 </p>
                 
@@ -933,9 +778,15 @@
                 <ul>
                     
                     <li>
-                        fermentation
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0006113"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0006113</a>)
+                        acquisition of nutrients from host
+                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0044002"
+                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0044002</a>)
+                    </li>
+                    
+                    <li>
+                        acquisition of nutrients from symbiont
+                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0051850"
+                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0051850</a>)
                     </li>
                     
                 </ul>
@@ -950,66 +801,26 @@
                     <li class="evidence-item">
                         <div>
                             
-                            <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                            
-                            - PARTIAL (IN_VIVO)
-                        </div>
-                        
-                        <div class="snippet">"Bacterial sequences belonged to the Candidate Division OP3, Firmicutes and the Alpha- and Beta-proteobacteria"</div>
-                        
-                    </li>
-                    
-                </ul>
-                
-            </div>
-            
-            <div class="interaction-card">
-                <div class="interaction-header">
-                    <h3>Proteobacterial Oligotrophic Metabolism</h3>
-                    <span class="interaction-type">CROSS_FEEDING</span>
-                </div>
-
-                
-                <p><strong>Source Taxon:</strong> Alphaproteobacteria</p>
-                
-
-                
-                <p><strong>Target Taxon:</strong> Betaproteobacteria</p>
-                
-
-                
-                <p><strong>Metabolites:</strong>
-                    
-                    organic molecular entity
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=50860"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:50860</a>), 
-                    
-                    dihydrogen
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=18276"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:18276</a>)
-                    
-                </p>
-                
-
-                
-
-                
-
-                
-                <h4>Evidence</h4>
-                <ul class="evidence-list">
-                    
-                    <li class="evidence-item">
-                        <div>
-                            
-                            <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/38515239/"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:38515239</a>
                             
                             - SUPPORT (IN_VIVO)
                         </div>
                         
-                        <div class="snippet">"Bacterial sequences belonged to the Candidate Division OP3, Firmicutes and the Alpha- and Beta-proteobacteria"</div>
+                        <div class="snippet">"eCO2 promoted ectomycorrhizal fungal associations"</div>
+                        
+                    </li>
+                    
+                    <li class="evidence-item">
+                        <div>
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/38515239/"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:38515239</a>
+                            
+                            - SUPPORT (IN_VIVO)
+                        </div>
+                        
+                        <div class="snippet">"Under eCO2, trees preferentially associated with ectomycorrhizal fungi using short-distance exploration strategies that targeted labile nitrogen"</div>
                         
                     </li>
                     
@@ -1019,28 +830,14 @@
             
             <div class="interaction-card">
                 <div class="interaction-header">
-                    <h3>Denitrification by Betaproteobacteria</h3>
-                    <span class="interaction-type">CROSS_FEEDING</span>
+                    <h3>Root Trait-Mediated Microbial Community Assembly</h3>
+                    <span class="interaction-type">NICHE_PARTITIONING</span>
                 </div>
 
                 
-                <p><strong>Source Taxon:</strong> Betaproteobacteria</p>
-                
 
                 
 
-                
-                <p><strong>Metabolites:</strong>
-                    
-                    nitrite
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=16301"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:16301</a>), 
-                    
-                    dinitrogen
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=17997"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:17997</a>)
-                    
-                </p>
                 
 
                 
@@ -1048,9 +845,9 @@
                 <ul>
                     
                     <li>
-                        denitrification
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0019333"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0019333</a>)
+                        response to other organism
+                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0051707"
+                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0051707</a>)
                     </li>
                     
                 </ul>
@@ -1065,13 +862,82 @@
                     <li class="evidence-item">
                         <div>
                             
-                            <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/38515239/"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:38515239</a>
                             
-                            - PARTIAL (IN_VIVO)
+                            - SUPPORT (IN_VIVO)
                         </div>
                         
-                        <div class="snippet">"Bacterial sequences belonged to the Candidate Division OP3, Firmicutes and the Alpha- and Beta-proteobacteria"</div>
+                        <div class="snippet">"Vascular plant fine root traits mediate climate change effects on microbial communities"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="interaction-card">
+                <div class="interaction-header">
+                    <h3>Viral-Host Dynamics and Niche Partitioning</h3>
+                    <span class="interaction-type">PREDATION</span>
+                </div>
+
+                
+                <p><strong>Source Taxon:</strong> Viruses</p>
+                
+
+                
+
+                
+
+                
+                <p><strong>Biological Processes:</strong></p>
+                <ul>
+                    
+                    <li>
+                        viral entry into host cell
+                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0046718"
+                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0046718</a>)
+                    </li>
+                    
+                    <li>
+                        host cell lysis by virus
+                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0019076"
+                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0019076</a>)
+                    </li>
+                    
+                </ul>
+                
+
+                
+
+                
+                <h4>Evidence</h4>
+                <ul class="evidence-list">
+                    
+                    <li class="evidence-item">
+                        <div>
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34836550/"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:34836550</a>
+                            
+                            - SUPPORT (IN_VIVO)
+                        </div>
+                        
+                        <div class="snippet">"Predicted host ranges were narrow, generally within a single bacterial genus"</div>
+                        
+                    </li>
+                    
+                    <li class="evidence-item">
+                        <div>
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34836550/"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:34836550</a>
+                            
+                            - SUPPORT (IN_VIVO)
+                        </div>
+                        
+                        <div class="snippet">"Viral community composition correlated significantly with peat depth, water content, and carbon chemistry"</div>
                         
                     </li>
                     
@@ -1083,6 +949,103 @@
         </section>
 
         <!-- Associated Datasets -->
+        
+        <section>
+            <h2>Associated Datasets</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Dataset</th>
+                        <th>Type</th>
+                        <th>Repository</th>
+                        <th>Accession</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    
+                    <tr>
+                        <td>
+                            <strong>SPRUCE 16S rRNA amplicon sequencing</strong>
+                            
+                            <br><span class="dataset-description">16S rRNA amplicon sequencing of bacterial and archaeal communities from plant fine roots, rhizospheres, and bulk peat across warming and eCO2 treatments</span>
+                            
+                        </td>
+                        <td><span class="role-badge">AMPLICON_16S</span></td>
+                        <td></td>
+                        <td>
+                            
+                            PMID:38515239
+                            
+                        </td>
+                    </tr>
+                    
+                    <tr>
+                        <td>
+                            <strong>SPRUCE ITS amplicon sequencing</strong>
+                            
+                            <br><span class="dataset-description">ITS amplicon sequencing of fungal communities from plant fine roots, rhizospheres, and bulk peat across warming and eCO2 treatments, identifying saprophytic and ectomycorrhizal functional guilds</span>
+                            
+                        </td>
+                        <td><span class="role-badge">AMPLICON_ITS</span></td>
+                        <td></td>
+                        <td>
+                            
+                            PMID:38515239
+                            
+                        </td>
+                    </tr>
+                    
+                    <tr>
+                        <td>
+                            <strong>SPRUCE peat metagenomes</strong>
+                            
+                            <br><span class="dataset-description">87 shotgun metagenomes from peat samples across depth gradients, warming treatments, and eCO2 treatments, enabling viral-host linkage prediction and taxonomic profiling</span>
+                            
+                        </td>
+                        <td><span class="role-badge">METAGENOMICS</span></td>
+                        <td></td>
+                        <td>
+                            
+                            PMID:34836550
+                            
+                        </td>
+                    </tr>
+                    
+                    <tr>
+                        <td>
+                            <strong>SPRUCE peat viromes</strong>
+                            
+                            <br><span class="dataset-description">5 viral size-fraction metagenomes (viromes) from peat samples, recovering 4,326 vOTUs with 32x higher vOTU recovery per sample than total metagenomes</span>
+                            
+                        </td>
+                        <td><span class="role-badge">METAGENOMICS</span></td>
+                        <td></td>
+                        <td>
+                            
+                            PMID:34836550
+                            
+                        </td>
+                    </tr>
+                    
+                    <tr>
+                        <td>
+                            <strong>SPRUCE metatranscriptomes</strong>
+                            
+                            <br><span class="dataset-description">Metatranscriptomic profiling of active gene expression in peat microbial communities under warming and eCO2, revealing functional responses to climate treatments</span>
+                            
+                        </td>
+                        <td><span class="role-badge">METATRANSCRIPTOMICS</span></td>
+                        <td></td>
+                        <td>
+                            
+                            PMID:38515239
+                            
+                        </td>
+                    </tr>
+                    
+                </tbody>
+            </table>
+        </section>
         
 
         <!-- Environmental Factors -->
@@ -1102,9 +1065,9 @@
                 <tbody>
                     
                     <tr>
-                        <td><strong>Temperature</strong></td>
-                        <td>54-60</td>
-                        <td>°C</td>
+                        <td><strong>Temperature Gradient</strong></td>
+                        <td>+0 to +9</td>
+                        <td>°C above ambient</td>
                     </tr>
                     
                     <tr class="evidence-row-container">
@@ -1113,23 +1076,12 @@
                                 
                                 <li class="evidence-item">
                                     
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38515239/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:38515239</a>
                                     
                                     - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"In addition, the high GC content of 16S rRNA gene sequences belonging to the archaea and to some OP3 OTUs suggests that at least these lineages are thermophilic"</div>
-                                    
-                                </li>
-                                
-                                <li class="evidence-item">
-                                    
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                                    
-                                    - SUPPORT (IN_VIVO)
-                                    
-                                    <div class="snippet">"The high GC content of 16S rRNA gene sequences belonging to the archaea and to some OP3 OTUs suggests that at least these lineages are thermophilic"</div>
+                                    <div class="snippet">"Whole-ecosystem warming gradient +0°C to 9°C"</div>
                                     
                                 </li>
                                 
@@ -1139,9 +1091,9 @@
                     
                     
                     <tr>
-                        <td><strong>Depth</strong></td>
-                        <td>700-760</td>
-                        <td>m</td>
+                        <td><strong>Elevated CO2</strong></td>
+                        <td>+500</td>
+                        <td>ppm above ambient</td>
                     </tr>
                     
                     <tr class="evidence-row-container">
@@ -1150,12 +1102,12 @@
                                 
                                 <li class="evidence-item">
                                     
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38515239/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:38515239</a>
                                     
                                     - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"We have explored the microbial diversity associated to these deep, saline hydrothermal waters collected in the deepest (ca"</div>
+                                    <div class="snippet">"Elevated CO2 (eCO2) treatment applied"</div>
                                     
                                 </li>
                                 
@@ -1165,9 +1117,9 @@
                     
                     
                     <tr>
-                        <td><strong>Oligotrophy</strong></td>
-                        <td>Extreme</td>
-                        <td>qualitative</td>
+                        <td><strong>Peat Depth Gradient</strong></td>
+                        <td>0-200</td>
+                        <td>cm depth</td>
                     </tr>
                     
                     <tr class="evidence-row-container">
@@ -1176,23 +1128,12 @@
                                 
                                 <li class="evidence-item">
                                     
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34836550/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:34836550</a>
                                     
                                     - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"These crystals formed under particularly stable geochemical conditions in cavities filled by low salinity hydrothermal water at 54-58°C"</div>
-                                    
-                                </li>
-                                
-                                <li class="evidence-item">
-                                    
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
-                                    
-                                    - SUPPORT (IN_VIVO)
-                                    
-                                    <div class="snippet">"thermophilic chemolithoautotrophs adapted to thrive in an extremely energy-limited environment"</div>
+                                    <div class="snippet">"Viral community composition correlated significantly with peat depth"</div>
                                     
                                 </li>
                                 
@@ -1202,9 +1143,9 @@
                     
                     
                     <tr>
-                        <td><strong>Isolation and Geological Stability</strong></td>
-                        <td>500,000+ years</td>
-                        <td>years</td>
+                        <td><strong>Water Content</strong></td>
+                        <td>Variable</td>
+                        <td>% volumetric water content</td>
                     </tr>
                     
                     <tr class="evidence-row-container">
@@ -1213,12 +1154,12 @@
                                 
                                 <li class="evidence-item">
                                     
-                                    <a href="https://doi.org/10.3389/fmicb.2013.00037"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">doi:10.3389/fmicb.2013.00037</a>
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34836550/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:34836550</a>
                                     
-                                    - PARTIAL (IN_VIVO)
+                                    - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"The Naica Mine in northern Mexico is famous for its giant gypsum crystals, which may reach up to 11 m long and contain fluid inclusions that might have captured microorganisms during their formation"</div>
+                                    <div class="snippet">"Viral community composition correlated with water content"</div>
                                     
                                 </li>
                                 
@@ -1228,9 +1169,9 @@
                     
                     
                     <tr>
-                        <td><strong>Astrobiology Relevance</strong></td>
-                        <td>High</td>
-                        <td>qualitative</td>
+                        <td><strong>Carbon Chemistry</strong></td>
+                        <td>Variable CH4/CO2</td>
+                        <td>ppm in pore water</td>
                     </tr>
                     
                     <tr class="evidence-row-container">
@@ -1239,17 +1180,31 @@
                                 
                                 <li class="evidence-item">
                                     
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23640690/"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:23640690</a>
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34836550/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:34836550</a>
                                     
                                     - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"The &#34;Cave of Crystals&#34; (aka &#39;Naica&#39;) in Chihuahua Mexico is a natural unique subterranean ecosystem which mainly consists of crystals made of calcium sulfate"</div>
+                                    <div class="snippet">"Viral community composition correlated with carbon chemistry (methane and CO2 concentrations)"</div>
                                     
                                 </li>
                                 
                             </ul>
                         </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td><strong>pH</strong></td>
+                        <td>3.5-4.5</td>
+                        <td>pH units</td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td><strong>Nutrient Status</strong></td>
+                        <td>Oligotrophic</td>
+                        <td>N/A</td>
                     </tr>
                     
                     
@@ -1288,46 +1243,32 @@
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
-        taxonData["Thaumarchaeota"] = {
-            id: "NCBITaxon:651137",
-            label: "Thaumarchaeota",
+        taxonData["Bacteria"] = {
+            id: "NCBITaxon:2",
+            label: "Bacteria",
             abundance: "DOMINANT",
-            roles: ["PRIMARY_PRODUCER"]
+            roles: ["PRIMARY_DEGRADER", "SECONDARY_FERMENTER"]
         };
         
-        taxonData["Thermoplasmatales environmental lineage"] = {
-            id: "NCBITaxon:2301",
-            label: "Thermoplasmatales environmental lineage",
-            abundance: "ABUNDANT",
-            roles: ["CROSS_FEEDER"]
-        };
-        
-        taxonData["Candidate Division OP3"] = {
-            id: "NCBITaxon:67812",
-            label: "Candidate Division OP3",
-            abundance: "COMMON",
-            roles: ["CROSS_FEEDER"]
-        };
-        
-        taxonData["Firmicutes"] = {
-            id: "NCBITaxon:1239",
-            label: "Firmicutes",
+        taxonData["Archaea"] = {
+            id: "NCBITaxon:2157",
+            label: "Archaea",
             abundance: "COMMON",
             roles: ["SECONDARY_FERMENTER"]
         };
         
-        taxonData["Alphaproteobacteria"] = {
-            id: "NCBITaxon:28211",
-            label: "Alphaproteobacteria",
-            abundance: "RARE",
-            roles: ["CROSS_FEEDER"]
+        taxonData["Fungi"] = {
+            id: "NCBITaxon:4751",
+            label: "Fungi",
+            abundance: "DOMINANT",
+            roles: ["PRIMARY_DEGRADER", "SYNTROPHIC_PARTNER"]
         };
         
-        taxonData["Betaproteobacteria"] = {
-            id: "NCBITaxon:28216",
-            label: "Betaproteobacteria",
-            abundance: "RARE",
-            roles: ["CROSS_FEEDER"]
+        taxonData["Viruses"] = {
+            id: "NCBITaxon:10239",
+            label: "Viruses",
+            abundance: "ABUNDANT",
+            roles: ["PRIMARY_DEGRADER"]
         };
         
 
@@ -1355,28 +1296,76 @@
         
         (function() {
             var intId = "interaction:0";
-            var intType = "CROSS_FEEDING";
+            var intType = "MUTUALISM";
             var metabolites = [];
             
             
-            metabolites.push("ammonia");
+            metabolites.push("carbon dioxide");
             
-            metabolites.push("nitrite");
+            metabolites.push("methane");
             
             
             var processes = [];
             
             
-            processes.push("nitrification");
+            processes.push("cellulose catabolic process");
             
-            processes.push("carbon fixation");
+            processes.push("lignin catabolic process");
+            
+            
+            var evidenceCount = 1;
+
+            nodes.push({
+                id: intId,
+                label: "Warming-Enhanced Saprophytic Decomposition",
+                type: "interaction",
+                interactionType: intType,
+                metabolites: metabolites,
+                processes: processes,
+                evidenceCount: evidenceCount
+            });
+
+            
+            var srcKey = "Fungi";
+            if (taxonNodeIds[srcKey]) {
+                links.push({ source: taxonNodeIds[srcKey], target: intId });
+            }
+            
+
+            
+            var tgtKey = "Bacteria";
+            if (taxonNodeIds[tgtKey]) {
+                links.push({ source: intId, target: taxonNodeIds[tgtKey] });
+            }
+            
+        })();
+        
+        (function() {
+            var intId = "interaction:1";
+            var intType = "MUTUALISM";
+            var metabolites = [];
+            
+            
+            metabolites.push("glucose");
+            
+            metabolites.push("L-glutamine");
+            
+            metabolites.push("ammonium");
+            
+            
+            var processes = [];
+            
+            
+            processes.push("acquisition of nutrients from host");
+            
+            processes.push("acquisition of nutrients from symbiont");
             
             
             var evidenceCount = 2;
 
             nodes.push({
                 id: intId,
-                label: "Thermophilic Ammonia Oxidation",
+                label: "Elevated CO2-Enhanced Ectomycorrhizal Symbiosis",
                 type: "interaction",
                 interactionType: intType,
                 metabolites: metabolites,
@@ -1385,75 +1374,31 @@
             });
 
             
-            var srcKey = "Thaumarchaeota";
+            var srcKey = "Fungi";
             if (taxonNodeIds[srcKey]) {
                 links.push({ source: taxonNodeIds[srcKey], target: intId });
             }
             
 
-            
-        })();
-        
-        (function() {
-            var intId = "interaction:1";
-            var intType = "CROSS_FEEDING";
-            var metabolites = [];
-            
-            
-            metabolites.push("organic molecular entity");
-            
-            
-            var processes = [];
-            
-            var evidenceCount = 1;
-
-            nodes.push({
-                id: intId,
-                label: "Heterotrophic Carbon Scavenging",
-                type: "interaction",
-                interactionType: intType,
-                metabolites: metabolites,
-                processes: processes,
-                evidenceCount: evidenceCount
-            });
-
-            
-            var srcKey = "Thermoplasmatales environmental lineage";
-            if (taxonNodeIds[srcKey]) {
-                links.push({ source: taxonNodeIds[srcKey], target: intId });
-            }
-            
-
-            
-            var tgtKey = "Candidate Division OP3";
-            if (taxonNodeIds[tgtKey]) {
-                links.push({ source: intId, target: taxonNodeIds[tgtKey] });
-            }
             
         })();
         
         (function() {
             var intId = "interaction:2";
-            var intType = "SYNTROPHY";
+            var intType = "NICHE_PARTITIONING";
             var metabolites = [];
-            
-            
-            metabolites.push("hydrogen");
-            
-            metabolites.push("acetate");
-            
             
             var processes = [];
             
             
-            processes.push("fermentation");
+            processes.push("response to other organism");
             
             
             var evidenceCount = 1;
 
             nodes.push({
                 id: intId,
-                label: "Fermentation and Syntrophy",
+                label: "Root Trait-Mediated Microbial Community Assembly",
                 type: "interaction",
                 interactionType: intType,
                 metabolites: metabolites,
@@ -1462,38 +1407,28 @@
             });
 
             
-            var srcKey = "Firmicutes";
-            if (taxonNodeIds[srcKey]) {
-                links.push({ source: taxonNodeIds[srcKey], target: intId });
-            }
-            
 
-            
-            var tgtKey = "Thermoplasmatales environmental lineage";
-            if (taxonNodeIds[tgtKey]) {
-                links.push({ source: intId, target: taxonNodeIds[tgtKey] });
-            }
             
         })();
         
         (function() {
             var intId = "interaction:3";
-            var intType = "CROSS_FEEDING";
+            var intType = "PREDATION";
             var metabolites = [];
-            
-            
-            metabolites.push("organic molecular entity");
-            
-            metabolites.push("dihydrogen");
-            
             
             var processes = [];
             
-            var evidenceCount = 1;
+            
+            processes.push("viral entry into host cell");
+            
+            processes.push("host cell lysis by virus");
+            
+            
+            var evidenceCount = 2;
 
             nodes.push({
                 id: intId,
-                label: "Proteobacterial Oligotrophic Metabolism",
+                label: "Viral-Host Dynamics and Niche Partitioning",
                 type: "interaction",
                 interactionType: intType,
                 metabolites: metabolites,
@@ -1502,51 +1437,7 @@
             });
 
             
-            var srcKey = "Alphaproteobacteria";
-            if (taxonNodeIds[srcKey]) {
-                links.push({ source: taxonNodeIds[srcKey], target: intId });
-            }
-            
-
-            
-            var tgtKey = "Betaproteobacteria";
-            if (taxonNodeIds[tgtKey]) {
-                links.push({ source: intId, target: taxonNodeIds[tgtKey] });
-            }
-            
-        })();
-        
-        (function() {
-            var intId = "interaction:4";
-            var intType = "CROSS_FEEDING";
-            var metabolites = [];
-            
-            
-            metabolites.push("nitrite");
-            
-            metabolites.push("dinitrogen");
-            
-            
-            var processes = [];
-            
-            
-            processes.push("denitrification");
-            
-            
-            var evidenceCount = 1;
-
-            nodes.push({
-                id: intId,
-                label: "Denitrification by Betaproteobacteria",
-                type: "interaction",
-                interactionType: intType,
-                metabolites: metabolites,
-                processes: processes,
-                evidenceCount: evidenceCount
-            });
-
-            
-            var srcKey = "Betaproteobacteria";
+            var srcKey = "Viruses";
             if (taxonNodeIds[srcKey]) {
                 links.push({ source: taxonNodeIds[srcKey], target: intId });
             }
@@ -1571,7 +1462,7 @@
         var svg = d3.select("#network-svg");
         var width = container.clientWidth - 32;
         // Dynamic height based on node count: minimum 500px, add 40px per node
-        var nodeCount = 11;
+        var nodeCount = 8;
         var height = Math.max(500, 400 + nodeCount * 20);
         svg.attr("width", width).attr("height", height);
 

--- a/docs/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.html
+++ b/docs/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>BioModels MODEL1806250005 Cicada Sulcia-Hodgkinia Symbiosis - CommunityMech</title>
+    <title>SynCom ARC Peanut Aflatoxin-Control and Nodulation-Coupling Community - CommunityMech</title>
     <style>
         :root {
             --primary: #3D7DD6;
@@ -372,7 +372,7 @@
     <header>
         <div class="container">
             <a href="../browser.html" class="back-link">← Back to Communities</a>
-            <h1>BioModels MODEL1806250005 Cicada Sulcia-Hodgkinia Symbiosis</h1>
+            <h1>SynCom ARC Peanut Aflatoxin-Control and Nodulation-Coupling Community</h1>
         </div>
     </header>
 
@@ -383,19 +383,31 @@
                 <div class="metadata-item">
                     <span class="metadata-label">Community ID</span>
                     <span class="metadata-value">
-                        <code style="background: var(--border); color: var(--text); padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.9rem;">CommunityMech:000008</code>
+                        <code style="background: var(--border); color: var(--text); padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.9rem;">CommunityMech:000314</code>
                     </span>
                 </div>
 
                 <div class="metadata-item">
                     <span class="metadata-label">Ecological State</span>
                     <span class="metadata-value">
-                        <span class="badge badge-natural">
-                            STABLE
+                        <span class="badge badge-engineered">
+                            ENGINEERED
                         </span>
                     </span>
                 </div>
 
+                
+                <div class="metadata-item">
+                    <span class="metadata-label">Environment</span>
+                    <span class="metadata-value">
+                        peanut rhizosphere
+                        <br>
+                        <a href="https://www.ebi.ac.uk/ols/ontologies/envo/terms?iri=http://purl.obolibrary.org/obo/ENVO_00005801"
+                           class="term-link" target="_blank" rel="noopener noreferrer">
+                            ENVO:00005801
+                        </a>
+                    </span>
+                </div>
                 
                 
             </div>
@@ -404,7 +416,8 @@
         <!-- Description -->
         
         <section class="description">
-            <p>BioModels record MODEL1806250005 is a multi-compartment metabolic model of the cicada Neotibicen canicularis and its bacterial endosymbionts Sulcia and Hodgkinia.</p>
+            <p>A four-strain rhizosphere synthetic community — three Bacillus isolates (Bl13-2C11, Ba13-20E05, Bm14-5G09) and one Enterobacter isolate (El17-4B09) — assembled to couple two functions that are normally pursued separately in peanut: suppression of the aflatoxin-producing fungus Aspergillus flavus, and induction of rhizobia-legume nodulation. Candidate genera were chosen from cross-regional rhizosphere surveys as taxa negatively correlated with Aspergillus abundance but not with Bradyrhizobium, so that antifungal activity would not come at the cost of the nitrogen- fixing symbiont; strains that inhibited Bradyrhizobium in coculture were screened out on exactly that criterion. The resulting community, SynCom ARC, reduced peanut aflatoxin by 85.6% across four years of field trials and enhanced nodulation and nitrogenase activity while retaining active nodules at harvest. The record captures the community as a deliberately compatibility- constrained consortium: its design problem is not maximal antifungal potency but antagonism of the pathogen that spares a mutualist.
+</p>
         </section>
         
 
@@ -425,70 +438,181 @@
                     
                     <tr>
                         <td>
-                            <strong>Neotibicen canicularis</strong>
+                            <strong>Bacillus (ARC strains Bl13-2C11, Ba13-20E05, Bm14-5G09)</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1699721"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=1386"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:1699721
+                                NCBITaxon:1386
                             </a>
                         </td>
                         <td>
-                            
-                            <div class="roles-list">
-                                
-                                <span class="role-badge">CROSS_FEEDER</span>
-                                
-                            </div>
                             
                         </td>
                         <td>N/A</td>
                     </tr>
                     
-                    
-                    <tr>
-                        <td>
-                            <strong>Sulcia</strong>
-                        </td>
-                        <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=336809"
-                               class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:336809
-                            </a>
-                        </td>
-                        <td>
-                            
-                            <div class="roles-list">
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
                                 
-                                <span class="role-badge">SYNTROPHIC_PARTNER</span>
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/42099455/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42099455</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"3 Bacillus (Bl13‐2C11, Ba13‐20E05, Bm14‐5G09) and 1 Enterobacter (El17‐4B09) were selected for further study"</div>
+                                    
+                                </li>
                                 
-                            </div>
-                            
+                            </ul>
                         </td>
-                        <td>N/A</td>
                     </tr>
                     
                     
                     <tr>
                         <td>
-                            <strong>Hodgkinia</strong>
+                            <strong>Enterobacter (ARC strain El17-4B09)</strong>
                         </td>
                         <td>
-                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=573657"
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=547"
                                class="term-link" target="_blank" rel="noopener noreferrer">
-                                NCBITaxon:573657
+                                NCBITaxon:547
                             </a>
                         </td>
                         <td>
                             
-                            <div class="roles-list">
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
                                 
-                                <span class="role-badge">SYNTROPHIC_PARTNER</span>
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/42099455/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42099455</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"nine strains demonstrated an aflatoxin inhibition rate exceeding 95%: 7 Bacillus, 2 Enterobacter"</div>
+                                    
+                                </li>
                                 
-                            </div>
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td>
+                            <strong>Bradyrhizobium PHNZY-24-6</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=374"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:374
+                            </a>
+                        </td>
+                        <td>
                             
                         </td>
                         <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/42099455/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42099455</a>
+                                    
+                                    - SUPPORT (IN_VITRO)
+                                    
+                                    <div class="snippet">"3 Bacillus inhibited Bradyrhizobium"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td>
+                            <strong>Aspergillus flavus</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=5059"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:5059
+                            </a>
+                        </td>
+                        <td>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/42099455/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42099455</a>
+                                    
+                                    - SUPPORT (IN_VIVO)
+                                    
+                                    <div class="snippet">"SynCom ARC inhibits A. flavus growth and reduces peanut aflatoxin levels by 85.6% in 4 year field trials"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
+                    </tr>
+                    
+                    
+                    <tr>
+                        <td>
+                            <strong>peanut</strong>
+                        </td>
+                        <td>
+                            <a href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=3818"
+                               class="term-link" target="_blank" rel="noopener noreferrer">
+                                NCBITaxon:3818
+                            </a>
+                        </td>
+                        <td>
+                            
+                        </td>
+                        <td>N/A</td>
+                    </tr>
+                    
+                    <tr class="evidence-row-container">
+                        <td colspan="4">
+                            <ul class="evidence-list">
+                                
+                                <li class="evidence-item">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/42099455/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42099455</a>
+                                    
+                                    - SUPPORT (IN_VIVO)
+                                    
+                                    <div class="snippet">"SynCom ARC enhances peanut nodulation and nitrogenase activity"</div>
+                                    
+                                </li>
+                                
+                            </ul>
+                        </td>
                     </tr>
                     
                     
@@ -504,15 +628,18 @@
             <div class="network-container" id="network-container">
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
-                    <title id="network-svg-title">Ecological interaction network for BioModels MODEL1806250005 Cicada Sulcia-Hodgkinia Symbiosis</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <title id="network-svg-title">Ecological interaction network for SynCom ARC Peanut Aflatoxin-Control and Nodulation-Coupling Community</title>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (competition, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -520,34 +647,14 @@
             
             <div class="interaction-card">
                 <div class="interaction-header">
-                    <h3>Sulcia Essential Amino Acid Provisioning</h3>
-                    <span class="interaction-type">MUTUALISM</span>
+                    <h3>SynCom ARC Suppression of Aspergillus flavus</h3>
+                    <span class="interaction-type">COMPETITION</span>
                 </div>
 
                 
-                <p><strong>Source Taxon:</strong> Sulcia</p>
-                
 
                 
-                <p><strong>Target Taxon:</strong> Neotibicen canicularis</p>
-                
 
-                
-                <p><strong>Metabolites:</strong>
-                    
-                    L-leucine
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=15603"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:15603</a>), 
-                    
-                    L-isoleucine
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=17191"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:17191</a>), 
-                    
-                    nitrogen
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=25555"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:25555</a>)
-                    
-                </p>
                 
 
                 
@@ -561,26 +668,13 @@
                     <li class="evidence-item">
                         <div>
                             
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/42099455/"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42099455</a>
                             
-                            - SUPPORT (COMPUTATIONAL)
+                            - SUPPORT (IN_VIVO)
                         </div>
                         
-                        <div class="snippet">"Sulcia and Hodgkinia with genomes of ≤0.3 Mb are calculated to recycle ∼30 to 80% of host-derived nitrogen to essential amino acids returned to the host"</div>
-                        
-                    </li>
-                    
-                    <li class="evidence-item">
-                        <div>
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
-                            
-                            - SUPPORT (COMPUTATIONAL)
-                        </div>
-                        
-                        <div class="snippet">"Our simulations reveal extensive bidirectional flux of multiple metabolites between each symbiont and the host"</div>
+                        <div class="snippet">"SynCom ARC inhibits A. flavus growth and reduces peanut aflatoxin levels by 85.6% in 4 year field trials"</div>
                         
                     </li>
                     
@@ -590,26 +684,14 @@
             
             <div class="interaction-card">
                 <div class="interaction-header">
-                    <h3>Hodgkinia Metabolic Complementarity</h3>
-                    <span class="interaction-type">MUTUALISM</span>
+                    <h3>SynCom ARC Induction of Rhizobia-Legume Nodulation</h3>
+                    <span class="interaction-type">COLONIZATION_FACILITATION</span>
                 </div>
 
                 
-                <p><strong>Source Taxon:</strong> Hodgkinia</p>
-                
 
                 
-                <p><strong>Target Taxon:</strong> Neotibicen canicularis</p>
-                
 
-                
-                <p><strong>Metabolites:</strong>
-                    
-                    nitrogen
-                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=25555"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:25555</a>)
-                    
-                </p>
                 
 
                 
@@ -623,26 +705,13 @@
                     <li class="evidence-item">
                         <div>
                             
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/42099455/"
+                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42099455</a>
                             
-                            - SUPPORT (COMPUTATIONAL)
+                            - SUPPORT (IN_VIVO)
                         </div>
                         
-                        <div class="snippet">"Sulcia and Hodgkinia with genomes of ≤0.3 Mb are calculated to recycle ∼30 to 80% of host-derived nitrogen to essential amino acids returned to the host"</div>
-                        
-                    </li>
-                    
-                    <li class="evidence-item">
-                        <div>
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                               class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
-                            
-                            - SUPPORT (COMPUTATIONAL)
-                        </div>
-                        
-                        <div class="snippet">"near-complete metabolic segregation (i.e., near absence of metabolic cross-feeding) between the two symbionts, a likely mode of host control over symbiont metabolism"</div>
+                        <div class="snippet">"SynCom ARC enhances peanut nodulation and nitrogenase activity, retains active nodules at harvest"</div>
                         
                     </li>
                     
@@ -655,83 +724,27 @@
 
         <!-- Associated Datasets -->
         
-        <section>
-            <h2>Associated Datasets</h2>
-            <table>
-                <thead>
-                    <tr>
-                        <th>Dataset</th>
-                        <th>Type</th>
-                        <th>Repository</th>
-                        <th>Accession</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    
-                    <tr>
-                        <td>
-                            <strong>BioModels model file</strong>
-                            
-                            <br><span class="dataset-description">Multi-compartment SBML model for cicada symbiosis.</span>
-                            
-                        </td>
-                        <td><span class="role-badge">OTHER</span></td>
-                        <td>OTHER</td>
-                        <td>
-                            
-                            <a href="https://www.ebi.ac.uk/biomodels/MODEL1806250005" class="term-link" target="_blank" rel="noopener noreferrer">Neotibicen_iNA533.xml</a>
-                            
-                        </td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                            <strong>Primary publication</strong>
-                            
-                            <br><span class="dataset-description">Study on the cost of metabolic interactions in insect-bacterial symbioses.</span>
-                            
-                        </td>
-                        <td><span class="role-badge">OTHER</span></td>
-                        <td>OTHER</td>
-                        <td>
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/" class="term-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
-                            
-                        </td>
-                    </tr>
-                    
-                </tbody>
-            </table>
-        </section>
-        
 
         <!-- Environmental Factors -->
         
+
+        
         <section>
-            <h2>External Resources</h2>
+            <h2>Environmental Factors</h2>
             <table>
                 <thead>
                     <tr>
-                        <th>Name</th>
-                        <th>Repository</th>
-                        <th>Resource ID</th>
+                        <th>Factor</th>
+                        <th>Value</th>
+                        <th>Unit</th>
                     </tr>
                 </thead>
                 <tbody>
                     
                     <tr>
-                        <td>
-                            <strong>BioModels entry</strong>
-                            
-                            <br><span class="dataset-description">Cicada symbiosis metabolic model.</span>
-                            
-                        </td>
-                        <td>BIOMODELS</td>
-                        <td>
-                            
-                            <a href="https://www.ebi.ac.uk/biomodels/MODEL1806250005" class="term-link" target="_blank" rel="noopener noreferrer">MODEL1806250005</a>
-                            
-                        </td>
+                        <td><strong>Multi-year multi-site field trial</strong></td>
+                        <td>4 years; 325 sites across 19 provinces</td>
+                        <td>N/A</td>
                     </tr>
                     
                     <tr class="evidence-row-container">
@@ -740,12 +753,12 @@
                                 
                                 <li class="evidence-item">
                                     
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30254121/"
-                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:30254121</a>
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/42099455/"
+                                       class="pmid-link" target="_blank" rel="noopener noreferrer">PMID:42099455</a>
                                     
-                                    - SUPPORT (COMPUTATIONAL)
+                                    - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"The Cost of Metabolic Interactions in Symbioses between Insects and Bacteria with Reduced Genomes."</div>
+                                    <div class="snippet">"boosts yield without super nodulation penalty in 325 sites of 19 provinces"</div>
                                     
                                 </li>
                                 
@@ -757,8 +770,6 @@
                 </tbody>
             </table>
         </section>
-        
-
         
 
         <!-- Growth Media -->
@@ -791,25 +802,39 @@
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
-        taxonData["Neotibicen canicularis"] = {
-            id: "NCBITaxon:1699721",
-            label: "Neotibicen canicularis",
+        taxonData["Bacillus (ARC strains Bl13-2C11, Ba13-20E05, Bm14-5G09)"] = {
+            id: "NCBITaxon:1386",
+            label: "Bacillus (ARC strains Bl13-2C11, Ba13-20E05, Bm14-5G09)",
             abundance: "UNKNOWN",
-            roles: ["CROSS_FEEDER"]
+            roles: []
         };
         
-        taxonData["Sulcia"] = {
-            id: "NCBITaxon:336809",
-            label: "Sulcia",
+        taxonData["Enterobacter (ARC strain El17-4B09)"] = {
+            id: "NCBITaxon:547",
+            label: "Enterobacter (ARC strain El17-4B09)",
             abundance: "UNKNOWN",
-            roles: ["SYNTROPHIC_PARTNER"]
+            roles: []
         };
         
-        taxonData["Hodgkinia"] = {
-            id: "NCBITaxon:573657",
-            label: "Hodgkinia",
+        taxonData["Bradyrhizobium PHNZY-24-6"] = {
+            id: "NCBITaxon:374",
+            label: "Bradyrhizobium PHNZY-24-6",
             abundance: "UNKNOWN",
-            roles: ["SYNTROPHIC_PARTNER"]
+            roles: []
+        };
+        
+        taxonData["Aspergillus flavus"] = {
+            id: "NCBITaxon:5059",
+            label: "Aspergillus flavus",
+            abundance: "UNKNOWN",
+            roles: []
+        };
+        
+        taxonData["peanut"] = {
+            id: "NCBITaxon:3818",
+            label: "peanut",
+            abundance: "UNKNOWN",
+            roles: []
         };
         
 
@@ -837,24 +862,16 @@
         
         (function() {
             var intId = "interaction:0";
-            var intType = "MUTUALISM";
+            var intType = "COMPETITION";
             var metabolites = [];
-            
-            
-            metabolites.push("L-leucine");
-            
-            metabolites.push("L-isoleucine");
-            
-            metabolites.push("nitrogen");
-            
             
             var processes = [];
             
-            var evidenceCount = 2;
+            var evidenceCount = 1;
 
             nodes.push({
                 id: intId,
-                label: "Sulcia Essential Amino Acid Provisioning",
+                label: "SynCom ARC Suppression of Aspergillus flavus",
                 type: "interaction",
                 interactionType: intType,
                 metabolites: metabolites,
@@ -863,36 +880,22 @@
             });
 
             
-            var srcKey = "Sulcia";
-            if (taxonNodeIds[srcKey]) {
-                links.push({ source: taxonNodeIds[srcKey], target: intId });
-            }
-            
 
-            
-            var tgtKey = "Neotibicen canicularis";
-            if (taxonNodeIds[tgtKey]) {
-                links.push({ source: intId, target: taxonNodeIds[tgtKey] });
-            }
             
         })();
         
         (function() {
             var intId = "interaction:1";
-            var intType = "MUTUALISM";
+            var intType = "COLONIZATION_FACILITATION";
             var metabolites = [];
-            
-            
-            metabolites.push("nitrogen");
-            
             
             var processes = [];
             
-            var evidenceCount = 2;
+            var evidenceCount = 1;
 
             nodes.push({
                 id: intId,
-                label: "Hodgkinia Metabolic Complementarity",
+                label: "SynCom ARC Induction of Rhizobia-Legume Nodulation",
                 type: "interaction",
                 interactionType: intType,
                 metabolites: metabolites,
@@ -901,17 +904,7 @@
             });
 
             
-            var srcKey = "Hodgkinia";
-            if (taxonNodeIds[srcKey]) {
-                links.push({ source: taxonNodeIds[srcKey], target: intId });
-            }
-            
 
-            
-            var tgtKey = "Neotibicen canicularis";
-            if (taxonNodeIds[tgtKey]) {
-                links.push({ source: intId, target: taxonNodeIds[tgtKey] });
-            }
             
         })();
         
@@ -931,7 +924,7 @@
         var svg = d3.select("#network-svg");
         var width = container.clientWidth - 32;
         // Dynamic height based on node count: minimum 500px, add 40px per node
-        var nodeCount = 5;
+        var nodeCount = 7;
         var height = Math.max(500, 400 + nodeCount * 20);
         svg.attr("width", width).attr("height", height);
 

--- a/docs/communities/Syntrophomonas_Methanospirillum_Syntrophy.html
+++ b/docs/communities/Syntrophomonas_Methanospirillum_Syntrophy.html
@@ -634,7 +634,7 @@
                             - SUPPORT (IN_VITRO)
                         </div>
                         
-                        <div class="snippet">"An anaerobic, nonphototrophic bacterium that beta-oxidizes saturated fatty acids (butyrate through octanoate) to acetate or acetate and propionate usi"</div>
+                        <div class="snippet">"An anaerobic, nonphototrophic bacterium that beta-oxidizes saturated fatty acids (butyrate through octanoate) to acetate or acetate and propionate using protons as the electron acceptor"</div>
                         
                     </li>
                     

--- a/docs/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.html
+++ b/docs/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.html
@@ -482,7 +482,7 @@
                                     
                                     - SUPPORT (IN_VITRO)
                                     
-                                    <div class="snippet">"benzoate-fermenting bacterium S."</div>
+                                    <div class="snippet">"benzoate-fermenting bacterium S. gentianae is approximately -45 kJ (mol benzoate)-1"</div>
                                     
                                 </li>
                                 

--- a/docs/communities/Trichodesmium_Alteromonas_Marine_Consortium.html
+++ b/docs/communities/Trichodesmium_Alteromonas_Marine_Consortium.html
@@ -671,7 +671,11 @@
                     
                     iron(2+)
                     (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=29033"
-                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:29033</a>)
+                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:29033</a>), 
+                    
+                    reactive oxygen species
+                    (<a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=26523"
+                        class="term-link" target="_blank" rel="noopener noreferrer">CHEBI:26523</a>)
                     
                 </p>
                 
@@ -1073,6 +1077,8 @@
             metabolites.push("phosphate");
             
             metabolites.push("iron(2+)");
+            
+            metabolites.push("reactive oxygen species");
             
             
             var processes = [];

--- a/docs/index.html
+++ b/docs/index.html
@@ -75,7 +75,7 @@
     <h1>CommunityMech</h1>
     <p class="tagline">Microbial community knowledge base — curated, evidence-backed interaction networks.</p>
     <div class="stats">
-      <div class="stat"><b>305</b><span>communities</span></div>
+      <div class="stat"><b>312</b><span>communities</span></div>
       <div class="stat"><b>16</b><span>categories</span></div>
       <div class="stat"><b>512-D</b><span>v3 embeddings</span></div>
     </div>

--- a/justfile
+++ b/justfile
@@ -305,6 +305,28 @@ gen-browser:
 gen-html:
     uv run python -m communitymech.render
 
+# Gate: docs/ must be what gen-html currently produces (#442).
+#
+# `generate-pages.yaml` serves the committed docs/ verbatim, so a data PR that
+# does not regenerate publishes a page contradicting the KB. That is not
+# hypothetical: docs/ had drifted on 7 pages — two rendering NCBITaxon:169215,
+# the *plant* genus Bosea, as a live NCBI link for a bacterium — and 7 records
+# had no published page at all, having been added without a regeneration.
+#
+# Cheap enough to gate on: the render is ~7s and deterministic, so a clean
+# checkout that runs it gets a byte-identical tree. Untracked files count —
+# a missing page is the failure mode that produced no diff at all.
+check-docs-current:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just gen-html >/dev/null
+    if [ -n "$(git status --porcelain docs/)" ]; then
+        echo "❌ docs/ is not what gen-html produces. Run 'just gen-html' and commit:"
+        git status --short docs/
+        exit 1
+    fi
+    echo "✅ docs/ matches the KB"
+
 # Generate UMAP visualization of community embedding space
 gen-umap:
     uv run communitymech generate-umap

--- a/justfile
+++ b/justfile
@@ -309,9 +309,10 @@ gen-html:
 #
 # `generate-pages.yaml` serves the committed docs/ verbatim, so a data PR that
 # does not regenerate publishes a page contradicting the KB. That is not
-# hypothetical: docs/ had drifted on 7 pages — two rendering NCBITaxon:169215,
-# the *plant* genus Bosea, as a live NCBI link for a bacterium — and 7 records
-# had no published page at all, having been added without a regeneration.
+# hypothetical: docs/ had drifted on 8 pages — two rendering NCBITaxon:169215,
+# the *plant* genus Bosea, as a live NCBI link for a bacterium, and one linking
+# Bacteroides ovatus to Phocaeicola vulgatus's taxon — and 7 records had no
+# published page at all, having been added without a regeneration.
 #
 # Cheap enough to gate on: the render is ~7s and deterministic, so a clean
 # checkout that runs it gets a byte-identical tree. Untracked files count —
@@ -319,7 +320,24 @@ gen-html:
 check-docs-current:
     #!/usr/bin/env bash
     set -euo pipefail
-    just gen-html >/dev/null
+    # Do NOT discard this output, and do not let the render's exit code slide.
+    # render_all used to swallow a per-record exception, leave the previous page
+    # in place, and still print "✅ Rendered 312" — so the tree had no diff and
+    # this gate reported it current, green in exactly the case where the
+    # regeneration it gates on had not happened (#442 review).
+    just gen-html
+    # An orphan: a page whose record was renamed or deleted. gen-html only ever
+    # writes, so the stale page stays tracked and published while the diff stays
+    # empty. f8d85b1 is a rename of exactly that shape.
+    orphans=""
+    for page in docs/communities/*.html; do
+        record="kb/communities/$(basename "$page" .html).yaml"
+        [ -f "$record" ] || orphans="$orphans $(basename "$page")"
+    done
+    if [ -n "$orphans" ]; then
+        echo "❌ published pages with no record (delete them):$orphans"
+        exit 1
+    fi
     if [ -n "$(git status --porcelain docs/)" ]; then
         echo "❌ docs/ is not what gen-html produces. Run 'just gen-html' and commit:"
         git status --short docs/

--- a/reports/gtdb_denominators.tsv
+++ b/reports/gtdb_denominators.tsv
@@ -1,5 +1,5 @@
 # mapping: NCBI2GTDB.tsv.gz	bytes=2895086	mtime=1785022111
-# taxa=578	varying=17
+# taxa=583	varying=18
 ncbi_id	label	aggregate_id	aggregate_frac	aggregate_named_id	aggregate_named_frac	deepest_id	deepest_frac	deepest_named_id	deepest_named_frac	varies	distinct_answers
 NCBITaxon:100176	Papillibacter cinnamivorans	GTDB:s__Papillibacter_cinnamivorans	1.0	GTDB:s__Papillibacter_cinnamivorans	1.0	GTDB:s__Papillibacter_cinnamivorans	1.0	GTDB:s__Papillibacter_cinnamivorans	1.0		1
 NCBITaxon:100226	Streptomyces coelicolor A3(2)	GTDB:s__Streptomyces_anthocyanicus	1.0	GTDB:s__Streptomyces_anthocyanicus	1.0	GTDB:s__Streptomyces_anthocyanicus	1.0	GTDB:s__Streptomyces_anthocyanicus	1.0		1
@@ -8,6 +8,7 @@ NCBITaxon:1021	Beggiatoa	GTDB:g__Beggiatoa	0.75	GTDB:g__Beggiatoa	1.0	GTDB:g__Be
 NCBITaxon:10239	Viruses	NONE		NONE		NONE		NONE			1
 NCBITaxon:1031	Thiothrix nivea	GTDB:s__Thiothrix_nivea	1.0	GTDB:s__Thiothrix_nivea	1.0	GTDB:s__Thiothrix_nivea	1.0	GTDB:s__Thiothrix_nivea	1.0		1
 NCBITaxon:1033	Afipia	GTDB:g__Afipia	0.957	GTDB:g__Afipia	1.0	GTDB:g__Afipia	0.955	GTDB:g__Afipia	1.0		1
+NCBITaxon:1033997	Nitrososphaeraceae	GTDB:f__Nitrososphaeraceae	1.0	GTDB:f__Nitrososphaeraceae	1.0	GTDB:f__Nitrososphaeraceae	1.0	GTDB:f__Nitrososphaeraceae	1.0		1
 NCBITaxon:105841	Anaerostipes caccae	GTDB:s__Anaerostipes_caccae	1.0	GTDB:s__Anaerostipes_caccae	1.0	GTDB:s__Anaerostipes_caccae	1.0	GTDB:s__Anaerostipes_caccae	1.0		1
 NCBITaxon:105972	Methylosarcina fibrata	GTDB:s__Methylosarcina_fibrata	1.0	GTDB:s__Methylosarcina_fibrata	1.0	GTDB:s__Methylosarcina_fibrata	1.0	GTDB:s__Methylosarcina_fibrata	1.0		1
 NCBITaxon:1061	Rhodobacter capsulatus	GTDB:s__Rhodobacter_capsulatus_B	1.0	GTDB:s__Rhodobacter_capsulatus_B	1.0	GTDB:s__Rhodobacter_capsulatus_B	1.0	GTDB:s__Rhodobacter_capsulatus_B	1.0		1
@@ -149,7 +150,6 @@ NCBITaxon:1681	Bifidobacterium bifidum	GTDB:s__Bifidobacterium_bifidum	1.0	GTDB:
 NCBITaxon:1682	Bifidobacterium longum subsp. infantis	GTDB:s__Bifidobacterium_infantis	0.94	GTDB:s__Bifidobacterium_infantis	0.94	GTDB:s__Bifidobacterium_infantis	0.94	GTDB:s__Bifidobacterium_infantis	0.94		1
 NCBITaxon:168384	Marvinbryantia formatexigens	GTDB:s__Marvinbryantia_formatexigens	1.0	GTDB:s__Marvinbryantia_formatexigens	1.0	GTDB:s__Marvinbryantia_formatexigens	1.0	GTDB:s__Marvinbryantia_formatexigens	1.0		1
 NCBITaxon:1685	Bifidobacterium breve	GTDB:s__Bifidobacterium_breve	0.99	GTDB:s__Bifidobacterium_breve	0.99	GTDB:s__Bifidobacterium_breve	0.99	GTDB:s__Bifidobacterium_breve	0.99		1
-NCBITaxon:169215	Bosea	GTDB:g__Bosea	0.981	GTDB:g__Bosea	1.0	GTDB:g__Bosea	0.981	GTDB:g__Bosea	1.0		1
 NCBITaxon:1696	Brevibacterium	GTDB:g__Brevibacterium	0.987	GTDB:g__Brevibacterium	1.0	GTDB:g__Brevibacterium	0.983	GTDB:g__Brevibacterium	1.0		1
 NCBITaxon:1699721	Neotibicen canicularis	NONE		NONE		NONE		NONE			1
 NCBITaxon:1707	Cellulomonas	GTDB:g__Cellulomonas	0.858	GTDB:g__Cellulomonas	0.888	GTDB:g__Cellulomonas	0.859	GTDB:g__Cellulomonas	0.897		1
@@ -188,6 +188,7 @@ NCBITaxon:1872648	Asticcacaulis sp.	NONE		NONE		NONE		NONE			1
 NCBITaxon:1873462	Microbacteriaceae bacterium	NONE		NONE		NONE		NONE			1
 NCBITaxon:1883	Streptomyces	GTDB:g__Streptomyces	0.973	GTDB:g__Streptomyces	0.99	GTDB:g__Streptomyces	0.972	GTDB:g__Streptomyces	0.99		1
 NCBITaxon:1889	Streptomyces ambofaciens	GTDB:s__Streptomyces_ambofaciens	1.0	GTDB:s__Streptomyces_ambofaciens	1.0	GTDB:s__Streptomyces_ambofaciens	1.0	GTDB:s__Streptomyces_ambofaciens	1.0		1
+NCBITaxon:189779	Nitrospiraceae	GTDB:f__Nitrospiraceae	0.621	GTDB:f__Leptospirillaceae	0.534	GTDB:f__Nitrospiraceae	0.668	AMBIGUOUS		VARIES	3
 NCBITaxon:1902583	Candidatus Desulfofervidus	NONE		NONE		NONE		NONE			1
 NCBITaxon:1904413	Suillus clintonianus	NONE		NONE		NONE		NONE			1
 NCBITaxon:1908224	Sphingopyxis sp.	NONE		NONE		NONE		NONE			1
@@ -269,10 +270,10 @@ NCBITaxon:266	Paracoccus denitrificans	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOU
 NCBITaxon:267377	Methanococcus maripaludis S2	GTDB:s__Methanococcus_maripaludis	1.0	GTDB:s__Methanococcus_maripaludis	1.0	GTDB:s__Methanococcus_maripaludis	1.0	GTDB:s__Methanococcus_maripaludis	1.0		1
 NCBITaxon:2675547	Chlorella sp. HS2	NONE		NONE		NONE		NONE			1
 NCBITaxon:267818	Lactobacillus kefiranofaciens	GTDB:s__Lactobacillus_kefiranofaciens	1.0	GTDB:s__Lactobacillus_kefiranofaciens	1.0	GTDB:s__Lactobacillus_kefiranofaciens	1.0	GTDB:s__Lactobacillus_kefiranofaciens	1.0		1
+NCBITaxon:2689614	Steroidobacteraceae	GTDB:f__Steroidobacteraceae	1.0	GTDB:f__Steroidobacteraceae	1.0	GTDB:f__Steroidobacteraceae	1.0	GTDB:f__Steroidobacteraceae	1.0		1
 NCBITaxon:2697049	Severe acute respiratory syndrome coronavirus 2	NONE		NONE		NONE		NONE			1
 NCBITaxon:269797	Methanosarcina barkeri str. Fusaro	GTDB:s__Methanosarcina_barkeri_B	1.0	GTDB:s__Methanosarcina_barkeri_B	1.0	GTDB:s__Methanosarcina_barkeri_B	1.0	GTDB:s__Methanosarcina_barkeri_B	1.0		1
 NCBITaxon:270351	Methylobacterium aquaticum	NONE		NONE		NONE		NONE			1
-NCBITaxon:2716471	Sulcia	NONE		NONE		NONE		NONE			1
 NCBITaxon:272772	Pseudomonas pudica	GTDB:s__Pseudomonas_E_pudica	1.0	GTDB:s__Pseudomonas_E_pudica	1.0	GTDB:s__Pseudomonas_E_pudica	1.0	GTDB:s__Pseudomonas_E_pudica	1.0		1
 NCBITaxon:2736640	Pseudonocardia broussonetiae	GTDB:s__Pseudonocardia_broussonetiae	1.0	GTDB:s__Pseudonocardia_broussonetiae	1.0	GTDB:s__Pseudonocardia_broussonetiae	1.0	GTDB:s__Pseudonocardia_broussonetiae	1.0		1
 NCBITaxon:2740557	Pauljensenia	GTDB:g__Pauljensenia	1.0	GTDB:g__Pauljensenia	1.0	GTDB:g__Pauljensenia	1.0	GTDB:g__Pauljensenia	1.0		1
@@ -284,6 +285,7 @@ NCBITaxon:28034	Sulfobacillus thermosulfidooxidans	GTDB:s__Sulfobacillus_thermos
 NCBITaxon:28037	Streptococcus mitis	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
 NCBITaxon:28065	Rhodoferax	GTDB:g__Rhodoferax	0.718	GTDB:g__Rhodoferax	0.706	GTDB:g__Rhodoferax	0.718	GTDB:g__Rhodoferax	0.706		1
 NCBITaxon:28108	Alteromonas macleodii	GTDB:s__Alteromonas_macleodii	0.9	GTDB:s__Alteromonas_macleodii	0.9	GTDB:s__Alteromonas_macleodii	0.9	GTDB:s__Alteromonas_macleodii	0.9		1
+NCBITaxon:28116	Bacteroides ovatus	GTDB:s__Bacteroides_ovatus	0.99	GTDB:s__Bacteroides_ovatus	0.99	GTDB:s__Bacteroides_ovatus	0.99	GTDB:s__Bacteroides_ovatus	0.99		1
 NCBITaxon:2818505	Myxococcota	GTDB:p__Myxococcota	0.903	GTDB:p__Myxococcota	0.836	GTDB:p__Myxococcota	0.9	GTDB:p__Myxococcota	0.826		1
 NCBITaxon:28211	Alphaproteobacteria	GTDB:c__Alphaproteobacteria	0.996	GTDB:c__Alphaproteobacteria	1.0	GTDB:c__Alphaproteobacteria	0.996	GTDB:c__Alphaproteobacteria	1.0		1
 NCBITaxon:28216	Betaproteobacteria	GTDB:c__Gammaproteobacteria	1.0	GTDB:c__Gammaproteobacteria	1.0	GTDB:c__Gammaproteobacteria	1.0	GTDB:c__Gammaproteobacteria	1.0		1
@@ -330,12 +332,14 @@ NCBITaxon:32046	Synechococcus elongatus	GTDB:s__Synechococcus_elongatus	0.85	GTD
 NCBITaxon:32049	Picosynechococcus sp. PCC 7002	GTDB:s__Limnothrix_sp001693275	1.0	GTDB:s__Limnothrix_sp001693275	1.0	GTDB:s__Limnothrix_sp001693275	1.0	GTDB:s__Limnothrix_sp001693275	1.0		1
 NCBITaxon:323259	Methanospirillum hungatei JF-1	GTDB:s__Methanospirillum_hungatei	1.0	GTDB:s__Methanospirillum_hungatei	1.0	GTDB:s__Methanospirillum_hungatei	1.0	GTDB:s__Methanospirillum_hungatei	1.0		1
 NCBITaxon:324747	Pseudoxanthomonas byssovorax	NONE		NONE		NONE		NONE			1
+NCBITaxon:327159	Candidatus Accumulibacter	NONE		NONE		NONE		NONE			1
 NCBITaxon:33035	Blautia producta	GTDB:s__Blautia_coccoides	1.0	GTDB:s__Blautia_coccoides	1.0	GTDB:s__Blautia_coccoides	1.0	GTDB:s__Blautia_coccoides	1.0		1
 NCBITaxon:33038	Mediterraneibacter gnavus	GTDB:s__Ruminococcus_B_gnavus	0.99	GTDB:s__Ruminococcus_B_gnavus	0.99	GTDB:s__Ruminococcus_B_gnavus	0.99	GTDB:s__Ruminococcus_B_gnavus	0.99		1
 NCBITaxon:33059	Acidithiobacillus caldus	GTDB:s__Acidithiobacillus_A_caldus	1.0	GTDB:s__Acidithiobacillus_A_caldus	1.0	GTDB:s__Acidithiobacillus_A_caldus	1.0	GTDB:s__Acidithiobacillus_A_caldus	1.0		1
 NCBITaxon:33075	Acidobacterium capsulatum	NONE		NONE		NONE		NONE			1
 NCBITaxon:332101	Clostridium drakei	GTDB:s__Clostridium_AM_drakei	1.0	GTDB:s__Clostridium_AM_drakei	1.0	GTDB:s__Clostridium_AM_drakei	1.0	GTDB:s__Clostridium_AM_drakei	1.0		1
 NCBITaxon:33642	Coscinodiscus radiatus	NONE		NONE		NONE		NONE			1
+NCBITaxon:336809	Candidatus Karelsulcia	NONE		NONE		NONE		NONE			1
 NCBITaxon:33849	Bacillariophyceae	NONE		NONE		NONE		NONE			1
 NCBITaxon:3386252	Candidatus Methanogaster	NONE		NONE		NONE		NONE			1
 NCBITaxon:33882	Microbacterium	GTDB:g__Microbacterium	0.995	GTDB:g__Microbacterium	1.0	GTDB:g__Microbacterium	0.995	GTDB:g__Microbacterium	1.0		1
@@ -548,6 +552,7 @@ NCBITaxon:84565	Sodalis	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
 NCBITaxon:84567	Pedobacter	GTDB:g__Pedobacter	0.924	GTDB:g__Pedobacter	0.902	GTDB:g__Pedobacter	0.924	GTDB:g__Pedobacter	0.902		1
 NCBITaxon:85021	Intrasporangiaceae	GTDB:f__Dermatophilaceae	0.997	GTDB:f__Dermatophilaceae	0.996	GTDB:f__Dermatophilaceae	0.997	GTDB:f__Dermatophilaceae	0.996		1
 NCBITaxon:853	Faecalibacterium prausnitzii	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
+NCBITaxon:85413	Allobosea	NONE		NONE		NONE		NONE			1
 NCBITaxon:857252	Halopseudomonas aestusnigri	GTDB:s__Halopseudomonas_aestusnigri	1.0	GTDB:s__Halopseudomonas_aestusnigri	1.0	GTDB:s__Halopseudomonas_aestusnigri	1.0	GTDB:s__Halopseudomonas_aestusnigri	1.0		1
 NCBITaxon:863	Syntrophomonas wolfei	AMBIGUOUS		AMBIGUOUS		AMBIGUOUS		AMBIGUOUS			1
 NCBITaxon:86795	Marmoricola	GTDB:g__Marmoricola	0.923	GTDB:g__Marmoricola	1.0	GTDB:g__Marmoricola	0.923	GTDB:g__Marmoricola	1.0		1

--- a/src/communitymech/render.py
+++ b/src/communitymech/render.py
@@ -73,7 +73,7 @@ class CommunityRenderer:
         self,
         communities_dir: Path = Path("kb/communities"),
         output_dir: Path | None = None,
-    ) -> None:
+    ) -> list[str]:
         """
         Render all community YAML files to HTML.
 
@@ -82,23 +82,40 @@ class CommunityRenderer:
             output_dir: Directory for output HTML files. Defaults to the repo's
                 `docs/communities`, which is git-tracked — a cwd-relative default
                 wrote a stray tree wherever the process ran (#407).
+
+        Returns:
+            The names of records that failed to render. Their pages are left as
+            they were, so a caller that ignores this cannot tell a current tree
+            from a stale one.
         """
         output_dir = output_dir if output_dir is not None else DOCS / "communities"
         yaml_files = sorted(communities_dir.glob("*.yaml"))
 
         print(f"\nRendering {len(yaml_files)} communities to HTML...")
 
+        failed: list[str] = []
         for yaml_file in yaml_files:
             try:
                 output_file = output_dir / f"{yaml_file.stem}.html"
                 self.render_community(yaml_file, output_file)
             except Exception as e:
                 print(f"  ✗ {yaml_file.name}: {e}")
+                failed.append(yaml_file.name)
 
-        print(f"\n✅ Rendered {len(yaml_files)} communities to {output_dir}")
+        # A swallowed failure used to leave the previous page in place and still
+        # print "✅ Rendered 312", so `check-docs-current` saw no diff and
+        # reported the tree current — green precisely when the regeneration it
+        # gates on had not happened (#442 review). Report the real count and
+        # exit non-zero.
+        rendered = len(yaml_files) - len(failed)
+        print(f"\n✅ Rendered {rendered} communities to {output_dir}")
+        if failed:
+            print(f"❌ {len(failed)} failed to render, so their pages are STALE: {failed}")
 
         # Generate index page
         self._generate_index(yaml_files, output_dir)
+
+        return failed
 
     def _generate_index(
         self,
@@ -192,10 +209,12 @@ def main():
         renderer.render_community(yaml_path, output_path)
     else:
         # Render all files
-        renderer.render_all(
+        failed = renderer.render_all(
             communities_dir=Path(args.communities_dir),
             output_dir=Path(args.output_dir),
         )
+        if failed:
+            raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_docs_do_not_contradict_the_kb.py
+++ b/tests/test_docs_do_not_contradict_the_kb.py
@@ -1,26 +1,39 @@
-"""The published site rendered a plant's taxon id for a bacterium (#442).
+"""The published site linked the wrong organism, twice (#442).
 
 `generate-pages.yaml` serves the committed `docs/` tree verbatim, and nothing
 regenerated or checked it. A data PR that corrected a record and did not re-run
 `just gen-html` published a page contradicting the KB — invisibly, since no
 schema validator or id↔label gate reads HTML.
 
-Both directions had drifted by the time this was written:
+Three ways it had drifted:
 
-* 7 pages carried taxon ids the record no longer held. Two rendered
-  `NCBITaxon:169215` — the *plant* genus *Bosea* — as a live NCBI link on a
-  bacterium, and `KBase_ORT_Workflow_Community_Model` still showed the
-  class/phylum ids its record replaced in 2a3b691.
-* 7 records had **no page at all**. That is the failure a diff of existing
-  files cannot see, which is why `just check-docs-current` counts untracked
-  files and why `test_every_record_has_a_published_page` is separate below.
+* **8 pages linked a taxon id the record no longer holds there.** Two rendered
+  `NCBITaxon:169215` — the flowering-plant genus *Bosea* — as a live NCBI link
+  on a bacterium. `BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom` linked
+  *Bacteroides ovatus* to `NCBITaxon:821`, which is *Phocaeicola vulgatus* —
+  the row above it.
+* **7 records had no page at all**, added without a regeneration. A diff of
+  existing files cannot see that, which is why the gate counts untracked files.
+* **Orphan pages** survive a record rename, since `gen-html` only writes.
 
-`just check-docs-current` (CI: `docs-current.yaml`) is the real gate — it
+The oracle here is positional, and that is the point. An earlier version of this
+file compared *sets* — every `NCBITaxon:` id anywhere in the page against every
+one anywhere in the record — and passed the *Bacteroides ovatus* case, because
+821 does appear in that record, one row up. Set membership cannot see a swap
+between two ids a record both contains, and swaps are what wrong-organism links
+are made of. Each `taxon_term.term.id` is also duplicated as
+`gtdb_classification.ncbi_source_id`, so the document-wide set is unusually
+forgiving.
+
+The renderer emits `taxonomy[].taxon_term.term.id` first and in record order;
+verified across all 312 pages, the record's taxonomy ids are a prefix of the
+page's NCBI links. Interaction participants add links after that prefix, so the
+check is a prefix comparison rather than equality.
+
+`just check-docs-current` (CI: `docs-current.yaml`) remains the real gate — it
 regenerates and demands a byte-identical tree. These tests are the fast local
-signal, and they state the *property* rather than the mechanism: a page must
-not assert a taxon id its record does not have. That distinction matters
-because the gate can only say "re-run the renderer", while a failure here names
-the contradiction.
+signal, and they name the contradiction where the gate can only say "re-run the
+renderer".
 """
 
 from __future__ import annotations
@@ -35,13 +48,24 @@ REPO = pathlib.Path(__file__).parent.parent
 PAGES = REPO / "docs/communities"
 RECORDS = REPO / "kb/communities"
 
-# Matches both the visible CURIE and the NCBI browser links the pages emit
-# (`wwwtax.cgi?id=169215`), since the link is what a reader actually follows.
-_CURIE = re.compile(r"NCBITaxon:(\d+)")
+# The link is what a reader actually follows, and it carries a bare numeric id.
 _LINK = re.compile(r"wwwtax\.cgi\?id=(\d+)")
+_CURIE = re.compile(r"NCBITaxon:(\d+)")
 
 
-def _record_taxon_ids(record: pathlib.Path) -> set[str]:
+def _taxonomy_ids(record: pathlib.Path) -> list[str]:
+    """The record's taxonomy ids, in order — the sequence the renderer emits."""
+    document = yaml.safe_load(record.read_text()) or {}
+    ids = []
+    for entry in document.get("taxonomy") or []:
+        term = ((entry or {}).get("taxon_term") or {}).get("term") or {}
+        value = term.get("id")
+        if isinstance(value, str) and value.startswith("NCBITaxon:"):
+            ids.append(value.split(":", 1)[1])
+    return ids
+
+
+def _all_record_ids(record: pathlib.Path) -> set[str]:
     document = yaml.safe_load(record.read_text()) or {}
     found: set[str] = set()
     stack = [document]
@@ -58,19 +82,20 @@ def _record_taxon_ids(record: pathlib.Path) -> set[str]:
 
 
 def _paired() -> list[tuple[pathlib.Path, pathlib.Path]]:
-    pairs = []
-    for record in sorted(RECORDS.glob("*.yaml")):
-        page = PAGES / f"{record.stem}.html"
-        if page.exists():
-            pairs.append((record, page))
-    return pairs
+    return [
+        (record, PAGES / f"{record.stem}.html")
+        for record in sorted(RECORDS.glob("*.yaml"))
+        if (PAGES / f"{record.stem}.html").exists()
+    ]
+
+
+_PAIRS = _paired()
 
 
 def test_there_are_pages_to_check():
     """Guard: if the pairing breaks, every test below passes vacuously."""
-    pairs = _paired()
-    assert len(pairs) > 300, (
-        f"only {len(pairs)} record/page pairs resolved; the naming convention "
+    assert len(_PAIRS) > 300, (
+        f"only {len(_PAIRS)} record/page pairs resolved; the naming convention "
         f"between kb/communities/*.yaml and docs/communities/*.html has "
         f"probably changed, and the checks below are no longer checking it"
     )
@@ -79,8 +104,7 @@ def test_there_are_pages_to_check():
 def test_every_record_has_a_published_page():
     """A record with no page is invisible on the site and produces no diff.
 
-    Seven were missing when this was written — added without regenerating, so
-    nothing anywhere reported them.
+    Seven were missing when this was written.
     """
     missing = [
         record.name
@@ -93,25 +117,53 @@ def test_every_record_has_a_published_page():
     )
 
 
-@pytest.mark.parametrize(("record", "page"), _paired(), ids=[r.stem for r, _ in _paired()])
-def test_no_page_asserts_a_taxon_id_its_record_does_not_have(
+def test_no_page_survives_its_record():
+    """An orphan page stays published after a rename, and the tree still diffs clean.
+
+    `gen-html` only ever writes, so a renamed record leaves the old page
+    tracked and served. f8d85b1 is a rename of exactly that shape.
+    """
+    orphans = [
+        page.name
+        for page in sorted(PAGES.glob("*.html"))
+        if not (RECORDS / f"{page.stem}.yaml").exists()
+    ]
+    assert orphans == [], f"these published pages have no record and should be deleted: {orphans}"
+
+
+@pytest.mark.parametrize(("record", "page"), _PAIRS, ids=[r.stem for r, _ in _PAIRS])
+def test_the_taxonomy_links_match_the_record_row_for_row(record: pathlib.Path, page: pathlib.Path):
+    """The strong check: right id, right row, right order.
+
+    A set comparison passes when two rows swap ids, which is precisely how
+    *Bacteroides ovatus* came to link to *Phocaeicola vulgatus*'s taxon.
+    """
+    expected = _taxonomy_ids(record)
+    rendered = _LINK.findall(page.read_text())
+
+    assert rendered[: len(expected)] == expected, (
+        f"{page.name} links taxa that do not match {record.name} row for row.\n"
+        f"  record: {expected}\n"
+        f"  page:   {rendered[: len(expected)]}\n"
+        f"The committed docs/ tree is published verbatim, so a mismatch here is "
+        f"a live wrong-organism link — run `just gen-html` and commit (#442)."
+    )
+
+
+@pytest.mark.parametrize(("record", "page"), _PAIRS, ids=[r.stem for r, _ in _PAIRS])
+def test_no_page_mentions_a_taxon_id_absent_from_its_record(
     record: pathlib.Path, page: pathlib.Path
 ):
-    """The property, stated directly: the page may not contradict the record.
+    """Covers what the positional check cannot: ids rendered after the prefix.
 
-    Checked one-directionally on purpose. A page carrying an id the record
-    dropped is a published falsehood — the Bosea case, where the link resolved
-    to a flowering plant. The converse (a record id absent from the page) is
-    routine: pages summarise, and not every id is rendered.
+    Interaction participants render below the taxonomy block, in no order this
+    test can predict, so they get the weaker set treatment.
     """
-    expected = _record_taxon_ids(record)
     text = page.read_text()
-    rendered = set(_CURIE.findall(text)) | set(_LINK.findall(text))
+    rendered = set(_LINK.findall(text)) | set(_CURIE.findall(text))
 
-    contradictions = sorted(rendered - expected)
+    contradictions = sorted(rendered - _all_record_ids(record))
     assert contradictions == [], (
         f"{page.name} renders NCBITaxon ids that {record.name} does not "
-        f"contain: {contradictions}. The committed docs/ tree is published "
-        f"verbatim, so this is live on the site — run `just gen-html` and "
-        f"commit (#442)."
+        f"contain anywhere: {contradictions} (#442)"
     )

--- a/tests/test_docs_do_not_contradict_the_kb.py
+++ b/tests/test_docs_do_not_contradict_the_kb.py
@@ -1,0 +1,117 @@
+"""The published site rendered a plant's taxon id for a bacterium (#442).
+
+`generate-pages.yaml` serves the committed `docs/` tree verbatim, and nothing
+regenerated or checked it. A data PR that corrected a record and did not re-run
+`just gen-html` published a page contradicting the KB — invisibly, since no
+schema validator or id↔label gate reads HTML.
+
+Both directions had drifted by the time this was written:
+
+* 7 pages carried taxon ids the record no longer held. Two rendered
+  `NCBITaxon:169215` — the *plant* genus *Bosea* — as a live NCBI link on a
+  bacterium, and `KBase_ORT_Workflow_Community_Model` still showed the
+  class/phylum ids its record replaced in 2a3b691.
+* 7 records had **no page at all**. That is the failure a diff of existing
+  files cannot see, which is why `just check-docs-current` counts untracked
+  files and why `test_every_record_has_a_published_page` is separate below.
+
+`just check-docs-current` (CI: `docs-current.yaml`) is the real gate — it
+regenerates and demands a byte-identical tree. These tests are the fast local
+signal, and they state the *property* rather than the mechanism: a page must
+not assert a taxon id its record does not have. That distinction matters
+because the gate can only say "re-run the renderer", while a failure here names
+the contradiction.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+import yaml
+
+REPO = pathlib.Path(__file__).parent.parent
+PAGES = REPO / "docs/communities"
+RECORDS = REPO / "kb/communities"
+
+# Matches both the visible CURIE and the NCBI browser links the pages emit
+# (`wwwtax.cgi?id=169215`), since the link is what a reader actually follows.
+_CURIE = re.compile(r"NCBITaxon:(\d+)")
+_LINK = re.compile(r"wwwtax\.cgi\?id=(\d+)")
+
+
+def _record_taxon_ids(record: pathlib.Path) -> set[str]:
+    document = yaml.safe_load(record.read_text()) or {}
+    found: set[str] = set()
+    stack = [document]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, dict):
+            value = node.get("id")
+            if isinstance(value, str) and value.startswith("NCBITaxon:"):
+                found.add(value.split(":", 1)[1])
+            stack.extend(node.values())
+        elif isinstance(node, list):
+            stack.extend(node)
+    return found
+
+
+def _paired() -> list[tuple[pathlib.Path, pathlib.Path]]:
+    pairs = []
+    for record in sorted(RECORDS.glob("*.yaml")):
+        page = PAGES / f"{record.stem}.html"
+        if page.exists():
+            pairs.append((record, page))
+    return pairs
+
+
+def test_there_are_pages_to_check():
+    """Guard: if the pairing breaks, every test below passes vacuously."""
+    pairs = _paired()
+    assert len(pairs) > 300, (
+        f"only {len(pairs)} record/page pairs resolved; the naming convention "
+        f"between kb/communities/*.yaml and docs/communities/*.html has "
+        f"probably changed, and the checks below are no longer checking it"
+    )
+
+
+def test_every_record_has_a_published_page():
+    """A record with no page is invisible on the site and produces no diff.
+
+    Seven were missing when this was written — added without regenerating, so
+    nothing anywhere reported them.
+    """
+    missing = [
+        record.name
+        for record in sorted(RECORDS.glob("*.yaml"))
+        if not (PAGES / f"{record.stem}.html").exists()
+    ]
+    assert missing == [], (
+        "these records have no published page; run `just gen-html` and commit "
+        f"docs/ (#442): {missing}"
+    )
+
+
+@pytest.mark.parametrize(("record", "page"), _paired(), ids=[r.stem for r, _ in _paired()])
+def test_no_page_asserts_a_taxon_id_its_record_does_not_have(
+    record: pathlib.Path, page: pathlib.Path
+):
+    """The property, stated directly: the page may not contradict the record.
+
+    Checked one-directionally on purpose. A page carrying an id the record
+    dropped is a published falsehood — the Bosea case, where the link resolved
+    to a flowering plant. The converse (a record id absent from the page) is
+    routine: pages summarise, and not every id is rendered.
+    """
+    expected = _record_taxon_ids(record)
+    text = page.read_text()
+    rendered = set(_CURIE.findall(text)) | set(_LINK.findall(text))
+
+    contradictions = sorted(rendered - expected)
+    assert contradictions == [], (
+        f"{page.name} renders NCBITaxon ids that {record.name} does not "
+        f"contain: {contradictions}. The committed docs/ tree is published "
+        f"verbatim, so this is live on the site — run `just gen-html` and "
+        f"commit (#442)."
+    )


### PR DESCRIPTION
Closes #442.

## The gap

`generate-pages.yaml` publishes the committed `docs/` tree **verbatim**, and nothing regenerated or checked it. A data PR that corrected a record and didn't re-run `just gen-html` shipped a page contradicting the KB — invisibly, since no schema validator or id↔label gate reads HTML.

It had drifted in both directions:

| | count | example |
|---|---|---|
| pages asserting ids the record no longer holds | 7 | `MSC1_Dominant_Core` and `EcoFAB_Ring_Trial_SynCom17` rendered `NCBITaxon:169215` — the flowering-plant genus *Bosea* — as a **live NCBI link** on a bacterium |
| records with **no page at all** | 7 | `SPRUCE_Peatland_Warming_Community`, `Chlorella_Keystone_Taxa_Antifungal_SynCom`, … |

The second is the one the issue didn't mention and the more interesting failure: those records were added without a regeneration, so they are simply absent from the published site, and a diff of *existing* files cannot see it. That's why the gate counts untracked files and why the missing-page test is separate.

`KBase_ORT_Workflow_Community_Model` was also still showing the class/phylum ids (`NCBITaxon:2157`/`1236`) its record replaced in 2a3b691.

## The decision the issue asked for

> Worth deciding whether `docs/` regeneration belongs in CI, or whether these artifacts should stop being committed.

**Gate it.** The render is **7.35s** and deterministic — a clean checkout that runs it produces a byte-identical tree, which I verified before building anything on the assumption. The alternative is "remember to run `just gen-html`", which is precisely what produced the drift.

## Changes

- **`just check-docs-current`** — regenerate, fail if the tree differs. Counts untracked files, so a missing page fails too.
- **`.github/workflows/docs-current.yaml`** — the CI gate.
- **`tests/test_docs_do_not_contradict_the_kb.py`** — the fast local signal. It states the *property* rather than the mechanism: a page may not assert a taxon id its record lacks. That distinction matters because the gate can only say "re-run the renderer", while a test failure names the contradiction.
- **`reports/gtdb_denominators.tsv`** regenerated — the issue's second artifact. The orphaned `NCBITaxon:169215 Bosea` row is gone and the ORT record's `1033997` is picked up; taxa 578 → 583.

### A trap I walked into and fixed

My first draft of the workflow filtered on `src/communitymech/render/**`. `render` is a **module** (`render.py`), not a package, so that glob matches nothing — a gate that never fires on renderer changes. This is the same mistake as TraitMech#198, called out in `label-correspondence.yaml`'s own header. The paths now name the files, verified against the tree.

## Verification

Mutation-checked in both directions:

```
restore the plant id 169215 into MSC1_Dominant_Core.html
  → FAILED ...test_no_page_asserts_a_taxon_id_its_record_does_not_have[MSC1_Dominant_Core]   (1 failed, 313 passed)
move SPRUCE_Peatland_Warming_Community.html aside
  → FAILED ...test_every_record_has_a_published_page                                          (2 failed, 311 passed)
restored → 314 passed
```

The gate itself was checked the same way: it exits 1 on the drifted tree and 0 once regenerated docs are committed.

`ruff` and `black` clean.

## Note

`docs/` is a large diff (20 pages modified, 7 added) because it is 312 generated files catching up on accumulated drift. Every change is renderer output — no hand edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)