### PR TITLE
Give FunctionalRoleEnum terms for biocontrol and N-fixing symbiosis (#301)

### DIFF
--- a/docs/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.html
+++ b/docs/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.html
@@ -505,6 +505,12 @@
                         </td>
                         <td>
                             
+                            <div class="roles-list">
+                                
+                                <span class="role-badge">PATHOGEN_ANTAGONIST</span>
+                                
+                            </div>
+                            
                         </td>
                         <td>N/A</td>
                     </tr>
@@ -552,6 +558,12 @@
                         </td>
                         <td>
                             
+                            <div class="roles-list">
+                                
+                                <span class="role-badge">PATHOGEN_ANTAGONIST</span>
+                                
+                            </div>
+                            
                         </td>
                         <td>N/A</td>
                     </tr>
@@ -587,6 +599,12 @@
                             </a>
                         </td>
                         <td>
+                            
+                            <div class="roles-list">
+                                
+                                <span class="role-badge">PATHOGEN_ANTAGONIST</span>
+                                
+                            </div>
                             
                         </td>
                         <td>N/A</td>
@@ -929,21 +947,21 @@
             id: "NCBITaxon:286",
             label: "Pseudomonas",
             abundance: "UNKNOWN",
-            roles: []
+            roles: ["PATHOGEN_ANTAGONIST"]
         };
         
         taxonData["Duganella"] = {
             id: "NCBITaxon:75654",
             label: "Duganella",
             abundance: "UNKNOWN",
-            roles: []
+            roles: ["PATHOGEN_ANTAGONIST"]
         };
         
         taxonData["Brevibacterium"] = {
             id: "NCBITaxon:1696",
             label: "Brevibacterium",
             abundance: "UNKNOWN",
-            roles: []
+            roles: ["PATHOGEN_ANTAGONIST"]
         };
         
         taxonData["Fusarium oxysporum"] = {

--- a/docs/communities/Legume_Rhizobia_Mars_Simulant_Symbiosis.html
+++ b/docs/communities/Legume_Rhizobia_Mars_Simulant_Symbiosis.html
@@ -465,7 +465,7 @@
                             
                             <div class="roles-list">
                                 
-                                <span class="role-badge">SYNTROPHIC_PARTNER</span>
+                                <span class="role-badge">NITROGEN_FIXING_SYMBIONT</span>
                                 
                             </div>
                             
@@ -507,7 +507,7 @@
                             
                             <div class="roles-list">
                                 
-                                <span class="role-badge">SYNTROPHIC_PARTNER</span>
+                                <span class="role-badge">NITROGEN_FIXING_SYMBIONT</span>
                                 
                             </div>
                             
@@ -745,14 +745,14 @@
             id: "NCBITaxon:382",
             label: "Sinorhizobium meliloti",
             abundance: "UNKNOWN",
-            roles: ["SYNTROPHIC_PARTNER"]
+            roles: ["NITROGEN_FIXING_SYMBIONT"]
         };
         
         taxonData["Sinorhizobium medicae"] = {
             id: "NCBITaxon:110321",
             label: "Sinorhizobium medicae",
             abundance: "UNKNOWN",
-            roles: ["SYNTROPHIC_PARTNER"]
+            roles: ["NITROGEN_FIXING_SYMBIONT"]
         };
         
 

--- a/kb/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.yaml
+++ b/kb/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.yaml
@@ -113,6 +113,8 @@ taxonomy:
       basis for this record's rhizosphere modeled_environment. Note the precursor's third genus is
       Rhizomicrobium, not the Brevibacterium of the 2026 SynCom, so the keystone set is not identical
       across the two studies.
+  functional_role:
+  - PATHOGEN_ANTAGONIST
 - taxon_term:
     preferred_term: Duganella
     term:
@@ -137,6 +139,8 @@ taxonomy:
     snippet: keystone taxa (Psedomonas, Duganella, Brevibacterium) interaction with C. fusca
       CHK0059 within plant hosts were identified
     explanation: Names Duganella as one of the three keystone taxa recombined into the SynCom.
+  functional_role:
+  - PATHOGEN_ANTAGONIST
 - taxon_term:
     preferred_term: Brevibacterium
     term:
@@ -161,6 +165,8 @@ taxonomy:
     snippet: keystone taxa (Psedomonas, Duganella, Brevibacterium) interaction with C. fusca
       CHK0059 within plant hosts were identified
     explanation: Names Brevibacterium as one of the three keystone taxa recombined into the SynCom.
+  functional_role:
+  - PATHOGEN_ANTAGONIST
 - taxon_term:
     preferred_term: Fusarium oxysporum
     term:

--- a/kb/communities/Legume_Rhizobia_Mars_Simulant_Symbiosis.yaml
+++ b/kb/communities/Legume_Rhizobia_Mars_Simulant_Symbiosis.yaml
@@ -82,7 +82,7 @@ taxonomy:
       A symbiotic nitrogen-fixing rhizobium partner of Medicago truncatula; ontology
       grounding is species-level.
   functional_role:
-  - SYNTROPHIC_PARTNER
+  - NITROGEN_FIXING_SYMBIONT
   evidence:
   - reference: PMID:34879082
     supports: SUPPORT
@@ -108,7 +108,7 @@ taxonomy:
       A symbiotic nitrogen-fixing rhizobium partner of Medicago truncatula; ontology
       grounding is species-level.
   functional_role:
-  - SYNTROPHIC_PARTNER
+  - NITROGEN_FIXING_SYMBIONT
   evidence:
   - reference: PMID:34879082
     supports: SUPPORT

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-08-06T15:08:35
+# Generation date: 2026-08-08T00:13:47
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech
@@ -2415,6 +2415,16 @@ class FunctionalRoleEnum(EnumDefinitionImpl):
     ELECTROTROPH = PermissibleValue(
         text="ELECTROTROPH",
         description="""Takes up electrons from an extracellular donor such as a cathode (electrotrophy / extracellular electron uptake).""",
+    )
+    PATHOGEN_ANTAGONIST = PermissibleValue(
+        text="PATHOGEN_ANTAGONIST",
+        description="""Suppresses a pathogen in the community — biocontrol. The defining function of the plant-associated SynComs, and the role that was missing when #298 reached for PRIMARY_DEGRADER instead: a biocontrol strain is not thereby shown to degrade complex substrates, so that value asserted a metabolism the source did not report (#301).
+Names the antagonist, not its target. A suppressed pathogen is usually not a community member at all — see #319 on interaction participants that are deliberately outside `taxonomy`.""",
+    )
+    NITROGEN_FIXING_SYMBIONT = PermissibleValue(
+        text="NITROGEN_FIXING_SYMBIONT",
+        description="""Fixes atmospheric nitrogen in symbiosis with a host, as rhizobia do in a legume nodule.
+Distinct from SYNTROPHIC_PARTNER, which #298 used for Bradyrhizobium for want of anything closer. Syntrophy denotes an obligate metabolic coupling — typically interspecies H2 or formate transfer — where neither partner can run the reaction alone. Rhizobial nodulation is a host-symbiont exchange of fixed N for photosynthate, which is a different relation, and PRIMARY_PRODUCER is also wrong because that value is about carbon (#301).""",
     )
 
     _defn = EnumDefinition(

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -313,6 +313,29 @@ enums:
         description: >-
           Takes up electrons from an extracellular donor such as a cathode
           (electrotrophy / extracellular electron uptake).
+      PATHOGEN_ANTAGONIST:
+        description: >-
+          Suppresses a pathogen in the community — biocontrol. The defining
+          function of the plant-associated SynComs, and the role that was
+          missing when #298 reached for PRIMARY_DEGRADER instead: a biocontrol
+          strain is not thereby shown to degrade complex substrates, so that
+          value asserted a metabolism the source did not report (#301).
+
+          Names the antagonist, not its target. A suppressed pathogen is
+          usually not a community member at all — see #319 on interaction
+          participants that are deliberately outside `taxonomy`.
+      NITROGEN_FIXING_SYMBIONT:
+        description: >-
+          Fixes atmospheric nitrogen in symbiosis with a host, as rhizobia do
+          in a legume nodule.
+
+          Distinct from SYNTROPHIC_PARTNER, which #298 used for Bradyrhizobium
+          for want of anything closer. Syntrophy denotes an obligate metabolic
+          coupling — typically interspecies H2 or formate transfer — where
+          neither partner can run the reaction alone. Rhizobial nodulation is
+          a host-symbiont exchange of fixed N for photosynthate, which is a
+          different relation, and PRIMARY_PRODUCER is also wrong because that
+          value is about carbon (#301).
 
   AtmosphereEnum:
     description: Atmospheric/oxygen requirements for growth


### PR DESCRIPTION
Closes #301.

## The gap

`FunctionalRoleEnum` is built around trophic and electron-transfer roles and has nothing for two functions central to the plant-associated SynComs, now a growing share of the KB. #298 reached for the nearest values and both were wrong **on the enum's own descriptions**:

- `PRIMARY_DEGRADER` for antifungal biocontrol strains never shown to degrade complex substrates
- `SYNTROPHIC_PARTNER` for rhizobia, where syntrophy means an obligate metabolic coupling (interspecies H₂/formate) and nodulation is a host–symbiont exchange

Both were removed rather than left as approximations, so those taxa carried **no role at all** — honest, and lossy: the KB then cannot answer *"which taxa here are biocontrol agents"*, which is a question these records exist to support.

## Two values, each explaining why the near-miss is wrong

`PATHOGEN_ANTAGONIST` and `NITROGEN_FIXING_SYMBIONT`. Each description says why the value a curator would otherwise reach for is incorrect, so the substitution isn't repeated.

## Applied only where the record says so in its own words

**`Chlorella_Keystone_Taxa_Antifungal_SynCom`** — *Pseudomonas*, *Duganella*, *Brevibacterium*. The description: *"the three keystone taxa suppressed the soilborne pathogen Fusarium oxysporum in both strawberry and tomato more strongly than any constituent strain alone"*.

*Fusarium* itself and the two plant hosts keep **no** role — the target of suppression is not an antagonist, and hosts are the #319 population deliberately outside `taxonomy`.

**`Legume_Rhizobia_Mars_Simulant_Symbiosis`** — *Sinorhizobium meliloti* / *S. medicae*, `SYNTROPHIC_PARTNER` → `NITROGEN_FIXING_SYMBIONT`. Description: *"a model legume-rhizobia nitrogen-fixing symbiosis … its symbiotic rhizobial partners"*.

## Deliberately not swept further

Surveying the KB turns up **22 rhizobial taxa across 15 records** with a spread of trophic roles — including `Bradyrhizobium elkanii` as `PRIMARY_PRODUCER` and three *Mesorhizobium* nodule isolates likewise, which look like the same substitution. But being a rhizobium doesn't establish that N fixation is what *that record's source* reports: `Rhizobium radiobacter` isn't a nodulating fixer, and the Panzhihua taxa are tailings isolates where degradation may be what was measured.

A bulk retro-fit would be exactly the guessing this issue is about. Filed as **#497** with the full survey and a suggested order of work.

## One process note

My first insert used a regex whose greedy body match ran past the entry boundary, so the second taxon appeared to already have a role. It asserted **before** the write, so nothing was damaged — redone with explicit line bounds. Final diff on that record: **6 insertions, 0 deletions**.

Schema change → datamodel regenerated; `docs/` regenerated for the two records (the #477 gate caught them). `validate-strict` 0 errors, `2364 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)