### PR TITLE
Record the answer to #319 on the slot it is about: hosts are not members

### DIFF
--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-08-08T00:48:13
+# Generation date: 2026-08-08T01:28:55
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -1640,7 +1640,34 @@ classes:
         required: false
         inlined_as_list: true
       taxonomy:
-        description: Organisms present in the community
+        description: >-
+          Organisms present in the community — its membership, not everything it
+          interacts with.
+
+          A host and an antagonist are **not** members (#319). The community
+          lives on or in its host and is applied against its antagonist; both
+          appear as `ecological_interactions` participants without appearing
+          here, which is why the network auditor reports them as
+          `UNKNOWN_SOURCE`/`UNKNOWN_TARGET` at warning severity rather than
+          gating on them (#326).
+
+          Of the 25 interaction participants currently outside this slot, 14 are
+          aggregate names for members that *are* present — `Variovorax` where
+          the record lists `Variovorax sp. CF313`, `YR634` and the rest — so
+          they are a naming coarseness rather than a membership question. The
+          remaining 11 are 6 hosts, 3 antagonists and 2 abiotic
+          (`anode`), and none of them belongs here.
+
+          The mirror-image question is #307: candidates deliberately screened
+          *out* are likewise not members, and live in
+          `engineering_design.counter_selection`. Both answers are the same, for
+          the same reason — this slot records what the community is made of, and
+          an edge to something outside it is not evidence that it should be
+          inside it.
+
+          `tests/test_interaction_participants_outside_taxonomy.py` holds the
+          population to those four groups, so a new host or antagonist has to be
+          classified rather than absorbed.
         range: TaxonomicComposition
         multivalued: true
       ecological_interactions:

--- a/tests/test_interaction_participants_outside_taxonomy.py
+++ b/tests/test_interaction_participants_outside_taxonomy.py
@@ -210,3 +210,32 @@ def test_the_group_sizes_are_what_the_decision_was_sized_against(group: str, exp
     which is a much smaller commitment than the headline count suggests.
     """
     assert len(globals()[group]) == expected
+
+
+def test_the_schema_records_the_membership_decision():
+    """#319's question, answered in the slot rather than in an issue thread.
+
+    "Should hosts and antagonists be taxonomy members?" was re-derived at least
+    twice — once when the auditor was written and once when this file was — and
+    each time from the same evidence. Recording it on `taxonomy` means the next
+    reader finds the answer where they are already looking.
+
+    Asserted positively: the description must *say* hosts and antagonists are
+    not members. A check that some phrase is absent would pass on a rewrite
+    that dropped the reasoning entirely.
+    """
+    import yaml
+
+    schema = yaml.safe_load(
+        (REPO / "src/communitymech/schema/communitymech.yaml").read_text(encoding="utf-8")
+    )
+    description = schema["classes"]["MicrobialCommunity"]["attributes"]["taxonomy"]["description"]
+
+    assert "#319" in description
+    lowered = description.lower()
+    assert "host" in lowered and "antagonist" in lowered, (
+        "the taxonomy slot no longer states whether hosts and antagonists are "
+        "members, which is the question #319 asked and this file pins the "
+        "population for"
+    )
+    assert "not" in lowered, "the decision was 'no'; the description must say so"


### PR DESCRIPTION
Closes #319.

**No data changes.** "No" is the status quo — those participants are already outside `taxonomy` and stay there. What changes is that the reasoning stops being re-derived.

## Why record it at all

The question was worked out at least twice from the same evidence — once when the network auditor was written (#326, which downgraded these to warning severity citing #319 by name) and once when `test_interaction_participants_outside_taxonomy.py` was. Each time the conclusion went into a comment rather than into the slot everyone reads. `taxonomy` already said *"organisms present in the community"*; this makes the implication explicit.

## The scoping that makes the decision easy

Of the **25** interaction participants outside `taxonomy`:

- **14 are UMBRELLA names for members that *are* present** — `Variovorax` where the record lists `Variovorax sp. CF313`, `YR634`, `GV004`…; `Olsenella (Actinobacteriota)` where taxonomy has `Olsenella_B sp. (MAG ATO3)`. A naming coarseness, not a membership question. Nobody would duplicate those.
- The real question is the remaining **11: 6 hosts, 3 antagonists, 2 abiotic**.

A community lives **on** its host and is applied **against** its antagonist. Neither is what the community is made of.

## Consistent with #307

That issue asked the mirror-image question — do deliberately screened-*out* candidates belong in `taxonomy`? — and answered no, for the same reason. They live in `engineering_design.counter_selection` instead. **An edge to something outside the community is not evidence that it should be inside it.**

The auditor's existing behaviour is already correct under this answer: these are reported at warning severity rather than gating, which is what you want for a deliberate absence.

## Verification

Mutation-checked: reverting the slot description to its one-line form fails the new test. Asserted **positively** — the description must *say* hosts and antagonists are not members, so a rewrite that silently drops the reasoning fails rather than passing.

`validate-strict` 0 errors, `2371 passed`, docs regenerated.

## Not decided here

The fragility #319 also names: the shielding rests on a single optional key. `scope` has `ifabsent: string(PAIRWISE)`, so dropping it from one interaction turns that participant into an error and reddens the build on a record nobody changed the biology of. That is pinned by `test_all_of_them_are_warnings_not_errors` and deserves its own fix — a participant's absence from `taxonomy` should probably be shielded by something that says *why* it is absent, not by an unrelated key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)