### PR TITLE
Enrich Suillus SynCom, and record why a high conditions score can mislead (#183)

### DIFF
--- a/docs/communities/Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom.html
+++ b/docs/communities/Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom.html
@@ -945,6 +945,291 @@
 
         <!-- Growth Media -->
         
+        <section>
+            <h2>Growth Media</h2>
+            
+            <div class="metadata">
+                <h3>
+                    Potato dextrose agar, ectomycorrhizal fungal isolation and culture
+                    
+                </h3>
+
+                
+
+                <div class="metadata-grid" style="margin-top: 1rem;">
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">pH</span>
+                        <span class="metadata-value">7.0</span>
+                    </div>
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Temperature</span>
+                        <span class="metadata-value">28.0 CELSIUS</span>
+                    </div>
+                    
+
+                    
+                </div>
+
+                
+                <h4 style="margin-top: 1rem; color: var(--text);">Composition</h4>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Component</th>
+                            <th>Concentration</th>
+                            <th>Unit</th>
+                            <th>CHEBI</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        
+                        <tr>
+                            <td><strong>potato extract</strong></td>
+                            <td>200.0</td>
+                            <td>g/L</td>
+                            <td>
+                                
+                                N/A
+                                
+                            </td>
+                        </tr>
+                        
+                        <tr>
+                            <td><strong>glucose</strong></td>
+                            <td>20.0</td>
+                            <td>g/L</td>
+                            <td>
+                                
+                                N/A
+                                
+                            </td>
+                        </tr>
+                        
+                        <tr>
+                            <td><strong>agar</strong></td>
+                            <td>15.0</td>
+                            <td>g/L</td>
+                            <td>
+                                
+                                N/A
+                                
+                            </td>
+                        </tr>
+                        
+                        <tr>
+                            <td><strong>streptomycin</strong></td>
+                            <td>50.0</td>
+                            <td>mg/L</td>
+                            <td>
+                                
+                                N/A
+                                
+                            </td>
+                        </tr>
+                        
+                    </tbody>
+                </table>
+                
+
+                
+                <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
+                    <strong>Preparation notes:</strong> The fungal partner&#39;s medium. Streptomycin is in the recipe to suppress bacteria during isolation from sporocarp tissue, so it belongs to the isolation step rather than to the co-culture. Extracted from the cached open-access full text - this record was among the 42 that #183 treated as access-blocked until the full-text sweep reached them.
+                </p>
+                
+
+                
+                <div style="margin-top: 1rem;">
+                    <h4 style="color: var(--text);">Evidence</h4>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41454778"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41454778
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"potato dextrose agar medium (PDA, 200 g L−1 potato extract, 20 g L−1 glucose, and 15 g L−1 agar, 50 mg L−1 streptomycin, pH 7.0) at 28°C"</p>
+                        
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+            <div class="metadata">
+                <h3>
+                    LB, bacterial partner culture
+                    
+                </h3>
+
+                
+
+                <div class="metadata-grid" style="margin-top: 1rem;">
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">pH</span>
+                        <span class="metadata-value">7.0</span>
+                    </div>
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Temperature</span>
+                        <span class="metadata-value">37.0 CELSIUS</span>
+                    </div>
+                    
+
+                    
+                </div>
+
+                
+                <h4 style="margin-top: 1rem; color: var(--text);">Composition</h4>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Component</th>
+                            <th>Concentration</th>
+                            <th>Unit</th>
+                            <th>CHEBI</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        
+                        <tr>
+                            <td><strong>tryptone</strong></td>
+                            <td>10.0</td>
+                            <td>g/L</td>
+                            <td>
+                                
+                                N/A
+                                
+                            </td>
+                        </tr>
+                        
+                        <tr>
+                            <td><strong>yeast extract</strong></td>
+                            <td>5.0</td>
+                            <td>g/L</td>
+                            <td>
+                                
+                                N/A
+                                
+                            </td>
+                        </tr>
+                        
+                        <tr>
+                            <td><strong>sodium chloride</strong></td>
+                            <td>10.0</td>
+                            <td>g/L</td>
+                            <td>
+                                
+                                N/A
+                                
+                            </td>
+                        </tr>
+                        
+                    </tbody>
+                </table>
+                
+
+                
+                <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
+                    <strong>Preparation notes:</strong> The bacterial partner, grown separately at a different temperature from the fungus - 37C against the fungus&#39;s 28C - and washed into 0.9% NaCl before the inoculum density was set by OD600.
+                </p>
+                
+
+                
+                <div style="margin-top: 1rem;">
+                    <h4 style="color: var(--text);">Evidence</h4>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41454778"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41454778
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"LB medium (tryptone 10 g L−1, yeast extract 5 g L−1, and NaCl 10 g L−1, pH 7.0) at 37°C"</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41454778"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41454778
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"Bacteria were grown and maintained in 50 ml LB medium at 37°C for 12 h"</p>
+                        
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+            <div class="metadata">
+                <h3>
+                    Confrontation assay plate
+                    
+                </h3>
+
+                
+
+                <div class="metadata-grid" style="margin-top: 1rem;">
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Temperature</span>
+                        <span class="metadata-value">28.0 CELSIUS</span>
+                    </div>
+                    
+
+                    
+                </div>
+
+                
+
+                
+                <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
+                    <strong>Preparation notes:</strong> The interaction assay itself, read as mycelial area after 14 days.
+                </p>
+                
+
+                
+                <div style="margin-top: 1rem;">
+                    <h4 style="color: var(--text);">Evidence</h4>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41454778"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41454778
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"Fungal plugs (8 mm) were placed in the center of the plate (60 mm) and incubated at 28°C in the dark"</p>
+                        
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+        </section>
+        
     </main>
 
     <footer>

--- a/kb/communities/Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom.yaml
+++ b/kb/communities/Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom.yaml
@@ -239,6 +239,93 @@ ecological_interactions:
       massoniana
     explanation: Supports increased ectomycorrhizal colonization of the pine host as the outcome of
       the thiamine cross-feeding.
+growth_media:
+- name: Potato dextrose agar, ectomycorrhizal fungal isolation and culture
+  composition:
+  - name: potato extract
+    concentration: 200.0
+    unit: g/L
+    from_source: true
+  - name: glucose
+    concentration: 20.0
+    unit: g/L
+    from_source: true
+  - name: agar
+    concentration: 15.0
+    unit: g/L
+    from_source: true
+  - name: streptomycin
+    concentration: 50.0
+    unit: mg/L
+    from_source: true
+  ph: 7.0
+  temperature: 28.0
+  temperature_unit: CELSIUS
+  preparation_notes: >-
+    The fungal partner's medium. Streptomycin is in the recipe to suppress bacteria during
+    isolation from sporocarp tissue, so it belongs to the isolation step rather than to the
+    co-culture. Extracted from the cached open-access full text - this record was among the
+    42 that #183 treated as access-blocked until the full-text sweep reached them.
+  evidence:
+  - reference: PMID:41454778
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: 'potato dextrose agar medium (PDA, 200 g L−1 potato extract, 20 g L−1 glucose, and
+      15 g L−1 agar, 50 mg L−1 streptomycin, pH 7.0) at 28°C'
+    explanation: Full recipe, pH and temperature for the fungal medium.
+- name: LB, bacterial partner culture
+  composition:
+  - name: tryptone
+    concentration: 10.0
+    unit: g/L
+    from_source: true
+  - name: yeast extract
+    concentration: 5.0
+    unit: g/L
+    from_source: true
+  - name: sodium chloride
+    concentration: 10.0
+    unit: g/L
+    from_source: true
+  ph: 7.0
+  temperature: 37.0
+  temperature_unit: CELSIUS
+  incubation_time: 12.0
+  incubation_time_unit: HOURS
+  vessel_type: 50 mL broth
+  preparation_notes: >-
+    The bacterial partner, grown separately at a different temperature from the fungus -
+    37C against the fungus's 28C - and washed into 0.9% NaCl before the inoculum density
+    was set by OD600.
+  evidence:
+  - reference: PMID:41454778
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: 'LB medium (tryptone 10 g L−1, yeast extract 5 g L−1, and NaCl 10 g L−1, pH 7.0)
+      at 37°C'
+    explanation: Full recipe, pH and temperature for the bacterial medium.
+  - reference: PMID:41454778
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Bacteria were grown and maintained in 50 ml LB medium at 37°C for 12 h
+    explanation: Volume and duration of the bacterial preculture.
+- name: Confrontation assay plate
+  temperature: 28.0
+  temperature_unit: CELSIUS
+  incubation_time: 14.0
+  incubation_time_unit: DAYS
+  light_regime: dark
+  vessel_type: 60 mm plate, 8 mm fungal plug at centre
+  preparation_notes: >-
+    The interaction assay itself, read as mycelial area after 14 days.
+  evidence:
+  - reference: PMID:41454778
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Fungal plugs (8 mm) were placed in the center of the plate (60 mm) and incubated
+      at 28°C in the dark
+    explanation: Plate format, plug size, temperature and light regime for the assay.
+
 environmental_factors:
 - name: Thiamine limitation of the fungal partner
   value: fungus cannot effectively obtain or synthesize thiamine


### PR DESCRIPTION
First record from the 42 that the full-text sweep (#509) unblocked.

## Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom

Three entries, because the two partners are grown **apart** and the assay is a third thing:

- **PDA** for the fungus — full recipe, pH 7.0, 28 °C. Streptomycin is in the recipe to suppress bacteria during isolation from sporocarp tissue, so it is noted as belonging to the *isolation* step rather than the co-culture.
- **LB** for the bacterium — full recipe, pH 7.0, **37 °C**, 50 mL for 12 h. A different temperature from the fungus, which is why these are separate entries rather than one averaged block.
- **the confrontation assay** — 60 mm plate, 8 mm plug, 28 °C in the dark, read as mycelial area at 14 days.

Four snippets, all verbatim; `validate-references` reports 0 issues.

## A refinement to the method, learned by nearly getting it wrong

I scored the 42 unblocked records by counting cultivation signals in their cached full text. **`Soil_Corrinoid_B12_Reservoir_Community` scored 5/5** — LB, M9-glycerol, 37 °C, 210 rpm, incubation times.

All of it belongs to an ***E. coli* reporter strain** used to quantify corrinoids extracted from soil. The record is a native grassland soil community characterised by metagenomics; **it was never cultured**. Adding those blocks would have asserted that a field community was grown in M9 at 37 °C.

Only reading the record caught it. The scan cannot — a paper about an uncultured community still describes plenty of lab work. `Oak_Ridge_FRC` (BIOREMEDIATION), `California_Grassland` (CARBON_SEQUESTRATION) and `PSY_Transgenic_Rice` (RHIZOSPHERE) all score 4–5/5 and are likely the same shape.

So the sweep's work-list needs a second filter the score cannot supply: **was this community cultured at all?** #183 already names the category — *"natural/field communities … which legitimately have none"* — and making the sources easy to reach made that easy to forget.

`2375 passed`, `validate-strict` 0 errors, docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)