### PR TITLE
Stop a working tool reporting "no issues" from a validator that never ran (#410)

### DIFF
--- a/scripts/apply_suggested_fixes.py
+++ b/scripts/apply_suggested_fixes.py
@@ -332,7 +332,7 @@ def main():
 
     if not report_path.exists():
         print(f"ERROR: Report not found: {report_path}")
-        print("Run: poetry run python scripts/curate_evidence_with_pdfs.py --quick")
+        print("Run: just validate-references FILE")
         return 1
 
     if not kb_dir.exists():
@@ -384,7 +384,7 @@ def main():
     if args.dry_run:
         print("\n  [DRY RUN] No files were modified.")
     else:
-        print("\n  Run validation: poetry run python scripts/curate_evidence_with_pdfs.py --quick")
+        print("\n  Run validation: just validate-references FILE")
     return 0
 
 

--- a/scripts/apply_suggested_snippets.py
+++ b/scripts/apply_suggested_snippets.py
@@ -277,7 +277,7 @@ def interactive_review(fixes: list[SnippetFix], yaml_path: Path, auto_approve: b
         print(f"❌ Failed:   {failed_count}")
         print(f"\n💾 Updated file: {yaml_path}")
         print(f"💾 Backup saved: {backup_path}")
-        print("\n🔍 Next: Validate with curate_evidence_with_pdfs.py")
+        print("\n🔍 Next: Validate with `just validate-references FILE`")
     else:
         print("\n⚠️  No fixes were applied")
         backup_path.unlink()  # Remove backup if no changes
@@ -319,7 +319,7 @@ def main():
 
     if not report_path.exists():
         print(f"❌ Report not found: {report_path}")
-        print("   Run: poetry run python scripts/curate_evidence_with_pdfs.py --quick")
+        print("   Run: just validate-references FILE")
         return 1
 
     # Parse report
@@ -336,9 +336,7 @@ def main():
     if applied > 0:
         print(f"\n✅ Successfully applied {applied} snippet fixes")
         print("\n📋 Next steps:")
-        print(
-            f"   1. Validate: poetry run python scripts/curate_evidence_with_pdfs.py --file {yaml_filename}"
-        )
+        print(f"   1. Validate: just validate-references kb/communities/{yaml_filename}")
         print(f"   2. Schema check: just validate {yaml_path}")
         print(f"   3. Review changes: git diff {yaml_path}")
         return 0

--- a/scripts/batch_snippet_fixer.py
+++ b/scripts/batch_snippet_fixer.py
@@ -82,6 +82,11 @@ def parse_curation_report(report_path: Path) -> list[dict[str, int]]:
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
+def _count(value: int) -> str:
+    """Render an issue count, never letting the -1 sentinel read as a number."""
+    return "could not validate" if value == -1 else str(value)
+
+
 def validate_file(yaml_path: Path) -> dict[str, int]:
     """
     Run snippet validation on a file and return issue counts.
@@ -106,8 +111,10 @@ def validate_file(yaml_path: Path) -> dict[str, int]:
 
     It now calls ``linkml-reference-validator``, which is what
     ``just validate-references`` runs and which does check snippets against
-    ``references_cache/``. That tool exits 0 when clean and 1 when it finds
-    issues; its "Total checks" line counts *issues*, not checks (#257, #466).
+    ``references_cache/``. It exits 0 when clean and 1 when it finds issues, and
+    prints ``Issues found: N`` only in the latter case — which is the line
+    parsed below. (Its ``Total checks`` line also counts issues rather than
+    checks, per #257 and #466, but nothing here reads it.)
     """
     try:
         result = subprocess.run(
@@ -146,6 +153,11 @@ def validate_file(yaml_path: Path) -> dict[str, int]:
         print(f"  ⚠️  Validator reported failure with no issue count: {output.strip()[-200:]}")
         return {"total": -1, "errors": -1, "warnings": -1}
 
+    # Everything under `total`. The old code split errors from warnings, but
+    # linkml-reference-validator reports one issue count, so filing all of it
+    # under `errors` and hardcoding `warnings: 0` stated something untrue —
+    # a cache miss prints [WARN] and would still have landed in `errors`
+    # (#487 review). The keys stay for callers; they now agree with the source.
     return {"total": errors, "errors": errors, "warnings": 0}
 
 
@@ -205,18 +217,26 @@ def process_files_batch(
                 print("\n📊 Post-processing validation...")
                 final_issues = validate_file(yaml_path)
 
+                # -1 means the validator could not run. Subtracting it
+                # reported `0 -> -1` as "fixed 1", with a green tick, and summed
+                # that fabricated 1 into the batch total — the same
+                # never-ran-but-looks-clean defect this function was fixed for,
+                # one frame up (#487 review).
+                unknown = -1 in (initial_issues["total"], final_issues["total"])
+                fixed = None if unknown else initial_issues["total"] - final_issues["total"]
+
                 print("\n📈 IMPROVEMENT:")
-                print(f"   Issues before: {initial_issues['total']}")
-                print(f"   Issues after:  {final_issues['total']}")
-                print(f"   Issues fixed:  {initial_issues['total'] - final_issues['total']}")
+                print(f"   Issues before: {_count(initial_issues['total'])}")
+                print(f"   Issues after:  {_count(final_issues['total'])}")
+                print(f"   Issues fixed:  {'unknown' if unknown else fixed}")
 
                 results.append(
                     {
                         "file": filename,
-                        "status": "processed",
+                        "status": "validation_failed" if unknown else "processed",
                         "issues_before": initial_issues["total"],
                         "issues_after": final_issues["total"],
-                        "issues_fixed": initial_issues["total"] - final_issues["total"],
+                        "issues_fixed": fixed,
                     }
                 )
             else:
@@ -238,9 +258,18 @@ def process_files_batch(
     print(f"Total files processed: {len(file_list)}\n")
 
     for result in results:
-        status_icon = "✅" if result["status"] == "processed" else "❌"
+        # `validation_failed` is its own icon: it is neither a clean pass nor a
+        # processing error, and a ✅ beside a file whose validation never ran is
+        # the whole defect (#487 review).
+        status_icon = {"processed": "✅", "validation_failed": "⚠️"}.get(result["status"], "❌")
         print(f"{status_icon} {result['file']}")
-        if result["status"] == "processed" and "issues_fixed" in result:
+        if result["status"] == "validation_failed":
+            print(
+                f"   Issues: {_count(result['issues_before'])} → "
+                f"{_count(result['issues_after'])} (fixed: unknown — the "
+                f"validator could not run, so this file is unverified)"
+            )
+        elif result["status"] == "processed" and result.get("issues_fixed") is not None:
             print(
                 f"   Issues: {result['issues_before']} → {result['issues_after']} "
                 f"(fixed {result['issues_fixed']})"
@@ -250,8 +279,19 @@ def process_files_batch(
         print()
 
     if validate_after and any(r["status"] == "processed" for r in results):
-        total_fixed = sum(r.get("issues_fixed", 0) for r in results if r["status"] == "processed")
+        total_fixed = sum(
+            r["issues_fixed"]
+            for r in results
+            if r["status"] == "processed" and r.get("issues_fixed") is not None
+        )
         print(f"🎉 Total issues fixed across all files: {total_fixed}")
+        unverified = [r["file"] for r in results if r["status"] == "validation_failed"]
+        if unverified:
+            # Said out loud, not left to be inferred from a smaller total.
+            print(
+                f"⚠️  {len(unverified)} file(s) could not be validated and are "
+                f"NOT counted above: {', '.join(unverified)}"
+            )
 
 
 def main():
@@ -287,13 +327,29 @@ def main():
         default=False,
         help="Only process evidence items with short snippets (<50 chars). Default: process all.",
     )
-    parser.add_argument(
+    # `--no-validate` existed with no `--validate` beside it, and
+    # `set_defaults(validate=False)` then pinned it False whatever was passed —
+    # so `validate_file` was unreachable from the CLI, and had been since the
+    # commit that introduced both (7c658e6). The flag advertised a choice the
+    # parser did not offer (#487 review).
+    validation = parser.add_mutually_exclusive_group()
+    validation.add_argument(
+        "--validate",
+        action="store_true",
+        dest="validate",
+        help=(
+            "Validate snippets before and after each file. Off by default: it "
+            "runs linkml-reference-validator twice per file (~1.3s each), so a "
+            "full 312-file sweep adds roughly 13 minutes."
+        ),
+    )
+    validation.add_argument(
         "--no-validate",
         action="store_false",
         dest="validate",
-        help="Skip validation before and after processing each file (much faster)",
+        help="Skip validation before and after processing each file (the default)",
     )
-    parser.set_defaults(validate=False)  # Off by default; too slow for batch runs
+    parser.set_defaults(validate=False)
     parser.add_argument(
         "--relaxed",
         action="store_true",

--- a/scripts/batch_snippet_fixer.py
+++ b/scripts/batch_snippet_fixer.py
@@ -79,53 +79,74 @@ def parse_curation_report(report_path: Path) -> list[dict[str, int]]:
     return files_with_issues
 
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
 def validate_file(yaml_path: Path) -> dict[str, int]:
     """
-    Run validation on a file and return issue counts.
+    Run snippet validation on a file and return issue counts.
 
-    Args:
-        yaml_path: Path to YAML file
+    Returns ``{"total": -1, ...}`` when validation could not be run. A caller
+    must distinguish that from a clean file, which is exactly what this used to
+    make impossible (#410).
 
-    Returns:
-        Dict with issue type counts
+    It shelled out to ``poetry run python scripts/curate_evidence_with_pdfs.py``.
+    Three things were wrong at once, and together they were silent:
+
+    * that script imports ``communitymech.literature_enhanced``, which has never
+      existed in any commit, so it cannot start;
+    * ``poetry`` is not this repo's runner — it uses ``uv``;
+    * ``cwd`` was ``yaml_path.parent.parent``, i.e. ``kb/``, not the repo root.
+
+    ``returncode`` was never checked. The subprocess failed, stdout and stderr
+    carried no ``ERROR: N`` for the regex to match, and the function returned
+    ``{"total": 0, "errors": 0, "warnings": 0}`` — reported to the caller as
+    *validated, no issues*. A validation step that reports success because it
+    never ran is worse than one that is simply missing.
+
+    It now calls ``linkml-reference-validator``, which is what
+    ``just validate-references`` runs and which does check snippets against
+    ``references_cache/``. That tool exits 0 when clean and 1 when it finds
+    issues; its "Total checks" line counts *issues*, not checks (#257, #466).
     """
     try:
         result = subprocess.run(
             [
-                "poetry",
+                "uv",
                 "run",
-                "python",
-                "scripts/curate_evidence_with_pdfs.py",
-                "--file",
-                yaml_path.name,
-                "--quick",
+                "linkml-reference-validator",
+                "validate",
+                "data",
+                str(yaml_path.resolve()),
+                "-s",
+                "src/communitymech/schema/communitymech.yaml",
+                "--config",
+                "conf/reference_validator.yaml",
             ],
-            cwd=yaml_path.parent.parent,
+            cwd=REPO_ROOT,
             capture_output=True,
             text=True,
-            timeout=300,
+            timeout=600,
         )
-
-        # Parse output for issue counts
-        output = result.stdout + result.stderr
-        issues = {"total": 0, "errors": 0, "warnings": 0}
-
-        # Look for issue counts in output
-        error_match = re.search(r"ERROR:\s*(\d+)", output)
-        warning_match = re.search(r"WARNING:\s*(\d+)", output)
-
-        if error_match:
-            issues["errors"] = int(error_match.group(1))
-        if warning_match:
-            issues["warnings"] = int(warning_match.group(1))
-
-        issues["total"] = issues["errors"] + issues["warnings"]
-
-        return issues
-
-    except Exception as e:
-        print(f"  ⚠️  Validation failed: {e}")
+    except Exception as exc:  # noqa: BLE001 — reported, not swallowed
+        print(f"  ⚠️  Validation could not run: {exc}")
         return {"total": -1, "errors": -1, "warnings": -1}
+
+    output = result.stdout + result.stderr
+    if result.returncode not in (0, 1):
+        # Anything else means the validator itself failed to run. Say so
+        # instead of reporting a clean file.
+        print(f"  ⚠️  Validator exited {result.returncode}: {output.strip()[-200:]}")
+        return {"total": -1, "errors": -1, "warnings": -1}
+
+    found = re.search(r"Issues found:\s*(\d+)", output)
+    errors = int(found.group(1)) if found else 0
+    if errors == 0 and result.returncode == 1:
+        # Non-zero without a parseable count: do not round down to clean.
+        print(f"  ⚠️  Validator reported failure with no issue count: {output.strip()[-200:]}")
+        return {"total": -1, "errors": -1, "warnings": -1}
+
+    return {"total": errors, "errors": errors, "warnings": 0}
 
 
 def process_files_batch(

--- a/scripts/intelligent_snippet_fixer.py
+++ b/scripts/intelligent_snippet_fixer.py
@@ -699,7 +699,7 @@ def interactive_fix_workflow(
     if applied_count > 0:
         print(f"\n💾 Updated file: {yaml_path}")
         print(f"💾 Backup saved: {backup_path}")
-        print("\n🔍 Next: Validate with curate_evidence_with_pdfs.py")
+        print("\n🔍 Next: Validate with `just validate-references FILE`")
     else:
         print("\n⚠️  No fixes were applied")
         if backup_path.exists():

--- a/tests/test_batch_snippet_fixer_validation.py
+++ b/tests/test_batch_snippet_fixer_validation.py
@@ -1,0 +1,147 @@
+"""A validation step reported "no issues" because it never ran (#410).
+
+`batch_snippet_fixer.validate_file` shelled out to
+`poetry run python scripts/curate_evidence_with_pdfs.py`. Three things were
+wrong at once, and together they were silent:
+
+* that script imports `communitymech.literature_enhanced`, which has never
+  existed in any commit, so it cannot start;
+* `poetry` is not this repo's runner — it uses `uv`;
+* `cwd` was `yaml_path.parent.parent`, i.e. `kb/`, not the repo root.
+
+`returncode` was never checked. Reproduced before the fix: the subprocess
+exited **2**, stdout and stderr carried no `ERROR: N` for the regex to match,
+and the function returned `{"total": 0, "errors": 0, "warnings": 0}` — which
+its caller reads as *validated, clean*.
+
+That is the defect class this repo keeps finding: not a crash, but a check that
+reports success because it did nothing. The distinction these tests defend is
+between **"clean"** and **"could not tell"**, which the old code could not
+express — `0` meant both.
+
+It now calls `linkml-reference-validator`, the tool behind
+`just validate-references`, which does check snippets against
+`references_cache/` (#466 established that it genuinely validates, despite its
+"Total checks" line counting issues rather than checks).
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import pathlib
+import subprocess
+import sys
+
+import pytest
+import yaml
+
+REPO = pathlib.Path(__file__).parent.parent
+CLEAN_RECORD = (
+    REPO / "kb/communities/Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.yaml"
+)
+
+
+@pytest.fixture(scope="module")
+def fixer():
+    spec = importlib.util.spec_from_file_location(
+        "batch_snippet_fixer", REPO / "scripts/batch_snippet_fixer.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["batch_snippet_fixer"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_a_file_that_cannot_be_validated_is_not_reported_as_clean(fixer, tmp_path):
+    """The whole point. `0` must mean clean, never "the validator never ran".
+
+    A missing path is the cheapest way to make validation impossible without
+    depending on the network or the cache.
+    """
+    result = fixer.validate_file(tmp_path / "does_not_exist.yaml")
+    assert result["total"] == -1, (
+        f"a file that could not be validated was reported as {result}, which a "
+        f"caller reads as clean (#410)"
+    )
+
+
+def test_the_validator_it_calls_can_actually_start(fixer):
+    """Guard against the original failure recurring in a new form.
+
+    The old target could not be imported at all, so `--help` failed. If the
+    replacement ever becomes unrunnable, this fails immediately rather than at
+    the next batch run.
+    """
+    result = subprocess.run(
+        ["uv", "run", "linkml-reference-validator", "validate", "data", "--help"],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+        timeout=600,
+    )
+    assert result.returncode == 0, result.stderr[-400:]
+
+
+def _strings_in(node: ast.AST) -> list[str]:
+    """Every string literal reachable inside a call, f-strings included."""
+    found = []
+    for child in ast.walk(node):
+        if isinstance(child, ast.Constant) and isinstance(child.value, str):
+            found.append(child.value)
+    return found
+
+
+def test_no_working_script_points_at_a_script_that_cannot_run():
+    """Four working tools told the user to run the broken one.
+
+    `batch_snippet_fixer` actually invoked it; three others printed it as the
+    next step. A dead pointer in a working tool is how a curator discovers the
+    breakage, which is the worst place to discover it.
+    """
+    dead = {"curate_evidence_with_pdfs", "review_literature", "quick_literature_review"}
+    offenders = []
+    for path in sorted((REPO / "scripts").glob("*.py")):
+        if path.stem in dead or path.stem == "extract_evidence_snippets":
+            continue  # the dead scripts may of course name themselves
+        tree = ast.parse(path.read_text())
+        # Strings that are *executed* — printed, or passed to subprocess — not
+        # every string in the file. A raw-text scan flagged this module's own
+        # docstring, which exists to explain the historical bug: it cannot tell
+        # a live instruction from prose documenting its removal, the same trap
+        # as grepping a curation note for the id it retired.
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = getattr(func, "id", None) or getattr(func, "attr", None)
+            if name not in ("print", "run", "Popen", "check_output", "call"):
+                continue
+            for text in _strings_in(node):
+                if any(script in text for script in dead):
+                    offenders.append(f"{path.name}: {text.strip()[:90]}")
+    assert offenders == [], (
+        "these working scripts still tell the user to run a script that cannot "
+        "start (#410):\n" + "\n".join(offenders)
+    )
+
+
+@pytest.mark.slow
+def test_a_clean_record_is_reported_clean_and_a_broken_one_is_not(fixer, tmp_path):
+    """The check must discriminate, or `-1` everywhere would pass the tests above.
+
+    Runs the real validator against the committed cache — no network, but it is
+    the slowest test here, so it carries the `slow` marker.
+    """
+    assert fixer.validate_file(CLEAN_RECORD)["total"] == 0
+
+    document = yaml.safe_load(CLEAN_RECORD.read_text())
+    document["taxonomy"][0]["evidence"][0][
+        "snippet"
+    ] = "ZZQQ this sentence appears in no publication whatsoever XKCD"
+    broken = tmp_path / "broken.yaml"
+    broken.write_text(yaml.safe_dump(document, sort_keys=False, allow_unicode=True, width=4096))
+
+    assert (
+        fixer.validate_file(broken)["total"] >= 1
+    ), "a snippet that appears in no publication was reported as clean"

--- a/tests/test_batch_snippet_fixer_validation.py
+++ b/tests/test_batch_snippet_fixer_validation.py
@@ -83,6 +83,22 @@ def test_the_validator_it_calls_can_actually_start(fixer):
     assert result.returncode == 0, result.stderr[-400:]
 
 
+def _known_broken() -> set[str]:
+    """The five scripts `tests/test_scripts_import.py` records as unrunnable."""
+    source = (REPO / "tests/test_scripts_import.py").read_text()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "_KNOWN_BROKEN" for target in node.targets
+        ):
+            return {
+                element.value
+                for element in ast.walk(node.value)
+                if isinstance(element, ast.Constant) and isinstance(element.value, str)
+            }
+    raise AssertionError("_KNOWN_BROKEN is gone from tests/test_scripts_import.py")
+
+
 def _strings_in(node: ast.AST) -> list[str]:
     """Every string literal reachable inside a call, f-strings included."""
     found = []
@@ -99,10 +115,15 @@ def test_no_working_script_points_at_a_script_that_cannot_run():
     next step. A dead pointer in a working tool is how a curator discovers the
     breakage, which is the worst place to discover it.
     """
-    dead = {"curate_evidence_with_pdfs", "review_literature", "quick_literature_review"}
+    # Read from the same list `test_scripts_import` maintains, rather than a
+    # second copy: two hand-kept lists drift, and the first version of this test
+    # named three of the five, so a pointer at `test_pdf_fetching` or
+    # `extract_evidence_snippets` sailed through (#487 review).
+    dead = {name.removesuffix(".py") for name in _known_broken()}
+    assert len(dead) >= 5, f"the known-broken list has shrunk unexpectedly: {sorted(dead)}"
     offenders = []
     for path in sorted((REPO / "scripts").glob("*.py")):
-        if path.stem in dead or path.stem == "extract_evidence_snippets":
+        if path.stem in dead:
             continue  # the dead scripts may of course name themselves
         tree = ast.parse(path.read_text())
         # Strings that are *executed* — printed, or passed to subprocess — not
@@ -115,7 +136,20 @@ def test_no_working_script_points_at_a_script_that_cannot_run():
                 continue
             func = node.func
             name = getattr(func, "id", None) or getattr(func, "attr", None)
-            if name not in ("print", "run", "Popen", "check_output", "call"):
+            # `system` and `write` too: os.system and sys.stdout.write are the
+            # shapes the first version missed.
+            if name not in (
+                "print",
+                "run",
+                "Popen",
+                "check_output",
+                "call",
+                "system",
+                "write",
+                "info",
+                "warning",
+                "error",
+            ):
                 continue
             for text in _strings_in(node):
                 if any(script in text for script in dead):
@@ -126,12 +160,19 @@ def test_no_working_script_points_at_a_script_that_cannot_run():
     )
 
 
-@pytest.mark.slow
+@pytest.mark.e2e
 def test_a_clean_record_is_reported_clean_and_a_broken_one_is_not(fixer, tmp_path):
     """The check must discriminate, or `-1` everywhere would pass the tests above.
 
-    Runs the real validator against the committed cache — no network, but it is
-    the slowest test here, so it carries the `slow` marker.
+    Marked `e2e`, which `pyproject.toml`'s `addopts = "-m 'not e2e'"` deselects
+    by default. Two reasons, both from the #487 review: `slow` is not a
+    registered marker here, so it only produced a warning and deselected
+    nothing; and this runs `linkml-reference-validator`, which #417 deliberately
+    keeps out of `just qc`. It resolves against the committed cache today, but
+    that is a property of which references this record happens to use, not a
+    guarantee — an uncached one would reach NCBI from inside the test suite.
+
+    Run it deliberately: `uv run pytest -m e2e tests/test_batch_snippet_fixer_validation.py`.
     """
     assert fixer.validate_file(CLEAN_RECORD)["total"] == 0
 


### PR DESCRIPTION
Partially addresses #410. The delete-or-port decision stays open; what this fixes is the part that was actually reachable — and silent.

## The live defect

#461 already documented the five scripts importing `communitymech.literature_enhanced`, a module that has never existed in any commit. What it did not reach: **four working scripts still pointed at one of them, and one actually invoked it.**

`batch_snippet_fixer.validate_file` ran:

```
poetry run python scripts/curate_evidence_with_pdfs.py --file X --quick
```

Three things wrong at once, and together they were silent:

1. that script cannot start — the import fails;
2. `poetry` is not this repo's runner (it uses `uv`);
3. `cwd` was `yaml_path.parent.parent`, i.e. `kb/`, not the repo root.

**`returncode` was never checked.** Reproduced against a real record before changing anything:

```
returncode: 2
stderr: can't open file '.../scripts/curate_evidence_with_pdfs.py'
REPORTED TO CALLER: {'total': 0, 'errors': 0, 'warnings': 0}   <-- reads as "validated, no issues"
```

The subprocess failed, no `ERROR: N` appeared for the regex to match, and the function returned zeros. `0` could not be distinguished from "could not tell". A validation step that reports success because it never ran is worse than one that is simply missing — this is the defect class this repo keeps surfacing, and here it was sitting inside a tool that looks like it works.

## The fix

`validate_file` now calls `linkml-reference-validator` — the tool behind `just validate-references`, which #466 established does genuinely check snippets against `references_cache/`. Returncodes other than 0/1, and a non-zero exit with no parseable issue count, both return `-1` rather than rounding down to clean.

Canaried on three inputs:

| input | result |
|---|---|
| clean record | `{'total': 0}` |
| record with a snippet that is in no publication | `{'total': 1}` — it actually detects now |
| unreadable file | `{'total': -1}` — "could not validate", **not** clean |

The three scripts that merely *printed* it as the next step — `apply_suggested_fixes`, `apply_suggested_snippets`, `intelligent_snippet_fixer` — now name `just validate-references`. A dead pointer inside a working tool is how a curator discovers the breakage, which is the worst place to discover it.

## The test caught its own docstring first

The guard against dead pointers scanned raw text, so it flagged the line in `batch_snippet_fixer.py` that *explains* the historical `poetry run ...` command. Exactly the trap from #471, where a grep for a retired CHEBI id matched the curation note documenting its retirement. It walks the AST now and inspects only strings passed to `print` or `subprocess`.

Mutation-checked: restoring the round-down-to-clean branch fails `test_a_file_that_cannot_be_validated_is_not_reported_as_clean`.

## What is deliberately not decided

Whether the five dead scripts are **deleted or ported**. The porting question is real, not bookkeeping:

- they call `fetch_paper(ref, download_pdf=...)` and subscript the result (`paper["abstract"]`);
- what exists is `fetch_paper(reference, email=...)` returning a **tuple** `(abstract, pdf_url)`;
- `LiteratureFetcher` has no PDF *download* at all — only `fetch_unpaywall(doi)`, which returns a URL. Two of the scripts advertise full-text extraction (`snippet_in_fulltext`), and one advertises a **sci-hub fallback** in its docstring.

Porting means writing capability that no working code in this repo has, guided only by drafts that never ran. `scripts/cache_fulltext.py` already covers "get OA full text into the cache" in a working form. My reading is that deletion is right, but it is a judgement about intent that belongs with whoever wrote them, so #410 stays open for it.

What is fixed is that **nothing working depends on them any more**, which is what made the breakage reachable.

`2319 passed, 16 skipped`. `ruff`, `black`, `mypy src/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)