### PR TITLE
Account for the interaction participants outside taxonomy, by kind (#319)

### DIFF
--- a/tests/test_interaction_participants_outside_taxonomy.py
+++ b/tests/test_interaction_participants_outside_taxonomy.py
@@ -1,0 +1,212 @@
+"""The 25 interaction participants that are not taxonomy members (#319).
+
+`UNKNOWN_SOURCE`/`UNKNOWN_TARGET` gate at error severity unless the interaction
+carries `scope: COMMUNITY_LEVEL`, which downgrades them to warning (#326). Every
+one is a warning today, so `main` is green — but the population has grown since
+#319 counted it, unnoticed, which is the thing this file fixes.
+
+The auditor reports **27 findings** over **25 distinct participants**: two are
+named as both a source and a target, in different interactions. The sets below
+are the 25, since the question is about organisms rather than edges.
+
+#319 asks a policy question: **should hosts and antagonists be `taxonomy`
+members?** That is a curation decision and this file does not make it. What it
+does is stop the population drifting while the decision is pending, and split it
+into the groups the decision actually applies to — because "23 unexplained
+warnings" is much harder to decide about than four kinds of thing:
+
+* **UMBRELLA (14)** — an aggregate name for members that *are* in taxonomy.
+  `Variovorax` where the records list `Variovorax sp. CF313`, `YR634`, …;
+  `Olsenella (Actinobacteriota)` where taxonomy has `Olsenella_B sp. (MAG ATO3)`.
+  These are not missing members; they are a coarser way of naming present ones.
+  Nothing to decide.
+* **HOST (6)** — the plant or animal the community lives on or in. `Medicago
+  truncatula (host legume)`, `Arabidopsis thaliana`, `Lactuca sativa`,
+  `Hordeum vulgare`, `Hypnum plumaeforme (moss host)`.
+* **ANTAGONIST (3)** — a pathogen the community suppresses, i.e. the point of
+  the experiment rather than a member of it. `Rhizoctonia solani`,
+  `Aeromonas hydrophila`, `Pseudomonas aeruginosa`.
+* **ABIOTIC (2)** — `anode`, and the biofilm on it.
+
+HOST and ANTAGONIST are the real question, and they are **9 of the 25** — a
+much smaller commitment than the headline count suggests. A community
+*interacts with* its host
+without the host being a member, which is an argument for leaving them out; the
+counter is that an edge to something absent from `taxonomy` is dangling by any
+graph reading. #307 asks the mirror-image question about deliberately excluded
+candidates and answered "no" there.
+
+A new participant in none of these lists fails, which forces the decision at the
+moment somebody adds one rather than in a bulk audit months later.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from communitymech.network.auditor import IssueType, NetworkIntegrityAuditor
+
+REPO = pathlib.Path(__file__).parent.parent
+COMMUNITIES = REPO / "kb/communities"
+
+# (record, participant) for every interaction endpoint absent from `taxonomy`,
+# grouped by why it is absent. Sourced from the auditor itself, not re-derived:
+# an independent matcher disagreed with it on 8 entries, because the auditor
+# resolves a participant by id as well as by name.
+UMBRELLA = {
+    (
+        "Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.yaml",
+        "Drosophila five-species bacterial microbiota",
+    ),
+    ("East_River_Floodplain_Core_Microbiome.yaml", "East River floodplain bacteria"),
+    ("East_River_Floodplain_Core_Microbiome.yaml", "core floodplain bacteria"),
+    ("GLBRC_UFMP_Fermentation_Community.yaml", "Olsenella (Actinobacteriota)"),
+    ("Hanford_300_Area_Unconfined_Aquifer_Community.yaml", "Hanford groundwater bacteria"),
+    (
+        "Hanford_300_Area_Unconfined_Aquifer_Community.yaml",
+        "aquifer redox guild bacteria and archaea",
+    ),
+    (
+        "Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.yaml",
+        "model lignocellulose consortium members",
+    ),
+    (
+        "ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.yaml",
+        "Desulfovibrio vulgaris Hildenborough and Geobacter sulfurreducens",
+    ),
+    (
+        "ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.yaml",
+        "three-species model community",
+    ),
+    ("Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.yaml", "other groundwater bacteria"),
+    (
+        "PET_Artificial_FourSpecies_Degradation_Consortium.yaml",
+        "engineered PETase/MHETase and TPA-utilization members",
+    ),
+    ("PMI_Variovorax_Thermotolerance_Collection.yaml", "Variovorax"),
+    ("Rice_Duckweed_Bacillus_SynCom.yaml", "Bacillus SynCom"),
+    (
+        "Saanich_Inlet_OMZ_Redox_Gradient_Community.yaml",
+        "Saanich Inlet redox-gradient microorganisms",
+    ),
+}
+HOST = {
+    ("Legume_Rhizobia_Mars_Simulant_Symbiosis.yaml", "Medicago truncatula (host legume)"),
+    ("Lunar_Martian_Simulant_PGPB_Lettuce_SynCom.yaml", "Lactuca sativa (lettuce host)"),
+    ("Lunar_Simulant_Phosphate_Solubilizing_Bacteria_Nicotiana.yaml", "Nicotiana benthamiana"),
+    ("Moss_Microbe_Complex_Regolith_Biofertilizer.yaml", "Hordeum vulgare (barley model crop)"),
+    ("Moss_Microbe_Complex_Regolith_Biofertilizer.yaml", "Hypnum plumaeforme (moss host)"),
+    ("PMI_Variovorax_Thermotolerance_Collection.yaml", "Arabidopsis thaliana"),
+}
+ANTAGONIST = {
+    ("Crucian_Carp_Gut_Disease_Resistance_SynCom.yaml", "Aeromonas hydrophila"),
+    ("Rice_Duckweed_Bacillus_SynCom.yaml", "Rhizoctonia solani"),
+    (
+        "Thermophilic_Lignocellulose_Composting_SynCom_Biosanitization.yaml",
+        "Pseudomonas aeruginosa",
+    ),
+}
+ABIOTIC = {
+    ("Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.yaml", "anode"),
+    (
+        "Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.yaml",
+        "anode-associated biofilm community",
+    ),
+}
+
+ACCOUNTED_FOR = UMBRELLA | HOST | ANTAGONIST | ABIOTIC
+
+
+def _outside_taxonomy() -> set[tuple[str, str]]:
+    """Every (record, participant) the auditor reports as not a member."""
+    auditor = NetworkIntegrityAuditor(COMMUNITIES)
+    found = set()
+    for path in sorted(COMMUNITIES.glob("*.yaml")):
+        for issue in auditor.audit_community(path) or []:
+            if issue["type"] in (IssueType.UNKNOWN_SOURCE, IssueType.UNKNOWN_TARGET):
+                found.add((path.name, issue.get("taxon")))
+    return found
+
+
+@pytest.fixture(scope="module")
+def outside() -> set[tuple[str, str]]:
+    return _outside_taxonomy()
+
+
+def test_there_are_participants_to_account_for(outside):
+    """Guard: at zero the accounting below passes vacuously."""
+    assert len(outside) > 20, (
+        f"only {len(outside)} participants sit outside taxonomy; if the policy "
+        f"in #319 has been settled and they were added as members, delete this "
+        f"file rather than letting it pass on an empty set"
+    )
+
+
+def test_every_one_is_accounted_for(outside):
+    """A new host or antagonist has to be classified, not absorbed.
+
+    This is the drift #319 could not see: it counted 23, and there are 27. Four
+    arrived without anyone deciding they should.
+    """
+    unaccounted = sorted(outside - ACCOUNTED_FOR)
+    assert unaccounted == [], (
+        "these interaction participants are absent from `taxonomy` and are in "
+        "none of the four groups this file tracks:\n"
+        + "\n".join(f"  {record}: {name!r}" for record, name in unaccounted)
+        + "\n\nAdd each to UMBRELLA, HOST, ANTAGONIST or ABIOTIC — or make it a "
+        "taxonomy member. Which of those is right is #319, and the point of "
+        "this failure is that the choice gets made now rather than in a bulk "
+        "audit later."
+    )
+
+
+def test_nothing_accounted_for_has_quietly_become_a_member(outside):
+    """The list must not rot in the other direction either."""
+    stale = sorted(ACCOUNTED_FOR - outside)
+    assert stale == [], (
+        "these are listed here but the auditor no longer reports them — they "
+        "were probably added to `taxonomy`, which is a #319 decision worth "
+        "recording. Remove them from this file:\n"
+        + "\n".join(f"  {record}: {name!r}" for record, name in stale)
+    )
+
+
+def test_all_of_them_are_warnings_not_errors(outside):
+    """`main` is green only because every one is COMMUNITY_LEVEL.
+
+    That is the fragility #319 names: the shielding rests on a single optional
+    key, and `scope` has `ifabsent: string(PAIRWISE)`. Dropping it from one
+    interaction turns that participant into an error and reddens the build on a
+    record nobody changed the biology of.
+    """
+    auditor = NetworkIntegrityAuditor(COMMUNITIES)
+    errors = []
+    for path in sorted(COMMUNITIES.glob("*.yaml")):
+        for issue in auditor.audit_community(path) or []:
+            if (
+                issue["type"] in (IssueType.UNKNOWN_SOURCE, IssueType.UNKNOWN_TARGET)
+                and issue["severity"] != "warning"
+            ):
+                errors.append(f"{path.name}: {issue.get('taxon')!r}")
+    assert errors == [], (
+        "these participants are outside `taxonomy` at error severity, so the "
+        "network gate fails. Either the interaction lost its "
+        "`scope: COMMUNITY_LEVEL`, or the participant belongs in `taxonomy` "
+        "(#319):\n" + "\n".join(errors)
+    )
+
+
+@pytest.mark.parametrize(
+    ("group", "expected"),
+    [("UMBRELLA", 14), ("HOST", 6), ("ANTAGONIST", 3), ("ABIOTIC", 2)],
+)
+def test_the_group_sizes_are_what_the_decision_was_sized_against(group: str, expected: int):
+    """#319's decision applies per group, so the group sizes are the input to it.
+
+    UMBRELLA needs no decision — those name members that are present, only more
+    coarsely. HOST and ANTAGONIST are the real question, and they are 9 of 25,
+    which is a much smaller commitment than the headline count suggests.
+    """
+    assert len(globals()[group]) == expected


### PR DESCRIPTION
#319 asks a curation-policy question — **should hosts and antagonists be `taxonomy` members?** This does not answer it. It stops the population drifting while the answer is pending, and splits it into the groups the answer actually applies to.

## Two things had changed since filing, neither noticed

- **The count moved.** #319 counted 23. The auditor now reports **27 findings over 25 distinct participants** (two are named as both source and target). Four arrived without anyone deciding they should.
- **They are no longer error-severity.** #326 downgraded `COMMUNITY_LEVEL` cases to warning, citing #319 by name at `auditor.py:356`. `main` is green at exit 1. The issue's *"deleting the scope key yields 2 errors and exit 3"* is still true — and is now pinned by a test rather than by a note in an issue.

## The classification is the part worth having

"23 unexplained warnings" is much harder to decide about than four kinds of thing:

| group | n | what it is |
|---|--:|---|
| **UMBRELLA** | 14 | an aggregate name for members that *are* in taxonomy — `Variovorax` where the record lists `Variovorax sp. CF313`, `YR634`, `GV004`…; `Olsenella (Actinobacteriota)` where taxonomy has `Olsenella_B sp. (MAG ATO3)` |
| **HOST** | 6 | *Medicago truncatula*, *Arabidopsis thaliana*, *Lactuca sativa*, *Hordeum vulgare*, *Hypnum plumaeforme*, *Nicotiana benthamiana* |
| **ANTAGONIST** | 3 | *Rhizoctonia solani*, *Aeromonas hydrophila*, *Pseudomonas aeruginosa* |
| **ABIOTIC** | 2 | `anode`, and the biofilm on it |

**The real question is 9 of 25, not 25.** More than half the population is umbrella descriptors naming present members more coarsely — nobody would argue those should be duplicated into `taxonomy`. That reframing is the contribution here; the decision on HOST and ANTAGONIST is still yours, and #307 asks the mirror-image question about deliberately excluded candidates.

## What the tests do

- A participant in none of the four groups **fails**, so the decision gets made when somebody adds one rather than in a bulk audit months later.
- A participant that quietly *becomes* a member also fails, so the list can't rot in the other direction.
- Every one must be a warning, which is the fragility #319 names — the shielding rests on a single optional key (`scope`, `ifabsent: string(PAIRWISE)`).

Mutation-checked:

```
add an unclassified pathogen        → test_every_one_is_accounted_for FAILS
strip scope: COMMUNITY_LEVEL        → test_all_of_them_are_warnings_not_errors FAILS
restored                            → 8 passed
```

## One process note

The lists are **generated from the auditor**, not hand-transcribed. My first draft was typed from console output truncated at 44 columns and got four filenames and two participant names wrong. Both accounting tests caught it immediately — which is the argument for having them, and a reminder that reading a number off a truncated terminal is not measuring it.

I also initially wrote a matcher of my own and got 35 participants including 4 `PAIRWISE` ones — which would mean CI was failing. It wasn't; my matcher was wrong, because the auditor resolves a participant by **id** as well as by name. The tests use the auditor.

`2358 passed, 16 skipped`. `ruff`, `black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)