### PR TITLE
Record what a GTDB sweep did, in the record rather than only in git (#395)

### DIFF
--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -1163,7 +1163,16 @@ def apply_to_community(
     # `evidence` list, joining two lines, emitting duplicate keys — and every one
     # was caught only by looking afterwards. Checking before the write turns that
     # class of mistake into a refusal (#378).
-    _assert_only_grounding_changed(path, doc, new_text, refresh=refresh)
+    new_text = _record_edit(
+        path.read_text(),
+        new_text,
+        action="GTDB_REFRESH" if refresh else "GTDB_GROUND",
+        changes=(
+            f"{'Refreshed' if refresh else 'Added'} {added} gtdb_classification "
+            f"block(s) from {MAPPING_REL.name} (#395)."
+        ),
+    )
+    _assert_only_grounding_changed(path, doc, new_text, refresh=refresh, curation_event=True)
 
     path.write_text(new_text)
     return added
@@ -1186,6 +1195,7 @@ def withdraw_ambiguous(path: Path, by_id, by_name, by_higher, **kwargs) -> int:
     entries = doc.get("taxonomy", []) or []
 
     drop_entry: list[bool] = []
+    withdrawn: list[str] = []
     for tc in entries:
         tt = (tc or {}).get("taxon_term", {}) or {}
         term = tt.get("term", {}) or {}
@@ -1203,7 +1213,18 @@ def withdraw_ambiguous(path: Path, by_id, by_name, by_higher, **kwargs) -> int:
         result = resolve_target(
             tid.split(":", 1)[1], term.get("label", ""), by_id, by_name, by_higher, **kwargs
         )
-        drop_entry.append(bool(result and result.get("ambiguous")))
+        ambiguous = bool(result and result.get("ambiguous"))
+        drop_entry.append(ambiguous)
+        if ambiguous:
+            # The value itself, not just the fact of a removal. #395 is about
+            # Serratia: withdrawn at 0.519, while #373/#374 argue that answer may
+            # have been the better one. A curator revisiting it should not have to
+            # read git to learn what was taken away.
+            old_block = tt.get("gtdb_classification") or {}
+            withdrawn.append(
+                f"{term.get('label') or tid} was {old_block.get('gtdb_id')} "
+                f"@{old_block.get('majority_fraction')}"
+            )
     if not any(drop_entry):
         return 0
 
@@ -1244,7 +1265,16 @@ def withdraw_ambiguous(path: Path, by_id, by_name, by_higher, **kwargs) -> int:
         removed += 1
 
     new_text = "\n".join(ln for i, ln in enumerate(lines) if i not in drop) + "\n"
-    _assert_only_grounding_changed(path, doc, new_text, withdraw=True)
+    new_text = _record_edit(
+        path.read_text(),
+        new_text,
+        action="GTDB_WITHDRAW_AMBIGUOUS",
+        changes=(
+            f"Withdrew {removed} GTDB grounding(s) the recompute now calls "
+            f"AMBIGUOUS: {'; '.join(withdrawn)} (#382, #395)."
+        ),
+    )
+    _assert_only_grounding_changed(path, doc, new_text, withdraw=True, curation_event=True)
     path.write_text(new_text)
     return removed
 
@@ -1354,13 +1384,25 @@ def apply_status_to_community(path: Path, by_id, by_name, by_higher, **kwargs) -
     out += lines[end:]
     new_text = "\n".join(out) + "\n"
 
-    _assert_only_status_changed(path, doc, new_text)
+    new_text = _record_edit(
+        path.read_text(),
+        new_text,
+        action="GTDB_SET_STATUS",
+        changes=f"Wrote gtdb_grounding_status on {written} taxonomy entries (#294, #395).",
+    )
+    _assert_only_status_changed(path, doc, new_text, curation_event=True)
     path.write_text(new_text)
     return written
 
 
-def _assert_only_status_changed(path: Path, before: dict, new_text: str) -> None:
-    """Fail loudly unless the edit touched the status slots and nothing else."""
+def _assert_only_status_changed(
+    path: Path, before: dict, new_text: str, curation_event: bool = False
+) -> None:
+    """Fail loudly unless the edit touched the status slots and nothing else.
+
+    `curation_event` allows exactly one appended `curation_history` entry, on
+    the same terms as the grounding guard (#395).
+    """
     try:
         after = yaml.safe_load(new_text)
     except yaml.YAMLError as exc:
@@ -1384,16 +1426,36 @@ def _assert_only_status_changed(path: Path, before: dict, new_text: str) -> None
     _DupDetector.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _no_dups)
     yaml.load(new_text, Loader=_DupDetector)  # noqa: S506 — subclass of SafeLoader
 
-    def _stripped(doc):
+    def _stripped(doc, *, drop_history=False):
         copy = yaml.safe_load(yaml.dump(doc, sort_keys=False, allow_unicode=True))
         for entry in (copy or {}).get("taxonomy") or []:
             tt = (entry or {}).get("taxon_term")
             if isinstance(tt, dict):
                 for key in STATUS_KEYS:
                     tt.pop(key, None)
+        if drop_history and isinstance(copy, dict):
+            copy.pop("curation_history", None)
         return copy
 
-    if _stripped(before) != _stripped(after):
+    if curation_event:
+        b_hist = (before or {}).get("curation_history") or []
+        a_hist = (after or {}).get("curation_history") or []
+        if a_hist[: len(b_hist)] != b_hist:
+            raise SystemExit(
+                f"{path.name}: the status edit rewrote existing curation_history — "
+                f"it may only append."
+            )
+        # Zero or one. Zero is legitimate: a no-op edit appends no event, so
+        # `--apply-status` stays byte-idempotent on a record already written.
+        if len(a_hist) not in (len(b_hist), len(b_hist) + 1):
+            raise SystemExit(
+                f"{path.name}: expected at most one new curation event, got "
+                f"{len(a_hist) - len(b_hist)}."
+            )
+
+    if _stripped(before, drop_history=curation_event) != _stripped(
+        after, drop_history=curation_event
+    ):
         raise SystemExit(
             f"{path.name}: the status edit changed something other than "
             f"{'/'.join(STATUS_KEYS)} — refusing to write."
@@ -1410,10 +1472,84 @@ def _assert_only_status_changed(path: Path, before: dict, new_text: str) -> None
         )
 
 
+def _record_edit(original: str, new_text: str, *, action: str, changes: str) -> str:
+    """Append a curation event, unless the edit was a no-op.
+
+    Idempotence is the constraint. `--apply-status` re-run over an already-
+    written record produces identical YAML, and the existing test suite asserts
+    that a second run leaves the file byte-identical. Appending an event
+    unconditionally broke that: every re-run grew the history by one entry
+    recording that nothing happened. An audit trail of non-events is worse than
+    none, because it buries the real ones.
+    """
+    if new_text == original:
+        return new_text
+    return _append_curation_event(new_text, action=action, changes=changes)
+
+
+def _append_curation_event(text: str, *, action: str, changes: str) -> str:
+    """Append one CurationEvent to a record's `curation_history`, as text.
+
+    Text rather than a YAML round-trip because every write path here is a
+    line-level editor: re-dumping the document would reformat all of it, and
+    `_assert_only_grounding_changed` exists precisely because four hand-rolled
+    attempts at whole-file edits corrupted records (#378).
+
+    Two cases. When `curation_history` is absent — 310 of the 312 records, since
+    #325 is still open — the key is appended at the end of the document. When it
+    is present, the event goes at the end of its block, found by scanning to the
+    next top-level key. Appending a second `curation_history:` instead would be
+    silently lossy, since PyYAML keeps only the last of two identical keys; the
+    duplicate-key detector in the write guard would catch it, but producing it
+    and relying on the guard is the wrong order.
+    """
+    event = {
+        "timestamp": datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
+        "curator": "gtdb_ground.py",
+        "action": action,
+        "changes": changes,
+    }
+    dumped = yaml.dump(
+        [event], sort_keys=False, allow_unicode=True, width=DUMP_WIDTH, default_flow_style=False
+    ).rstrip("\n")
+
+    lines = text.rstrip("\n").split("\n")
+    for i, line in enumerate(lines):
+        if line.rstrip() != "curation_history:":
+            continue
+        end = len(lines)
+        for j in range(i + 1, len(lines)):
+            # Only a new top-level KEY ends the block. `- timestamp: ...` also
+            # starts at column 0 — testing `not line[0].isspace()` treated the
+            # list's own first item as the next section and inserted the event
+            # ABOVE the existing history, which the append-only write guard then
+            # correctly refused. Match the same `^[A-Za-z_]` rule the rest of
+            # this module uses to find section ends.
+            if re.match(r"^[A-Za-z_]", lines[j]):
+                end = j
+                break
+        return "\n".join(lines[:end] + dumped.split("\n") + lines[end:]) + "\n"
+
+    return "\n".join(lines + ["curation_history:"] + dumped.split("\n")) + "\n"
+
+
 def _assert_only_grounding_changed(
-    path: Path, before: dict, new_text: str, refresh: bool = False, withdraw: bool = False
+    path: Path,
+    before: dict,
+    new_text: str,
+    refresh: bool = False,
+    withdraw: bool = False,
+    curation_event: bool = False,
 ) -> None:
-    """Fail loudly unless the edit touched gtdb_classification and nothing else."""
+    """Fail loudly unless the edit touched gtdb_classification and nothing else.
+
+    `curation_event` widens that by exactly one thing: `curation_history` may
+    gain a single entry at the end. Deliberately narrow — an append-only check
+    on one key, not a general exemption — because the guard's value is that it
+    refuses everything it was not told to expect (#395).
+    """
     try:
         after = yaml.safe_load(new_text)
     except yaml.YAMLError as exc:
@@ -1492,9 +1628,23 @@ def _assert_only_grounding_changed(
     b_tax, a_tax = before.get("taxonomy") or [], after.get("taxonomy") or []
     if len(b_tax) != len(a_tax):
         raise SystemExit(f"{path.name}: taxonomy went from {len(b_tax)} to {len(a_tax)} entries.")
-    if {k: v for k, v in before.items() if k != "taxonomy"} != {
-        k: v for k, v in after.items() if k != "taxonomy"
-    }:
+    b_rest = {k: v for k, v in before.items() if k != "taxonomy"}
+    a_rest = {k: v for k, v in after.items() if k != "taxonomy"}
+    if curation_event:
+        b_hist = b_rest.pop("curation_history", None) or []
+        a_hist = a_rest.pop("curation_history", None) or []
+        if a_hist[: len(b_hist)] != b_hist:
+            raise SystemExit(
+                f"{path.name}: the edit rewrote existing curation_history — it may " f"only append."
+            )
+        # Zero or one. Zero is legitimate: a no-op edit appends no event, so
+        # `--apply-status` stays byte-idempotent on a record already written.
+        if len(a_hist) not in (len(b_hist), len(b_hist) + 1):
+            raise SystemExit(
+                f"{path.name}: expected at most one new curation event, got "
+                f"{len(a_hist) - len(b_hist)}."
+            )
+    if b_rest != a_rest:
         raise SystemExit(f"{path.name}: content outside taxonomy changed.")
 
     for b, a in zip(b_tax, a_tax, strict=True):

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -70,6 +70,7 @@ MAPPING_REL = Path("data/raw/NCBI2GTDB.tsv.gz")
 # `scripts/` is on sys.path when this runs as `python scripts/gtdb_ground.py`,
 # so reach the package the same way the other scripts do.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from communitymech.curate.curation_event import record_curation_event  # noqa: E402
 from communitymech.validators.ncbi_domain import outside_gtdb_scope  # noqa: E402
 
 # NCBI2GTDB.tsv column indices (0-based); see header row.
@@ -1168,7 +1169,7 @@ def apply_to_community(
         new_text,
         action="GTDB_REFRESH" if refresh else "GTDB_GROUND",
         changes=(
-            f"{'Refreshed' if refresh else 'Added'} {added} gtdb_classification "
+            f"{'Refreshed' if refresh else 'Added'} {{n}} gtdb_classification "
             f"block(s) from {MAPPING_REL.name} (#395)."
         ),
     )
@@ -1388,7 +1389,7 @@ def apply_status_to_community(path: Path, by_id, by_name, by_higher, **kwargs) -
         path.read_text(),
         new_text,
         action="GTDB_SET_STATUS",
-        changes=f"Wrote gtdb_grounding_status on {written} taxonomy entries (#294, #395).",
+        changes="Wrote gtdb_grounding_status on {n} taxonomy entries (#294, #395).",
     )
     _assert_only_status_changed(path, doc, new_text, curation_event=True)
     path.write_text(new_text)
@@ -1472,19 +1473,74 @@ def _assert_only_status_changed(
         )
 
 
+def _changed_entries(original: str, new_text: str) -> int:
+    """How many taxonomy entries actually differ. Not how many were visited.
+
+    NOTE this is deliberately a different number from the one the write paths
+    return and print. `apply_to_community` reports `added` — blocks the line
+    editor wrote — so stdout can say "applied 2 block(s)" while the event says
+    "Refreshed 1", when one of the two was rewritten to the value it already
+    held. The event is the accurate one, and it is the one that persists;
+    stdout's count is left alone because callers and tests read it as
+    "entries processed" (review of #483).
+
+    The counts the write paths return (`added`, `written`) are of entries the
+    line editor *processed*, which is not the same thing: `--apply-status` over
+    an already-written record rewrites six identical entries and reports six.
+    An event saying "wrote status on 6" when nothing moved is a false record,
+    and #395 is about the record being true (review of #483).
+    """
+    try:
+        before = yaml.safe_load(original) or {}
+        after = yaml.safe_load(new_text) or {}
+    except yaml.YAMLError:
+        return 0
+    b_tax = before.get("taxonomy") or []
+    a_tax = after.get("taxonomy") or []
+    if len(b_tax) != len(a_tax):
+        return max(len(b_tax), len(a_tax))
+    # Lengths are equal by the guard above, so strict= is safe and states it.
+    return sum(1 for b, a in zip(b_tax, a_tax, strict=True) if b != a)
+
+
+def _semantically_equal(original: str, new_text: str) -> bool:
+    """Compare parsed documents, ignoring `curation_history`.
+
+    Byte comparison was wrong for a file with no trailing newline or with CRLF
+    endings: the callers rebuild text via `splitlines()` + `"\n".join(...)`, so
+    such a file is never byte-equal and earned a spurious event on its first
+    run (review of #483). Parsing compares what the record means.
+    """
+    try:
+        before = yaml.safe_load(original) or {}
+        after = yaml.safe_load(new_text) or {}
+    except yaml.YAMLError:
+        return False
+    before.pop("curation_history", None)
+    after.pop("curation_history", None)
+    return before == after
+
+
 def _record_edit(original: str, new_text: str, *, action: str, changes: str) -> str:
-    """Append a curation event, unless the edit was a no-op.
+    """Append a curation event, unless the edit changed nothing.
 
     Idempotence is the constraint. `--apply-status` re-run over an already-
-    written record produces identical YAML, and the existing test suite asserts
-    that a second run leaves the file byte-identical. Appending an event
-    unconditionally broke that: every re-run grew the history by one entry
-    recording that nothing happened. An audit trail of non-events is worse than
-    none, because it buries the real ones.
+    written record produces identical YAML, and the existing suite asserts a
+    second run leaves the file byte-identical. Appending unconditionally broke
+    that: every re-run grew the history by one entry recording that nothing had
+    happened. An audit trail of non-events is worse than none, because it
+    buries the real ones.
+
+    `{n}` in `changes` is filled with the number of entries that actually
+    differ, so the event cannot claim work the edit did not do.
     """
-    if new_text == original:
+    if _semantically_equal(original, new_text):
         return new_text
-    return _append_curation_event(new_text, action=action, changes=changes)
+    return _append_curation_event(
+        new_text,
+        action=action,
+        changes=changes.replace("{n}", str(_changed_entries(original, new_text))),
+    )
 
 
 def _append_curation_event(text: str, *, action: str, changes: str) -> str:
@@ -1503,22 +1559,46 @@ def _append_curation_event(text: str, *, action: str, changes: str) -> str:
     duplicate-key detector in the write guard would catch it, but producing it
     and relying on the guard is the wrong order.
     """
-    event = {
-        "timestamp": datetime.now(timezone.utc)
-        .isoformat(timespec="seconds")
-        .replace("+00:00", "Z"),
-        "curator": "gtdb_ground.py",
-        "action": action,
-        "changes": changes,
-    }
+    # Built by the shared helper rather than by hand: it owns the field names
+    # and the timestamp format, and `audit_writers.py` cannot tell a hand-rolled
+    # dict from the real thing — its check is a regex for the literal
+    # `'curator':`, so a drifting copy would keep reporting `yes` (review of
+    # #483). Only the *insertion* has to be bespoke here, because every write
+    # path in this module is a line-level editor.
+    holder: dict = {}
+    record_curation_event(holder, curator="gtdb_ground.py", action=action, changes=changes)
+    event = holder["curation_history"][0]
     dumped = yaml.dump(
         [event], sort_keys=False, allow_unicode=True, width=DUMP_WIDTH, default_flow_style=False
     ).rstrip("\n")
 
     lines = text.rstrip("\n").split("\n")
+    # A document end marker would put the appended key outside the document.
+    if any(ln.rstrip() in ("...", "---") for ln in lines[1:]):
+        raise SystemExit(
+            "record uses explicit YAML document markers; curation_history cannot "
+            "be appended safely by line edit (#395)."
+        )
     for i, line in enumerate(lines):
-        if line.rstrip() != "curation_history:":
+        # `curation_history:`, `curation_history: []`, `curation_history:  # note`
+        # are the same key. Matching the bare string alone appended a SECOND
+        # `curation_history:` for the other two, which PyYAML resolves by
+        # keeping only the last — silently dropping the existing history. The
+        # write guard caught it, but producing corruption and relying on the
+        # guard is the wrong order (review of #483).
+        head = re.match(r"^curation_history:\s*(.*)$", line)
+        if not head:
             continue
+        rest = head.group(1).strip()
+        if rest and not rest.startswith("#"):
+            # An inline value: `curation_history: []`. Replace it with a block,
+            # since an event cannot be appended to a flow sequence by line edit.
+            if rest not in ("[]", "~", "null"):
+                raise SystemExit(
+                    f"record has an inline curation_history value ({rest!r}) that "
+                    f"is not an empty list; refusing to edit it (#395)."
+                )
+            lines[i] = "curation_history:"
         end = len(lines)
         for j in range(i + 1, len(lines)):
             # Only a new top-level KEY ends the block. `- timestamp: ...` also
@@ -1530,8 +1610,18 @@ def _append_curation_event(text: str, *, action: str, changes: str) -> str:
             if re.match(r"^[A-Za-z_]", lines[j]):
                 end = j
                 break
-        return "\n".join(lines[:end] + dumped.split("\n") + lines[end:]) + "\n"
-
+        # Back off over a comment block introducing that next key, so the event
+        # is not inserted below it — which would silently re-attach the comment
+        # to curation_history.
+        while end > i + 1 and lines[end - 1].lstrip().startswith("#"):
+            end -= 1
+        while end > i + 1 and not lines[end - 1].strip():
+            end -= 1
+        # An indented sequence (`  - action: ...`) cannot take a column-0 item.
+        items = [ln for ln in lines[i + 1 : end] if ln.strip().startswith("- ")]
+        indent = " " * (len(items[0]) - len(items[0].lstrip())) if items else ""
+        body = [f"{indent}{ln}" if ln.strip() else ln for ln in dumped.split("\n")]
+        return "\n".join(lines[:end] + body + lines[end:]) + "\n"
     return "\n".join(lines + ["curation_history:"] + dumped.split("\n")) + "\n"
 
 

--- a/tests/test_gtdb_curation_history.py
+++ b/tests/test_gtdb_curation_history.py
@@ -31,6 +31,7 @@ inserted the event ABOVE the existing history. The guard refused the write.
 from __future__ import annotations
 
 import importlib.util
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -162,8 +163,21 @@ def test_an_existing_history_is_preserved_and_appended_to(gtdb, mapping, tmp_pat
     original = _history(source)
     assert original, "this fixture needs a record that already has curation_history"
 
+    # Strip the statuses so the run has something to do. Without this the edit
+    # is a no-op, no event is appended, and the test fails for the right reason
+    # but the wrong subject — it is the *insertion point* under test here, not
+    # the no-op short-circuit.
     record = tmp_path / source.name
-    record.write_text(source.read_text())
+    record.write_text(
+        "\n".join(
+            line
+            for line in source.read_text().splitlines()
+            if not line.strip().startswith(("gtdb_grounding_status:", "gtdb_candidates:"))
+            and not re.match(r"^\s+- GTDB:", line)
+        )
+        + "\n"
+    )
+    assert _history(record), "history must survive the strip"
 
     result = _run("--community", str(record), "--apply-status")
     assert result.returncode == 0, result.stderr[-500:]
@@ -248,6 +262,118 @@ def test_the_writer_audit_now_sees_the_append():
     )
     row = [line for line in result.stdout.splitlines() if line.startswith("scripts/gtdb_ground.py")]
     assert row, f"gtdb_ground.py is missing from the writer audit:\n{result.stdout[:400]}"
+    # By column, not by substring: `"\tno\t" not in row` cannot see a `no` in the
+    # LAST field, which has no trailing tab, and says nothing if the audit
+    # reorders its columns (review of #483).
+    fields = row[0].split("\t")
+    assert len(fields) >= 3, f"the audit's row format changed: {row[0]!r}"
+    assert fields[2] == "yes", (
+        f"audit-writers reports gtdb_ground.py still has no curation_history "
+        f"append: {row[0]} (#395)"
+    )
     assert (
-        "\tno\t" not in row[0]
-    ), f"audit-writers still reports a missing safeguard for gtdb_ground.py: {row[0]} (#395)"
+        "no" not in fields[1:]
+    ), f"audit-writers reports another missing safeguard for gtdb_ground.py: {row[0]}"
+
+
+# ---------------------------------------------------------------------------
+# Pure-text tests for the insertion itself. These need NO crosswalk, so unlike
+# the end-to-end tests above they actually run in CI — where the four
+# `mapping`-dependent ones skip, leaving the one piece of genuinely new,
+# edge-case-prone logic exercised only on the author's machine (review of #483).
+# ---------------------------------------------------------------------------
+
+
+def _appended(gtdb, text: str) -> dict:
+    out = gtdb._append_curation_event(text, action="GTDB_SET_STATUS", changes="probe")
+    return yaml.safe_load(out)
+
+
+def test_a_record_with_no_history_gains_the_key(gtdb):
+    doc = _appended(gtdb, "id: X\nname: probe\n")
+    assert [e["action"] for e in doc["curation_history"]] == ["GTDB_SET_STATUS"]
+    assert doc["name"] == "probe"
+
+
+def test_an_empty_inline_list_is_not_duplicated(gtdb):
+    """`curation_history: []` is the same key.
+
+    Matching only the bare string appended a SECOND `curation_history:`, and
+    PyYAML keeps the last of two identical keys — silently dropping whatever
+    the first held. The write guard caught it, but producing corruption and
+    relying on the guard is the wrong order.
+    """
+    out = gtdb._append_curation_event(
+        "id: X\ncuration_history: []\nname: probe\n", action="GTDB_GROUND", changes="probe"
+    )
+    assert out.count("curation_history:") == 1, out
+    assert [e["action"] for e in yaml.safe_load(out)["curation_history"]] == ["GTDB_GROUND"]
+
+
+def test_a_trailing_comment_on_the_key_is_handled(gtdb):
+    out = gtdb._append_curation_event(
+        "id: X\ncuration_history:  # notes follow\n- action: KEEP\nname: probe\n",
+        action="GTDB_GROUND",
+        changes="probe",
+    )
+    assert out.count("curation_history:") == 1
+    assert [e["action"] for e in yaml.safe_load(out)["curation_history"]] == [
+        "KEEP",
+        "GTDB_GROUND",
+    ]
+
+
+def test_an_indented_sequence_stays_parseable(gtdb):
+    """A column-0 item cannot be appended to an indented sequence."""
+    doc = _appended(gtdb, "id: X\ncuration_history:\n  - action: KEEP\nname: probe\n")
+    assert [e["action"] for e in doc["curation_history"]] == ["KEEP", "GTDB_SET_STATUS"]
+
+
+def test_the_event_goes_last_not_first(gtdb):
+    """The bug the append-only write guard caught."""
+    doc = _appended(gtdb, "id: X\ncuration_history:\n- action: FIRST\n- action: SECOND\n")
+    assert [e["action"] for e in doc["curation_history"]] == [
+        "FIRST",
+        "SECOND",
+        "GTDB_SET_STATUS",
+    ]
+
+
+def test_a_comment_introducing_the_next_key_is_not_absorbed(gtdb):
+    """Inserting below it would silently re-attach the comment to the history."""
+    out = gtdb._append_curation_event(
+        "id: X\ncuration_history:\n- action: KEEP\n# about the name\nname: probe\n",
+        action="GTDB_GROUND",
+        changes="probe",
+    )
+    lines = out.splitlines()
+    assert lines.index("# about the name") > lines.index("  action: GTDB_GROUND")
+    assert [e["action"] for e in yaml.safe_load(out)["curation_history"]] == ["KEEP", "GTDB_GROUND"]
+
+
+def test_a_document_end_marker_is_refused_rather_than_corrupted(gtdb):
+    with pytest.raises(SystemExit, match="document markers"):
+        gtdb._append_curation_event("id: X\nname: probe\n...\n", action="A", changes="b")
+
+
+def test_a_missing_trailing_newline_is_not_a_change(gtdb):
+    """Byte comparison called this a change and earned a false event.
+
+    The callers rebuild text with `splitlines()` + `"\\n".join(...) + "\\n"`, so a
+    file without a trailing newline is never byte-equal to its own rewrite.
+    """
+    assert gtdb._semantically_equal("id: X\nname: probe", "id: X\nname: probe\n")
+    assert (
+        gtdb._record_edit("id: X\nname: probe", "id: X\nname: probe\n", action="A", changes="b")
+        == "id: X\nname: probe\n"
+    )
+
+
+def test_the_event_counts_entries_that_actually_differ(gtdb):
+    """`{n}` must not restate how many entries the line editor visited."""
+    before = "taxonomy:\n- taxon_term: {a: 1}\n- taxon_term: {b: 2}\n"
+    after = "taxonomy:\n- taxon_term: {a: 9}\n- taxon_term: {b: 2}\n"
+    assert gtdb._changed_entries(before, after) == 1
+
+    out = gtdb._record_edit(before, after, action="GTDB_GROUND", changes="changed {n} block(s)")
+    assert "changed 1 block(s)" in out

--- a/tests/test_gtdb_curation_history.py
+++ b/tests/test_gtdb_curation_history.py
@@ -1,0 +1,253 @@
+"""A withdrawn grounding survived only in git (#395).
+
+`just audit-writers` reported `scripts/gtdb_ground.py` as the one YAML-writing
+module with no `record_curation_event` append. So when #394 withdrew
+`NCBITaxon:429` *Methylobacter* (`g__Methylobacter_A`, 0.662) and
+`NCBITaxon:613` *Serratia* (`g__Serratia`, 0.519), those values left the records
+entirely. `gtdb_grounding_status: AMBIGUOUS` says the tool is unsure *now*; it
+does not say a grounding was once stored, or what it was.
+
+That matters most for *Serratia*, where #373/#374 argue the withdrawn answer may
+have been the better one — its grounding was type-anchored, and the recompute
+that removed it was a raw majority. A curator revisiting the decision had to
+read git to find out what had been taken away.
+
+All three write paths now append a `CurationEvent`, and the withdrawal records
+**the value**, not merely the fact:
+
+    Withdrew 1 GTDB grounding(s) the recompute now calls AMBIGUOUS:
+    Methylobacter was GTDB:g__Methylobacter_A @0.662 (#382, #395).
+
+The append is text-level, because every write path here is a line-level editor —
+a YAML round-trip would reformat the whole record, which is the corruption class
+`_assert_only_grounding_changed` exists to prevent (#378). Both write guards
+were widened by exactly one thing: `curation_history` may gain one entry at the
+end. That narrowness is the point, and it earned its keep immediately — the
+first version of the insertion scanned for the next line starting at column 0 to
+find the end of the block, which matched the list's own `- timestamp:` item and
+inserted the event ABOVE the existing history. The guard refused the write.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).parent.parent
+
+# One line in the fixture, split here only to stay inside the 100-column lint.
+LINEAGE = (
+    "d__Bacteria;p__Pseudomonadota;c__Gammaproteobacteria;o__Methylococcales;"
+    "f__Methylomonadaceae;g__Methylobacter_A"
+)
+
+PROBE = """id: CommunityMech:TEST
+name: withdraw probe
+taxonomy:
+- taxon_term:
+    preferred_term: Methylobacter
+    term:
+      id: NCBITaxon:429
+      label: Methylobacter
+    gtdb_classification:
+      gtdb_id: GTDB:g__Methylobacter_A
+      gtdb_taxon: Methylobacter_A
+      gtdb_lineage: {LINEAGE}
+      ncbi_source_id: NCBITaxon:429
+      majority_fraction: 0.662
+      support_genomes: 43
+      total_genomes: 65
+      is_reclassified: true
+      mapping_source: probe
+""".replace("{LINEAGE}", LINEAGE)
+
+
+@pytest.fixture(scope="module")
+def gtdb():
+    spec = importlib.util.spec_from_file_location("gtdb_ground", REPO / "scripts/gtdb_ground.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["gtdb_ground"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def mapping(gtdb):
+    """Skip where the kg-microbe crosswalk is absent, CI included."""
+    try:
+        path = gtdb.resolve_kg_microbe_dir(None) / "data/raw/NCBI2GTDB.tsv.gz"
+    except SystemExit as exc:
+        pytest.skip(f"kg-microbe mapping unavailable: {str(exc).splitlines()[0]}")
+    if not path.exists():
+        pytest.skip(f"kg-microbe NCBI2GTDB mapping not available at {path}")
+    return path
+
+
+def _run(*args):
+    return subprocess.run(
+        ["uv", "run", "python", "scripts/gtdb_ground.py", *args],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+        timeout=1800,
+    )
+
+
+def _history(path: Path) -> list[dict]:
+    return (yaml.safe_load(path.read_text()) or {}).get("curation_history") or []
+
+
+def test_a_withdrawal_records_what_it_removed(gtdb, mapping, tmp_path):
+    """The point of #395: the value must survive, not just the fact of removal."""
+    record = tmp_path / "wd.yaml"
+    record.write_text(PROBE)
+
+    result = _run("--community", str(record), "--withdraw-ambiguous")
+    assert result.returncode == 0, result.stderr[-500:]
+
+    document = yaml.safe_load(record.read_text())
+    assert "gtdb_classification" not in document["taxonomy"][0]["taxon_term"]
+
+    events = _history(record)
+    assert len(events) == 1, f"expected one curation event, got {events}"
+    event = events[0]
+    assert event["action"] == "GTDB_WITHDRAW_AMBIGUOUS"
+    assert event["curator"] == "gtdb_ground.py"
+    # The two facts a curator needs and would otherwise have to git-blame for.
+    assert "GTDB:g__Methylobacter_A" in event["changes"]
+    assert "0.662" in event["changes"]
+
+
+def test_applying_a_grounding_records_it(gtdb, mapping, tmp_path):
+    record = tmp_path / "apply.yaml"
+    record.write_text(
+        "id: CommunityMech:TEST\n"
+        "name: probe\n"
+        "taxonomy:\n"
+        "- taxon_term:\n"
+        "    preferred_term: Bosea\n"
+        "    term:\n"
+        "      id: NCBITaxon:85413\n"
+        "      label: Bosea\n"
+    )
+    result = _run("--community", str(record), "--apply")
+    assert result.returncode == 0, result.stderr[-500:]
+
+    events = _history(record)
+    assert [e["action"] for e in events] == ["GTDB_GROUND"]
+
+
+def test_setting_status_records_it(gtdb, mapping, tmp_path):
+    record = tmp_path / "status.yaml"
+    record.write_text(PROBE)
+
+    result = _run("--community", str(record), "--apply-status")
+    assert result.returncode == 0, result.stderr[-500:]
+    assert [e["action"] for e in _history(record)] == ["GTDB_SET_STATUS"]
+
+
+def test_an_existing_history_is_preserved_and_appended_to(gtdb, mapping, tmp_path):
+    """The bug the write guard caught: the event landed above the existing list.
+
+    `curation_history:`'s own items start at column 0 (`- timestamp:`), so a
+    scan for "the next line not starting with whitespace" finds the first item
+    and treats it as the next top-level key.
+    """
+    source = REPO / "kb/communities/ANME_SRB_Anaerobic_Methanotrophic_Syntrophic_Consortia.yaml"
+    original = _history(source)
+    assert original, "this fixture needs a record that already has curation_history"
+
+    record = tmp_path / source.name
+    record.write_text(source.read_text())
+
+    result = _run("--community", str(record), "--apply-status")
+    assert result.returncode == 0, result.stderr[-500:]
+
+    events = _history(record)
+    assert len(events) == len(original) + 1
+    assert events[: len(original)] == original, "existing events must be untouched"
+    assert events[-1]["action"] == "GTDB_SET_STATUS", "the new event goes last"
+
+
+def test_the_write_guard_refuses_a_rewrite_of_existing_history(gtdb):
+    """The exemption is append-only, and narrow on purpose.
+
+    Called directly: no write path should be able to produce this, which is
+    exactly why the guard should still refuse it.
+    """
+    before = {"taxonomy": [], "curation_history": [{"action": "KEEP"}]}
+    rewritten = yaml.safe_dump(
+        {"taxonomy": [], "curation_history": [{"action": "CLOBBERED"}, {"action": "NEW"}]}
+    )
+    with pytest.raises(SystemExit, match="may only append"):
+        gtdb._assert_only_grounding_changed(
+            Path("probe.yaml"), before, rewritten, curation_event=True
+        )
+
+
+def test_the_write_guard_refuses_more_than_one_new_event(gtdb):
+    before = {"taxonomy": [], "curation_history": [{"action": "KEEP"}]}
+    two = yaml.safe_dump(
+        {
+            "taxonomy": [],
+            "curation_history": [{"action": "KEEP"}, {"action": "A"}, {"action": "B"}],
+        }
+    )
+    with pytest.raises(SystemExit, match="at most one new curation event"):
+        gtdb._assert_only_grounding_changed(Path("probe.yaml"), before, two, curation_event=True)
+
+
+def test_the_guard_still_refuses_unrelated_changes(gtdb):
+    """Widening it for curation_history must not have opened anything else.
+
+    The edit here is otherwise well-formed — it appends exactly one event — so
+    the only thing left to refuse is the changed `name`. An earlier version of
+    this test supplied no event at all and passed for the wrong reason: it
+    tripped the "exactly one new curation event" check before reaching the one
+    it meant to exercise.
+    """
+    before = {"taxonomy": [], "name": "before", "curation_history": [{"action": "KEEP"}]}
+    changed = yaml.safe_dump(
+        {
+            "taxonomy": [],
+            "name": "after",
+            "curation_history": [{"action": "KEEP"}, {"action": "NEW"}],
+        }
+    )
+    with pytest.raises(SystemExit, match="outside taxonomy changed"):
+        gtdb._assert_only_grounding_changed(
+            Path("probe.yaml"), before, changed, curation_event=True
+        )
+
+
+def test_the_guard_allows_no_event_when_nothing_changed(gtdb):
+    """Zero is legitimate, and is what keeps `--apply-status` idempotent.
+
+    Appending unconditionally made every re-run grow the history by an entry
+    saying nothing happened, which broke the byte-idempotence the existing
+    suite asserts and buries the real events.
+    """
+    before = {"taxonomy": [], "curation_history": [{"action": "KEEP"}]}
+    unchanged = yaml.safe_dump({"taxonomy": [], "curation_history": [{"action": "KEEP"}]})
+    gtdb._assert_only_grounding_changed(Path("probe.yaml"), before, unchanged, curation_event=True)
+
+
+def test_the_writer_audit_now_sees_the_append():
+    """`audit-writers` is what reported this gap; it should stop reporting it."""
+    result = subprocess.run(
+        ["uv", "run", "python", "scripts/audit_writers.py"],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+        timeout=600,
+    )
+    row = [line for line in result.stdout.splitlines() if line.startswith("scripts/gtdb_ground.py")]
+    assert row, f"gtdb_ground.py is missing from the writer audit:\n{result.stdout[:400]}"
+    assert (
+        "\tno\t" not in row[0]
+    ), f"audit-writers still reports a missing safeguard for gtdb_ground.py: {row[0]} (#395)"

--- a/tests/test_gtdb_refresh.py
+++ b/tests/test_gtdb_refresh.py
@@ -142,6 +142,18 @@ def test_refresh_preserves_everything_outside_the_grounding(gtdb, rows, record):
     gtdb.apply_to_community(record, *rows, "test-source", refresh=True)
     after = yaml.safe_load(record.read_text())
 
+    # `curation_history` is the one exception, added in #395: a write that
+    # changes something appends one event recording it. Checked here rather
+    # than excluded silently, so this test still fails if the append grows into
+    # anything more than that.
+    before_history = before.pop("curation_history", None) or []
+    after_history = after.pop("curation_history", None) or []
+    assert after_history[: len(before_history)] == before_history
+    assert len(after_history) - len(before_history) <= 1
+    if after_history[len(before_history) :]:
+        assert after_history[-1]["action"] == "GTDB_REFRESH"
+        assert after_history[-1]["curator"] == "gtdb_ground.py"
+
     assert {k: v for k, v in before.items() if k != "taxonomy"} == {
         k: v for k, v in after.items() if k != "taxonomy"
     }

--- a/tests/test_gtdb_status_writer.py
+++ b/tests/test_gtdb_status_writer.py
@@ -254,9 +254,17 @@ def test_withdrawal_removes_an_ambiguous_block_and_nothing_else(gtdb, tmp_path):
     assert after["taxonomy"][0]["taxon_term"]["notes"] == "a sibling that must survive"
     assert after["taxonomy"][1]["taxon_term"]["gtdb_classification"]["gtdb_id"] == "GTDB:g__Kept"
 
+    # The withdrawal now records what it removed (#395) — assert on that rather
+    # than dropping curation_history from the comparison, since the value
+    # surviving in-band is the whole point of the change.
+    event = (after.get("curation_history") or [])[-1]
+    assert event["action"] == "GTDB_WITHDRAW_AMBIGUOUS"
+    assert "GTDB:g__" in event["changes"], "the withdrawn grounding must be named"
+
     def stripped(document):
         for entry in document["taxonomy"]:
             entry["taxon_term"].pop("gtdb_classification", None)
+        document.pop("curation_history", None)
         return document
 
     assert stripped(before) == stripped(after)


### PR DESCRIPTION
Closes #395, taking option 1 — the one the issue notes generalises.

## The gap

`just audit-writers` reported `scripts/gtdb_ground.py` as the **one** YAML-writing module with no curation-event append. So when #394 withdrew `NCBITaxon:429` *Methylobacter* (`g__Methylobacter_A`, 0.662) and `NCBITaxon:613` *Serratia* (`g__Serratia`, 0.519), those values left the records entirely.

`gtdb_grounding_status: AMBIGUOUS` says the tool is unsure *now*. It does not say a grounding was once stored, or what it was. That matters most for *Serratia*, where #373/#374 argue the withdrawn answer may have been the better one — it was type-anchored, and the recompute that removed it was a raw majority.

## What lands

All three write paths (`--apply`, `--refresh`, `--withdraw-ambiguous`, `--apply-status`) append a `CurationEvent`. Withdrawal records **the value**:

```yaml
- timestamp: '2026-08-07T20:33:05Z'
  curator: gtdb_ground.py
  action: GTDB_WITHDRAW_AMBIGUOUS
  changes: 'Withdrew 1 GTDB grounding(s) the recompute now calls AMBIGUOUS:
    Methylobacter was GTDB:g__Methylobacter_A @0.662 (#382, #395).'
```

The append is **text-level**, not a YAML round-trip: every write path here is a line-level editor, and re-dumping the document would reformat all of it — the corruption class `_assert_only_grounding_changed` exists to prevent (#378). Both write guards were widened by exactly one thing: `curation_history` may gain at most one entry, appended. Narrow on purpose.

## Three things went wrong building it

Recording these because two were caught by existing machinery doing its job, not by me reading carefully.

**The event landed above the existing history.** My first insertion scanned for the next line starting at column 0 to find the end of the block. A top-level list item — `- timestamp:` — also starts at column 0, so it treated the list's own first entry as the next section. **The append-only guard refused the write**, which is exactly what it is for. Now uses the same `^[A-Za-z_]` rule the rest of the module uses for section ends.

**Appending unconditionally broke idempotence.** `test_apply_status_is_idempotent` asserts a second run leaves the file byte-identical; every re-run was growing the history by an entry recording that nothing happened. An audit trail of non-events buries the real ones. `_record_edit` now returns early on a no-op edit, and both guards accept zero-or-one event. Verified on a real record: two runs → one event, byte-identical output.

**One of my own new tests passed for the wrong reason.** It asserted the guard refuses an unrelated change, but supplied no curation event — so it tripped the event-count check before reaching the one it meant to exercise. Split into two tests that each fail for their own reason.

## Existing tests

Two asserted "nothing outside the grounding changed", now false by design. I updated them to **assert the exception** rather than exclude `curation_history` from the comparison — the withdrawal test checks the removed grounding is *named* in the event, since that is the point. Excluding it would have made them pass while checking less.

## Verification

Canaried on real records before trusting anything, and checked the side effect on disk rather than the exit code:

- `--apply --refresh` on `Richmond_Mine_AMD_Biofilm` → one `GTDB_REFRESH` event.
- `--withdraw-ambiguous` on a *Methylobacter* probe → grounding gone, value preserved in the event.
- `--apply-status` on a record that **already has** `curation_history` → existing event untouched, new one appended last.
- `--apply-status` twice → byte-identical, one event.

`audit-writers` now reports all safeguards present for this module, and a test pins that so the gap cannot silently reopen. `2299 passed, 16 skipped`. **No stored grounding changes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)