### PR TITLE
Enrich one #183 record from full text already cached, and size the rest

### DIFF
--- a/docs/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.html
+++ b/docs/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.html
@@ -908,6 +908,150 @@
 
         <!-- Growth Media -->
         
+        <section>
+            <h2>Growth Media</h2>
+            
+            <div class="metadata">
+                <h3>
+                    R2A broth, Chlorella fusca CHK0059 culture
+                    
+                </h3>
+
+                
+
+                <div class="metadata-grid" style="margin-top: 1rem;">
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Temperature</span>
+                        <span class="metadata-value">28.0 CELSIUS</span>
+                    </div>
+                    
+
+                    
+                </div>
+
+                
+                <h4 style="margin-top: 1rem; color: var(--text);">Composition</h4>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Component</th>
+                            <th>Concentration</th>
+                            <th>Unit</th>
+                            <th>CHEBI</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        
+                        <tr>
+                            <td><strong>R2A</strong></td>
+                            <td>3.15</td>
+                            <td>g/L</td>
+                            <td>
+                                
+                                N/A
+                                
+                            </td>
+                        </tr>
+                        
+                    </tbody>
+                </table>
+                
+
+                
+                <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
+                    <strong>Preparation notes:</strong> The alga&#39;s own culture, which is what the SynCom is assembled from. Extracted from the cached open-access full text rather than the abstract - #183 lists this record among those lacking growth conditions because the conditions are Methods-level, and the Methods are reachable now (PMC full text cached).
+                </p>
+                
+
+                
+                <div style="margin-top: 1rem;">
+                    <h4 style="color: var(--text);">Evidence</h4>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41937467"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41937467
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"inoculate the single fresh CHK0059 colony to R2A broth (MB cell R2A 3.15 g per L), temperature; 28°C, period; 5 days, light; 16 h and dark; 8 hr in a day"</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41937467"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41937467
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"C. fusca CHK0059 were streaked on R2A medium (MB cell R2A 3.15 g, Agar 20 g per L)"</p>
+                        
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+            <div class="metadata">
+                <h3>
+                    Treated-sample incubation, viability assay
+                    
+                </h3>
+
+                
+
+                <div class="metadata-grid" style="margin-top: 1rem;">
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Temperature</span>
+                        <span class="metadata-value">27.0 CELSIUS</span>
+                    </div>
+                    
+
+                    
+                </div>
+
+                
+
+                
+                <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
+                    <strong>Preparation notes:</strong> The assay leg rather than the maintenance culture - samples were sampled at 12, 24, 36 and 48 h, and viability read by dilution plating back onto R2A.
+                </p>
+                
+
+                
+                <div style="margin-top: 1rem;">
+                    <h4 style="color: var(--text);">Evidence</h4>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41937467"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41937467
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"the samples were cultured in a 27°C shaking incubator for designated time intervals (12 h, 24 h, 36 h, and 48 h)"</p>
+                        
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+        </section>
+        
     </main>
 
     <footer>

--- a/kb/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.yaml
+++ b/kb/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.yaml
@@ -255,6 +255,51 @@ ecological_interactions:
     explanation: PARTIAL - establishes that D-mannitol enriches Pseudomonas, but the paper reports
       an abundance shift under treatment rather than demonstrating that the microalga secretes
       D-mannitol in planta, so the algal origin of the signal remains inferred.
+growth_media:
+- name: R2A broth, Chlorella fusca CHK0059 culture
+  composition:
+  - name: R2A
+    concentration: 3.15
+    unit: g/L
+    from_source: true
+  temperature: 28.0
+  temperature_unit: CELSIUS
+  incubation_time: 5.0
+  incubation_time_unit: DAYS
+  light_regime: 16 h light / 8 h dark
+  vessel_type: Broth culture, from a single colony picked off R2A agar
+  preparation_notes: >-
+    The alga's own culture, which is what the SynCom is assembled from. Extracted from the
+    cached open-access full text rather than the abstract - #183 lists this record among
+    those lacking growth conditions because the conditions are Methods-level, and the
+    Methods are reachable now (PMC full text cached).
+  evidence:
+  - reference: PMID:41937467
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: 'inoculate the single fresh CHK0059 colony to R2A broth (MB cell R2A 3.15 g per L),
+      temperature; 28°C, period; 5 days, light; 16 h and dark; 8 hr in a day'
+    explanation: Names the medium, temperature, duration and photoperiod in one sentence.
+  - reference: PMID:41937467
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: C. fusca CHK0059 were streaked on R2A medium (MB cell R2A 3.15 g, Agar 20 g per L)
+    explanation: The solid form the single colony was picked from.
+- name: Treated-sample incubation, viability assay
+  temperature: 27.0
+  temperature_unit: CELSIUS
+  vessel_type: Shaking incubator
+  preparation_notes: >-
+    The assay leg rather than the maintenance culture - samples were sampled at 12, 24, 36
+    and 48 h, and viability read by dilution plating back onto R2A.
+  evidence:
+  - reference: PMID:41937467
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the samples were cultured in a 27°C shaking incubator for designated time intervals
+      (12 h, 24 h, 36 h, and 48 h)
+    explanation: Names the assay temperature, agitation and sampling schedule.
+
 environmental_factors:
 - name: D-mannitol amendment
   value: '2%'


### PR DESCRIPTION
#183 defers this work to *"when the relevant full texts are reachable"*. Some already are, and nobody had checked which.

## The gap grew rather than shrank

**87 of 312** records carry no `growth_media` or `cultivation_setup`, where #183 counted **52 of 295**. The corpus grew and the new records arrived without conditions.

## 9 of the 87 were never blocked

| | count |
|---|--:|
| OA full text **already cached** | **9** — actionable now, no new access |
| abstract only | 78 |
| nothing cached | 0 |

The Methods for those 9 were sitting in `references_cache/` the whole time. #183's framing is right for 78 and wrong for 9.

## The canary

`Chlorella_Keystone_Taxa_Antifungal_SynCom`. Its cached full text states the conditions plainly:

> "inoculate the single fresh CHK0059 colony to R2A broth (MB cell R2A 3.15 g per L), temperature; 28°C, period; 5 days, light; 16 h and dark; 8 hr in a day"

Two media blocks — the alga's maintenance culture (R2A 3.15 g/L, 28 °C, 5 days, 16/8 photoperiod) and the assay leg (27 °C shaking, sampled 12/24/36/48 h) — with three verbatim evidence snippets. **All three validate as substrings of the cached source**: `validate-references` reports 0 issues on the record.

## One correction while writing it

I put `preparation_notes` on a *composition* entry. `GrowthMediaComponent` takes `name` / `concentration` / `unit` / `chebi_term` / `from_source` — no notes field. `just validate` caught it before commit; the component now carries `concentration: 3.15, unit: g/L, from_source: true`, which is the structured form rather than prose anyway.

## What is left, as a work-list not a count

The remaining 8 cached-and-ready records are enumerated on the issue. Not all will have Methods-level conditions — some are field or computational records that legitimately have none — but they can be **checked** without new access, which is the difference from the other 78.

And the 78 are worth re-testing rather than assuming: `cache_fulltext.py` gained a DOI path in #259, Europe PMC's OA holdings change, and #347's SPRUCE paper turned out to be OA when that issue had assumed otherwise.

`2375 passed`, `validate-strict` 0 errors, docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)