### PR TITLE
Enrich two more #183 records from cached full text (84 → 82)

### DIFF
--- a/docs/communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.html
+++ b/docs/communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.html
@@ -796,6 +796,176 @@
 
         <!-- Growth Media -->
         
+        <section>
+            <h2>Growth Media</h2>
+            
+            <div class="metadata">
+                <h3>
+                    Phytate Low liquid medium, strain preculture
+                    
+                </h3>
+
+                
+
+                <div class="metadata-grid" style="margin-top: 1rem;">
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Temperature</span>
+                        <span class="metadata-value">30.0 CELSIUS</span>
+                    </div>
+                    
+
+                    
+                </div>
+
+                
+                <h4 style="margin-top: 1rem; color: var(--text);">Composition</h4>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Component</th>
+                            <th>Concentration</th>
+                            <th>Unit</th>
+                            <th>CHEBI</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        
+                        <tr>
+                            <td><strong>Phytate Low</strong></td>
+                            <td>N/A</td>
+                            <td>N/A</td>
+                            <td>
+                                
+                                N/A
+                                
+                            </td>
+                        </tr>
+                        
+                    </tbody>
+                </table>
+                
+
+                
+                <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
+                    <strong>Preparation notes:</strong> Each of the five strains was grown separately before the consortium was mixed. The medium name is the source&#39;s own (&#34;Phytate Low&#34;), which suits strains selected for phosphate solubilisation. Extracted from the cached open-access full text; #183 listed this record as lacking growth conditions because they are Methods-level.
+                </p>
+                
+
+                
+                <div style="margin-top: 1rem;">
+                    <h4 style="color: var(--text);">Evidence</h4>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/42050290"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:42050290
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"Cultures were incubated at 30 °C for 48 h under constant agitation at 150 rpm"</p>
+                        
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+            <div class="metadata">
+                <h3>
+                    PBS consortium suspension, applied inoculum
+                    
+                </h3>
+
+                
+
+                <div class="metadata-grid" style="margin-top: 1rem;">
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">pH</span>
+                        <span class="metadata-value">7.4</span>
+                    </div>
+                    
+
+                    
+
+                    
+                </div>
+
+                
+                <h4 style="margin-top: 1rem; color: var(--text);">Composition</h4>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Component</th>
+                            <th>Concentration</th>
+                            <th>Unit</th>
+                            <th>CHEBI</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        
+                        <tr>
+                            <td><strong>Phosphate-buffered saline (PBS 1x)</strong></td>
+                            <td>N/A</td>
+                            <td>N/A</td>
+                            <td>
+                                
+                                N/A
+                                
+                            </td>
+                        </tr>
+                        
+                    </tbody>
+                </table>
+                
+
+                
+                <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
+                    <strong>Preparation notes:</strong> The delivered inoculum rather than a growth step - equal volumes of each standardised suspension combined to ten litres, at OD 0.1, roughly 1e7 CFU per mL per strain.
+                </p>
+                
+
+                
+                <div style="margin-top: 1rem;">
+                    <h4 style="color: var(--text);">Evidence</h4>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/42050290"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:42050290
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"combined to prepare the consortium in a final volume of ten L of PBS (137 mM NaCl, 2.7 mM KCl, 10 mM Na₂HPO₄, 1.8 mM KH₂PO₄; pH 7.4)"</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/42050290"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:42050290
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"the final solution reached an OD of 0.1 (approximately 10⁷ CFU mL⁻¹ per strain)"</p>
+                        
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+        </section>
+        
     </main>
 
     <footer>

--- a/docs/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.html
+++ b/docs/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.html
@@ -771,6 +771,187 @@
 
         <!-- Growth Media -->
         
+        <section>
+            <h2>Growth Media</h2>
+            
+            <div class="metadata">
+                <h3>
+                    Vitamin B12-supplemented BG11, Syn7002 culture
+                    
+                </h3>
+
+                
+
+                <div class="metadata-grid" style="margin-top: 1rem;">
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Temperature</span>
+                        <span class="metadata-value">28.0 CELSIUS</span>
+                    </div>
+                    
+
+                    
+                </div>
+
+                
+                <h4 style="margin-top: 1rem; color: var(--text);">Composition</h4>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Component</th>
+                            <th>Concentration</th>
+                            <th>Unit</th>
+                            <th>CHEBI</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        
+                        <tr>
+                            <td><strong>BG11</strong></td>
+                            <td>N/A</td>
+                            <td>N/A</td>
+                            <td>
+                                
+                                N/A
+                                
+                            </td>
+                        </tr>
+                        
+                        <tr>
+                            <td><strong>vitamin B12</strong></td>
+                            <td>4.0</td>
+                            <td>µg/L</td>
+                            <td>
+                                
+                                N/A
+                                
+                            </td>
+                        </tr>
+                        
+                    </tbody>
+                </table>
+                
+
+                
+                <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
+                    <strong>Preparation notes:</strong> The cyanobacterial partner&#39;s culture, and the axis the record is about - the B12-free form of the same medium is what makes MesTH&#39;s provision measurable. The 4 µg/L figure is the supplement used for the Syn7002+B12 control arm. Extracted from the cached open-access full text; #183 listed this record as lacking growth conditions because they are Methods-level.
+                </p>
+                
+
+                
+                <div style="margin-top: 1rem;">
+                    <h4 style="color: var(--text);">Evidence</h4>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41790499"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41790499
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"was cultivated in vitamin B12-supplemented BG11 medium at 28 °C under a light intensity of 70 µmol m−2 s−1 with shaking at 180 r.p.m."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41790499"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41790499
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"For the Syn7002+vitamin B12 group, vitamin B12 (4 µg l−1) was supplemented"</p>
+                        
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+            <div class="metadata">
+                <h3>
+                    LB, MesTH isolation and culture
+                    
+                </h3>
+
+                
+
+                <div class="metadata-grid" style="margin-top: 1rem;">
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Temperature</span>
+                        <span class="metadata-value">28.0 CELSIUS</span>
+                    </div>
+                    
+
+                    
+                </div>
+
+                
+                <h4 style="margin-top: 1rem; color: var(--text);">Composition</h4>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Component</th>
+                            <th>Concentration</th>
+                            <th>Unit</th>
+                            <th>CHEBI</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        
+                        <tr>
+                            <td><strong>LB</strong></td>
+                            <td>N/A</td>
+                            <td>N/A</td>
+                            <td>
+                                
+                                N/A
+                                
+                            </td>
+                        </tr>
+                        
+                    </tbody>
+                </table>
+                
+
+                
+                <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
+                    <strong>Preparation notes:</strong> The bacterial partner was purified and grown on LB, then washed into B12-free BG11 before the co-culture, so the only B12 in the assay is what MesTH makes.
+                </p>
+                
+
+                
+                <div style="margin-top: 1rem;">
+                    <h4 style="color: var(--text);">Evidence</h4>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41790499"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41790499
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"MesTH was purified using the streak plate method on LB medium, after which it was cultured in LB medium. Both MesTH and Syn7002 were then washed with vitamin B12-free BG11"</p>
+                        
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+        </section>
+        
     </main>
 
     <footer>

--- a/kb/communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.yaml
+++ b/kb/communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.yaml
@@ -220,6 +220,51 @@ ecological_interactions:
     explanation: PARTIAL - the host benefit is measured and quantified, but the paper does not
       identify which consortium members or mechanisms produce it, and the effect did not hold across
       all three genotypes.
+growth_media:
+- name: Phytate Low liquid medium, strain preculture
+  composition:
+  - name: Phytate Low
+    from_source: true
+  temperature: 30.0
+  temperature_unit: CELSIUS
+  incubation_time: 48.0
+  incubation_time_unit: HOURS
+  shaking_speed: 150.0
+  shaking_speed_unit: RPM
+  preparation_notes: >-
+    Each of the five strains was grown separately before the consortium was mixed. The
+    medium name is the source's own ("Phytate Low"), which suits strains selected for
+    phosphate solubilisation. Extracted from the cached open-access full text; #183 listed
+    this record as lacking growth conditions because they are Methods-level.
+  evidence:
+  - reference: PMID:42050290
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Cultures were incubated at 30 °C for 48 h under constant agitation at 150 rpm
+    explanation: Names the temperature, duration and agitation for the preculture.
+- name: PBS consortium suspension, applied inoculum
+  composition:
+  - name: Phosphate-buffered saline (PBS 1x)
+    from_source: true
+  ph: 7.4
+  inoculum_size: 10000000.0
+  inoculum_unit: CFU/mL
+  preparation_notes: >-
+    The delivered inoculum rather than a growth step - equal volumes of each standardised
+    suspension combined to ten litres, at OD 0.1, roughly 1e7 CFU per mL per strain.
+  evidence:
+  - reference: PMID:42050290
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: 'combined to prepare the consortium in a final volume of ten L of PBS (137 mM NaCl,
+      2.7 mM KCl, 10 mM Na₂HPO₄, 1.8 mM KH₂PO₄; pH 7.4)'
+    explanation: Names the carrier, its composition and pH.
+  - reference: PMID:42050290
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the final solution reached an OD of 0.1 (approximately 10⁷ CFU mL⁻¹ per strain)
+    explanation: The applied cell density per strain.
+
 environmental_factors:
 - name: Root community restructuring without diversity change
   description: >

--- a/kb/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.yaml
+++ b/kb/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.yaml
@@ -210,6 +210,58 @@ ecological_interactions:
     explanation: PARTIAL - microscopy establishes spatial association but does not identify which
       taxon the rod-shaped cells belong to, nor whether the association is required for the
       exchange, so it is recorded at community level without a named partner.
+growth_media:
+- name: Vitamin B12-supplemented BG11, Syn7002 culture
+  composition:
+  - name: BG11
+    from_source: true
+  - name: vitamin B12
+    concentration: 4.0
+    unit: µg/L
+    from_source: true
+  temperature: 28.0
+  temperature_unit: CELSIUS
+  light_intensity: 70.0
+  light_intensity_unit: UMOL_PHOTONS_M2_S
+  shaking_speed: 180.0
+  shaking_speed_unit: RPM
+  preparation_notes: >-
+    The cyanobacterial partner's culture, and the axis the record is about - the B12-free
+    form of the same medium is what makes MesTH's provision measurable. The 4 µg/L figure
+    is the supplement used for the Syn7002+B12 control arm. Extracted from the cached
+    open-access full text; #183 listed this record as lacking growth conditions because
+    they are Methods-level.
+  evidence:
+  - reference: PMID:41790499
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: was cultivated in vitamin B12-supplemented BG11 medium at 28 °C under a light intensity
+      of 70 µmol m−2 s−1 with shaking at 180 r.p.m.
+    explanation: Names the medium, temperature, irradiance and agitation.
+  - reference: PMID:41790499
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: 'For the Syn7002+vitamin B12 group, vitamin B12 (4 µg l−1) was supplemented'
+    explanation: The supplement concentration for the control arm.
+- name: LB, MesTH isolation and culture
+  composition:
+  - name: LB
+    from_source: true
+  temperature: 28.0
+  temperature_unit: CELSIUS
+  shaking_speed: 180.0
+  shaking_speed_unit: RPM
+  preparation_notes: >-
+    The bacterial partner was purified and grown on LB, then washed into B12-free BG11
+    before the co-culture, so the only B12 in the assay is what MesTH makes.
+  evidence:
+  - reference: PMID:41790499
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: MesTH was purified using the streak plate method on LB medium, after which it was
+      cultured in LB medium. Both MesTH and Syn7002 were then washed with vitamin B12-free BG11
+    explanation: Names the medium and the wash that sets up the B12-limited co-culture.
+
 environmental_factors:
 - name: Vitamin B12-positive control supplementation
   description: >


### PR DESCRIPTION
Third pass over the cached-and-ready subset. Both sources were already in `references_cache/` with OA full text.

## Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom

Two entries, because the source separates **growth** from **delivery**:

- **Phytate Low** liquid medium, 30 °C, 48 h, 150 rpm — each of the five strains grown separately before mixing. The medium name is the source's own, and suits strains selected for phosphate solubilisation.
- **the applied inoculum**, which is not a growth step: equal volumes combined to ten litres of PBS at pH 7.4, OD 0.1, ≈1e7 CFU/mL per strain.

## Mesorhizobium_Synechococcus_B12_Synthetic_Consortium

Two entries, and the B12 axis is the point of the record:

- **B12-supplemented BG11** for Syn7002 — 28 °C, 70 µmol m⁻² s⁻¹, 180 rpm, with the 4 µg/L supplement used for the `Syn7002+B12` control arm.
- **LB** for MesTH, then washed into **B12-free** BG11 before co-culture — which is what makes the bacterium's B12 provision measurable rather than confounded. Recording only "LB" would have lost the part that makes the experiment work.

## Verification

All six evidence snippets are verbatim substrings of their cached sources — `validate-references` reports 0 issues on both records.

## Where the gap stands

**82 of 312**, from 84. Four of the nine cached-and-ready records remain, one of which (`SynCom_ARC_Peanut_Aflatoxin_Nodulation`) scored 0/4 on a conditions scan and may legitimately have none.

`2375 passed`, `validate-strict` 0 errors, docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)