### PR TITLE
Count the coarseness of the community-level connectivity credit (#312)

### DIFF
--- a/tests/test_community_level_connectivity_credit.py
+++ b/tests/test_community_level_connectivity_credit.py
@@ -1,0 +1,172 @@
+"""How much of the corpus `DISCONNECTED` cannot reach, and why (#312).
+
+`audit_community` credits a `COMMUNITY_LEVEL` interaction as connecting **every**
+member of the record. Defensible — such an interaction asserts something holding
+across the community rather than between a named pair — and unavoidably coarse,
+because `EcologicalInteraction` has only `source_taxon` and `target_taxon` and no
+way to say *which* members participate.
+
+So the credit is all-or-nothing, and in a record carrying both kinds of edge a
+taxon in no pairwise edge is credited by an unrelated community-level one. In
+`GLBRC_Populus_Variovorax_SynCom28` a single community-level interaction makes
+`DISCONNECTED` unreachable for all 28 taxa.
+
+#312 records this rather than fixing it, and was right to: not crediting was
+measured and is worse in both directions — community-level-only crediting leaves
+1 finding across the corpus (vacuous), dropping the exemption without the credit
+reports 390 (noise). Together they land at a usable number.
+
+What this file adds is that the coarseness is now **counted**, so it cannot grow
+unnoticed. It already has: #312 measured 412 of 518 taxa credited solely by the
+rule, and it is 407 of 522 today — the shape is stable, the corpus moved.
+
+The refinement #312 proposes — an optional `participating_taxa` on
+`EcologicalInteraction`, crediting only named members when present and falling
+back to all members when absent — is a schema change that overlaps #307's
+question of how to express which taxa a community-level statement is *about*.
+Deliberately not done here. These bounds are loose because the point is to catch
+a step change, not to freeze a number that legitimate curation moves.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+import yaml
+
+REPO = pathlib.Path(__file__).parent.parent
+COMMUNITIES = REPO / "kb/communities"
+
+
+def _names(block: dict) -> set[str]:
+    """Every string a pairwise edge could use to name this member."""
+    found = set()
+    if block.get("preferred_term"):
+        found.add(block["preferred_term"])
+    term = block.get("term") or {}
+    for key in ("label", "id"):
+        if term.get(key):
+            found.add(term[key])
+    return found
+
+
+def _survey() -> dict[str, int]:
+    records = with_cl = mixed = cl_only = 0
+    taxa = solely = 0
+    for path in sorted(COMMUNITIES.glob("*.yaml")):
+        document = yaml.safe_load(path.read_text()) or {}
+        records += 1
+        interactions = [
+            i for i in (document.get("ecological_interactions") or []) if isinstance(i, dict)
+        ]
+        community_level = [i for i in interactions if i.get("scope") == "COMMUNITY_LEVEL"]
+        if not community_level:
+            continue
+        with_cl += 1
+        if len(community_level) < len(interactions):
+            mixed += 1
+        else:
+            cl_only += 1
+
+        members = [(t or {}).get("taxon_term") or {} for t in (document.get("taxonomy") or [])]
+        pairwise: set[str] = set()
+        for interaction in interactions:
+            if interaction.get("scope") == "COMMUNITY_LEVEL":
+                continue
+            for role in ("source_taxon", "target_taxon"):
+                node = interaction.get(role)
+                if isinstance(node, dict):
+                    pairwise |= _names(node)
+                elif isinstance(node, str):
+                    pairwise.add(node)
+        taxa += len(members)
+        solely += sum(1 for m in members if not (_names(m) & pairwise))
+    return {
+        "records": records,
+        "with_community_level": with_cl,
+        "mixed": mixed,
+        "community_level_only": cl_only,
+        "taxa": taxa,
+        "credited_solely_by_the_rule": solely,
+    }
+
+
+@pytest.fixture(scope="module")
+def survey() -> dict[str, int]:
+    return _survey()
+
+
+def test_the_survey_sees_the_corpus(survey):
+    """Guard: a broken walk would make every bound below pass on zeros."""
+    assert survey["records"] > 300
+    assert survey["with_community_level"] > 100
+
+
+def test_most_records_carry_a_community_level_interaction(survey):
+    """The rule's reach. #312 measured 156; loose bounds, since curation adds records."""
+    assert 130 <= survey["with_community_level"] <= 200, survey
+
+
+def test_the_mixed_records_are_where_the_coarseness_bites(survey):
+    """A record with both kinds is where an unrelated edge credits a lone taxon.
+
+    #312 measured 46. In the community-level-only records the credit is not
+    coarse — there is no pairwise edge it could be masking.
+    """
+    assert 35 <= survey["mixed"] <= 80, survey
+    assert survey["mixed"] + survey["community_level_only"] == survey["with_community_level"]
+
+
+def test_the_share_credited_solely_by_the_rule_has_not_stepped_up(survey):
+    """The headline number, and the one worth watching.
+
+    #312: 412 of 518. Today: 407 of 522. Bounded as a *share* rather than a
+    count, so adding records does not trip it but a change in the rule's reach
+    does.
+    """
+    share = survey["credited_solely_by_the_rule"] / survey["taxa"]
+    assert 0.65 <= share <= 0.90, (
+        f"{survey['credited_solely_by_the_rule']} of {survey['taxa']} taxa "
+        f"({share:.0%}) are credited only by the community-level rule. #312 "
+        f"measured 412 of 518 (80%). A step change means either the rule's "
+        f"reach moved or curation added many pairwise edges — both worth "
+        f"looking at before adjusting this bound."
+    )
+
+
+def test_the_worked_example_still_shows_the_limit():
+    """`GLBRC_Populus_Variovorax_SynCom28` is #312's illustration.
+
+    28 taxa, and one community-level interaction makes DISCONNECTED unreachable
+    for every one. If this record ever gains pairwise edges the example should
+    move rather than be quietly dropped.
+    """
+    path = COMMUNITIES / "GLBRC_Populus_Variovorax_SynCom28.yaml"
+    assert path.exists(), "the worked example record is gone; pick another and update #312"
+    document = yaml.safe_load(path.read_text()) or {}
+    members = document.get("taxonomy") or []
+    interactions = [
+        i for i in (document.get("ecological_interactions") or []) if isinstance(i, dict)
+    ]
+    assert len(members) >= 20
+    assert any(i.get("scope") == "COMMUNITY_LEVEL" for i in interactions)
+
+
+def test_the_schema_still_cannot_name_participants():
+    """The root cause, and the thing whose arrival should retire this file.
+
+    `EcologicalInteraction` has `source_taxon`/`target_taxon` and nothing else,
+    which is why the credit can only be all-or-nothing. When
+    `participating_taxa` (or whatever #307 settles on) lands, this fails — and
+    the credit rule should become precise in the same change.
+    """
+    schema = yaml.safe_load(
+        (REPO / "src/communitymech/schema/communitymech.yaml").read_text(encoding="utf-8")
+    )
+    attributes = schema["classes"]["EcologicalInteraction"]["attributes"]
+    assert "participating_taxa" not in attributes, (
+        "EcologicalInteraction can now name its participants, so the "
+        "all-or-nothing credit in audit_community should be narrowed to them "
+        "and this file retired (#312, #307)."
+    )


### PR DESCRIPTION
#312 records a known trade-off rather than a defect, and was right not to fix it. This makes the trade-off's size a checked number instead of a figure in an issue.

## Why the trade-off stands

Crediting a `COMMUNITY_LEVEL` interaction to **every** member is coarse. Not crediting was measured and is worse in both directions: community-level-only crediting leaves **1** finding across the corpus (vacuous); dropping the exemption without the credit reports **390** (noise). Together they land at a usable number. Nothing here changes that.

## What was missing: nobody was counting

| | #312 measured | today |
|---|--:|--:|
| records with ≥1 `COMMUNITY_LEVEL` | 156 | **157** |
| …also carrying pairwise edges | 46 | **48** |
| …`COMMUNITY_LEVEL` only | 110 | **109** |
| taxa credited **solely** by the rule | 412 / 518 | **407 / 522** |

The shape is stable and the corpus moved — the expected direction. But nothing was checking, and #319 in this same cluster had grown 23 → 27 exactly that way, unnoticed until I measured it two PRs ago.

Bounded as a **share** rather than a count, so adding records doesn't trip it while a change in the rule's reach does.

`GLBRC_Populus_Variovorax_SynCom28` is pinned as the worked example: 28 taxa, one community-level interaction, `DISCONNECTED` unreachable for all of them.

## The test that earns its place

`test_the_schema_still_cannot_name_participants` asserts `EcologicalInteraction` still has only `source_taxon`/`target_taxon` — the root cause of the credit being all-or-nothing.

When `participating_taxa` lands, **it fails**, so whoever adds it is told in the same change to narrow the credit rule and retire this file. That's the opposite of a gate that blocks progress: it fires when the refinement arrives, and points at what else must move with it.

Mutation-checked: adding `participating_taxa` to the schema fails exactly that test.

#312 says the refinement should be designed with #307's question of how to express which taxa a community-level statement is *about*. This does not pre-empt that.

`2364 passed, 16 skipped`. `ruff`, `black` clean. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)