### PR TITLE
Model ROS detoxification as the process it was already described as (#297)

### DIFF
--- a/docs/communities/Trichodesmium_Alteromonas_Marine_Consortium.html
+++ b/docs/communities/Trichodesmium_Alteromonas_Marine_Consortium.html
@@ -681,6 +681,17 @@
                 
 
                 
+                <p><strong>Biological Processes:</strong></p>
+                <ul>
+                    
+                    <li>
+                        reactive oxygen species detoxification
+                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0098869"
+                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0098869</a>)
+                    </li>
+                    
+                </ul>
+                
 
                 
 
@@ -1082,6 +1093,10 @@
             
             
             var processes = [];
+            
+            
+            processes.push("reactive oxygen species detoxification");
+            
             
             var evidenceCount = 2;
 

--- a/kb/communities/Trichodesmium_Alteromonas_Marine_Consortium.yaml
+++ b/kb/communities/Trichodesmium_Alteromonas_Marine_Consortium.yaml
@@ -150,7 +150,23 @@ ecological_interactions:
     term:
       id: CHEBI:26523
       label: reactive oxygen species
-    notes: Reactive oxygen species detoxification is an inferred interaction process.
+    notes: The compound. What the consortium does with it is the sibling biological_processes
+      entry - ROS is involved in the interaction, and its detoxification is the process
+      (#297).
+  biological_processes:
+  - preferred_term: reactive oxygen species detoxification
+    term:
+      id: GO:0098869
+      label: cellular oxidant detoxification
+    notes: 'Modelled as both compound and process, which is what the note this replaces
+      described: "reactive oxygen species detoxification is an inferred interaction process".
+      CHEBI:26523 is the species; GO:0098869 is what is done to it. Its definition -
+      "reduces or removes the toxicity of superoxide radicals or hydrogen peroxide" - is
+      the general oxidant case, chosen over GO:0141082 "symbiont-mediated detoxification
+      of host-generated reactive oxygen species", which would assert a host-symbiont
+      relation this consortium does not have, and over GO:0061692, which is hydrogen
+      peroxide only. Inherits the interaction''s COMPUTATIONAL evidence: this is the
+      inferred axis the source names, not a measured one (#297).'
   evidence:
   - reference: PMID:28440800
     supports: SUPPORT


### PR DESCRIPTION
Closes #297, taking the "both" option.

## The choice

#296 rehomed an orphaned note onto a `metabolites` entry reading *"Reactive oxygen species detoxification is an inferred interaction **process**"* — a note that says *process* while sitting on a compound. #297 recorded that as a modelling question and left it open: compound, process, or both.

**Both**, because the record already asserted both in prose. `CHEBI:26523` is the species; `GO:0098869` *cellular oxidant detoxification* is what is done to it. Grounding the process adds **no new claim** — it makes the claim the note already made machine-readable, which is the objection #297 raised against introducing a GO term on a record whose sourcing is inferential.

## Why GO:0098869 and not the nearer-looking terms

| candidate | why not |
|---|---|
| `GO:0141082` symbiont-mediated detoxification of **host-generated** ROS | asserts a host–symbiont relation this consortium does not have — *Trichodesmium* and *Alteromonas* are a consortium, and the ROS is photosynthetic, not host-generated |
| `GO:0061692` cellular detoxification of **hydrogen peroxide** | H₂O₂ only, where the record says ROS generally |

`GO:0098869`'s definition — *"reduces or removes the toxicity of superoxide radicals or hydrogen peroxide"* — is the general oxidant case and matches the note exactly. Verified non-obsolete with canonical label; the id↔label gate goes **6094 → 6095 OK_CANONICAL** with no exception added.

## The follow-up question #297 asks

> if a GO term is added, check the same question for the other two "inferred interaction axis" metabolites (phosphate, iron(2+))

**Checked — and the answer is no**, for a reason worth recording. Clean terms exist (`GO:0006826` iron ion transport, `GO:0006817` phosphate ion transport), but both are *cellular transport* processes while the record's notes describe ecological *acquisition axes*. Grounding them would introduce a claim the record does not make — the same over-claiming that rules out `GO:0141082` above.

The ROS case is different precisely because **its note already named the process**. That distinction is the whole basis for treating one differently from the other two, so it is in the record's notes rather than only here.

## Verification

- `linkml-validate`: no issues
- `validate-strict`: 0 ERROR rows
- id↔label: `✅ All id↔label pairs correspond`
- `2364 passed, 16 skipped`
- **`docs/` regenerated** — the #477 gate caught the stale page and refused until it was committed, which is exactly what it exists for.

The new entry inherits the interaction's `COMPUTATIONAL` evidence; this is the inferred axis the source names, not a measured one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)