### PR TITLE
Enrich two more #183 records from cached full text (87 → 84)

### DIFF
--- a/docs/communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.html
+++ b/docs/communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.html
@@ -727,6 +727,176 @@
 
         <!-- Growth Media -->
         
+        <section>
+            <h2>Growth Media</h2>
+            
+            <div class="metadata">
+                <h3>
+                    Bifidobacterium broth, B. breve maintenance
+                    
+                </h3>
+
+                
+
+                <div class="metadata-grid" style="margin-top: 1rem;">
+                    
+
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Atmosphere</span>
+                        <span class="metadata-value">ANAEROBIC</span>
+                    </div>
+                    
+                </div>
+
+                
+                <h4 style="margin-top: 1rem; color: var(--text);">Composition</h4>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Component</th>
+                            <th>Concentration</th>
+                            <th>Unit</th>
+                            <th>CHEBI</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        
+                        <tr>
+                            <td><strong>Bifidobacterium broth</strong></td>
+                            <td>N/A</td>
+                            <td>N/A</td>
+                            <td>
+                                
+                                N/A
+                                
+                            </td>
+                        </tr>
+                        
+                    </tbody>
+                </table>
+                
+
+                
+                <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
+                    <strong>Preparation notes:</strong> Maintenance culture for the bacterial partner, kept as -80C glycerol stocks. Extracted from the cached open-access full text; #183 listed this record as lacking growth conditions because they are Methods-level.
+                </p>
+                
+
+                
+                <div style="margin-top: 1rem;">
+                    <h4 style="color: var(--text);">Evidence</h4>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41688526"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41688526
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"B. breve (ATCC 15700) was maintained anaerobically in Bifidobacterium broth, streaked to isolate single colonies, and preserved at −80°C in 50% glycerol"</p>
+                        
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+            <div class="metadata">
+                <h3>
+                    Serum-free YI-S co-culture assay
+                    
+                </h3>
+
+                
+
+                <div class="metadata-grid" style="margin-top: 1rem;">
+                    
+
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Atmosphere</span>
+                        <span class="metadata-value">ANAEROBIC</span>
+                    </div>
+                    
+                </div>
+
+                
+                <h4 style="margin-top: 1rem; color: var(--text);">Composition</h4>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Component</th>
+                            <th>Concentration</th>
+                            <th>Unit</th>
+                            <th>CHEBI</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        
+                        <tr>
+                            <td><strong>YI-S, serum-free</strong></td>
+                            <td>N/A</td>
+                            <td>N/A</td>
+                            <td>
+                                
+                                N/A
+                                
+                            </td>
+                        </tr>
+                        
+                    </tbody>
+                </table>
+                
+
+                
+                <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
+                    <strong>Preparation notes:</strong> The assay the record is about - B. breve at 1e8 CFU against T. vaginalis at 1e7 cells, the ratio taken from the prior study the source cites. Viability and bacterial counts were read at sequential time points.
+                </p>
+                
+
+                
+                <div style="margin-top: 1rem;">
+                    <h4 style="color: var(--text);">Evidence</h4>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41688526"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41688526
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"Both organisms were combined in serum-free YI-S and incubated anaerobically for four hours"</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41688526"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41688526
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"Mid-log phase bacteria and parasites were adjusted to 108 CFU and 107 cells, respectively"</p>
+                        
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+        </section>
+        
     </main>
 
     <footer>

--- a/docs/communities/Mars_Meteorite_EETA79001_Growth_Panel.html
+++ b/docs/communities/Mars_Meteorite_EETA79001_Growth_Panel.html
@@ -687,6 +687,163 @@
 
         <!-- Growth Media -->
         
+        <section>
+            <h2>Growth Media</h2>
+            
+            <div class="metadata">
+                <h3>
+                    Alga-Gro, phototroph maintenance
+                    
+                </h3>
+
+                
+
+                <div class="metadata-grid" style="margin-top: 1rem;">
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Temperature</span>
+                        <span class="metadata-value">23.0 CELSIUS</span>
+                    </div>
+                    
+
+                    
+                </div>
+
+                
+                <h4 style="margin-top: 1rem; color: var(--text);">Composition</h4>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Component</th>
+                            <th>Concentration</th>
+                            <th>Unit</th>
+                            <th>CHEBI</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        
+                        <tr>
+                            <td><strong>Alga-Gro</strong></td>
+                            <td>N/A</td>
+                            <td>N/A</td>
+                            <td>
+                                
+                                N/A
+                                
+                            </td>
+                        </tr>
+                        
+                    </tbody>
+                </table>
+                
+
+                
+                <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
+                    <strong>Preparation notes:</strong> Maintenance for the two phototrophs across the experiment. Extracted from the cached open-access full text; #183 listed this record as lacking growth conditions because they are Methods-level.
+                </p>
+                
+
+                
+                <div style="margin-top: 1rem;">
+                    <h4 style="color: var(--text);">Evidence</h4>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/38665180"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:38665180
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"Chr20 cultures were grown and maintained in 50 mL stocks in Alga-Gro media at room temperature (23 °C) in a foil-lined culture box fitted with a plant growth lamp (λ = 455–650 nm) and set to a cycle of 16-hour day light"</p>
+                        
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+            <div class="metadata">
+                <h3>
+                    Tryptic soy agar, heterotroph preculture
+                    
+                </h3>
+
+                
+
+                <div class="metadata-grid" style="margin-top: 1rem;">
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Temperature</span>
+                        <span class="metadata-value">25.0 CELSIUS</span>
+                    </div>
+                    
+
+                    
+                </div>
+
+                
+                <h4 style="margin-top: 1rem; color: var(--text);">Composition</h4>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Component</th>
+                            <th>Concentration</th>
+                            <th>Unit</th>
+                            <th>CHEBI</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        
+                        <tr>
+                            <td><strong>Tryptic soy agar (TSA)</strong></td>
+                            <td>N/A</td>
+                            <td>N/A</td>
+                            <td>
+                                
+                                N/A
+                                
+                            </td>
+                        </tr>
+                        
+                    </tbody>
+                </table>
+                
+
+                
+                <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
+                    <strong>Preparation notes:</strong> The bacterial partners were brought to a defined state on TSA before the regolith exposure, and enumerated back onto TSA as CFU afterwards.
+                </p>
+                
+
+                
+                <div style="margin-top: 1rem;">
+                    <h4 style="color: var(--text);">Evidence</h4>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/38665180"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:38665180
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"a 20-hour culture of each bacteria was streaked onto a fresh TSA plate and incubated at 25 °C"</p>
+                        
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+        </section>
+        
     </main>
 
     <footer>

--- a/kb/communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.yaml
+++ b/kb/communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.yaml
@@ -154,6 +154,51 @@ ecological_interactions:
     snippet: it does not confer protection on host epithelial cells during infection
     explanation: States the negative host-protection result directly; recorded because a negative
       outcome here is the paper's main corrective to the expected protective role.
+growth_media:
+- name: Bifidobacterium broth, B. breve maintenance
+  composition:
+  - name: Bifidobacterium broth
+    from_source: true
+  atmosphere: ANAEROBIC
+  vessel_type: Broth, with single colonies picked from streaked plates
+  preparation_notes: >-
+    Maintenance culture for the bacterial partner, kept as -80C glycerol stocks. Extracted
+    from the cached open-access full text; #183 listed this record as lacking growth
+    conditions because they are Methods-level.
+  evidence:
+  - reference: PMID:41688526
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: B. breve (ATCC 15700) was maintained anaerobically in Bifidobacterium broth, streaked
+      to isolate single colonies, and preserved at −80°C in 50% glycerol
+    explanation: Names the medium, the atmosphere and the strain for the maintenance culture.
+- name: Serum-free YI-S co-culture assay
+  composition:
+  - name: YI-S, serum-free
+    from_source: true
+  atmosphere: ANAEROBIC
+  incubation_time: 4.0
+  incubation_time_unit: HOURS
+  inoculum_size: 100000000.0
+  inoculum_unit: CFU
+  preparation_notes: >-
+    The assay the record is about - B. breve at 1e8 CFU against T. vaginalis at 1e7 cells,
+    the ratio taken from the prior study the source cites. Viability and bacterial counts
+    were read at sequential time points.
+  evidence:
+  - reference: PMID:41688526
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Both organisms were combined in serum-free YI-S and incubated anaerobically for four
+      hours
+    explanation: Names the co-culture medium, atmosphere and duration.
+  - reference: PMID:41688526
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Mid-log phase bacteria and parasites were adjusted to 108 CFU and 107 cells, respectively
+    explanation: The inoculum for each partner. The source renders the exponents without
+      superscripts, so 108 and 107 are 1e8 and 1e7.
+
 environmental_factors:
 - name: Co-culture duration
   value: 4 h

--- a/kb/communities/Mars_Meteorite_EETA79001_Growth_Panel.yaml
+++ b/kb/communities/Mars_Meteorite_EETA79001_Growth_Panel.yaml
@@ -158,6 +158,47 @@ taxonomy:
 # regolith (never co-cultured), so no interspecies interaction was measured. The shared
 # community-level capacity to grow on martian regolith is captured in the description
 # and environmental_factors instead.
+growth_media:
+- name: Alga-Gro, phototroph maintenance
+  composition:
+  - name: Alga-Gro
+    from_source: true
+  temperature: 23.0
+  temperature_unit: CELSIUS
+  light_regime: 16 h light / 8 h dark, plant growth lamp at 455-650 nm
+  vessel_type: 50 mL stocks in a foil-lined culture box
+  preparation_notes: >-
+    Maintenance for the two phototrophs across the experiment. Extracted from the cached
+    open-access full text; #183 listed this record as lacking growth conditions because
+    they are Methods-level.
+  evidence:
+  - reference: PMID:38665180
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Chr20 cultures were grown and maintained in 50 mL stocks in Alga-Gro media at room
+      temperature (23 °C) in a foil-lined culture box fitted with a plant growth lamp (λ = 455–650
+      nm) and set to a cycle of 16-hour day light
+    explanation: Names the medium, temperature, vessel, lamp spectrum and photoperiod.
+- name: Tryptic soy agar, heterotroph preculture
+  composition:
+  - name: Tryptic soy agar (TSA)
+    from_source: true
+  temperature: 25.0
+  temperature_unit: CELSIUS
+  incubation_time: 20.0
+  incubation_time_unit: HOURS
+  vessel_type: TSA plate
+  preparation_notes: >-
+    The bacterial partners were brought to a defined state on TSA before the regolith
+    exposure, and enumerated back onto TSA as CFU afterwards.
+  evidence:
+  - reference: PMID:38665180
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: a 20-hour culture of each bacteria was streaked onto a fresh TSA plate and incubated
+      at 25 °C
+    explanation: Names the medium, duration and temperature for the bacterial preculture.
+
 environmental_factors:
 - name: Actual martian regolith substrate (Mars meteorite EETA79001)
   value: EETA79001 meteorite sawdust


### PR DESCRIPTION
Continuing the cached-and-ready subset from #505. Both sources were already in `references_cache/` with OA full text, so neither needed the institutional access #183 is waiting on.

## Bifidobacterium_Trichomonas_Vaginal_Coculture

- **B. breve maintenance** — anaerobic Bifidobacterium broth, colonies picked from streaked plates
- **the co-culture assay** — serum-free YI-S, anaerobic, 4 hours, with the 1e8 CFU / 1e7 cells inoculum ratio the source takes from a prior study

## Mars_Meteorite_EETA79001_Growth_Panel

- **Alga-Gro** for the two phototrophs — 23 °C, 16 h/8 h photoperiod under a 455–650 nm lamp, 50 mL stocks in a foil-lined box
- **TSA preculture** for the bacterial partners — 25 °C for 20 h, which is also what they were enumerated back onto as CFU

## Verification

All five evidence snippets are **verbatim substrings** of the cached sources — `validate-references` reports 0 issues on both records.

## One rendering note kept in the record

The Bifidobacterium source prints its exponents without superscripts, so *"108 CFU and 107 cells"* means 1e8 and 1e7. The snippet quotes the source **as it renders** and the `explanation` says what it means — rather than editing the quote to match the intended value, which is the RENDERING trap the justfile warns about and which #347 was about on the other side.

## Where the gap stands

**84 of 312**, from 87. Six of the nine cached-and-ready records remain — and one of those (`SynCom_ARC_Peanut_Aflatoxin_Nodulation`) scored **0/4** on a conditions scan, so it may legitimately have none, which #183 anticipates for field and computational records.

`2375 passed`, `validate-strict` 0 errors, docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)