### PR TITLE
Give counter-selection a machine-readable home (#307)

### DIFF
--- a/kb/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.yaml
+++ b/kb/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.yaml
@@ -54,6 +54,21 @@ engineering_design:
       were excluded. Carried on the design rather than on an interaction because the excluded
       isolates are indistinguishable from the retained ones at the taxonomic resolution the source
       provides.
+  counter_selection:
+  - criterion: Inhibited Bradyrhizobium in coculture, so retaining them would have traded
+      nodulation against aflatoxin suppression - the trade-off this community exists to avoid.
+    excluded_count: 3
+    evidence:
+    - reference: PMID:42099455
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: 3 Bacillus inhibited Bradyrhizobium
+      explanation: >-
+        The counter-selection, now structured rather than only prose (#307). `excluded_taxon`
+        is deliberately empty: the source does not say which three isolates they were, and at
+        the genus-level NCBITaxon:1386 grounding it supports they are indistinguishable from
+        the retained Bacillus members - so naming one would assert an identity the paper does
+        not. `excluded_count` carries what is known.
 environment_term:
   preferred_term: peanut rhizosphere
   term:

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-08-08T00:13:47
+# Generation date: 2026-08-08T00:48:13
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech
@@ -1161,6 +1161,49 @@ class ExternalResource(YAMLRoot):
 
 
 @dataclass(repr=False)
+class CounterSelection(YAMLRoot):
+    """
+    A candidate, or set of candidates, excluded from a community during assembly, with the criterion that excluded it
+    (#307).
+    Screening is how most synthetic communities are built, and "we excluded X because it antagonised Y" is often the
+    most informative sentence in the paper. Recording it makes the design constraint queryable and evidence-backed
+    rather than prose.
+    """
+
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = COMMUNITYMECH["CounterSelection"]
+    class_class_curie: ClassVar[str] = "communitymech:CounterSelection"
+    class_name: ClassVar[str] = "CounterSelection"
+    class_model_uri: ClassVar[URIRef] = COMMUNITYMECH.CounterSelection
+
+    criterion: str = None
+    excluded_taxon: Optional[Union[dict, TaxonDescriptor]] = None
+    excluded_count: Optional[int] = None
+    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
+        empty_list()
+    )
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.criterion):
+            self.MissingRequiredField("criterion")
+        if not isinstance(self.criterion, str):
+            self.criterion = str(self.criterion)
+
+        if self.excluded_taxon is not None and not isinstance(self.excluded_taxon, TaxonDescriptor):
+            self.excluded_taxon = TaxonDescriptor(**as_dict(self.excluded_taxon))
+
+        if self.excluded_count is not None and not isinstance(self.excluded_count, int):
+            self.excluded_count = int(self.excluded_count)
+
+        self._normalize_inlined_as_dict(
+            slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=False
+        )
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
 class CommunityEngineeringDesign(YAMLRoot):
     """
     Design intent and implementation details for engineered or synthetic communities
@@ -1179,6 +1222,9 @@ class CommunityEngineeringDesign(YAMLRoot):
     passaging_regimen: Optional[str] = None
     perturbation_design: Optional[str] = None
     measurement_endpoints: Optional[Union[str, list[str]]] = empty_list()
+    counter_selection: Optional[
+        Union[Union[dict, CounterSelection], list[Union[dict, CounterSelection]]]
+    ] = empty_list()
     protocol_url: Optional[str] = None
     notes: Optional[str] = None
     evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = (
@@ -1208,6 +1254,13 @@ class CommunityEngineeringDesign(YAMLRoot):
         self.measurement_endpoints = [
             v if isinstance(v, str) else str(v) for v in self.measurement_endpoints
         ]
+
+        self._normalize_inlined_as_dict(
+            slot_name="counter_selection",
+            slot_type=CounterSelection,
+            key_name="criterion",
+            keyed=False,
+        )
 
         if self.protocol_url is not None and not isinstance(self.protocol_url, str):
             self.protocol_url = str(self.protocol_url)
@@ -4343,6 +4396,42 @@ slots.externalResource__evidence = Slot(
     range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
 )
 
+slots.counterSelection__criterion = Slot(
+    uri=COMMUNITYMECH.criterion,
+    name="counterSelection__criterion",
+    curie=COMMUNITYMECH.curie("criterion"),
+    model_uri=COMMUNITYMECH.counterSelection__criterion,
+    domain=None,
+    range=str,
+)
+
+slots.counterSelection__excluded_taxon = Slot(
+    uri=COMMUNITYMECH.excluded_taxon,
+    name="counterSelection__excluded_taxon",
+    curie=COMMUNITYMECH.curie("excluded_taxon"),
+    model_uri=COMMUNITYMECH.counterSelection__excluded_taxon,
+    domain=None,
+    range=Optional[Union[dict, TaxonDescriptor]],
+)
+
+slots.counterSelection__excluded_count = Slot(
+    uri=COMMUNITYMECH.excluded_count,
+    name="counterSelection__excluded_count",
+    curie=COMMUNITYMECH.curie("excluded_count"),
+    model_uri=COMMUNITYMECH.counterSelection__excluded_count,
+    domain=None,
+    range=Optional[int],
+)
+
+slots.counterSelection__evidence = Slot(
+    uri=COMMUNITYMECH.evidence,
+    name="counterSelection__evidence",
+    curie=COMMUNITYMECH.curie("evidence"),
+    model_uri=COMMUNITYMECH.counterSelection__evidence,
+    domain=None,
+    range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]],
+)
+
 slots.communityEngineeringDesign__objective = Slot(
     uri=COMMUNITYMECH.objective,
     name="communityEngineeringDesign__objective",
@@ -4395,6 +4484,15 @@ slots.communityEngineeringDesign__measurement_endpoints = Slot(
     model_uri=COMMUNITYMECH.communityEngineeringDesign__measurement_endpoints,
     domain=None,
     range=Optional[Union[str, list[str]]],
+)
+
+slots.communityEngineeringDesign__counter_selection = Slot(
+    uri=COMMUNITYMECH.counter_selection,
+    name="communityEngineeringDesign__counter_selection",
+    curie=COMMUNITYMECH.curie("counter_selection"),
+    model_uri=COMMUNITYMECH.communityEngineeringDesign__counter_selection,
+    domain=None,
+    range=Optional[Union[Union[dict, CounterSelection], list[Union[dict, CounterSelection]]]],
 )
 
 slots.communityEngineeringDesign__protocol_url = Slot(

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -1443,6 +1443,45 @@ classes:
         range: EvidenceItem
         multivalued: true
 
+  CounterSelection:
+    description: >-
+      A candidate, or set of candidates, excluded from a community during
+      assembly, with the criterion that excluded it (#307).
+
+      Screening is how most synthetic communities are built, and "we excluded X
+      because it antagonised Y" is often the most informative sentence in the
+      paper. Recording it makes the design constraint queryable and
+      evidence-backed rather than prose.
+    attributes:
+      criterion:
+        description: >-
+          Why these candidates were excluded - the screen they failed.
+          Required: an exclusion without a reason records that something was
+          dropped while losing the only part that is informative.
+        required: true
+      excluded_taxon:
+        description: >-
+          The excluded candidate, where the source resolves it.
+
+          Optional on purpose. The motivating case cannot fill it: three
+          Bacillus isolates were excluded for inhibiting Bradyrhizobium, and at
+          the genus-level grounding the source supports they are
+          indistinguishable from the retained ones, so naming a taxon here
+          would assert an identity the paper does not (#305, #307). Use
+          `excluded_count` when the number is known but the identity is not.
+        range: TaxonDescriptor
+      excluded_count:
+        description: >-
+          How many candidates were excluded, when the source gives a number but
+          not resolvable identities. Carries the fact that the screen removed
+          three isolates even where `excluded_taxon` must stay empty.
+        range: integer
+        minimum_value: 1
+      evidence:
+        description: Evidence for the exclusion
+        range: EvidenceItem
+        multivalued: true
+
   CommunityEngineeringDesign:
     description: Design intent and implementation details for engineered or synthetic communities
     attributes:
@@ -1458,6 +1497,20 @@ classes:
         description: Planned perturbations applied to probe or tune community behavior
       measurement_endpoints:
         description: Primary readouts used to evaluate design outcomes
+        multivalued: true
+      counter_selection:
+        description: >-
+          Candidates deliberately excluded during assembly, and why. The schema
+          could express what a community IS but not what it was deliberately
+          NOT, so a screening constraint had only two homes: an
+          `ecological_interaction`, which asserts an edge between members and is
+          wrong when the excluded strains are not members, or prose in `notes`,
+          which no consumer can query (#307).
+
+          Not an interaction: these subjects are outside the community by
+          construction, which is why they live here rather than in
+          `ecological_interactions` (#300, #305).
+        range: CounterSelection
         multivalued: true
       protocol_url:
         description: URL to an assembly or cultivation protocol, if available

--- a/tests/test_counter_selection.py
+++ b/tests/test_counter_selection.py
@@ -1,0 +1,115 @@
+"""Counter-selection had nowhere to live but prose (#307).
+
+A synthetic community is often defined as much by what was screened *out* as by
+what shipped. `SynCom_ARC` is exactly that: candidate *Bacillus* isolates that
+inhibited *Bradyrhizobium* were excluded, so the community suppresses aflatoxin
+without costing nodulation. That constraint is the whole design.
+
+Before this there were two homes for it, and #305 had to pick the least bad:
+
+* an `ecological_interaction` — machine-readable, and **wrong**. The excluded
+  and retained isolates are indistinguishable at the genus grounding the source
+  supports, so a typed `Bacillus -> Bradyrhizobium COMPETITION` edge asserts to
+  anyone reading the graph that an ARC *member* antagonises the mutualist ARC
+  was built to spare — the opposite of the finding.
+* `engineering_design.notes` prose — accurate, and invisible to any consumer.
+
+`CounterSelection` is the third option. It sits on the design rather than in
+`ecological_interactions` because its subjects are outside the community by
+construction.
+
+`excluded_taxon` is optional, which is the point rather than laziness: ARC's
+source does not say which three isolates were dropped, so `excluded_count`
+carries what is known and the taxon slot stays empty rather than asserting an
+identity the paper does not support.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+import yaml
+
+REPO = pathlib.Path(__file__).parent.parent
+SCHEMA = REPO / "src/communitymech/schema/communitymech.yaml"
+ARC = REPO / "kb/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.yaml"
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict:
+    return yaml.safe_load(SCHEMA.read_text(encoding="utf-8"))
+
+
+def test_the_class_exists_and_requires_a_criterion(schema):
+    """An exclusion without a reason drops the only informative part."""
+    attributes = schema["classes"]["CounterSelection"]["attributes"]
+    assert attributes["criterion"].get("required") is True
+    assert set(attributes) >= {"criterion", "excluded_taxon", "excluded_count", "evidence"}
+
+
+def test_the_excluded_taxon_is_optional(schema):
+    """Required would force ARC to name isolates its source does not name."""
+    assert (
+        schema["classes"]["CounterSelection"]["attributes"]["excluded_taxon"].get("required")
+        is not True
+    )
+
+
+def test_it_hangs_off_the_design_not_the_interactions(schema):
+    """The subjects are outside the community, so this is not an interaction."""
+    design = schema["classes"]["CommunityEngineeringDesign"]["attributes"]
+    assert design["counter_selection"]["range"] == "CounterSelection"
+    assert design["counter_selection"].get("multivalued") is True
+    interaction = schema["classes"]["EcologicalInteraction"]["attributes"]
+    assert "counter_selection" not in interaction
+
+
+def test_the_motivating_record_now_carries_it_structurally():
+    """#305 chose prose because there was no alternative; there is one now."""
+    document = yaml.safe_load(ARC.read_text(encoding="utf-8"))
+    entries = (document.get("engineering_design") or {}).get("counter_selection") or []
+    assert len(entries) == 1, entries
+
+    entry = entries[0]
+    assert "Bradyrhizobium" in entry["criterion"]
+    assert entry["excluded_count"] == 3
+    assert "excluded_taxon" not in entry, (
+        "ARC's source does not resolve which three isolates were excluded; naming "
+        "one asserts an identity the paper does not support (#305, #307)"
+    )
+    assert entry.get("evidence"), "an exclusion should be evidence-backed like everything else"
+
+
+def test_the_prose_that_explains_the_choice_survives():
+    """The note says *why* this is not an interaction, which the data cannot.
+
+    Structuring the fact is not a reason to drop the reasoning behind the
+    modelling decision — that is what sends the next curator back to the
+    misleading edge.
+    """
+    document = yaml.safe_load(ARC.read_text(encoding="utf-8"))
+    notes = (document.get("engineering_design") or {}).get("notes") or ""
+    assert "ecological interaction" in notes.lower()
+
+
+def test_no_record_smuggles_the_exclusion_back_into_the_graph():
+    """The edge #305 refused to write must not reappear.
+
+    A `Bacillus -> Bradyrhizobium` antagonism edge inside ARC would say a member
+    attacks the mutualist the community was assembled to protect.
+    """
+    document = yaml.safe_load(ARC.read_text(encoding="utf-8"))
+    for interaction in document.get("ecological_interactions") or []:
+        if not isinstance(interaction, dict):
+            continue
+        pair = {
+            str((interaction.get(role) or {}).get("preferred_term", ""))
+            for role in ("source_taxon", "target_taxon")
+        }
+        antagonistic = interaction.get("interaction_type") in {"COMPETITION", "AMENSALISM"}
+        assert not (
+            antagonistic
+            and any("Bacillus" in p for p in pair)
+            and any("Bradyrhizobium" in p for p in pair)
+        ), f"the counter-selection is back as a typed edge: {interaction.get('interaction_type')}"


### PR DESCRIPTION
Closes #307, implementing its sketch.

## The gap

The schema could express what a community **is** but not what it was deliberately **not**. #305 hit this with `SynCom_ARC`, whose entire design is a counter-selection — candidate *Bacillus* isolates that inhibited *Bradyrhizobium* were excluded, so the community suppresses aflatoxin without costing nodulation.

It had two homes, and #305 took the least bad:

| option | verdict |
|---|---|
| an `ecological_interaction` | machine-readable and **wrong** — a typed `Bacillus → Bradyrhizobium COMPETITION` edge tells anyone reading the graph that an ARC *member* antagonises the mutualist ARC was built to spare |
| `engineering_design.notes` prose | accurate and invisible to any consumer |

## `CounterSelection`

On `CommunityEngineeringDesign`, not in `ecological_interactions` — its subjects are outside the community by construction.

**`excluded_taxon` is optional, and that is the design.** It answers the open question #307 raises: *how to represent an exclusion whose subjects cannot be resolved apart from the retained members.* ARC's source doesn't say which three isolates were dropped, and at the genus-level `NCBITaxon:1386` grounding they're indistinguishable from the retained members — so `excluded_count: 3` carries what is known and the taxon slot stays empty rather than asserting an identity the paper does not support.

**`criterion` is required.** An exclusion without a reason records that something was dropped while losing the only informative part.

## ARC migrated

Reusing the evidence item already carrying `snippet: 3 Bacillus inhibited Bradyrhizobium`. **The prose notes stay** — they explain *why* this is not an interaction, which structured data cannot, and dropping that reasoning is what would send the next curator back to the misleading edge.

```yaml
counter_selection:
- criterion: Inhibited Bradyrhizobium in coculture, so retaining them would have traded
    nodulation against aflatoxin suppression - the trade-off this community exists to avoid.
  excluded_count: 3
  evidence: [...]
```

## Verification

Mutation-checked both guarantees:

```
name an excluded taxon on ARC   → test_the_motivating_record_now_carries_it_structurally FAILS
make `criterion` optional       → test_the_class_exists_and_requires_a_criterion FAILS
```

Plus a test that the edge #305 refused to write cannot reappear as a typed `Bacillus`/`Bradyrhizobium` antagonism inside ARC.

`validate-strict` 0 errors, `2370 passed`. Schema change → datamodel and docs regenerated.

## Still open in #307

Whether the audit should stop penalising the honest choice. Removing the edge left ARC with only `COMMUNITY_LEVEL` interactions, which #312 measured as an all-or-nothing credit — so the record is scored as if nothing connects it. Same "cannot distinguish ruled-out from absent" shape as #294. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)