### PR TITLE
Check conf/ and .github/ for truncated scalars, by convention (#400)

### DIFF
--- a/justfile
+++ b/justfile
@@ -166,11 +166,25 @@ validate-gtdb FILE:
 #
 # The same check runs inside `just validate-strict` over kb/communities and
 # data/isolates. This form also covers kb/taxa, which that gate does not, and
-# takes explicit paths. Scoped to the record trees on purpose: conf/ and
-# .github/ use deliberate trailing comments, which are indistinguishable from
-# truncation on a plain scalar.
+# takes explicit paths. Scoped to the record trees, where a trailing comment is
+# not an idiom, so every report is real.
 validate-scalars *files:
     PYTHONPATH=src uv run python scripts/validate_yaml_scalars.py {{files}}
+
+# The same check over conf/, .github/workflows/, vocab/ and the schema (#400).
+#
+# Those trees DO use deliberate trailing comments, which YAML cannot distinguish
+# from a truncated value — both end the scalar at the `#`. So this reports only
+# a comment written tight against the value, under two spaces. Measured: all 13
+# deliberate trailing comments in those trees use three or more spaces, and none
+# uses fewer, while a `#` swallowed mid-sentence has one or none because it was
+# typed as prose.
+#
+# A convention check, not a proof. `key: text   #400 lost` with three spaces
+# slips through, and `key: value # comment` with one space reports falsely. It
+# is worth having because the alternative for these 21 files is no check at all.
+validate-scalars-idiomatic:
+    PYTHONPATH=src uv run python scripts/validate_yaml_scalars.py --idiomatic
 
 # Find one NCBITaxon id standing in for two different organisms (#292).
 #

--- a/justfile
+++ b/justfile
@@ -171,18 +171,20 @@ validate-gtdb FILE:
 validate-scalars *files:
     PYTHONPATH=src uv run python scripts/validate_yaml_scalars.py {{files}}
 
-# The same check over conf/, .github/workflows/, vocab/ and the schema (#400).
+# The same check over the non-record trees: conf/, .github/, vocab/, the schema,
+# history/ and examples/ (#400). Part of `just qc`.
 #
-# Those trees DO use deliberate trailing comments, which YAML cannot distinguish
-# from a truncated value — both end the scalar at the `#`. So this reports only
-# a comment written tight against the value, under two spaces. Measured: all 13
-# deliberate trailing comments in those trees use three or more spaces, and none
-# uses fewer, while a `#` swallowed mid-sentence has one or none because it was
-# typed as prose.
+# The STRICT rule applies here too. Only three files use a deliberate trailing
+# comment — conf/id_label_targets.yaml and two workflows — and only those are
+# relaxed, by RELAXED_FILES in the script. The other 21 keep the strong
+# guarantee, which the first version of this spent to buy the three.
 #
-# A convention check, not a proof. `key: text   #400 lost` with three spaces
-# slips through, and `key: value # comment` with one space reports falsely. It
-# is worth having because the alternative for these 21 files is no check at all.
+# For those three, the relaxed rule reports only a `#` written tight against the
+# value, under two spaces: measured, every deliberate trailing comment in them
+# uses three or more, while a `#` swallowed mid-sentence has one or none. That
+# is a convention, not a proof — `key: text   #400 lost` slips through — so it
+# is applied as narrowly as possible. A value lost ENTIRELY stays strict
+# regardless of spacing, since no deliberate comment leaves its key valueless.
 validate-scalars-idiomatic:
     PYTHONPATH=src uv run python scripts/validate_yaml_scalars.py --idiomatic
 
@@ -417,7 +419,7 @@ lint:
 # `validate-references-all` is deliberately NOT here; see `qc-references` (#417).
 #
 # Full QC: lint + test + every offline validator
-qc: lint test validate-all validate-taxa validate-strict validate-gtdb-all validate-scalars validate-terms-all validate-terms-taxa
+qc: lint test validate-all validate-taxa validate-strict validate-gtdb-all validate-scalars validate-scalars-idiomatic validate-terms-all validate-terms-taxa
     @echo "✅ All QC checks passed!"
 
 # Separate from `qc` because it is the one check that cannot pass: it needs the

--- a/scripts/validate_yaml_scalars.py
+++ b/scripts/validate_yaml_scalars.py
@@ -28,23 +28,52 @@ from communitymech.validators.yaml_scalars import find_truncated_scalars  # noqa
 # instead (#399 review, #391).
 DEFAULT_DIRS = ("kb/communities", "data/isolates", "kb/taxa")
 
+# Trees where a trailing comment is an ordinary idiom, so the strict rule would
+# report 13 deliberate comments as truncation. Checked under `--require-gap`
+# instead: report only a `#` written tight against the value (#400). Also .yml,
+# which the workflows use and the record trees do not.
+IDIOMATIC_DIRS = ("conf", ".github/workflows", "vocab", "src/communitymech/schema")
+
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("files", nargs="*", type=Path, help="YAML file(s); default: all records")
+    parser.add_argument(
+        "--require-gap",
+        action="store_true",
+        help=(
+            "Report only comments written tight against the value (<2 spaces "
+            "before the #). For trees where deliberate trailing comments are an "
+            "idiom; a convention check rather than a proof (#400)."
+        ),
+    )
+    parser.add_argument(
+        "--idiomatic",
+        action="store_true",
+        help=(
+            f"Check {', '.join(IDIOMATIC_DIRS)} instead of the record trees, "
+            f"which implies --require-gap."
+        ),
+    )
     args = parser.parse_args(argv)
+    require_gap = args.require_gap or args.idiomatic
 
+    directories = IDIOMATIC_DIRS if args.idiomatic else DEFAULT_DIRS
     paths = args.files or [
         path
-        for directory in DEFAULT_DIRS
-        for path in sorted((REPO_ROOT / directory).rglob("*.yaml"))
+        for directory in directories
+        for suffix in ("*.yaml", "*.yml")
+        for path in sorted((REPO_ROOT / directory).rglob(suffix))
     ]
     # A directory argument is what `validate_strict.py` accepts, so accept it
     # here too rather than dying on IsADirectoryError. The two CLIs disagreeing
     # on their contract is a trap for whoever wires them together (#399 review).
     expanded: list[Path] = []
     for path in paths:
-        expanded.extend(sorted(path.rglob("*.yaml")) if path.is_dir() else [path])
+        if path.is_dir():
+            expanded.extend(sorted(p for s in ("*.yaml", "*.yml") for p in path.rglob(s)))
+        else:
+            expanded.append(path)
     paths = expanded
     if not paths:
         print("[scalars] no files to check", file=sys.stderr)
@@ -55,7 +84,7 @@ def main(argv: list[str] | None = None) -> int:
         if not path.exists():
             print(f"[scalars] no such file: {path}", file=sys.stderr)
             return 2
-        issues.extend(find_truncated_scalars(path))
+        issues.extend(find_truncated_scalars(path, require_gap=require_gap))
 
     for issue in issues:
         print(issue)

--- a/scripts/validate_yaml_scalars.py
+++ b/scripts/validate_yaml_scalars.py
@@ -18,6 +18,8 @@ import argparse
 import sys
 from pathlib import Path
 
+import yaml
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
@@ -28,35 +30,51 @@ from communitymech.validators.yaml_scalars import find_truncated_scalars  # noqa
 # instead (#399 review, #391).
 DEFAULT_DIRS = ("kb/communities", "data/isolates", "kb/taxa")
 
-# Trees where a trailing comment is an ordinary idiom, so the strict rule would
-# report 13 deliberate comments as truncation. Checked under `--require-gap`
-# instead: report only a `#` written tight against the value (#400). Also .yml,
-# which the workflows use and the record trees do not.
-IDIOMATIC_DIRS = ("conf", ".github/workflows", "vocab", "src/communitymech/schema")
+# The non-record YAML trees, which had no scalar check at all (#400). `.github`
+# rather than `.github/workflows`, so a future dependabot.yml or ISSUE_TEMPLATE
+# is covered; `history` and `examples` carry prose and were missed by the first
+# pass (review of #488).
+IDIOMATIC_DIRS = (
+    "conf",
+    ".github",
+    "vocab",
+    "src/communitymech/schema",
+    "history",
+    "examples",
+)
+
+# The strict rule runs on these trees too. Only these three files use a
+# deliberate trailing comment, and only they are relaxed to the gap rule.
+#
+# The first version relaxed all 21 files to buy the 3 — spending the strong
+# guarantee on 18 that did not need it, including every file in `vocab/` and the
+# schema, which have no trailing comments at all (review of #488). A per-file
+# list does go stale, which is what #400 says about allowlists; the answer is
+# that going stale here means a file gets *stricter* than it needs and reports a
+# comment somebody wrote on purpose, which is visible and cheap. The failure
+# mode of the alternative is silence.
+RELAXED_FILES = frozenset(
+    {
+        "conf/id_label_targets.yaml",
+        ".github/workflows/curation-history.yaml",
+        ".github/workflows/kgx-release.yaml",
+    }
+)
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("files", nargs="*", type=Path, help="YAML file(s); default: all records")
     parser.add_argument(
-        "--require-gap",
-        action="store_true",
-        help=(
-            "Report only comments written tight against the value (<2 spaces "
-            "before the #). For trees where deliberate trailing comments are an "
-            "idiom; a convention check rather than a proof (#400)."
-        ),
-    )
-    parser.add_argument(
         "--idiomatic",
         action="store_true",
         help=(
-            f"Check {', '.join(IDIOMATIC_DIRS)} instead of the record trees, "
-            f"which implies --require-gap."
+            f"Check the non-record trees ({', '.join(IDIOMATIC_DIRS)}) instead of "
+            f"the records. Strict everywhere except the {len(RELAXED_FILES)} files "
+            f"that use a deliberate trailing comment (#400)."
         ),
     )
     args = parser.parse_args(argv)
-    require_gap = args.require_gap or args.idiomatic
 
     directories = IDIOMATIC_DIRS if args.idiomatic else DEFAULT_DIRS
     paths = args.files or [
@@ -80,18 +98,38 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     issues = []
+    unparseable = []
     for path in paths:
         if not path.exists():
             print(f"[scalars] no such file: {path}", file=sys.stderr)
             return 2
-        issues.extend(find_truncated_scalars(path, require_gap=require_gap))
+        # `find_truncated_scalars` returns [] for a file it cannot parse, which
+        # is right for the record trees — `validate-strict` reports
+        # yaml_parse_error separately there. The non-record trees have no such
+        # backstop, so an unparseable file would pass this sweep at exit 0 and
+        # take any real truncation in it down with it (review of #488).
+        if args.idiomatic:
+            try:
+                yaml.safe_load(path.read_text())
+            except yaml.YAMLError as exc:
+                unparseable.append(f"{path}: {str(exc).splitlines()[0]}")
+                continue
+        # Per file, not per run: the record trees are never relaxed, and
+        # neither are the 18 non-record files that do not need it.
+        relative = path.resolve().relative_to(REPO_ROOT).as_posix()
+        issues.extend(find_truncated_scalars(path, require_gap=relative in RELAXED_FILES))
 
     for issue in issues:
         print(issue)
 
-    print(f"\nfiles checked: {len(paths)}", file=sys.stderr)
+    for problem in unparseable:
+        print(f"[scalars] unparseable, so NOT checked: {problem}", file=sys.stderr)
+
+    print(f"\nfiles checked: {len(paths) - len(unparseable)}", file=sys.stderr)
     print(f"truncated scalars: {len(issues)}", file=sys.stderr)
-    return 1 if issues else 0
+    if unparseable:
+        print(f"unparseable files: {len(unparseable)}", file=sys.stderr)
+    return 1 if issues or unparseable else 0
 
 
 if __name__ == "__main__":

--- a/src/communitymech/validators/yaml_scalars.py
+++ b/src/communitymech/validators/yaml_scalars.py
@@ -143,8 +143,15 @@ def find_truncated_scalars(path: Path, *, require_gap: bool = False) -> list[Sca
         remainder = lines[end.line][end.column :]
         if not remainder.lstrip().startswith("#"):
             continue
-        if require_gap and len(remainder) - len(remainder.lstrip()) >= 2:
+        if require_gap and event.value != "" and len(remainder) - len(remainder.lstrip()) >= 2:
             # Two or more spaces: written as a deliberate end-of-line comment.
+            #
+            # Except when the value is EMPTY. `description:  #400 all of it` is
+            # total loss — the whole value became a comment — and no deliberate
+            # end-of-line comment leaves its key valueless, so the ambiguity the
+            # gap rule exists to resolve does not arise. This module's own
+            # header calls that the worst case; relaxing it would have been the
+            # one place the relaxation cost something real (review of #488).
             continue
 
         key = _name_for(lines, end.line)

--- a/src/communitymech/validators/yaml_scalars.py
+++ b/src/communitymech/validators/yaml_scalars.py
@@ -95,8 +95,30 @@ class ScalarIssue:
         return f"{self.file}:{self.line}: {self.message}"
 
 
-def find_truncated_scalars(path: Path) -> list[ScalarIssue]:
-    """Report plain scalars in `path` that a mid-line comment cut short."""
+def find_truncated_scalars(path: Path, *, require_gap: bool = False) -> list[ScalarIssue]:
+    """Report plain scalars in `path` that a mid-line comment cut short.
+
+    `require_gap` reports only comments written *tight* against the value —
+    fewer than two spaces before the `#`. YAML cannot distinguish
+
+        notes: some text #398 here        <- prose the author lost
+        fetch-depth: 0  # need the merge base   <- a comment on purpose
+
+    because both end the value at the `#`. Nothing in the document separates
+    them, which is why the check was scoped to the record trees, where trailing
+    comments are not an idiom and every report is therefore real (#398, #399).
+
+    Elsewhere they are an idiom, and the one thing that does separate them is
+    how they are written. Measured across `conf/`, `.github/workflows/`,
+    `vocab/` and the schema: all 13 deliberate trailing comments use **three or
+    more** spaces before the `#`, and none uses fewer. A `#` swallowed
+    mid-sentence has one or none, because it was typed as part of the prose.
+
+    So this is a convention check, not a proof: an author who writes
+    `notes: text   #398 here` with three spaces defeats it, and one who writes
+    `key: value # comment` with a single space gets a false report. It is
+    offered for trees where the alternative is no checking at all (#400).
+    """
     text = path.read_text()
     lines = text.splitlines()
 
@@ -120,6 +142,9 @@ def find_truncated_scalars(path: Path) -> list[ScalarIssue]:
             continue
         remainder = lines[end.line][end.column :]
         if not remainder.lstrip().startswith("#"):
+            continue
+        if require_gap and len(remainder) - len(remainder.lstrip()) >= 2:
+            # Two or more spaces: written as a deliberate end-of-line comment.
             continue
 
         key = _name_for(lines, end.line)

--- a/tests/test_yaml_scalar_truncation.py
+++ b/tests/test_yaml_scalar_truncation.py
@@ -19,6 +19,7 @@ the true positives.
 
 from __future__ import annotations
 
+import importlib.util
 import subprocess
 from pathlib import Path
 
@@ -277,40 +278,107 @@ def test_the_report_names_the_right_field(tmp_path, name, text, key):
 # truncation, which is why conf/ and .github/ were left unchecked entirely.
 # ---------------------------------------------------------------------------
 
-_IDIOMATIC_DIRS = ("conf", ".github/workflows", "vocab", "src/communitymech/schema")
+
+def _cli():
+    """The CLI module, so its directory list and allowlist are not duplicated.
+
+    An earlier version re-declared `_IDIOMATIC_DIRS` here. Shrinking the CLI's
+    list to one directory then dropped the sweep from 24 files to 1 with the
+    whole suite still green — the test asserted over its own private copy
+    (review of #488).
+    """
+    spec = importlib.util.spec_from_file_location(
+        "validate_yaml_scalars", Path(__file__).parent.parent / "scripts/validate_yaml_scalars.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _idiomatic_files() -> list[Path]:
-    repo = Path(__file__).parent.parent
+    cli = _cli()
     return [
         path
-        for directory in _IDIOMATIC_DIRS
+        for directory in cli.IDIOMATIC_DIRS
         for suffix in ("*.yaml", "*.yml")
-        for path in sorted((repo / directory).rglob(suffix))
+        for path in sorted((Path(__file__).parent.parent / directory).rglob(suffix))
     ]
 
 
-def test_the_idiomatic_trees_have_files_to_check():
-    """Guard: an empty sweep would make the two tests below vacuous."""
-    assert len(_idiomatic_files()) >= 15, _idiomatic_files()
-
-
-def test_require_gap_silences_every_deliberate_trailing_comment():
-    """The whole reason those trees were unchecked.
-
-    Without `require_gap` these files produce 13 reports, all of them comments
-    somebody wrote on purpose — a gate that cries wolf 13 times is one nobody
-    runs.
-    """
-    strict = sum(len(find_truncated_scalars(p)) for p in _idiomatic_files())
-    gapped = sum(len(find_truncated_scalars(p, require_gap=True)) for p in _idiomatic_files())
-    assert strict > 0, (
-        "the strict rule no longer reports anything in these trees, so the "
-        "trailing-comment idiom may be gone and require_gap may be unnecessary"
+def test_the_idiomatic_sweep_covers_what_it_claims_to():
+    """A shrinking directory list is the way this check quietly stops checking."""
+    assert len(_idiomatic_files()) >= 20, (
+        f"the non-record sweep covers {len(_idiomatic_files())} files; "
+        f"IDIOMATIC_DIRS has probably shrunk (#400)"
     )
-    assert gapped == 0, (
-        f"require_gap still reports {gapped} deliberate comment(s); the "
-        f"two-space convention no longer holds across these trees (#400)"
+
+
+def test_only_the_listed_files_need_relaxing():
+    """The strong rule stays on everything that does not need relaxing.
+
+    The first version relaxed all 21 files to buy the 3 that use a trailing
+    comment. This fails if a *new* file starts using the idiom — which is the
+    moment to decide deliberately whether to quote it or add it to the list,
+    rather than having the whole tree already downgraded (review of #488).
+    """
+    cli = _cli()
+    repo = Path(__file__).parent.parent
+    needs = {
+        path.resolve().relative_to(repo).as_posix()
+        for path in _idiomatic_files()
+        if find_truncated_scalars(path)
+    }
+    assert needs == set(cli.RELAXED_FILES), (
+        f"files needing the gap rule have changed.\n"
+        f"  newly needing it: {sorted(needs - set(cli.RELAXED_FILES))}\n"
+        f"  no longer needing it: {sorted(set(cli.RELAXED_FILES) - needs)}\n"
+        f"Quote the value, or add the file to RELAXED_FILES deliberately (#400)."
+    )
+
+
+def test_the_relaxed_files_are_clean_under_the_gap_rule():
+    """And the reports they lose really are deliberate comments.
+
+    On failure this prints the issues, because the overwhelmingly likely cause
+    is a real truncation somebody just committed — not the convention breaking
+    down. The first version's message sent the reader to re-litigate the
+    heuristic and named neither file nor line (review of #488).
+    """
+    repo = Path(__file__).parent.parent
+    remaining = [
+        issue
+        for name in sorted(_cli().RELAXED_FILES)
+        for issue in find_truncated_scalars(repo / name, require_gap=True)
+    ]
+    assert (
+        remaining == []
+    ), "these look like real truncations, not deliberate comments:\n" + "\n".join(
+        str(issue) for issue in remaining
+    )
+
+
+def test_the_sweep_includes_yml_not_just_yaml():
+    """One file in the sweep is `.yml`, and it is a workflow.
+
+    The PR body claimed two of four trees would otherwise find nothing; that was
+    wrong — 20 of 21 files were `.yaml`. The change is still needed, and was
+    untested until the review pointed out that reverting it broke nothing.
+    """
+    assert any(
+        path.suffix == ".yml" for path in _idiomatic_files()
+    ), "no .yml in the sweep; the suffix expansion may have been reverted (#400)"
+    assert any(path.suffix == ".yaml" for path in _idiomatic_files())
+
+
+def test_the_record_trees_are_never_relaxed():
+    """`require_gap` must not reach kb/. `just validate-scalars` is kb/taxa's only
+    scalar gate — validate-strict's roots are the other two trees."""
+    cli = _cli()
+    assert not any(name.startswith(("kb/", "data/")) for name in cli.RELAXED_FILES)
+    # And the flag is not reachable from the CLI at all any more.
+    assert (
+        "--require-gap"
+        not in Path(Path(__file__).parent.parent / "scripts/validate_yaml_scalars.py").read_text()
     )
 
 
@@ -322,6 +390,10 @@ def test_require_gap_silences_every_deliberate_trailing_comment():
         ("two spaces is a deliberate comment", "key: value  # on purpose\n", 0),
         ("three spaces, as the repo actually writes them", "key: value   # on purpose\n", 0),
         ("a quoted value is never reported", 'key: "text # inside"  # comment\n', 0),
+        # Total loss stays strict however it is spaced: no deliberate
+        # end-of-line comment leaves its key valueless.
+        ("total loss, two spaces", "description:  #400 all of it\n", 1),
+        ("total loss, one space", "description: #400 all of it\n", 1),
     ],
 )
 def test_the_gap_rule_case_by_case(tmp_path, label, text, expected):
@@ -333,8 +405,8 @@ def test_the_gap_rule_case_by_case(tmp_path, label, text, expected):
     assert len(find_truncated_scalars(_write(tmp_path, text), require_gap=True)) == expected, label
 
 
-def test_require_gap_still_catches_a_real_truncation_in_a_conf_shaped_file(tmp_path):
-    """The check must discriminate, or silencing 13 would be all it did."""
+def test_the_gap_rule_still_catches_a_real_truncation(tmp_path):
+    """The check must discriminate, or silencing the aligned block is all it does."""
     text = (
         "targets:\n"
         "  - name: probe\n"

--- a/tests/test_yaml_scalar_truncation.py
+++ b/tests/test_yaml_scalar_truncation.py
@@ -269,3 +269,79 @@ def test_the_report_names_the_right_field(tmp_path, name, text, key):
     """
     issue = find_truncated_scalars(_write(tmp_path, text))[0]
     assert issue.key == key, name
+
+
+# ---------------------------------------------------------------------------
+# `require_gap`: extending the check to trees where a deliberate trailing
+# comment is an idiom (#400). The strict rule reports 13 of those as
+# truncation, which is why conf/ and .github/ were left unchecked entirely.
+# ---------------------------------------------------------------------------
+
+_IDIOMATIC_DIRS = ("conf", ".github/workflows", "vocab", "src/communitymech/schema")
+
+
+def _idiomatic_files() -> list[Path]:
+    repo = Path(__file__).parent.parent
+    return [
+        path
+        for directory in _IDIOMATIC_DIRS
+        for suffix in ("*.yaml", "*.yml")
+        for path in sorted((repo / directory).rglob(suffix))
+    ]
+
+
+def test_the_idiomatic_trees_have_files_to_check():
+    """Guard: an empty sweep would make the two tests below vacuous."""
+    assert len(_idiomatic_files()) >= 15, _idiomatic_files()
+
+
+def test_require_gap_silences_every_deliberate_trailing_comment():
+    """The whole reason those trees were unchecked.
+
+    Without `require_gap` these files produce 13 reports, all of them comments
+    somebody wrote on purpose — a gate that cries wolf 13 times is one nobody
+    runs.
+    """
+    strict = sum(len(find_truncated_scalars(p)) for p in _idiomatic_files())
+    gapped = sum(len(find_truncated_scalars(p, require_gap=True)) for p in _idiomatic_files())
+    assert strict > 0, (
+        "the strict rule no longer reports anything in these trees, so the "
+        "trailing-comment idiom may be gone and require_gap may be unnecessary"
+    )
+    assert gapped == 0, (
+        f"require_gap still reports {gapped} deliberate comment(s); the "
+        f"two-space convention no longer holds across these trees (#400)"
+    )
+
+
+@pytest.mark.parametrize(
+    ("label", "text", "expected"),
+    [
+        ("one space is prose the author lost", "key: some text #400 lost here\n", 1),
+        ("no space at all", "key: some text#400 lost here\n", 0),
+        ("two spaces is a deliberate comment", "key: value  # on purpose\n", 0),
+        ("three spaces, as the repo actually writes them", "key: value   # on purpose\n", 0),
+        ("a quoted value is never reported", 'key: "text # inside"  # comment\n', 0),
+    ],
+)
+def test_the_gap_rule_case_by_case(tmp_path, label, text, expected):
+    """`#` with no preceding space does not open a comment in YAML at all.
+
+    So `some text#400` keeps its tail and is correctly not reported — the rule
+    only has to separate one space from two.
+    """
+    assert len(find_truncated_scalars(_write(tmp_path, text), require_gap=True)) == expected, label
+
+
+def test_require_gap_still_catches_a_real_truncation_in_a_conf_shaped_file(tmp_path):
+    """The check must discriminate, or silencing 13 would be all it did."""
+    text = (
+        "targets:\n"
+        "  - name: probe\n"
+        "    reason: no clean CHEBI term #398 needs minting\n"
+        "    policy: canonical   # deliberate comment\n"
+    )
+    issues = find_truncated_scalars(_write(tmp_path, text), require_gap=True)
+    assert len(issues) == 1, issues
+    assert issues[0].truncated_to == "no clean CHEBI term"
+    assert "needs minting" in issues[0].lost


### PR DESCRIPTION
Closes #400, taking **option 2** — because measuring the data made it stronger than the issue assumed.

## The problem

YAML cannot distinguish a lost tail from a deliberate comment:

```yaml
notes: some text #398 here              # prose the author lost
fetch-depth: 0  # need the merge base   # a comment on purpose
```

Both end the value at the `#`. So #399 scoped the check to the record trees, where trailing comments are not an idiom — leaving `conf/`, `.github/workflows/`, `vocab/` and the schema with **no check at all**, because the strict rule reported 13 intentional comments there.

## What the measurement showed

The issue proposed "two or more spaces" as a heuristic. It is sharper than that:

| | count |
|---|---:|
| deliberate trailing comments with **≥2** spaces before `#` | **13** |
| with **<2** spaces | **0** |

The minimum observed is **three** spaces, not two. And a `#` swallowed mid-sentence has one space or none, because it was typed as prose. The two populations do not overlap.

## What lands

- `find_truncated_scalars(path, require_gap=True)` — report only a comment written tight against the value.
- `just validate-scalars-idiomatic` / `--idiomatic` — run that over the four trees.
- The record trees keep the **strict** rule unchanged.

**21 files that had no check now have one, with 0 false reports.** A truncation planted in `conf/id_label_targets.yaml` is caught with the tail it lost:

```
conf/id_label_targets.yaml:43: plain scalar `synonym_scope` is cut short by a mid-line
comment: keeps 'exact_related', loses '#400 this tail is lost'.
```

## Stated plainly as a convention check, not a proof

The docstring and the recipe both say it: `key: text   #400 lost` with three spaces slips through, and `key: value # comment` with one space would report falsely. It is worth having because the alternative for those 21 files is nothing — and #400 itself notes `conf/id_label_targets.yaml` carries prose `reason:` fields that are exactly the at-risk shape, safe today only because they happen to be quoted.

## Two details worth flagging

**`key: text#400` with no space is correctly not reported** — that does not open a YAML comment at all, so the tail survives. The rule only has to separate one space from two, which is a narrower job than it first looks. Pinned as a test case.

**The CLI did not know about `.yml`.** The workflows use it and the record trees do not, so without teaching the expansion about it, two of the four trees would have been swept and found nothing — which looks identical to passing.

## Verification

Mutation-checked both directions:

```
drop the gap check (strict everywhere) → 4 failed
make require_gap suppress everything   → 2 failed
restored                               → 44 passed
```

`2326 passed, 16 skipped`. `ruff`, `black`, `mypy src/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)