### PR TITLE
Finish #183's cached-and-ready subset: 6 enriched, 3 legitimately conditionless

### DIFF
--- a/docs/communities/Human_Gut_FourMember_Proteome_Complementarity_Consortium.html
+++ b/docs/communities/Human_Gut_FourMember_Proteome_Complementarity_Consortium.html
@@ -742,6 +742,221 @@
 
         <!-- Growth Media -->
         
+        <section>
+            <h2>Growth Media</h2>
+            
+            <div class="metadata">
+                <h3>
+                    YCFA with wheat straw fibre, anaerobic Hungate tubes
+                    
+                </h3>
+
+                
+
+                <div class="metadata-grid" style="margin-top: 1rem;">
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Temperature</span>
+                        <span class="metadata-value">37.0 CELSIUS</span>
+                    </div>
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Atmosphere</span>
+                        <span class="metadata-value">ANAEROBIC</span>
+                    </div>
+                    
+                </div>
+
+                
+                <h4 style="margin-top: 1rem; color: var(--text);">Composition</h4>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Component</th>
+                            <th>Concentration</th>
+                            <th>Unit</th>
+                            <th>CHEBI</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        
+                        <tr>
+                            <td><strong>Yeast casitone fatty acids (YCFA) medium</strong></td>
+                            <td>N/A</td>
+                            <td>N/A</td>
+                            <td>
+                                
+                                N/A
+                                
+                            </td>
+                        </tr>
+                        
+                        <tr>
+                            <td><strong>wheat straw fibre</strong></td>
+                            <td>0.5</td>
+                            <td>%</td>
+                            <td>
+                                
+                                N/A
+                                
+                            </td>
+                        </tr>
+                        
+                    </tbody>
+                </table>
+                
+
+                
+                <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
+                    <strong>Preparation notes:</strong> The fibre arm of the two-carbon-source design. Stability came from serial transfer - fresh medium every 24 h over five transfers - rather than from a single long incubation. Extracted from the cached open-access full text; #183 listed this record as lacking growth conditions because they are Methods-level.
+                </p>
+                
+
+                
+                <div style="margin-top: 1rem;">
+                    <h4 style="color: var(--text);">Evidence</h4>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/42032280"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:42032280
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"Bacteria were grown anaerobically in Hungate tubes containing yeast casitone fatty acids (YCFA) medium"</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/42032280"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:42032280
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"supplemented with 0.5% wheat straw fibre (collected at the Agricultural Research Organization, Volcani Center, Israel) or 0.5% fructose as carbon sources for 24 h at 37 °C"</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/42032280"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:42032280
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"the cultures were transferred to fresh media every 24 h over a span of 5 transfers"</p>
+                        
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+            <div class="metadata">
+                <h3>
+                    YCFA with fructose, anaerobic Hungate tubes
+                    
+                </h3>
+
+                
+
+                <div class="metadata-grid" style="margin-top: 1rem;">
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Temperature</span>
+                        <span class="metadata-value">37.0 CELSIUS</span>
+                    </div>
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Atmosphere</span>
+                        <span class="metadata-value">ANAEROBIC</span>
+                    </div>
+                    
+                </div>
+
+                
+                <h4 style="margin-top: 1rem; color: var(--text);">Composition</h4>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Component</th>
+                            <th>Concentration</th>
+                            <th>Unit</th>
+                            <th>CHEBI</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        
+                        <tr>
+                            <td><strong>Yeast casitone fatty acids (YCFA) medium</strong></td>
+                            <td>N/A</td>
+                            <td>N/A</td>
+                            <td>
+                                
+                                N/A
+                                
+                            </td>
+                        </tr>
+                        
+                        <tr>
+                            <td><strong>fructose</strong></td>
+                            <td>0.5</td>
+                            <td>%</td>
+                            <td>
+                                
+                                N/A
+                                
+                            </td>
+                        </tr>
+                        
+                    </tbody>
+                </table>
+                
+
+                
+                <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
+                    <strong>Preparation notes:</strong> The soluble-sugar arm, run in parallel with the fibre arm above. Kept as its own entry because the carbon source is the experimental variable, not an incidental detail.
+                </p>
+                
+
+                
+                <div style="margin-top: 1rem;">
+                    <h4 style="color: var(--text);">Evidence</h4>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/42032280"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:42032280
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"or 0.5% fructose as carbon sources for 24 h at 37 °C"</p>
+                        
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+        </section>
+        
     </main>
 
     <footer>

--- a/kb/communities/Human_Gut_FourMember_Proteome_Complementarity_Consortium.yaml
+++ b/kb/communities/Human_Gut_FourMember_Proteome_Complementarity_Consortium.yaml
@@ -183,6 +183,68 @@ ecological_interactions:
       identity outweighed carbon source" is a property of the same partner-specific remodelling
       rather than a second interaction between taxa. The design varied carbon source independently,
       which is what gives the comparison force.
+growth_media:
+- name: YCFA with wheat straw fibre, anaerobic Hungate tubes
+  composition:
+  - name: Yeast casitone fatty acids (YCFA) medium
+    from_source: true
+  - name: wheat straw fibre
+    concentration: 0.5
+    unit: '%'
+    from_source: true
+  atmosphere: ANAEROBIC
+  temperature: 37.0
+  temperature_unit: CELSIUS
+  incubation_time: 24.0
+  incubation_time_unit: HOURS
+  vessel_type: Hungate tube
+  preparation_notes: >-
+    The fibre arm of the two-carbon-source design. Stability came from serial transfer -
+    fresh medium every 24 h over five transfers - rather than from a single long
+    incubation. Extracted from the cached open-access full text; #183 listed this record
+    as lacking growth conditions because they are Methods-level.
+  evidence:
+  - reference: PMID:42032280
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Bacteria were grown anaerobically in Hungate tubes containing yeast casitone fatty
+      acids (YCFA) medium
+    explanation: Names the atmosphere, vessel and base medium.
+  - reference: PMID:42032280
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: supplemented with 0.5% wheat straw fibre (collected at the Agricultural Research
+      Organization, Volcani Center, Israel) or 0.5% fructose as carbon sources for 24 h at 37 °C
+    explanation: Names both carbon sources, the concentration, duration and temperature.
+  - reference: PMID:42032280
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the cultures were transferred to fresh media every 24 h over a span of 5 transfers
+    explanation: The serial-transfer regimen used to stabilise the community.
+- name: YCFA with fructose, anaerobic Hungate tubes
+  composition:
+  - name: Yeast casitone fatty acids (YCFA) medium
+    from_source: true
+  - name: fructose
+    concentration: 0.5
+    unit: '%'
+    from_source: true
+  atmosphere: ANAEROBIC
+  temperature: 37.0
+  temperature_unit: CELSIUS
+  incubation_time: 24.0
+  incubation_time_unit: HOURS
+  vessel_type: Hungate tube
+  preparation_notes: >-
+    The soluble-sugar arm, run in parallel with the fibre arm above. Kept as its own entry
+    because the carbon source is the experimental variable, not an incidental detail.
+  evidence:
+  - reference: PMID:42032280
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: or 0.5% fructose as carbon sources for 24 h at 37 °C
+    explanation: The alternative carbon source at the same concentration and conditions.
+
 environmental_factors:
 - name: Distinct carbon sources
   description: >


### PR DESCRIPTION
Last of the nine records that had OA full text **already** in `references_cache/` — and so were never blocked on the institutional access #183 is waiting for.

## Human_Gut_FourMember_Proteome_Complementarity_Consortium

Two entries, because the carbon source is the **experimental variable** rather than an incidental detail:

- YCFA in anaerobic Hungate tubes, 37 °C, 24 h, with **0.5% wheat straw fibre**
- the same, with **0.5% fructose**

Community stability came from **serial transfer** — fresh medium every 24 h over five transfers — recorded because that is the regimen, not the incubation. Four snippets, all verbatim; `validate-references` reports 0 issues.

## The remaining three have nothing to extract, and that is the right answer

- Both SPRUCE records cite `PMID:34836550`, a **metagenomic field survey**. Its only "medium" is CC-licence boilerplate; its only "incubated at" is a 70 °C DNA-extraction step. Nothing was cultured.
- `SynCom_ARC_Peanut_Aflatoxin_Nodulation` scored **0/4** — its cached text carries no °C, no incubation, no culturing.

#183 anticipates exactly this: *"natural/field communities or pure computational GEM models, which legitimately have none."* So these are not gaps, and establishing that is the useful outcome rather than forcing a block into them.

## Where the subset lands

| | |
|---|--:|
| enriched from cached full text | **6** |
| legitimately conditionless | **3** |
| **cached-and-ready subset** | **exhausted** |

Gap **87 → 81** across this thread. The other 78 still need access, which is what #183 was actually about.

`2375 passed`, `validate-strict` 0 errors, docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)