### PR TITLE
Restore the sp.-at-species-rank check, as over-grounding rather than a clash (#449)

### DIFF
--- a/src/communitymech/validators/shared_taxon_ids.py
+++ b/src/communitymech/validators/shared_taxon_ids.py
@@ -309,6 +309,58 @@ def _names_disagree(first: str, second: str, rank: str | None, known: frozenset)
     return left[1] != right[1]
 
 
+def _says_unnamed_species(name: str) -> bool:
+    """Does this name *literally* decline to name a species — `Genus sp.`?
+
+    Distinct from `_core(...)[1] == "sp"`, which is also what a bare strain code
+    reduces to. That difference is the whole of #449. `Marinobacter CS1` names a
+    strain and may well *be* the species it sits beside, so sharing a species id
+    with it is ordinary; `Marinobacter sp.` asserts the species is unnamed,
+    which a named species id contradicts. Treating the two alike is what #447
+    did, and it is right at genus rank and wrong at species rank.
+    """
+    core = _core(name)
+    if core is None or core[1] != "sp":
+        return False
+    cleaned = re.sub(r"\(.*?\)", " ", name or "").replace(".", " ")
+    cleaned = _CANDIDATUS.sub("", cleaned.strip()).strip()
+    cleaned = cleaned.replace("[", "").replace("]", "")
+    match = _CORE.match(cleaned)
+    # Only the placeholder path counts. When `_CORE` does not match at all, the
+    # `sp` came from the strain-code fallback.
+    return bool(match and _PLACEHOLDER.match(match.group(2).lower()))
+
+
+def _over_grounded(first: str, second: str, rank: str | None, known: frozenset) -> bool:
+    """Is one of these an `sp.` sitting on an id that names a species (#449)?
+
+    A different claim from `_names_disagree`, and reported separately. Neither
+    name is wrong about the organism — nobody has said two incompatible things
+    — but a species id asserts one named species, so an entry that declines to
+    name one is grounded finer than it knows. That is the #292 shape with the
+    `sp.` entry as the victim rather than the culprit.
+
+    Genus rank is exempt, because a genus id legitimately hosts unnamed
+    isolates; that is #447's point and it stands.
+    """
+    if rank in ("genus", "subgenus"):
+        return False
+    left, right = _core(first), _core(second)
+    if left is None or right is None:
+        return False
+    if left in known and right in known:
+        return False
+    if not _same_genus(left[0], right[0]):
+        return False  # a genuine clash, already reported by _names_disagree
+    # Reuse the cores parsed above rather than re-deriving them: calling
+    # _core again returns Optional, which is not indexable, and the guard that
+    # makes it safe is several lines away.
+    pairs = ((first, left), (second, right))
+    unnamed = [n for n, _ in pairs if _says_unnamed_species(n)]
+    named = [n for n, core in pairs if core[1] != "sp"]
+    return len(unnamed) == 1 and len(named) == 1
+
+
 def check_record(taxonomy: list) -> list[str]:
     """Messages for each specific id shared by genuinely different organisms.
 
@@ -351,14 +403,25 @@ def check_record(taxonomy: list) -> list[str]:
         rank = rank_of(curie)
         known = known_cores(curie)
         clashing: set[str] = set()
+        over: set[str] = set()
         for i in range(len(names)):
             for j in range(i):
                 if _names_disagree(names[i], names[j], rank, known):
                     clashing.update((names[i], names[j]))
-        if not clashing:
-            continue
-        problems.append(
-            f"{curie} ({rank}) is used for taxa that cannot all be it: "
-            + ", ".join(repr(n) for n in sorted(clashing))
-        )
+                elif _over_grounded(names[i], names[j], rank, known):
+                    over.update((names[i], names[j]))
+        if clashing:
+            problems.append(
+                f"{curie} ({rank}) is used for taxa that cannot all be it: "
+                + ", ".join(repr(n) for n in sorted(clashing))
+            )
+        # Reported separately, and only where there is no clash to report: the
+        # two are different claims. A clash says somebody is wrong about the
+        # organism; this says nobody is wrong, but an entry that declines to
+        # name a species is sitting on an id that names one (#449).
+        if over and not clashing:
+            problems.append(
+                f"{curie} ({rank}) names a species, but is also used for an entry "
+                f"that does not name one: " + ", ".join(repr(n) for n in sorted(over))
+            )
     return problems

--- a/src/communitymech/validators/shared_taxon_ids.py
+++ b/src/communitymech/validators/shared_taxon_ids.py
@@ -85,7 +85,11 @@ SPECIFIC_RANKS = frozenset(
 _CORE = re.compile(r"^([A-Za-z][A-Za-z0-9_\-]*)\s+([a-z][a-z0-9_\-]*)")
 # GTDB-style placeholder epithets: `sp.`, `sp900119625`, `sp002874965`. All mean
 # "unnamed species", so two of them under one genus are not a contradiction.
-_PLACEHOLDER = re.compile(r"^sp\d*$")
+# `spp` too: it is the plural of `sp.` and says the same thing. Matching only
+# `sp` left it read as a *named* epithet, so `Bifidobacterium spp.` beside
+# `Bifidobacterium longum` was reported as a hard clash — neither protected as
+# unnamed nor reported as over-grounding (review of #484). 7 names in the KB.
+_PLACEHOLDER = re.compile(r"^spp?\d*$")
 # GTDB splits one NCBI genus into `Olsenella`, `Olsenella_A`, `Olsenella_B`. NCBI
 # genus names never contain an underscore, so stripping this suffix is
 # unambiguous, and two GTDB splits of one genus are not two different genera.
@@ -125,6 +129,21 @@ def _looks_like_a_strain_code(token: str, following: str | None = None) -> bool:
     return token.isupper() and any(c.isdigit() for c in (following or ""))
 
 
+def _clean(name: str) -> str:
+    """Strip parentheticals, `Candidatus`, and NCBI's provisional brackets.
+
+    Shared by `_core` and `_says_unnamed_species`. It was duplicated
+    byte-for-byte between them, which meant any future change to one silently
+    desynchronised the other — and the failure mode is a name flipping between
+    "unnamed species" and "strain code", the exact distinction #449 rests on
+    (review of #484).
+    """
+    cleaned = re.sub(r"\(.*?\)", " ", name or "").replace(".", " ")
+    cleaned = _CANDIDATUS.sub("", cleaned.strip()).strip()
+    # A provisional genus is bracketed in NCBI: `[Clostridium] scindens`.
+    return cleaned.replace("[", "").replace("]", "")
+
+
 def _core(name: str) -> tuple[str, str] | None:
     """(genus, epithet) for a Latin binomial, or None if the name is not one.
 
@@ -147,10 +166,7 @@ def _core(name: str) -> tuple[str, str] | None:
     one is how a gate starts firing on correct records — 12 names became
     parseable here, and every one is an organism.
     """
-    cleaned = re.sub(r"\(.*?\)", " ", name or "").replace(".", " ")
-    cleaned = _CANDIDATUS.sub("", cleaned.strip()).strip()
-    # A provisional genus is bracketed in NCBI: `[Clostridium] scindens`.
-    cleaned = cleaned.replace("[", "").replace("]", "")
+    cleaned = _clean(name)
     match = _CORE.match(cleaned)
     if not match:
         strain = _STRAIN.match(cleaned)
@@ -322,16 +338,25 @@ def _says_unnamed_species(name: str) -> bool:
     core = _core(name)
     if core is None or core[1] != "sp":
         return False
-    cleaned = re.sub(r"\(.*?\)", " ", name or "").replace(".", " ")
-    cleaned = _CANDIDATUS.sub("", cleaned.strip()).strip()
-    cleaned = cleaned.replace("[", "").replace("]", "")
+    cleaned = _clean(name)
     match = _CORE.match(cleaned)
-    # Only the placeholder path counts. When `_CORE` does not match at all, the
-    # `sp` came from the strain-code fallback.
-    return bool(match and _PLACEHOLDER.match(match.group(2).lower()))
+    if not match or not _PLACEHOLDER.match(match.group(2).lower()):
+        # `_CORE` did not match, so the `sp` came from the strain-code
+        # fallback: `Marinobacter CS1`.
+        return False
+    # A trailing strain code identifies an isolate, and an isolate may well BE
+    # the species beside it — so `Marinobacter sp. CS1` is no more
+    # over-grounded than `Marinobacter CS1`. The first draft flagged one and
+    # not the other, which made the gate's verdict depend on an orthographic
+    # choice with no semantic content, contradicting `_core`'s own docstring
+    # ("exactly as `Marinobacter sp. CS1` would") (review of #484). Only a bare
+    # `Genus sp.` — declining to name a species *and* naming no isolate —
+    # is reported.
+    rest = cleaned[match.end() :].strip()
+    return not rest
 
 
-def _over_grounded(first: str, second: str, rank: str | None, known: frozenset) -> bool:
+def _over_grounded(first: str, second: str, rank: str | None, known: frozenset) -> str | None:
     """Is one of these an `sp.` sitting on an id that names a species (#449)?
 
     A different claim from `_names_disagree`, and reported separately. Neither
@@ -344,21 +369,28 @@ def _over_grounded(first: str, second: str, rank: str | None, known: frozenset) 
     isolates; that is #447's point and it stands.
     """
     if rank in ("genus", "subgenus"):
-        return False
+        return None
     left, right = _core(first), _core(second)
     if left is None or right is None:
-        return False
+        return None
     if left in known and right in known:
-        return False
+        return None
     if not _same_genus(left[0], right[0]):
-        return False  # a genuine clash, already reported by _names_disagree
+        return None  # a genuine clash, already reported by _names_disagree
     # Reuse the cores parsed above rather than re-deriving them: calling
     # _core again returns Optional, which is not indexable, and the guard that
     # makes it safe is several lines away.
     pairs = ((first, left), (second, right))
     unnamed = [n for n, _ in pairs if _says_unnamed_species(n)]
     named = [n for n, core in pairs if core[1] != "sp"]
-    return len(unnamed) == 1 and len(named) == 1
+    # A *named* partner is required. Two unnamed entries on one id assert
+    # nothing incompatible with each other — two MAGs of one species sharing
+    # that species' id is ordinary metagenomics, and the KB does exactly that
+    # for `Olsenella_B sp. (MAG ATO3)` and `(MAG ATO6)`. Only a named entry
+    # establishes that the id denotes a species this one declines to name.
+    if len(unnamed) != 1 or len(named) != 1:
+        return None
+    return unnamed[0]
 
 
 def check_record(taxonomy: list) -> list[str]:
@@ -408,8 +440,10 @@ def check_record(taxonomy: list) -> list[str]:
             for j in range(i):
                 if _names_disagree(names[i], names[j], rank, known):
                     clashing.update((names[i], names[j]))
-                elif _over_grounded(names[i], names[j], rank, known):
-                    over.update((names[i], names[j]))
+                else:
+                    offender = _over_grounded(names[i], names[j], rank, known)
+                    if offender is not None:
+                        over.add(offender)
         if clashing:
             problems.append(
                 f"{curie} ({rank}) is used for taxa that cannot all be it: "
@@ -419,9 +453,21 @@ def check_record(taxonomy: list) -> list[str]:
         # two are different claims. A clash says somebody is wrong about the
         # organism; this says nobody is wrong, but an entry that declines to
         # name a species is sitting on an id that names one (#449).
+        #
+        # One id, one message, deliberately. Where an id has both, the
+        # over-grounded entry goes unmentioned until the clash is fixed and the
+        # gate is re-run. The clash is the more serious claim and usually
+        # changes which id the entries carry, which can resolve the
+        # over-grounding on its own — so leading with both would often report a
+        # finding that the first fix removes (#484 review).
         if over and not clashing:
+            # Only the over-grounded entries, not their innocent partners: the
+            # asymmetry is the whole finding, and sorting both names together
+            # made the curator re-derive which one to change. The remedy is
+            # specific enough to state (review of #484).
             problems.append(
-                f"{curie} ({rank}) names a species, but is also used for an entry "
-                f"that does not name one: " + ", ".join(repr(n) for n in sorted(over))
+                f"{curie} ({rank}) denotes one organism, but "
+                + ", ".join(repr(n) for n in sorted(over))
+                + " does not name a species — ground it to the genus id instead"
             )
     return problems

--- a/tests/test_shared_taxon_ids.py
+++ b/tests/test_shared_taxon_ids.py
@@ -320,8 +320,13 @@ def test_an_sp_on_a_species_id_is_reported_as_over_grounding(caplog):
         ]
     )
     assert len(problems) == 1, problems
-    assert "does not name one" in problems[0]
+    assert "does not name a species" in problems[0]
     assert "cannot all be it" not in problems[0], "this is over-grounding, not a clash"
+    # Only the offender is named. Listing both made the curator re-derive which
+    # of the two to change, and the innocent partner is not the finding.
+    assert "Variovorax sp." in problems[0]
+    assert "Variovorax paradoxus" not in problems[0]
+    assert "genus id" in problems[0], "the remedy is specific enough to state"
 
 
 def test_a_clash_takes_precedence_over_over_grounding():
@@ -543,3 +548,80 @@ def test_what_this_gate_does_not_catch():
         )
         == []
     ), "if this now fires, the gate got stronger and the docstring is stale"
+
+
+def test_a_strain_code_is_silent_however_it_is_spelled():
+    """`Genus CODE` and `Genus sp. CODE` are the same organism (#484 review).
+
+    `_core`'s own docstring says so — `Marinobacter CS1` reduces "exactly as
+    `Marinobacter sp. CS1` would". The first draft of #449 flagged the second
+    and not the first, making the gate's verdict depend on an orthographic
+    choice with no semantic content. A trailing strain code names an isolate,
+    and an isolate may well BE the species beside it, so neither is reported.
+    """
+    for name in ("Marinobacter CS1", "Marinobacter sp. CS1"):
+        assert (
+            check_record(
+                [_entry(name, "NCBITaxon:2743"), _entry("Marinobacter nauticus", "NCBITaxon:2743")]
+            )
+            == []
+        ), name
+
+
+def test_the_moved_case_still_does_not_fire_at_species_rank():
+    """`Variovorax sp. BK119` carries a strain code, so it stays silent.
+
+    This case originally sat at NCBITaxon:34073 and an earlier draft of #449
+    moved it to the genus id because it had started firing. With the strain-code
+    rule above it belongs back at species rank, unfired — which is the stronger
+    statement, since ~155 KB names have this exact shape.
+    """
+    assert (
+        check_record(
+            [
+                _entry("Variovorax sp. BK119", "NCBITaxon:34073"),
+                _entry("Variovorax paradoxus", "NCBITaxon:34073"),
+            ]
+        )
+        == []
+    )
+
+
+def test_spp_is_treated_as_unnamed_not_as_a_named_epithet():
+    """`spp.` is the plural of `sp.` and means the same thing.
+
+    Matching only `^sp\d*$` left it parsing as a *named* epithet, so
+    `Bifidobacterium spp.` beside `Bifidobacterium longum` was reported as a
+    hard clash — the worst of both worlds: not protected as unnamed, and
+    reported as the more severe claim (#484 review). 7 names in the KB have
+    this spelling.
+    """
+    problems = check_record(
+        [
+            _entry("Bifidobacterium spp.", "NCBITaxon:216816"),
+            _entry("Bifidobacterium longum", "NCBITaxon:216816"),
+        ]
+    )
+    assert len(problems) == 1, problems
+    assert "cannot all be it" not in problems[0], "spp. is unnamed, not a clashing epithet"
+    assert "does not name a species" in problems[0]
+
+
+def test_two_unnamed_entries_on_one_species_id_are_not_reported():
+    """A deliberate limit, not an oversight.
+
+    Two MAGs of one species sharing that species' id is ordinary metagenomics,
+    and the KB does exactly that — `Olsenella_B sp. (MAG ATO3)` and
+    `(MAG ATO6)` both on NCBITaxon:133926. Neither asserts anything the other
+    contradicts. Only a *named* partner establishes that the id denotes a
+    species the other declines to name (#484 review).
+    """
+    assert (
+        check_record(
+            [
+                _entry("Olsenella_B sp. (MAG ATO3)", "NCBITaxon:133926"),
+                _entry("Olsenella_B sp900119625 (MAG ATO6)", "NCBITaxon:133926"),
+            ]
+        )
+        == []
+    )

--- a/tests/test_shared_taxon_ids.py
+++ b/tests/test_shared_taxon_ids.py
@@ -267,14 +267,74 @@ def test_two_strain_isolates_of_different_genera_are_caught():
             "NCBITaxon:2743",
         ),
         (
-            "the same, spelled sp.",
+            "an sp. beside a named species under a GENUS id",
             ["Variovorax sp. BK119", "Variovorax paradoxus"],
-            "NCBITaxon:34073",
+            "NCBITaxon:34072",
         ),
     ],
 )
 def test_an_unnamed_species_cannot_contradict_a_named_one(label, names, curie):
+    """Neither is a *clash* — nobody has said two incompatible things.
+
+    The second case moved from the species id (34073, `Variovorax paradoxus`)
+    to the genus id (34072) when #449 split over-grounding out. At genus rank
+    an unnamed isolate beside a named species is ordinary and stays silent; at
+    species rank it is now reported, as over-grounding rather than a clash. The
+    strain-code case stays silent at *both* ranks, which is #447's point.
+    """
     assert check_record([_entry(n, curie) for n in names]) == [], label
+
+
+def test_a_strain_code_is_never_over_grounded_even_at_species_rank():
+    """#447 in one line, and the constraint #449 had to respect.
+
+    `Marinobacter CS1` names a strain, which may well BE the species it sits
+    beside, so sharing that species id asserts nothing wrong. Only a name that
+    *literally* declines to name a species is over-grounded — the distinction
+    the `sp` bucket alone cannot make, since both reduce to it.
+    """
+    assert (
+        check_record(
+            [
+                _entry("Marinobacter CS1", "NCBITaxon:2743"),
+                _entry("Marinobacter nauticus", "NCBITaxon:2743"),
+            ]
+        )
+        == []
+    )
+
+
+def test_an_sp_on_a_species_id_is_reported_as_over_grounding(caplog):
+    """The loss #449 recorded, restored — and framed as the claim it is.
+
+    A species id asserts one named species, so `Variovorax sp.` sitting on
+    `NCBITaxon:34073` (*Variovorax paradoxus*) is grounded finer than it knows.
+    That is the #292 shape with the `sp.` entry as the victim rather than the
+    culprit, and it is a different claim from a clash — so it gets its own
+    message rather than being folded into "cannot all be it".
+    """
+    problems = check_record(
+        [
+            _entry("Variovorax sp.", "NCBITaxon:34073"),
+            _entry("Variovorax paradoxus", "NCBITaxon:34073"),
+        ]
+    )
+    assert len(problems) == 1, problems
+    assert "does not name one" in problems[0]
+    assert "cannot all be it" not in problems[0], "this is over-grounding, not a clash"
+
+
+def test_a_clash_takes_precedence_over_over_grounding():
+    """One id, one message: a wrong organism is the more serious claim."""
+    problems = check_record(
+        [
+            _entry("Variovorax sp.", "NCBITaxon:34073"),
+            _entry("Variovorax paradoxus", "NCBITaxon:34073"),
+            _entry("Bacillus subtilis", "NCBITaxon:34073"),
+        ]
+    )
+    assert len(problems) == 1, problems
+    assert "cannot all be it" in problems[0]
 
 
 def test_a_broad_id_shared_across_guilds_is_fine():


### PR DESCRIPTION
Closes #449, taking the "sharper rule" the issue proposed.

## The tradeoff

#447 made an unnamed epithet never contradict a named one, because widening `_core` put strain codes into the `sp` bucket and `Marinobacter CS1` may well *be* the species it sits beside. Correct at genus rank. At **species** rank it gave something up — a species id asserts one named species, so `Genus sp.` carrying it is over-grounded.

## What makes both work

Two different things reduce to `sp`, and `_core` collapses them — which is why #447 had to suppress both:

| name | reduces to | asserts |
|---|---|---|
| `Variovorax sp.` | `("variovorax", "sp")` | the species is **unnamed** |
| `Marinobacter CS1` | `("marinobacter", "sp")` | **nothing** about the species — may be the one beside it |

A new `_says_unnamed_species` re-separates them by checking whether the *placeholder* path or the *strain-code fallback* produced the `sp`. The check fires only on the first, so #447's fix is untouched.

## Reported as its own claim

Not folded into `cannot all be it`. A clash says somebody is **wrong about the organism**; this says nobody is wrong, but an entry that declines to name a species is sitting on an id that names one. Different claims deserve different messages, and the issue explicitly flagged this ("possibly a different, lower-severity category").

```
NCBITaxon:34073 (species) names a species, but is also used for an entry
that does not name one: 'Variovorax paradoxus', 'Variovorax sp.'
```

A clash on the same id takes precedence, so one id still yields one message.

## Verification

**The KB is unaffected — 316 files, 0 findings**, exactly as #449 predicted. That means no live hit proves this works, so the mutation matrix carries the weight:

```
remove the over-grounding call  → FAILED test_an_sp_on_a_species_id_is_reported_as_over_grounding
flag strain codes too (undo #447) → FAILED test_a_strain_code_is_never_over_grounded_even_at_species_rank
                                  → FAILED test_an_unnamed_species_cannot_contradict_a_named_one[strain code…]
restored                          → 67 passed
```

Both directions of the tradeoff are now pinned: removing the new check fails, and reintroducing #447's false positive also fails.

One existing parametrized case moved from the species id `NCBITaxon:34073` (*Variovorax paradoxus*) to the genus id `34072`, because at species rank that pair is now legitimately reported. The strain-code case stays at species rank and stays silent, which is the point.

## Also

mypy caught a latent crash in my first draft: it re-derived `_core(n)[1]` inside a comprehension, and `_core` returns `Optional`. The guard above made it safe in practice but sat several lines away; it now reuses the cores already parsed.

`2311 passed, 16 skipped`. `ruff`, `black`, `mypy src/` clean.

## Not addressed

#449 notes this "overlaps #419's territory (a name finer or coarser than its id) and might belong with it". I have kept it here because the mechanism is the shared-id gate's, not #419's, but the two categories are worth reconciling if #419 is taken up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)